### PR TITLE
Fix bonk OIDC and always post preview comment

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -20,6 +20,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Two CI fixes:

**Bonk OIDC**: Adds the missing `id-token: write` permission to the bonk workflow. Bonk authenticates via OIDC token exchange with its backend, which broke when we hardened workflow permissions to explicit allow-lists.

**Preview comment**: The publish-preview step only posted a PR comment when Docker images were rebuilt, leaving SDK-only PRs without any preview info. Now it always posts, choosing between the full Docker template and a lighter SDK-only template that shows the npm preview install command and notes that Docker images are unchanged.