### PR TITLE
fix: opencode remove redundant git clone

### DIFF
--- a/examples/opencode/src/index.ts
+++ b/examples/opencode/src/index.ts
@@ -52,11 +52,6 @@ async function handleSdkTest(
   env: Env
 ): Promise<Response> {
   try {
-    // Clone a repo to give the agent something to work with
-    await sandbox.gitCheckout('https://github.com/cloudflare/agents.git', {
-      targetDir: '/home/user/agents'
-    });
-
     // Get typed SDK client
     const { client } = await createOpencode<OpencodeClient>(sandbox, {
       directory: '/home/user/agents',


### PR DESCRIPTION
The SDK Test was cloning the agents repo, but it was already cloned in the Dockerfile

```
SDK test error: Error: GitError: Failed to clone repository 'https://github.com/cloudflare/agents.git': fatal: destination path '/home/user/agents' already exists and is not an empty directory.
```