### PR TITLE
Remove official Claude plugins marketplace URL

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -148,7 +148,6 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: |
-            https://github.com/anthropics/claude-plugins-official.git
             https://github.com/obra/superpowers-marketplace.git
           plugins: |
             pr-review-toolkit@claude-plugins-official


### PR DESCRIPTION
Removed the official Claude plugins marketplace URL from the workflow.