### PR TITLE
Speed up E2E git clone coverage

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -277,7 +277,17 @@ jobs:
 
       - name: Run E2E tests
         run: |
-          npx vitest run --config vitest.e2e.config.ts
+          set -e
+
+          npx vitest run --config vitest.e2e.config.ts --exclude tests/e2e/git-clone-workflow.test.ts &
+          PID_FAST=$!
+
+          npx vitest run --config vitest.e2e.config.ts tests/e2e/git-clone-workflow.test.ts &
+          PID_GIT=$!
+
+          wait $PID_FAST
+          wait $PID_GIT
+
           npx playwright test --config tests/e2e/browser/playwright.config.ts
         env:
           TEST_WORKER_URL: ${{ steps.get-url.outputs.worker_url }}

--- a/packages/sandbox-container/src/managers/git-manager.ts
+++ b/packages/sandbox-container/src/managers/git-manager.ts
@@ -43,7 +43,7 @@ export class GitManager {
     targetDir: string,
     options: CloneOptions = {}
   ): string[] {
-    const args = ['git', 'clone'];
+    const args = ['git', 'clone', '--filter=blob:none'];
 
     if (options.branch) {
       args.push('--branch', options.branch);

--- a/packages/sandbox-container/tests/managers/git-manager.test.ts
+++ b/packages/sandbox-container/tests/managers/git-manager.test.ts
@@ -46,6 +46,7 @@ describe('GitManager', () => {
       expect(args).toEqual([
         'git',
         'clone',
+        '--filter=blob:none',
         'https://github.com/user/repo.git',
         '/tmp/target'
       ]);
@@ -60,6 +61,7 @@ describe('GitManager', () => {
       expect(args).toEqual([
         'git',
         'clone',
+        '--filter=blob:none',
         '--branch',
         'develop',
         'https://github.com/user/repo.git',
@@ -76,6 +78,7 @@ describe('GitManager', () => {
       expect(args).toEqual([
         'git',
         'clone',
+        '--filter=blob:none',
         '--depth',
         '1',
         'https://github.com/user/repo.git',
@@ -92,6 +95,7 @@ describe('GitManager', () => {
       expect(args).toEqual([
         'git',
         'clone',
+        '--filter=blob:none',
         '--branch',
         'main',
         '--depth',
@@ -110,6 +114,7 @@ describe('GitManager', () => {
       expect(args).toEqual([
         'git',
         'clone',
+        '--filter=blob:none',
         '--depth',
         '5',
         'https://github.com/user/repo.git',

--- a/packages/sandbox-container/tests/services/git-service.test.ts
+++ b/packages/sandbox-container/tests/services/git-service.test.ts
@@ -153,7 +153,7 @@ describe('GitService', () => {
       expect(mockSessionManager.executeInSession).toHaveBeenNthCalledWith(
         1,
         'default',
-        "'git' 'clone' 'https://github.com/user/repo.git' '/workspace/repo'"
+        "'git' 'clone' '--filter=blob:none' 'https://github.com/user/repo.git' '/workspace/repo'"
       );
 
       // Verify SessionManager was called for getting current branch
@@ -205,7 +205,7 @@ describe('GitService', () => {
       expect(mockSessionManager.executeInSession).toHaveBeenNthCalledWith(
         1,
         'session-123',
-        "'git' 'clone' '--branch' 'develop' 'https://github.com/user/repo.git' '/tmp/custom-target'"
+        "'git' 'clone' '--filter=blob:none' '--branch' 'develop' 'https://github.com/user/repo.git' '/tmp/custom-target'"
       );
     });
 

--- a/tests/e2e/git-clone-workflow.test.ts
+++ b/tests/e2e/git-clone-workflow.test.ts
@@ -67,7 +67,7 @@ describe('Git Clone Error Handling', () => {
  * Git Shallow Clone Tests
  *
  * Tests the depth option for shallow clones.
- * Uses facebook/react which has extensive history to properly test shallow cloning.
+ * Uses github/gitignore for real-remote coverage with faster clone times.
  */
 describe('Git Shallow Clone', () => {
   let workerUrl: string;
@@ -82,12 +82,12 @@ describe('Git Shallow Clone', () => {
   test('should clone repository with depth: 1 (shallow clone)', async () => {
     const testDir = uniqueTestPath('shallow-clone-1');
 
-    // Clone with depth: 1 - use a repo with extensive history
+    // Clone with depth: 1 against a real remote repository
     const cloneResponse = await fetch(`${workerUrl}/api/git/clone`, {
       method: 'POST',
       headers,
       body: JSON.stringify({
-        repoUrl: 'https://github.com/facebook/react',
+        repoUrl: 'https://github.com/github/gitignore',
         targetDir: testDir,
         depth: 1
       })
@@ -129,55 +129,6 @@ describe('Git Shallow Clone', () => {
     expect(shallowData.stdout.trim()).toBe('true');
   }, 120000);
 
-  test('should clone repository with depth: 5 (limited history)', async () => {
-    const testDir = uniqueTestPath('shallow-clone-5');
-
-    // Clone with depth: 5 - use a repo with extensive history
-    const cloneResponse = await fetch(`${workerUrl}/api/git/clone`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        repoUrl: 'https://github.com/facebook/react',
-        targetDir: testDir,
-        depth: 5
-      })
-    });
-
-    expect(cloneResponse.status).toBe(200);
-    const cloneData = (await cloneResponse.json()) as GitCheckoutResult;
-    expect(cloneData.success).toBe(true);
-
-    // Verify commit count is exactly 5
-    const countResponse = await fetch(`${workerUrl}/api/execute`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        command: `cd ${testDir} && git rev-list --count HEAD`
-      })
-    });
-
-    expect(countResponse.status).toBe(200);
-    const countData = (await countResponse.json()) as ExecResult;
-    expect(countData.exitCode).toBe(0);
-
-    const commitCount = parseInt(countData.stdout.trim(), 10);
-    expect(commitCount).toBe(5);
-
-    // Verify the repo is marked as shallow
-    const shallowResponse = await fetch(`${workerUrl}/api/execute`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        command: `cd ${testDir} && git rev-parse --is-shallow-repository`
-      })
-    });
-
-    expect(shallowResponse.status).toBe(200);
-    const shallowData = (await shallowResponse.json()) as ExecResult;
-    expect(shallowData.exitCode).toBe(0);
-    expect(shallowData.stdout.trim()).toBe('true');
-  }, 120000);
-
   test('should clone repository with branch and depth combined', async () => {
     const testDir = uniqueTestPath('shallow-branch');
 
@@ -186,7 +137,7 @@ describe('Git Shallow Clone', () => {
       method: 'POST',
       headers,
       body: JSON.stringify({
-        repoUrl: 'https://github.com/facebook/react',
+        repoUrl: 'https://github.com/github/gitignore',
         branch: 'main',
         targetDir: testDir,
         depth: 1


### PR DESCRIPTION
## Summary
This PR reduces E2E runtime for git clone coverage without changing the
core intent (real remote GitHub clones are still exercised).

## What changed
- Added `--filter=blob:none` to git clone arguments.
- Updated shallow-clone E2E repo from `facebook/react` to
  `github/gitignore` (still real remote, much lighter transfer).
- Removed one redundant shallow-clone scenario (`depth: 5`) while keeping:
  - depth-based shallow clone validation
  - branch + depth validation
- In PR CI, run `git-clone-workflow.test.ts` in parallel with the rest of
  the Vitest E2E suite.

## Data / expected impact
Baseline from current CI log:
- `tests/e2e/git-clone-workflow.test.ts`: **196s** total
  - shallow clone tests: **86s**, **46s**, **50s**

Expected after this PR:
- ~2-3.5 minutes faster per E2E job, depending on network variability.
- Since HTTP and WebSocket jobs run in matrix, this should reduce overall
  PR E2E wall time by roughly the same order.

## Validation
- `npm run check`
- `bun test tests/managers/git-manager.test.ts tests/services/git-service.test.ts`