### PR TITLE
Use larger runners for CI build, test, and perf jobs

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-8core
     timeout-minutes: 15
     outputs:
       worker_url: ${{ steps.deploy.outputs.worker_url }}
@@ -114,7 +114,7 @@ jobs:
 
   performance-tests:
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-8core
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       runner:
         type: string
-        default: 'ubuntu-latest'
+        default: 'ubuntu-24.04-8core'
       skip_docker:
         type: boolean
         default: false

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       runner:
         type: string
-        default: 'ubuntu-latest'
+        default: 'ubuntu-24.04-8core'
       worker_name_prefix:
         type: string
         required: true

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       runner:
         type: string
-        default: 'ubuntu-latest'
+        default: 'ubuntu-24.04-4core'
       run_sdk_tests:
         type: boolean
         default: true


### PR DESCRIPTION
## Summary

- Upgrade build and E2E workflows to `ubuntu-24.04-8core` runners for faster Docker builds and test execution
- Upgrade quality workflow to `ubuntu-24.04-4core` for lint, typecheck, and unit test jobs
- Upgrade both performance workflow jobs to `ubuntu-24.04-8core`
- Lightweight utility workflows (cleanup, bonk, opencode) left on `ubuntu-latest`