### PR TITLE
Use environment protection for external PR workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,8 +1,8 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, labeled]
+  pull_request_target:
+    types: [opened, synchronize]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -13,14 +13,12 @@ on:
 jobs:
   claude-review:
     # Skip review for automated "Version Packages" PRs created by changesets
-    # For external PRs: requires 'ci' label
-    # For internal PRs: runs automatically
-    if: |
-      github.event.pull_request.title != 'Version Packages' &&
-      (github.event.pull_request.head.repo.full_name == github.repository ||
-       contains(github.event.pull_request.labels.*.name, 'ci'))
+    # For external PRs: requires manual approval via 'external-pr' environment
+    # For internal PRs: runs automatically without approval
+    if: github.event.pull_request.title != 'Version Packages'
 
     runs-on: ubuntu-latest
+    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'external-pr' || null }}
     permissions:
       contents: read
       pull-requests: read
@@ -31,6 +29,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
       - name: Run Claude Code Review

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -5,8 +5,8 @@ permissions:
   pull-requests: write # Required for pkg.pr.new to comment on PRs
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
     paths:
       - '**'
       - '!**/*.md'
@@ -14,18 +14,17 @@ on:
 
 jobs:
   publish-preview:
-    # For external PRs: requires 'ci' label
-    # For internal PRs: runs automatically
-    if: |
-      github.event.pull_request.head.repo.full_name == github.repository ||
-      contains(github.event.pull_request.labels.*.name, 'ci')
+    # For external PRs: requires manual approval via 'external-pr' environment
+    # For internal PRs: runs automatically without approval
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'external-pr' || null }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -4,8 +4,8 @@ permissions:
   contents: read
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -20,6 +20,8 @@ jobs:
       version: ${{ steps.get-version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -72,17 +74,17 @@ jobs:
         run: npm run test -w @repo/sandbox-container
 
   # E2E tests against deployed worker
-  # For external PRs: requires 'ci' label
-  # For internal PRs: runs automatically
+  # For external PRs: requires manual approval via 'external-pr' environment
+  # For internal PRs: runs automatically without approval
   e2e-tests:
     needs: unit-tests
-    if: |
-      github.event.pull_request.head.repo.full_name == github.repository ||
-      contains(github.event.pull_request.labels.*.name, 'ci')
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'external-pr' || null }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -103,7 +105,7 @@ jobs:
       - name: Set environment name
         id: env-name
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
             echo "env_name=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
             echo "worker_name=sandbox-e2e-test-worker-pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           else
@@ -161,7 +163,7 @@ jobs:
 
       # Cleanup: Delete test worker and container (only for PR environments)
       - name: Cleanup test deployment
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request_target'
         continue-on-error: true
         run: |
           cd tests/e2e/test-worker


### PR DESCRIPTION
Fixes external PRs from forks not being able to run E2E tests, Docker publishing, or Claude reviews due to lack of secret access.

Switches to pull_request_target with environment protection. External PR workflows pause awaiting manual approval in GitHub UI. Internal PRs run immediately.

Replaces the label-based approach that didn't work.