### PR TITLE
Update containers config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ First, setup your wrangler.json to use the sandbox:
     {
       "class_name": "Sandbox",
       "image": "./Dockerfile",
-      "name": "sandbox"
+      "max_instances": 1
     }
   ],
   "durable_objects": {


### PR DESCRIPTION
The containers config currently requires `max_instances` to work correctly. I also removed the `name` which should be filled in automatically based on the worker and to avoid every use of this example creating containers with the same name.