### PR TITLE
Post preview comment on all PRs, not just Docker

### DIFF
--- a/.github/templates/pr-preview-comment.md
+++ b/.github/templates/pr-preview-comment.md
@@ -1,3 +1,5 @@
+<!-- sandbox-preview -->
+
 ### 🐳 Docker Images Published
 
 | Variant  | Image              |

--- a/.github/templates/pr-preview-main-comment.md
+++ b/.github/templates/pr-preview-main-comment.md
@@ -1,0 +1,13 @@
+<!-- sandbox-preview -->
+
+### 📦 Preview Build
+
+**Version:** `{{VERSION}}`
+
+Install the SDK preview:
+
+```
+npm i https://pkg.pr.new/cloudflare/sandbox-sdk/@cloudflare/sandbox@{{PR_NUMBER}}
+```
+
+> 🐳 Docker images were not rebuilt — no container changes detected. Use the [latest release images](https://hub.docker.com/r/cloudflare/sandbox/tags) from Docker Hub.

--- a/.github/workflows/pr-privileged.yml
+++ b/.github/workflows/pr-privileged.yml
@@ -377,36 +377,38 @@ jobs:
 
       - run: npx pkg-pr-new publish './packages/sandbox'
 
-      # PR comment with Docker image tags
+      # PR comment with preview info
       - uses: actions/github-script@v8
-        if: ${{ needs.detect-changes.outputs.docker-changed == 'true' }}
         with:
           script: |
             const fs = require('fs');
             const version = '${{ steps.version.outputs.version }}';
-            const runId = '${{ github.run_id }}';
-            const defaultTag = `cloudflare/sandbox:${version}`;
-            const pythonTag = `cloudflare/sandbox:${version}-python`;
-            const opencodeTag = `cloudflare/sandbox:${version}-opencode`;
-            const muslTag = `cloudflare/sandbox:${version}-musl`;
-            const desktopTag = `cloudflare/sandbox:${version}-desktop`;
-            const templatePath = '.github/templates/pr-preview-comment.md';
+            const dockerChanged = '${{ needs.detect-changes.outputs.docker-changed }}' === 'true';
+            const prNumber = '${{ github.event.pull_request.number }}';
+            const templatePath = dockerChanged
+              ? '.github/templates/pr-preview-comment.md'
+              : '.github/templates/pr-preview-main-comment.md';
             if (fs.existsSync(templatePath)) {
               let body = fs.readFileSync(templatePath, 'utf8');
-              body = body
-                .replace(/\{\{VERSION\}\}/g, version)
-                .replace(/\{\{RUN_ID\}\}/g, runId)
-                .replace(/\{\{DEFAULT_TAG\}\}/g, defaultTag)
-                .replace(/\{\{PYTHON_TAG\}\}/g, pythonTag)
-                .replace(/\{\{OPENCODE_TAG\}\}/g, opencodeTag)
-                .replace(/\{\{MUSL_TAG\}\}/g, muslTag)
-                .replace(/\{\{DESKTOP_TAG\}\}/g, desktopTag);
+              body = body.replace(/\{\{VERSION\}\}/g, version);
+              body = body.replace(/\{\{PR_NUMBER\}\}/g, prNumber);
+              if (dockerChanged) {
+                const runId = '${{ github.run_id }}';
+                const defaultTag = `cloudflare/sandbox:${version}`;
+                body = body
+                  .replace(/\{\{RUN_ID\}\}/g, runId)
+                  .replace(/\{\{DEFAULT_TAG\}\}/g, defaultTag)
+                  .replace(/\{\{PYTHON_TAG\}\}/g, `cloudflare/sandbox:${version}-python`)
+                  .replace(/\{\{OPENCODE_TAG\}\}/g, `cloudflare/sandbox:${version}-opencode`)
+                  .replace(/\{\{MUSL_TAG\}\}/g, `cloudflare/sandbox:${version}-musl`)
+                  .replace(/\{\{DESKTOP_TAG\}\}/g, `cloudflare/sandbox:${version}-desktop`);
+              }
               const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner, repo: context.repo.repo,
                 issue_number: context.issue.number
               });
               const existing = comments.find(c =>
-                c.user.type === 'Bot' && c.body?.includes('Docker Images Published')
+                c.user.type === 'Bot' && c.body?.includes('<!-- sandbox-preview -->')
               );
               if (existing) {
                 await github.rest.issues.updateComment({


### PR DESCRIPTION
## Summary

The publish-preview step only posted a PR comment when Docker images were rebuilt, leaving SDK-only PRs without any preview info. Now it always posts, choosing between the full Docker template and a lighter SDK-only template that shows the npm preview install command and notes that Docker images are unchanged.

This PR will self-test the SDK-only path since it has no Docker changes.