### PR TITLE
Fix Docker bake building from main instead of PR branch

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -191,6 +191,7 @@ jobs:
           BUN_VERSION: ${{ steps.bun-version.outputs.version }}
         with:
           files: docker-bake.hcl
+          source: .
           targets: main
           load: true
 


### PR DESCRIPTION
## Bug

Since `pull_request_target` was introduced in #458, every PR's Docker image has been built from the **main branch** instead of the PR branch. This means E2E tests always run against stale container code, forcing contributors to manually delete container configs to test their changes.

## Root Cause

`docker/bake-action@v6` defaults to [Git remote context][1] at the workflow ref. For `pull_request_target`, that ref is always the base branch (main) — not the PR head. Despite `actions/checkout` correctly placing PR code on disk, the bake action bypasses local files and pulls source directly from main.

Evidence from PR #437 CI logs:
- PR head commit: `ae42c52`
- Bake context used: `856f4dd` (main HEAD)
- E2E failure: container missing PR's backup gitignore feature

## Fix

Add `source: .` to the bake action, switching it from Git remote context to [path context][2]. This makes bake use the locally checked-out PR code, which `actions/checkout` already places correctly.

All existing CI optimizations (content-addressed Docker cache, GHCR layer cache, deploy-skip, docker-skip) are unaffected — they operate independently of the bake source parameter.

[1]: https://github.com/docker/bake-action#git-context
[2]: https://github.com/docker/bake-action#path-context