### PR TITLE
build.ts: resolve bun PATH robustly in Ubuntu snap

### DIFF
--- a/packages/sandbox-container/build.ts
+++ b/packages/sandbox-container/build.ts
@@ -62,9 +62,10 @@ console.log(
 console.log('Building standalone binary...');
 
 // Compile standalone binary (bundles Bun runtime)
+const bunExecutable = process.execPath;
 const proc = Bun.spawn(
   [
-    'bun',
+    bunExecutable,
     'build',
     'src/main.ts',
     '--compile',


### PR DESCRIPTION
update build to grab the bun path before spawn

bg: I have `bun` installed on my wsl ubuntu flavour.
The build would fail because it did not find bun executable on path.
In my Ubuntu flavoured wsl, bun is installed using snap