### PR TITLE
remove yarn/pnpm from the image

### DIFF
--- a/.changeset/wide-radios-brush.md
+++ b/.changeset/wide-radios-brush.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/sandbox": patch
+---
+
+remove yarn and pnpm from the image

--- a/packages/sandbox/Dockerfile
+++ b/packages/sandbox/Dockerfile
@@ -56,8 +56,6 @@ RUN curl -fsSL https://bun.sh/install | bash \
     && mv /root/.bun/bin/bunx /usr/local/bin/bunx \
     && rm -rf /root/.bun
 
-# Install global npm packages as root
-RUN npm install -g yarn pnpm
 
 # Set up working directory
 WORKDIR /app
@@ -66,9 +64,8 @@ WORKDIR /app
 RUN python3 --version && \
     node --version && \
     npm --version && \
-    bun --version && \
-    yarn --version && \
-    pnpm --version
+    bun --version
+    
 
 # Copy container source files
 COPY container_src/ ./


### PR DESCRIPTION
(just to have a conversation about things we could potentially trim from the image)

the additional package managers seem like overkill, and don't have much value over npm+bun (especially because we don't have persistent volumes/caches)