### PR TITLE
Add new dependencies to package.json

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -18,6 +18,12 @@
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
-    "@types/react-katex": "^3.0.4"
+    "@cloudflare/vite-plugin": "^1.13.13",
+    "@types/react-katex": "^3.0.4",
+    "@vitejs/plugin-react": "^4.3.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "vite": "^6.0.0",
+    "wrangler": "^4.43.0"
   }
 }


### PR DESCRIPTION
Without these items in the package.json the steps written in Readme.md to get the project working (`npm install` and `npm start`) doesnt work. 

Claude Summary
The issue was that your package.json was missing several required dependencies:

vite - The build tool and dev server
@vitejs/plugin-react - Vite plugin for React support react and react-dom - React framework libraries
@cloudflare/vite-plugin - Cloudflare's Vite integration I added all missing dependencies with the correct versions:

vite@^6.0.0 (upgraded from 5 to 6 to match the Cloudflare plugin requirements) @cloudflare/vite-plugin@^1.13.13
@vitejs/plugin-react@^4.3.0
react@^18.3.0
react-dom@^18.3.0