### PR TITLE
Optimize CI workflows for faster PR checks

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,10 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Skip review for automated "Version Packages" PRs created by changesets

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -12,8 +12,13 @@ on:
       - '!**/*.md'
       - '!.changeset/**'
 
+concurrency:
+  group: pkg-pr-new-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   publish-preview:
+    if: ${{ !contains(github.event.pull_request.title, 'Version Packages') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -73,6 +73,7 @@ jobs:
   # E2E tests against deployed worker
   e2e-tests:
     needs: unit-tests
+    if: ${{ !contains(github.event.pull_request.title, 'Version Packages') }}
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
@@ -123,10 +124,6 @@ jobs:
           platforms: linux/amd64 # Explicit single-arch for compatibility with release-amd64 cache
           load: true # Load into Docker daemon for local testing
           tags: cloudflare/sandbox-test:${{ needs.unit-tests.outputs.version || '0.0.0' }}
-          cache-from: |
-            type=gha,scope=pr-${{ github.event.pull_request.number }}-amd64
-            type=gha,scope=release-amd64
-          cache-to: type=gha,mode=max,scope=pr-${{ github.event.pull_request.number }}-amd64
           build-args: |
             SANDBOX_VERSION=${{ needs.unit-tests.outputs.version || '0.0.0' }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,9 +71,76 @@ jobs:
       - name: Run container unit tests
         run: npm run test -w @repo/sandbox-container
 
+  # E2E tests - runs on every push to main
+  e2e-tests:
+    needs: [unit-tests]
+    if: ${{ github.repository_owner == 'cloudflare' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'npm'
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Generate wrangler config
+        run: |
+          cd tests/e2e/test-worker
+          ./generate-config.sh sandbox-e2e-test-worker-main
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build test worker Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: packages/sandbox/Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: cloudflare/sandbox-test:${{ needs.unit-tests.outputs.version }}
+          build-args: |
+            SANDBOX_VERSION=${{ needs.unit-tests.outputs.version }}
+
+      - name: Deploy test worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: tests/e2e/test-worker
+          command: deploy --name sandbox-e2e-test-worker-main
+
+      - name: Run E2E tests
+        env:
+          TEST_WORKER_URL: https://sandbox-e2e-test-worker-main.agents-b8a.workers.dev
+        run: npm run test:e2e
+
+      - name: Cleanup test deployment
+        if: always()
+        continue-on-error: true
+        run: |
+          cd tests/e2e/test-worker
+          ../../../scripts/cleanup-test-deployment.sh sandbox-e2e-test-worker-main
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
   # Release publish - only runs if changesets exist
   publish-release:
-    needs: [unit-tests]
+    needs: [unit-tests, e2e-tests]
     if: ${{ github.repository_owner == 'cloudflare' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
Remove GitHub Actions Docker cache that was adding 60s overhead with poor hit rates. Add concurrency controls to prevent redundant workflow runs on rapid PR updates.

Add E2E tests to release workflow to catch race conditions when multiple PRs merge to main. Skip E2E tests and preview publish for Version Packages PRs since changes are already tested in contributor PRs before merge.