### PR TITLE
Enforce code owner approval on all PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ghostwriternr @whoiskatrin


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` with `@ghostwriternr` and `@whoiskatrin` as global owners
- Branch protection already updated to require code owner approval, dismiss stale reviews, and enforce for admins