### PR TITLE
fix: handle potential undefined value for envVars

### DIFF
--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -286,7 +286,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     if (this.defaultSession) {
       // Set environment variables by executing export commands in the existing session
       for (const [key, value] of Object.entries(envVars)) {
-        const escapedValue = value.replace(/'/g, "'\\''");
+        const escapedValue = value?.replace(/'/g, "'\\''");
         const exportCommand = `export ${key}='${escapedValue}'`;
 
         const result = await this.client.commands.execute(


### PR DESCRIPTION
```sh
✘ [ERROR] Uncaught TypeError: Cannot read properties of undefined (reading 'replace') Error

      at setEnvVars

[wrangler:error] TypeError: Cannot read properties of undefined (reading 'replace')
    at async Object.fetch
```

If the value of the environment variable is undefined, it throws the above error. It's not easy to understand what is causing it, adding an optional chaining operator avoid the error. It is worth noting that the `exportCommand` will be effectively become `export ${key}='undefined'`.