### PR TITLE
Fix CMD path to handle WORKDIR changes

### DIFF
--- a/.changeset/fix-workdir-cmd-path.md
+++ b/.changeset/fix-workdir-cmd-path.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Fix container startup failures when WORKDIR is changed in derived Dockerfiles

--- a/packages/sandbox/Dockerfile
+++ b/packages/sandbox/Dockerfile
@@ -187,4 +187,4 @@ COPY packages/sandbox/startup.sh ./
 RUN chmod +x startup.sh
 
 # Use startup script
-CMD ["./startup.sh"]
+CMD ["/container-server/startup.sh"]

--- a/packages/sandbox/startup.sh
+++ b/packages/sandbox/startup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec bun dist/index.js
+exec bun /container-server/dist/index.js


### PR DESCRIPTION
Users extending the base Dockerfile with custom WORKDIR directives
encountered container startup failures due to relative paths in both
the startup script and CMD directive.

Changed both to use absolute paths, making the container immune to
WORKDIR changes in derived images.