### PR TITLE
Fix sandbox site processing spinner stroke color

### DIFF
--- a/sites/sandbox/src/sections/features.tsx
+++ b/sites/sandbox/src/sections/features.tsx
@@ -69,12 +69,12 @@ export function Features() {
                 <title>Processing</title>
                 <path
                   d="M20.5 12C20.5 16.6944 16.6944 20.5 12 20.5C7.30558 20.5 3.5 16.6944 3.5 12C3.5 7.30558 7.30558 3.5 12 3.5C16.6944 3.5 20.5 7.30558 20.5 12Z"
-                  stroke="black"
+                  stroke="currentColor"
                   strokeOpacity="0.2"
                 />
                 <path
                   d="M20.3681 13.5C19.7463 16.9921 16.9921 19.7463 13.5 20.3681"
-                  stroke="black"
+                  stroke="currentColor"
                   strokeLinecap="round"
                 />
               </svg>


### PR DESCRIPTION
This change makes a small styling fix to the `sandbox.cloudflare.com` site where the loading spinner for the "processing" part of the features section color was always set to black. It instead now inherits the current color which correctly honours dark mode.

## Before
<img width="1053" height="603" alt="Screenshot 2025-12-11 at 11 02 33 am" src="https://github.com/user-attachments/assets/a30141f9-b03d-47a5-97a1-89e9064e5e0a" />

## After
<img width="949" height="500" alt="Screenshot 2025-12-11 at 11 02 22 am" src="https://github.com/user-attachments/assets/b75eefe6-8500-404e-804b-9f3808f3b690" />
