### PR TITLE
fix: renew activity timeout when keepAlive is enabled

### DIFF
--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -987,9 +987,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   override async onActivityExpired(): Promise<void> {
     if (this.keepAliveEnabled) {
       this.logger.debug(
-        'Activity expired but keepAlive is enabled - container will stay alive'
+        'Activity expired but keepAlive is enabled - renewing activity timeout'
       );
-      // Do nothing - don't call stop(), container stays alive
+      // Renew the activity timer so the container stays alive
+      this.renewActivityTimeout();
     } else {
       // Default behavior: stop the container
       this.logger.debug('Activity expired - stopping container');


### PR DESCRIPTION
When `keepAlive: true` is set, containers were still hibernating after the `sleepAfter` duration. 

The issue is in `onActivityExpired()`. When keepAlive is enabled, we skip calling `stop()` but we don't actually renew the activity timer. So the container goes idle and eventually hibernates anyway.

So we should call `renewActivityTimeout()` from the `@cloudflare/containers` base class when keepAlive is true. This resets the timer so the container stays alive until explicitly destroyed.

## Before
```typescript
if (this.keepAliveEnabled) {
  // Do nothing - don't call stop(), container stays alive
}
```

## After
```typescript
if (this.keepAliveEnabled) {
  this.renewActivityTimeout(); // Actually keep it alive
}
```