### PR TITLE
Improve backup error for local R2 binding mismatch

### DIFF
--- a/.changeset/improve-backup-error-message.md
+++ b/.changeset/improve-backup-error-message.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Improve error message when backup upload verification fails due to a local/remote R2 mismatch. When using `wrangler dev`, presigned URLs upload to real R2 while the `BACKUP_BUCKET` binding defaults to local storage. The error now suggests adding `"remote": true` to the R2 binding in `wrangler.jsonc`.

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -2951,8 +2951,18 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     const bucket = this.requireBackupBucket();
     const head = await bucket.head(r2Key);
     if (!head || head.size !== archiveSize) {
+      const actualSize = head?.size ?? 0;
+      // curl succeeded but R2 binding sees nothing — almost certainly a
+      // local-dev mismatch where presigned URLs target real R2 while the
+      // BACKUP_BUCKET binding points to local (miniflare) storage.
+      const localDevHint =
+        result.exitCode === 0 && actualSize === 0
+          ? ' This usually means the BACKUP_BUCKET R2 binding is using local storage ' +
+            'while presigned URLs upload to remote R2. Add `"remote": true` to your ' +
+            'BACKUP_BUCKET R2 binding in wrangler.jsonc to fix this.'
+          : '';
       throw new BackupCreateError({
-        message: `Upload verification failed: expected ${archiveSize} bytes, got ${head?.size ?? 0}`,
+        message: `Upload verification failed: expected ${archiveSize} bytes, got ${actualSize}.${localDevHint}`,
         code: ErrorCode.BACKUP_CREATE_FAILED,
         httpStatus: 500,
         context: { dir, backupId },


### PR DESCRIPTION
## Summary

When running `wrangler dev`, presigned URLs point to real R2 storage while the `BACKUP_BUCKET` binding defaults to miniflare's local simulation. The container uploads the archive to real R2 successfully, but the SDK's verification step calls `bucket.head()` against local R2 and sees 0 bytes — producing a cryptic `Upload verification failed: expected X bytes, got 0` error.

This change detects that specific pattern (curl succeeded but head returns 0 bytes) and surfaces an actionable error message suggesting the user add `"remote": true` to their R2 binding configuration in `wrangler.jsonc`. The fix is scoped to the error message only; no behavioral changes to the backup flow itself.