### PR TITLE
Inject CA certificate into Docker build locally

### DIFF
--- a/packages/sandbox/Dockerfile
+++ b/packages/sandbox/Dockerfile
@@ -220,10 +220,14 @@ ENV SANDBOX_VERSION=${SANDBOX_VERSION}
 # CA certificate installation
 RUN mkdir -p /usr/local/share/ca-certificates
 RUN --mount=type=secret,id=wrangler_ca \
-    cp /run/secrets/wrangler_ca /usr/local/share/ca-certificates/wrangler-dev-ca.crt && \
-    cat /run/secrets/wrangler_ca >> /etc/ssl/certs/ca-certificates.crt && \
-    apk add --no-cache ca-certificates && \
-    update-ca-certificates
+    if [ -f /run/secrets/wrangler_ca ] && [ -s /run/secrets/wrangler_ca ]; then \
+        cp /run/secrets/wrangler_ca /usr/local/share/ca-certificates/wrangler-dev-ca.crt && \
+        cat /run/secrets/wrangler_ca >> /etc/ssl/certs/ca-certificates.crt && \
+        apk add --no-cache ca-certificates && \
+        update-ca-certificates; \
+    else \
+        apk add --no-cache ca-certificates; \
+    fi
 
 RUN apk add --no-cache bash file git curl libstdc++ libgcc s3fs-fuse fuse
 

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -45,7 +45,7 @@
     "check": "biome check && npm run typecheck",
     "fix": "biome check --fix && npm run typecheck",
     "typecheck": "tsc --noEmit",
-    "docker:local": "cd ../.. && docker build -f packages/sandbox/Dockerfile --target default --platform linux/amd64 --build-arg SANDBOX_VERSION=$npm_package_version -t cloudflare/sandbox-test:$npm_package_version . && docker build -f packages/sandbox/Dockerfile --target python --platform linux/amd64 --build-arg SANDBOX_VERSION=$npm_package_version -t cloudflare/sandbox-test:$npm_package_version-python . && docker build -f packages/sandbox/Dockerfile --target opencode --platform linux/amd64 --build-arg SANDBOX_VERSION=$npm_package_version -t cloudflare/sandbox-test:$npm_package_version-opencode . && cd tests/e2e/test-worker && sed -E \"s|cloudflare/sandbox-test:[0-9]+\\.[0-9]+\\.[0-9]+|cloudflare/sandbox-test:$npm_package_version|g\" Dockerfile.standalone > Dockerfile.standalone.tmp && docker build -f Dockerfile.standalone.tmp --platform linux/amd64 -t cloudflare/sandbox-test:$npm_package_version-standalone . && rm Dockerfile.standalone.tmp && cd ../../.. && docker build -f packages/sandbox/Dockerfile --target musl --platform linux/amd64 --build-arg SANDBOX_VERSION=$npm_package_version -t cloudflare/sandbox-test:$npm_package_version-musl --secret id=wrangler_ca,src=${NODE_EXTRA_CA_CERTS:-/dev/null} .",
+    "docker:local": "scripts/docker-local.sh",
     "test": "vitest run --config vitest.config.ts \"$@\"",
     "test:e2e": "npm run test:e2e:vitest && npm run test:e2e:browser",
     "test:e2e:vitest": "cd ../../tests/e2e/test-worker && ./generate-config.sh && cd ../../.. && vitest run --config vitest.e2e.config.ts \"$@\"",

--- a/packages/sandbox/scripts/docker-local.sh
+++ b/packages/sandbox/scripts/docker-local.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run from the repo root
+cd "$(dirname "$0")/../../.."
+
+VERSION="$npm_package_version"
+IMAGE="cloudflare/sandbox-test"
+
+docker build \
+  -f packages/sandbox/Dockerfile \
+  --target default \
+  --platform linux/amd64 \
+  --build-arg SANDBOX_VERSION="$VERSION" \
+  -t "$IMAGE:$VERSION" \
+  .
+
+docker build \
+  -f packages/sandbox/Dockerfile \
+  --target python \
+  --platform linux/amd64 \
+  --build-arg SANDBOX_VERSION="$VERSION" \
+  -t "$IMAGE:$VERSION-python" \
+  .
+
+docker build \
+  -f packages/sandbox/Dockerfile \
+  --target opencode \
+  --platform linux/amd64 \
+  --build-arg SANDBOX_VERSION="$VERSION" \
+  -t "$IMAGE:$VERSION-opencode" \
+  .
+
+STANDALONE_DIR="tests/e2e/test-worker"
+sed -E "s|$IMAGE:[0-9]+\.[0-9]+\.[0-9]+|$IMAGE:$VERSION|g" \
+  "$STANDALONE_DIR/Dockerfile.standalone" > "$STANDALONE_DIR/Dockerfile.standalone.tmp"
+docker build \
+  -f "$STANDALONE_DIR/Dockerfile.standalone.tmp" \
+  --platform linux/amd64 \
+  -t "$IMAGE:$VERSION-standalone" \
+  "$STANDALONE_DIR"
+rm "$STANDALONE_DIR/Dockerfile.standalone.tmp"
+
+docker build \
+  -f packages/sandbox/Dockerfile \
+  --target musl \
+  --platform linux/amd64 \
+  --build-arg SANDBOX_VERSION="$VERSION" \
+  -t "$IMAGE:$VERSION-musl" \
+  --secret id=wrangler_ca,src="${NODE_EXTRA_CA_CERTS:-/dev/null}" \
+  .


### PR DESCRIPTION
# Summary

We now inject & install the CA certificate installed at `$NODE_EXTRA_CA_CERTS` into the sandbox Docker image when building locally. This solves the issue of building sandbox locally when using Warp.

Also moves the `docker:local` command into its own script, as it was getting too long to comprehend easily.

This solves #45 for internal development, we will still face issues when using the sandbox Docker image when using Warp, that will be a separate patch