### PR TITLE
Add contents: write permission to bonk workflow

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -15,6 +15,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: false
     permissions:
+      contents: write
       id-token: write
       issues: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- Add `contents: write` permission to the bonk workflow so the action can write to repository contents