### PR TITLE
Add SSL certificate secret to opencode container

### DIFF
--- a/packages/sandbox/Dockerfile
+++ b/packages/sandbox/Dockerfile
@@ -199,6 +199,12 @@ ENTRYPOINT ["/container-server/sandbox"]
 # ============================================================================
 FROM runtime-base AS opencode
 
+RUN --mount=type=secret,id=wrangler_ca \
+    if [ -f /run/secrets/wrangler_ca ] && [ -s /run/secrets/wrangler_ca ]; then \
+        cp /run/secrets/wrangler_ca /usr/local/share/ca-certificates/wrangler-dev-ca.crt && \
+        update-ca-certificates; \
+    fi
+
 # Install OpenCode CLI via npm (avoids GitHub API rate limits)
 RUN npm i -g opencode-ai \
     && opencode --version

--- a/packages/sandbox/scripts/docker-local.sh
+++ b/packages/sandbox/scripts/docker-local.sh
@@ -29,6 +29,7 @@ docker build \
   --platform linux/amd64 \
   --build-arg SANDBOX_VERSION="$VERSION" \
   -t "$IMAGE:$VERSION-opencode" \
+  --secret id=wrangler_ca,src="${NODE_EXTRA_CA_CERTS:-/dev/null}" \
   .
 
 docker build \


### PR DESCRIPTION
# Summary

Adds the SSL certificate fix from #429 into the OpenCode container to fix E2E test running when using Warp.