### PR TITLE
Pass session env vars to PTY on creation

### DIFF
--- a/.changeset/pty-inherit-session-state.md
+++ b/.changeset/pty-inherit-session-state.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Pass session env vars and working directory to PTY on creation

--- a/packages/sandbox-container/src/services/session-manager.ts
+++ b/packages/sandbox-container/src/services/session-manager.ts
@@ -755,9 +755,11 @@ export class SessionManager {
         return { success: true, data: session.pty };
       }
 
-      // Capture the session shell's current environment so the PTY
-      // inherits env vars set via setEnvVars().
-      let sessionEnv: Record<string, string> = {};
+      // Capture the session shell's current environment and working
+      // directory so the PTY inherits env vars set via setEnvVars()
+      // and reflects any directory changes made in the session.
+      const sessionEnv: Record<string, string> = {};
+      let sessionCwd: string = CONFIG.DEFAULT_CWD;
       try {
         const envResult = await session.exec('env -0');
         if (envResult.exitCode === 0 && envResult.stdout) {
@@ -768,14 +770,19 @@ export class SessionManager {
             }
           }
         }
+
+        const cwdResult = await session.exec('pwd');
+        if (cwdResult.exitCode === 0 && cwdResult.stdout?.trim()) {
+          sessionCwd = cwdResult.stdout.trim();
+        }
       } catch {
-        this.logger.warn('Failed to capture session environment for PTY', {
+        this.logger.warn('Failed to capture session state for PTY', {
           sessionId
         });
       }
 
       const pty = new Pty({
-        cwd: CONFIG.DEFAULT_CWD,
+        cwd: sessionCwd,
         env: sessionEnv,
         logger: this.logger
       });


### PR DESCRIPTION
## Summary
- Fixes `setEnvVars()` not being reflected in terminal sessions
- `getPty()` now captures the session shell's environment via `env -0` before spawning the PTY process
- Env vars like `ANTHROPIC_API_KEY`, `SHELL`, `PATH` set through `setEnvVars()` are now inherited by the terminal

## Context
Currently, calling `sandbox.setEnvVars({ ANTHROPIC_API_KEY: '...' })` before `sandbox.terminal(request)` has no effect on the PTY — the Pty constructor receives no `env` and the spawned process only inherits `process.env` from the container.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
