### PR TITLE
Change default directory to a clean /workspace

### DIFF
--- a/examples/basic/app/index.tsx
+++ b/examples/basic/app/index.tsx
@@ -1426,7 +1426,7 @@ function FilesTab({
           <div className="input-group">
             <input
               type="text"
-              placeholder="File path (e.g., /app/package.json)"
+              placeholder="File path (e.g., /workspace/package.json)"
               value={selectedFile || ""}
               onChange={(e) => setSelectedFile(e.target.value)}
               className="file-input"
@@ -1455,7 +1455,7 @@ function FilesTab({
           <div className="input-group">
             <input
               type="text"
-              placeholder="File path (e.g., /app/hello.txt)"
+              placeholder="File path (e.g., /workspace/hello.txt)"
               value={newFileName}
               onChange={(e) => setNewFileName(e.target.value)}
               className="file-input"
@@ -1485,7 +1485,7 @@ function FilesTab({
           <div className="input-group">
             <input
               type="text"
-              placeholder="Directory path (e.g., /app/src)"
+              placeholder="Directory path (e.g., /workspace/src)"
               value={newDirName}
               onChange={(e) => setNewDirName(e.target.value)}
               className="file-input"

--- a/packages/sandbox/Dockerfile
+++ b/packages/sandbox/Dockerfile
@@ -56,21 +56,23 @@ COPY --from=bun-source /usr/local/bin/bun /usr/local/bin/bun
 COPY --from=bun-source /usr/local/bin/bunx /usr/local/bin/bunx
 
 
-# Set up working directory
-WORKDIR /app
+# Set up container server directory
+WORKDIR /container-server
 
 # Verify installations
 RUN python3 --version && \
     node --version && \
     npm --version && \
     bun --version
-    
 
-# Copy container source files
+# Copy container source files to server directory
 COPY container_src/ ./
+
+# Create clean workspace directory for users
+RUN mkdir -p /workspace
 
 # Expose the application port
 EXPOSE 3000
 
-# Run the application
+# Run the application from container server directory
 CMD ["bun", "index.ts"]

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -176,7 +176,7 @@ for await (const log of parseSSEStream<LogEvent>(logStream)) {
 Write content to a file.
 
 ```typescript
-await sandbox.writeFile("/app.js", "console.log('Hello!');");
+await sandbox.writeFile("/workspace/app.js", "console.log('Hello!');");
 ```
 
 #### `readFile(path, options?)`
@@ -314,7 +314,7 @@ const sandbox = getSandbox(env.Sandbox, "node-app");
 
 // Write a simple Express server
 await sandbox.writeFile(
-  "/app.js",
+  "/workspace/app.js",
   `
   const express = require('express');
   const app = express();
@@ -498,7 +498,7 @@ Maintain context across commands:
 const sessionId = crypto.randomUUID();
 
 // Commands in the same session share working directory
-await sandbox.exec("cd /app", { sessionId });
+await sandbox.exec("cd /workspace", { sessionId });
 await sandbox.exec("npm install", { sessionId });
 const app = await sandbox.startProcess("npm start", { sessionId });
 ```

--- a/packages/sandbox/container_src/handler/exec.ts
+++ b/packages/sandbox/container_src/handler/exec.ts
@@ -16,7 +16,7 @@ function executeCommand(
       shell: true,
       stdio: ["pipe", "pipe", "pipe"] as const,
       detached: options.background || false,
-      cwd: options.cwd,
+      cwd: options.cwd || "/workspace", // Default to /workspace instead of current working directory
       env: options.env ? { ...process.env, ...options.env } : process.env
     };
 
@@ -186,6 +186,7 @@ export async function handleStreamingExecuteRequest(
           shell: true,
           stdio: ["pipe", "pipe", "pipe"] as const,
           detached: background || false,
+          cwd: "/workspace", // Default to /workspace for consistency
         };
 
         const child = spawn(command, spawnOptions);

--- a/packages/sandbox/container_src/handler/process.ts
+++ b/packages/sandbox/container_src/handler/process.ts
@@ -72,7 +72,7 @@ export async function handleStartProcessRequest(
         // Start the actual process
         try {
             const spawnOptions: SpawnOptions = {
-                cwd: options.cwd || process.cwd(),
+                cwd: options.cwd || "/workspace", // Default to /workspace for consistency with exec commands
                 env: { ...process.env, ...options.env },
                 detached: false,
                 shell: true,


### PR DESCRIPTION
- Move container server code from /app to /container-server
- Default user commands to run in clean /workspace directory
- Update documentation examples to use /workspace paths
- Update UI placeholders to suggest /workspace paths
- Create /workspace directory in container for user operations

This gives developers a clean workspace without server implementation files cluttering their view.

Fixes #34 