### PR TITLE
Determine if the port is specified in the URL.

### DIFF
--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -135,6 +135,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       return parseInt(proxyMatch[1]);
     }
 
+    if (url.port) {
+      return parseInt(url.port);
+    }
+
     // All other requests go to control plane on port 3000
     // This includes /api/* endpoints and any other control requests
     return 3000;


### PR DESCRIPTION
The port can be specified in the URL. This change allows us to extract the port and parse it to a number.

Closes #65.