### PR TITLE
Fix killProcess status not updating when process already exited

### DIFF
--- a/packages/sandbox-container/src/services/process-service.ts
+++ b/packages/sandbox-container/src/services/process-service.ts
@@ -349,27 +349,20 @@ export class ProcessService {
         };
       }
 
-      // All processes use SessionManager for unified execution model
-      if (!process.commandHandle) {
-        // Process has no commandHandle - likely already completed or malformed
-        return {
-          success: true
-        };
+      if (process.commandHandle) {
+        await this.sessionManager.killCommand(
+          process.commandHandle.sessionId,
+          process.commandHandle.commandId
+        );
       }
 
-      const result = await this.sessionManager.killCommand(
-        process.commandHandle.sessionId,
-        process.commandHandle.commandId
-      );
-
-      if (result.success) {
-        await this.store.update(id, {
-          status: 'killed',
-          endTime: new Date()
-        });
+      // Always update status - the process may have already exited but
+      // streaming hasn't caught up yet
+      if (process.status === 'running') {
+        await this.store.update(id, { status: 'killed', endTime: new Date() });
       }
 
-      return result;
+      return { success: true };
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
@@ -565,9 +558,7 @@ export class ProcessService {
     }
   }
 
-  // Cleanup method for graceful shutdown
   async destroy(): Promise<void> {
-    // Kill all running processes
     await this.killAllProcesses();
   }
 }


### PR DESCRIPTION
## Summary

Fixes flaky E2E test `should manage multiple background processes` by ensuring process status is always updated to 'killed' when kill is requested.

## Problem

When a process exits naturally but the streaming output generator hasn't processed the completion event yet, `killCommand` returns `false` (nothing to kill). The old code only updated status to 'killed' when `killCommand` succeeded, leaving processes stuck in 'running' status forever.

## Solution

Always update status to 'killed' when kill is requested, regardless of whether `killCommand` found anything to kill. The actual OS process is dead either way - we just weren't tracking it correctly.

## Testing

- All unit tests pass
- Fixes the race condition that caused intermittent E2E failures