### PR TITLE
Add backup exclude options and defaults

### DIFF
--- a/.changeset/backup-exclude-patterns.md
+++ b/.changeset/backup-exclude-patterns.md
@@ -1,0 +1,7 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Add backup exclude support so `createBackup()` can skip files and directories.
+Use `exclude` for custom patterns and `excludeDefaults: true` to skip common
+build and dependency paths like `node_modules`, `.git`, and `dist`.

--- a/packages/sandbox-container/src/handlers/backup-handler.ts
+++ b/packages/sandbox-container/src/handlers/backup-handler.ts
@@ -115,12 +115,28 @@ export class BackupHandler extends BaseHandler<Request, Response> {
       );
     }
 
+    if (
+      body.exclude !== undefined &&
+      (!Array.isArray(body.exclude) ||
+        body.exclude.some((pattern) => typeof pattern !== 'string'))
+    ) {
+      return this.createErrorResponse(
+        {
+          message: 'exclude must be an array of strings',
+          code: ErrorCode.INVALID_BACKUP_CONFIG
+        },
+        context,
+        Operation.BACKUP_CREATE
+      );
+    }
+
     const sessionId = body.sessionId ?? context.sessionId ?? 'default';
 
     const result = await this.backupService.createArchive(
       body.dir,
       body.archivePath,
-      sessionId
+      sessionId,
+      body.exclude
     );
 
     if (result.success) {

--- a/packages/sandbox-container/src/services/backup-service.ts
+++ b/packages/sandbox-container/src/services/backup-service.ts
@@ -96,7 +96,8 @@ export class BackupService {
   async createArchive(
     dir: string,
     archivePath: string,
-    sessionId = 'default'
+    sessionId = 'default',
+    exclude?: string[]
   ): Promise<ServiceResult<CreateArchiveResult>> {
     const opLogger = this.logger.child({ operation: Operation.BACKUP_CREATE });
 
@@ -153,17 +154,39 @@ export class BackupService {
         });
       }
 
+      const excludeFilePath = `${archivePath}.exclude`;
+      if (exclude && exclude.length > 0) {
+        const writeExcludeResult = await this.sessionManager.executeInSession(
+          sessionId,
+          `printf '%s\\n' ${exclude.map(shellEscape).join(' ')} > ${shellEscape(excludeFilePath)}`
+        );
+        if (
+          !writeExcludeResult.success ||
+          writeExcludeResult.data.exitCode !== 0
+        ) {
+          return serviceError({
+            message: 'Failed to write exclude patterns file',
+            code: ErrorCode.BACKUP_CREATE_FAILED,
+            details: { dir, archivePath }
+          });
+        }
+      }
+
       // Create squashfs archive with zstd compression
       // -no-progress suppresses progress output
       // -noappend creates a fresh archive (no appending to existing)
-      const squashCmd = [
+      const squashCmdParts = [
         BIN.mksquashfs,
         shellEscape(dir),
         shellEscape(archivePath),
         '-comp zstd',
         '-no-progress',
         '-noappend'
-      ].join(' ');
+      ];
+      if (exclude && exclude.length > 0) {
+        squashCmdParts.push(`-ef ${shellEscape(excludeFilePath)}`);
+      }
+      const squashCmd = squashCmdParts.join(' ');
 
       opLogger.info('Creating squashfs archive', {
         dir,
@@ -175,6 +198,12 @@ export class BackupService {
         sessionId,
         squashCmd
       );
+
+      if (exclude && exclude.length > 0) {
+        await this.sessionManager
+          .executeInSession(sessionId, `rm -f ${shellEscape(excludeFilePath)}`)
+          .catch(() => {});
+      }
 
       if (!createResult.success) {
         return serviceError({

--- a/packages/sandbox/src/clients/backup-client.ts
+++ b/packages/sandbox/src/clients/backup-client.ts
@@ -23,12 +23,14 @@ export class BackupClient extends BaseHttpClient {
   async createArchive(
     dir: string,
     archivePath: string,
-    sessionId: string
+    sessionId: string,
+    exclude?: string[]
   ): Promise<CreateBackupResponse> {
     try {
       const data: CreateBackupRequest = {
         dir,
         archivePath,
+        exclude,
         sessionId
       };
 

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -3133,7 +3133,22 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     this.requirePresignedUrlSupport();
     const DEFAULT_TTL_SECONDS = 259200; // 3 days
     const MAX_NAME_LENGTH = 256;
-    const { dir, name, ttl = DEFAULT_TTL_SECONDS } = options;
+    const DEFAULT_BACKUP_EXCLUDE_PATTERNS = [
+      'node_modules',
+      '.git',
+      'dist',
+      'build',
+      '.next',
+      '.turbo',
+      '.cache'
+    ];
+    const {
+      dir,
+      name,
+      ttl = DEFAULT_TTL_SECONDS,
+      exclude,
+      excludeDefaults = false
+    } = options;
     Sandbox.validateBackupDir(dir, 'BackupOptions.dir');
     if (name !== undefined) {
       if (typeof name !== 'string' || name.length > MAX_NAME_LENGTH) {
@@ -3169,16 +3184,67 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       });
     }
 
+    if (typeof excludeDefaults !== 'boolean') {
+      throw new InvalidBackupConfigError({
+        message: 'BackupOptions.excludeDefaults must be a boolean',
+        code: ErrorCode.INVALID_BACKUP_CONFIG,
+        httpStatus: 400,
+        context: { reason: 'excludeDefaults must be a boolean' },
+        timestamp: new Date().toISOString()
+      });
+    }
+
+    const hasControlChars = (value: string): boolean => {
+      for (let i = 0; i < value.length; i++) {
+        const code = value.charCodeAt(i);
+        if (code <= 31 || code === 127) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    if (
+      exclude !== undefined &&
+      (!Array.isArray(exclude) ||
+        exclude.some(
+          (pattern) => typeof pattern !== 'string' || hasControlChars(pattern)
+        ))
+    ) {
+      throw new InvalidBackupConfigError({
+        message:
+          'BackupOptions.exclude must be an array of strings without control characters',
+        code: ErrorCode.INVALID_BACKUP_CONFIG,
+        httpStatus: 400,
+        context: {
+          reason:
+            'exclude must be an array of strings without control characters'
+        },
+        timestamp: new Date().toISOString()
+      });
+    }
+
+    const effectiveExclude = [
+      ...(excludeDefaults ? DEFAULT_BACKUP_EXCLUDE_PATTERNS : []),
+      ...(exclude ?? [])
+    ];
+
     const backupSession = await this.ensureBackupSession();
     const backupId = crypto.randomUUID();
     const archivePath = `/var/backups/${backupId}.sqsh`;
 
-    this.logger.info('Creating backup', { backupId, dir, name });
+    this.logger.info('Creating backup', {
+      backupId,
+      dir,
+      name,
+      excludeCount: effectiveExclude.length
+    });
 
     const createResult = await this.client.backup.createArchive(
       dir,
       archivePath,
-      backupSession
+      backupSession,
+      effectiveExclude.length > 0 ? effectiveExclude : undefined
     );
 
     if (!createResult.success) {

--- a/packages/shared/src/request-types.ts
+++ b/packages/shared/src/request-types.ts
@@ -151,6 +151,8 @@ export interface CreateBackupRequest {
   dir: string;
   /** Path where the container should write the archive */
   archivePath: string;
+  /** Optional mksquashfs exclude patterns (passed to `-ef`) */
+  exclude?: string[];
   sessionId?: string;
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -936,6 +936,20 @@ export interface BackupOptions {
   name?: string;
   /** Seconds until automatic garbage collection. Default: 259200 (3 days). No upper limit. */
   ttl?: number;
+  /**
+   * Optional mksquashfs exclude patterns.
+   *
+   * Patterns are passed directly to mksquashfs via `-ef` (one pattern per line).
+   * Common examples: `node_modules`, `.git`, `dist`, `*.log`.
+   */
+  exclude?: string[];
+  /**
+   * Add default exclude patterns for common dependency/build directories.
+   *
+   * Current defaults: `node_modules`, `.git`, `dist`, `build`, `.next`, `.turbo`, `.cache`.
+   * Default: false.
+   */
+  excludeDefaults?: boolean;
 }
 
 /**

--- a/tests/e2e/backup-workflow.test.ts
+++ b/tests/e2e/backup-workflow.test.ts
@@ -184,6 +184,137 @@ describe('Backup Workflow E2E', () => {
     }, 60000);
   });
 
+  describe('Backup excludes', () => {
+    test('should exclude files from BackupOptions.exclude', async () => {
+      if (!backupBucketAvailable) return;
+
+      const TEST_DIR = `/workspace/exclude-backup-test-${crypto.randomUUID().slice(0, 8)}`;
+
+      // Create files where one path should be excluded from backup
+      const setupResponse = await fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          command: [
+            `mkdir -p ${TEST_DIR}/node_modules`,
+            `echo "keep" > ${TEST_DIR}/keep.txt`,
+            `echo "exclude-me" > ${TEST_DIR}/node_modules/a.txt`
+          ].join(' && ')
+        })
+      });
+      expect(setupResponse.ok).toBe(true);
+
+      const backupResponse = await fetch(`${workerUrl}/api/backup/create`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          dir: TEST_DIR,
+          exclude: ['node_modules']
+        })
+      });
+      expect(backupResponse.ok).toBe(true);
+      const backup = (await backupResponse.json()) as BackupResponse;
+
+      // Remove all original content before restore
+      await fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          command: `rm -rf ${TEST_DIR} && mkdir -p ${TEST_DIR}`
+        })
+      });
+
+      const restoreResponse = await fetch(`${workerUrl}/api/backup/restore`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ id: backup.id, dir: TEST_DIR })
+      });
+      expect(restoreResponse.ok).toBe(true);
+
+      const verifyResponse = await fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          command: [
+            `test -f ${TEST_DIR}/keep.txt && echo keep:yes || echo keep:no`,
+            `test -e ${TEST_DIR}/node_modules/a.txt && echo excluded:no || echo excluded:yes`
+          ].join('; ')
+        })
+      });
+      const verifyResult = (await verifyResponse.json()) as ExecuteResponse;
+      expect(verifyResult.exitCode).toBe(0);
+      expect(verifyResult.stdout).toContain('keep:yes');
+      expect(verifyResult.stdout).toContain('excluded:yes');
+
+      await cleanupDir(workerUrl, headers, TEST_DIR);
+    }, 60000);
+
+    test('should apply excludeDefaults for common build/dependency dirs', async () => {
+      if (!backupBucketAvailable) return;
+
+      const TEST_DIR = `/workspace/exclude-defaults-test-${crypto.randomUUID().slice(0, 8)}`;
+
+      const setupResponse = await fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          command: [
+            `mkdir -p ${TEST_DIR}/.git ${TEST_DIR}/dist`,
+            `echo "keep" > ${TEST_DIR}/keep.txt`,
+            `echo "git-config" > ${TEST_DIR}/.git/config`,
+            `echo "bundle" > ${TEST_DIR}/dist/app.js`
+          ].join(' && ')
+        })
+      });
+      expect(setupResponse.ok).toBe(true);
+
+      const backupResponse = await fetch(`${workerUrl}/api/backup/create`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          dir: TEST_DIR,
+          excludeDefaults: true
+        })
+      });
+      expect(backupResponse.ok).toBe(true);
+      const backup = (await backupResponse.json()) as BackupResponse;
+
+      await fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          command: `rm -rf ${TEST_DIR} && mkdir -p ${TEST_DIR}`
+        })
+      });
+
+      const restoreResponse = await fetch(`${workerUrl}/api/backup/restore`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ id: backup.id, dir: TEST_DIR })
+      });
+      expect(restoreResponse.ok).toBe(true);
+
+      const verifyResponse = await fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          command: [
+            `test -f ${TEST_DIR}/keep.txt && echo keep:yes || echo keep:no`,
+            `test -e ${TEST_DIR}/.git/config && echo git:no || echo git:yes`,
+            `test -e ${TEST_DIR}/dist/app.js && echo dist:no || echo dist:yes`
+          ].join('; ')
+        })
+      });
+      const verifyResult = (await verifyResponse.json()) as ExecuteResponse;
+      expect(verifyResult.exitCode).toBe(0);
+      expect(verifyResult.stdout).toContain('keep:yes');
+      expect(verifyResult.stdout).toContain('git:yes');
+      expect(verifyResult.stdout).toContain('dist:yes');
+
+      await cleanupDir(workerUrl, headers, TEST_DIR);
+    }, 60000);
+  });
+
   describe('Nested directory tree backup', () => {
     test('should backup and restore a directory tree with nested files', async () => {
       if (!backupBucketAvailable) return;


### PR DESCRIPTION
## Summary
This PR adds end-to-end support for excluding files from backup archives.

`createBackup()` now supports:
- `exclude: string[]` for custom mksquashfs exclude patterns
- `excludeDefaults: boolean` to include a default ignore set

Default excludes are:
`node_modules`, `.git`, `dist`, `build`, `.next`, `.turbo`, `.cache`

## Why
Backups currently include dependency and build directories by default,
which can make archives much larger than needed and slow down backup and
restore workflows.

## API and behavior
`BackupOptions.exclude` is now wired through SDK -> DO -> container backup
service. Patterns are passed to `mksquashfs -ef` (one pattern per line).

`excludeDefaults` defaults to `false` for backward-compatible behavior.
Validation was added for `exclude` and `excludeDefaults` inputs.

## Tests
Added two backup workflow E2E tests:
- restore excludes paths passed in `exclude`
- restore excludes default paths when `excludeDefaults: true`

Also ran local type checks through the pre-push hook.

## Reviewer notes
This is intentionally minimal and keeps the existing backup flow. The
only functional flow change is passing an optional exclude file to
`mksquashfs`.
