### PR TITLE
Improve DX with new Dockerfile.desktop image

### DIFF
--- a/packages/sandbox/Dockerfile
+++ b/packages/sandbox/Dockerfile
@@ -218,6 +218,14 @@ ENTRYPOINT ["/container-server/sandbox"]
 # ============================================================================
 FROM golang:1.24-bookworm AS go-builder
 
+RUN mkdir -p /usr/local/share/ca-certificates
+RUN --mount=type=secret,id=wrangler_ca \
+    if [ -f /run/secrets/wrangler_ca ] && [ -s /run/secrets/wrangler_ca ]; then \
+        cp /run/secrets/wrangler_ca /usr/local/share/ca-certificates/wrangler-dev-ca.crt && \
+        apt-get update && apt-get install -y --no-install-recommends ca-certificates && \
+        update-ca-certificates; \
+    fi
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc libx11-dev libxtst-dev libxinerama-dev libpng-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/packages/sandbox/scripts/docker-local.sh
+++ b/packages/sandbox/scripts/docker-local.sh
@@ -31,6 +31,15 @@ docker build \
   -t "$IMAGE:$VERSION-opencode" \
   .
 
+docker build \
+  -f packages/sandbox/Dockerfile \
+  --target desktop \
+  --platform linux/amd64 \
+  --build-arg SANDBOX_VERSION="$VERSION" \
+  -t "$IMAGE:$VERSION-desktop" \
+  --secret id=wrangler_ca,src="${NODE_EXTRA_CA_CERTS:-/dev/null}" \
+  .
+
 STANDALONE_DIR="tests/e2e/test-worker"
 sed -E "s|$IMAGE:[0-9]+\.[0-9]+\.[0-9]+|$IMAGE:$VERSION|g" \
   "$STANDALONE_DIR/Dockerfile.standalone" > "$STANDALONE_DIR/Dockerfile.standalone.tmp"


### PR DESCRIPTION
# Summary

We now build the new desktop Dockerfile by default when you run `npm run docker:rebuild`, allowing for easier DX when running E2E tests as it is required.

It also fixes an issue with Warp/VPN certificates during build, for more info see #429