### PR TITLE
Update JS Docs to better reflect token requirements for tokens for `exposePort()`

### DIFF
--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -2228,7 +2228,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    * @param options - Configuration options
    * @param options.hostname - Your Worker's domain name (required for preview URL construction)
    * @param options.name - Optional friendly name for the port
-   * @param options.token - Optional custom token for the preview URL (1-16 characters: lowercase letters, numbers, hyphens, underscores)
+   * @param options.token - Optional custom token for the preview URL (1-16 characters: lowercase letters, numbers, underscores)
    *                       If not provided, a random 16-character token will be generated automatically
    * @returns Preview URL information including the full URL, port number, and optional name
    *
@@ -2241,9 +2241,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    * // With custom token for stable URLs across deployments
    * const { url } = await sandbox.exposePort(8080, {
    *   hostname: 'example.com',
-   *   token: 'my-token-v1'
+   *   token: 'my_token_v1'
    * });
-   * // url: https://8080-sandbox-id-my-token-v1.example.com
+   * // url: https://8080-sandbox-id-my_token_v1.example.com
    */
   async exposePort(
     port: number,

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -821,7 +821,7 @@ describe('Sandbox - Automatic Session Management', () => {
       });
 
       expect(result.url).toMatch(
-        /^https:\/\/8080-my-project-[a-z0-9_-]{16}\.example\.com\/?$/
+        /^https:\/\/8080-my-project-[a-z0-9_]{16}\.example\.com\/?$/
       );
       expect(result.port).toBe(8080);
     });
@@ -839,7 +839,7 @@ describe('Sandbox - Automatic Session Management', () => {
       const result = await sandbox.exposePort(4000, { hostname: 'my-app.dev' });
 
       expect(result.url).toMatch(
-        /^https:\/\/4000-myproject-123-[a-z0-9_-]{16}\.my-app\.dev\/?$/
+        /^https:\/\/4000-myproject-123-[a-z0-9_]{16}\.my-app\.dev\/?$/
       );
       expect(result.port).toBe(4000);
     });
@@ -859,7 +859,7 @@ describe('Sandbox - Automatic Session Management', () => {
       });
 
       expect(result.url).toMatch(
-        /^http:\/\/8080-test-sandbox-[a-z0-9_-]{16}\.localhost:3000\/?$/
+        /^http:\/\/8080-test-sandbox-[a-z0-9_]{16}\.localhost:3000\/?$/
       );
     });
 


### PR DESCRIPTION
## Fix preview URL token documentation and test assertions

Resolves #372 

The JSDoc on `exposePort()` incorrectly listed hyphens as allowed characters in custom tokens and used hyphenated examples (e.g., `my-token-v1`). The actual validation regex (`/^[a-z0-9_]+$/`) already rejected hyphens — only the docs were wrong.
**Changes:**
- **`packages/sandbox/src/sandbox.ts`** — Removed "hyphens" from the allowed-characters description in the `exposePort()` JSDoc and updated examples to use underscores (`my_token_v1`).
- **`packages/sandbox/tests/sandbox.test.ts`** — Tightened three test regex assertions from `[a-z0-9_-]{16}` to `[a-z0-9_]{16}` to match the actual token character set.
> **Note:** Companion documentation changes are in a separate PR to `cloudflare/cloudflare-docs`.
---
_Generated by OpenCode._