### PR TITLE
Fix CI cleanup scripts leaving orphaned resources

### DIFF
--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -38,7 +38,9 @@ jobs:
           # List all containers and extract unique worker names for PR test workers
           CONTAINERS=$(npx wrangler containers list 2>/dev/null || echo "")
 
-          echo "$CONTAINERS" | grep -E 'sandbox-e2e-test-worker-pr-[0-9]+(-http|-websocket)?' | sed 's/.*"name": "\([^"]*\)".*/\1/' | sed 's/-python$//' | sed 's/-opencode$//' | sed 's/-standalone$//' | sort -u | while read -r WORKER_NAME; do
+          # Validate JSON and extract unique base worker names using jq
+          # Strip variant suffixes (-python, -opencode, -standalone, -musl) to get the base worker name
+          echo "$CONTAINERS" | jq -r '.[].name' 2>/dev/null | grep -E '^sandbox-e2e-test-worker-pr-[0-9]+-(http|websocket)' | sed 's/-python$//' | sed 's/-opencode$//' | sed 's/-standalone$//' | sed 's/-musl$//' | sort -u | while read -r WORKER_NAME; do
             if [ -z "$WORKER_NAME" ]; then
               continue
             fi
@@ -86,6 +88,36 @@ jobs:
             fi
           done
 
+          # Also check for stale main-branch worker containers
+          MAIN_WORKER="sandbox-e2e-test-worker-main"
+          MAIN_EXISTS=$(echo "$CONTAINERS" | jq -r ".[].name" 2>/dev/null | grep -c "^${MAIN_WORKER}" || true)
+
+          if [ "$MAIN_EXISTS" -gt 0 ]; then
+            echo ""
+            echo "Checking main-branch worker: $MAIN_WORKER"
+
+            # Check when last main branch workflow ran
+            LAST_MAIN_RUN=$(gh run list --workflow=release.yml --branch=main --limit=1 --json updatedAt -q '.[0].updatedAt' 2>/dev/null || echo "")
+
+            if [ -n "$LAST_MAIN_RUN" ]; then
+              MAIN_UPDATED_SECONDS=$(date -d "$LAST_MAIN_RUN" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$LAST_MAIN_RUN" +%s 2>/dev/null)
+              TIME_SINCE_MAIN=$((CURRENT_TIME - MAIN_UPDATED_SECONDS))
+              HOURS_SINCE_MAIN=$((TIME_SINCE_MAIN / 3600))
+              echo "  Last release workflow: $HOURS_SINCE_MAIN hours ago"
+
+              if [ "$TIME_SINCE_MAIN" -gt "$STALE_THRESHOLD" ]; then
+                echo "  ✓ Main worker is stale (>24h) - will clean up"
+                echo "  Calling cleanup script for: $MAIN_WORKER"
+                ../../../scripts/cleanup-test-deployment.sh "$MAIN_WORKER" 2>&1 | sed 's/^/  /'
+              else
+                echo "  ✗ Main worker is recent - skipping"
+              fi
+            else
+              echo "  ⚠️  Could not determine last main run - cleaning up to be safe"
+              ../../../scripts/cleanup-test-deployment.sh "$MAIN_WORKER" 2>&1 | sed 's/^/  /'
+            fi
+          fi
+
           echo ""
           echo "=== Stale worker cleanup complete ==="
         working-directory: tests/e2e/test-worker
@@ -118,7 +150,7 @@ jobs:
             if [ "$PR_STATE" = "CLOSED" ] || [ "$PR_STATE" = "MERGED" ] || [ "$PR_STATE" = "NOT_FOUND" ]; then
               echo "  PR is $PR_STATE - cleaning up images..."
 
-              for image in sandbox sandbox-python sandbox-opencode sandbox-standalone; do
+              for image in sandbox sandbox-python sandbox-opencode sandbox-standalone sandbox-musl; do
                 echo "  Deleting $image:pr-$PR_NUMBER..."
                 npx wrangler containers images delete "$image:pr-$PR_NUMBER" 2>/dev/null || true
               done

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           cd tests/e2e/test-worker
           # Clean up both transport variants
-          for suffix in "" "-http" "-websocket"; do
+          for suffix in "-http" "-websocket"; do
             WORKER="${{ steps.worker-name.outputs.worker_prefix }}${suffix}"
             echo "Cleaning up: $WORKER"
             ../../../scripts/cleanup-test-deployment.sh "$WORKER" || true
@@ -50,7 +50,7 @@ jobs:
           PR=${{ github.event.pull_request.number }}
           echo "Deleting PR images from Cloudflare registry..."
 
-          for image in sandbox sandbox-python sandbox-opencode sandbox-standalone; do
+          for image in sandbox sandbox-python sandbox-opencode sandbox-standalone sandbox-musl; do
             echo "Deleting $image:pr-$PR..."
             npx wrangler containers images delete "$image:pr-$PR" || true
           done


### PR DESCRIPTION
## Summary

The cleanup system had multiple bugs causing containers and images to accumulate after PR merges and main branch runs. This PR fixes all three cleanup files:

**`scripts/cleanup-test-deployment.sh`** — The script captured wrangler stderr warnings via `2>&1`, which poisoned the JSON output and caused `jq` to fail silently. Switched to `2>/dev/null` and replaced the fragile `grep -q '^\['` JSON check with `jq empty`. Also added the `-musl` container variant which was missing entirely.

**`.github/workflows/cleanup-stale.yml`** — The cron job parsed container names using `grep | sed` on raw JSON, which didn't work with pretty-printed output. Replaced with `jq -r '.[].name'` pipeline. Also added `-musl` suffix stripping, `sandbox-musl` to the image cleanup loop, and a new block to detect and clean stale main-branch workers (`sandbox-e2e-test-worker-main`), which were previously invisible to the PR-only grep pattern.

**`.github/workflows/cleanup.yml`** — Added `sandbox-musl` to the image deletion loop and removed the bare worker name suffix (`""`) that was never actually deployed (only `-http` and `-websocket` variants exist).

## Verification

Tested the fixed cleanup script against 3 real orphaned workers in the live account (PR #383 http/websocket, PR #390 http). All containers were found and deleted successfully, including the musl variant. The jq parsing pipeline was also verified against the full `wrangler containers list` output.