### PR TITLE
fix(opencode): check /global/health returns 200 before marking server ready

### DIFF
--- a/.changeset/fix-opencode-flaky-test.md
+++ b/.changeset/fix-opencode-flaky-test.md
@@ -1,0 +1,7 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Fix flaky OpenCode E2E test by checking health endpoint readiness
+
+Changed `waitForPort` to verify `/global/health` returns HTTP 200 instead of just checking if the server accepts connections at `/`. This ensures the OpenCode server is fully initialized before `createOpencodeServer` returns, preventing 500 errors when tests immediately call the health endpoint.

--- a/packages/sandbox/src/opencode/opencode.ts
+++ b/packages/sandbox/src/opencode/opencode.ts
@@ -95,7 +95,8 @@ async function ensureOpencodeServer(
       try {
         await existingProcess.waitForPort(port, {
           mode: 'http',
-          path: '/',
+          path: '/global/health',
+          status: 200,
           timeout: OPENCODE_STARTUP_TIMEOUT_MS
         });
       } catch (e) {
@@ -134,7 +135,8 @@ async function ensureOpencodeServer(
         try {
           await retryProcess.waitForPort(port, {
             mode: 'http',
-            path: '/',
+            path: '/global/health',
+            status: 200,
             timeout: OPENCODE_STARTUP_TIMEOUT_MS
           });
         } catch (e) {
@@ -223,11 +225,12 @@ async function startOpencodeServer(
     env: Object.keys(env).length > 0 ? env : undefined
   });
 
-  // Wait for server to be ready
+  // Wait for server to be ready - check the actual health endpoint
   try {
     await process.waitForPort(port, {
       mode: 'http',
-      path: '/',
+      path: '/global/health',
+      status: 200,
       timeout: OPENCODE_STARTUP_TIMEOUT_MS
     });
     getLogger().info('OpenCode server started successfully', {


### PR DESCRIPTION
## Problem
The OpenCode E2E test `should proxy OpenCode global health through proxyToOpencodeServer` was flaky and consistently returning 500 instead of 200 in CI.

## Root Cause
`createOpencodeServer` was using `waitForPort` with path `/` to check if the server was ready. This only verifies the server accepts HTTP connections, but the `/global/health` endpoint can still return 500 while the server is initializing.

## Fix
Changed all `waitForPort` calls to check `/global/health` with expected status `200` instead of just `/`:
- When reusing existing process that's still starting
- When retrying after concurrent startup race condition  
- When starting a new server

This ensures the OpenCode server is fully initialized (health endpoint returns 200) before `createOpencodeServer` returns.

## Testing
- Build: ✓
- Typecheck: ✓
- Unit tests: ✓ (32 tests including OpenCode tests)