### PR TITLE
Export SDK error classes from @cloudflare/sandbox root

### DIFF
--- a/.changeset/export-root-error-classes.md
+++ b/.changeset/export-root-error-classes.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Export the SDK's typed error classes from `@cloudflare/sandbox` so applications can use exact `instanceof` checks from the root package.

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -126,21 +126,52 @@ export type {
   ExecutionCallbacks,
   InterpreterClient
 } from './clients/interpreter-client.js';
-// Export backup and process readiness errors
+// Export SDK error classes
 export {
   BackupCreateError,
   BackupExpiredError,
   BackupNotFoundError,
   BackupRestoreError,
+  CodeExecutionError,
+  CommandError,
+  CommandNotFoundError,
+  ContextNotFoundError,
+  CustomDomainRequiredError,
   DesktopInvalidCoordinatesError,
   DesktopInvalidOptionsError,
   DesktopNotStartedError,
   DesktopProcessCrashedError,
   DesktopStartFailedError,
   DesktopUnavailableError,
+  FileExistsError,
+  FileNotFoundError,
+  FileSystemError,
+  FileTooLargeError,
+  GitAuthenticationError,
+  GitBranchNotFoundError,
+  GitCheckoutError,
+  GitCloneError,
+  GitError,
+  GitNetworkError,
+  GitRepositoryNotFoundError,
+  InterpreterNotReadyError,
   InvalidBackupConfigError,
+  InvalidGitUrlError,
+  InvalidPortError,
+  PermissionDeniedError,
+  PortAlreadyExposedError,
+  PortError,
+  PortInUseError,
+  PortNotExposedError,
+  ProcessError,
   ProcessExitedBeforeReadyError,
-  ProcessReadyTimeoutError
+  ProcessNotFoundError,
+  ProcessReadyTimeoutError,
+  SandboxError,
+  ServiceNotRespondingError,
+  SessionAlreadyExistsError,
+  SessionDestroyedError,
+  ValidationFailedError
 } from './errors';
 // Export file streaming utilities for binary file support
 export { collectFile, streamFile } from './file-stream';

--- a/packages/sandbox/tests/public-exports.test.ts
+++ b/packages/sandbox/tests/public-exports.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import * as internalErrors from '../src/errors';
+import * as sandboxSdk from '../src/index';
+
+const rootErrorExports = {
+  BackupCreateError: [
+    sandboxSdk.BackupCreateError,
+    internalErrors.BackupCreateError
+  ],
+  BackupExpiredError: [
+    sandboxSdk.BackupExpiredError,
+    internalErrors.BackupExpiredError
+  ],
+  BackupNotFoundError: [
+    sandboxSdk.BackupNotFoundError,
+    internalErrors.BackupNotFoundError
+  ],
+  BackupRestoreError: [
+    sandboxSdk.BackupRestoreError,
+    internalErrors.BackupRestoreError
+  ],
+  CodeExecutionError: [
+    sandboxSdk.CodeExecutionError,
+    internalErrors.CodeExecutionError
+  ],
+  CommandError: [sandboxSdk.CommandError, internalErrors.CommandError],
+  CommandNotFoundError: [
+    sandboxSdk.CommandNotFoundError,
+    internalErrors.CommandNotFoundError
+  ],
+  ContextNotFoundError: [
+    sandboxSdk.ContextNotFoundError,
+    internalErrors.ContextNotFoundError
+  ],
+  CustomDomainRequiredError: [
+    sandboxSdk.CustomDomainRequiredError,
+    internalErrors.CustomDomainRequiredError
+  ],
+  DesktopInvalidCoordinatesError: [
+    sandboxSdk.DesktopInvalidCoordinatesError,
+    internalErrors.DesktopInvalidCoordinatesError
+  ],
+  DesktopInvalidOptionsError: [
+    sandboxSdk.DesktopInvalidOptionsError,
+    internalErrors.DesktopInvalidOptionsError
+  ],
+  DesktopNotStartedError: [
+    sandboxSdk.DesktopNotStartedError,
+    internalErrors.DesktopNotStartedError
+  ],
+  DesktopProcessCrashedError: [
+    sandboxSdk.DesktopProcessCrashedError,
+    internalErrors.DesktopProcessCrashedError
+  ],
+  DesktopStartFailedError: [
+    sandboxSdk.DesktopStartFailedError,
+    internalErrors.DesktopStartFailedError
+  ],
+  DesktopUnavailableError: [
+    sandboxSdk.DesktopUnavailableError,
+    internalErrors.DesktopUnavailableError
+  ],
+  FileExistsError: [sandboxSdk.FileExistsError, internalErrors.FileExistsError],
+  FileNotFoundError: [
+    sandboxSdk.FileNotFoundError,
+    internalErrors.FileNotFoundError
+  ],
+  FileSystemError: [sandboxSdk.FileSystemError, internalErrors.FileSystemError],
+  FileTooLargeError: [
+    sandboxSdk.FileTooLargeError,
+    internalErrors.FileTooLargeError
+  ],
+  GitAuthenticationError: [
+    sandboxSdk.GitAuthenticationError,
+    internalErrors.GitAuthenticationError
+  ],
+  GitBranchNotFoundError: [
+    sandboxSdk.GitBranchNotFoundError,
+    internalErrors.GitBranchNotFoundError
+  ],
+  GitCheckoutError: [
+    sandboxSdk.GitCheckoutError,
+    internalErrors.GitCheckoutError
+  ],
+  GitCloneError: [sandboxSdk.GitCloneError, internalErrors.GitCloneError],
+  GitError: [sandboxSdk.GitError, internalErrors.GitError],
+  GitNetworkError: [sandboxSdk.GitNetworkError, internalErrors.GitNetworkError],
+  GitRepositoryNotFoundError: [
+    sandboxSdk.GitRepositoryNotFoundError,
+    internalErrors.GitRepositoryNotFoundError
+  ],
+  InterpreterNotReadyError: [
+    sandboxSdk.InterpreterNotReadyError,
+    internalErrors.InterpreterNotReadyError
+  ],
+  InvalidBackupConfigError: [
+    sandboxSdk.InvalidBackupConfigError,
+    internalErrors.InvalidBackupConfigError
+  ],
+  InvalidGitUrlError: [
+    sandboxSdk.InvalidGitUrlError,
+    internalErrors.InvalidGitUrlError
+  ],
+  InvalidPortError: [
+    sandboxSdk.InvalidPortError,
+    internalErrors.InvalidPortError
+  ],
+  PermissionDeniedError: [
+    sandboxSdk.PermissionDeniedError,
+    internalErrors.PermissionDeniedError
+  ],
+  PortAlreadyExposedError: [
+    sandboxSdk.PortAlreadyExposedError,
+    internalErrors.PortAlreadyExposedError
+  ],
+  PortError: [sandboxSdk.PortError, internalErrors.PortError],
+  PortInUseError: [sandboxSdk.PortInUseError, internalErrors.PortInUseError],
+  PortNotExposedError: [
+    sandboxSdk.PortNotExposedError,
+    internalErrors.PortNotExposedError
+  ],
+  ProcessError: [sandboxSdk.ProcessError, internalErrors.ProcessError],
+  ProcessExitedBeforeReadyError: [
+    sandboxSdk.ProcessExitedBeforeReadyError,
+    internalErrors.ProcessExitedBeforeReadyError
+  ],
+  ProcessNotFoundError: [
+    sandboxSdk.ProcessNotFoundError,
+    internalErrors.ProcessNotFoundError
+  ],
+  ProcessReadyTimeoutError: [
+    sandboxSdk.ProcessReadyTimeoutError,
+    internalErrors.ProcessReadyTimeoutError
+  ],
+  SandboxError: [sandboxSdk.SandboxError, internalErrors.SandboxError],
+  ServiceNotRespondingError: [
+    sandboxSdk.ServiceNotRespondingError,
+    internalErrors.ServiceNotRespondingError
+  ],
+  SessionAlreadyExistsError: [
+    sandboxSdk.SessionAlreadyExistsError,
+    internalErrors.SessionAlreadyExistsError
+  ],
+  SessionDestroyedError: [
+    sandboxSdk.SessionDestroyedError,
+    internalErrors.SessionDestroyedError
+  ],
+  ValidationFailedError: [
+    sandboxSdk.ValidationFailedError,
+    internalErrors.ValidationFailedError
+  ]
+} as const;
+
+describe('public SDK exports', () => {
+  it('re-exports SDK error classes from the root package', () => {
+    for (const [exportName, [publicExport, internalExport]] of Object.entries(
+      rootErrorExports
+    )) {
+      expect(publicExport).toBe(internalExport);
+      expect(publicExport?.name).toBe(exportName);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #517.

The published package already contains the SDK's concrete error classes internally, but the root `@cloudflare/sandbox` entrypoint did not re-export many of them. That made exact error handling awkward for consumers because `instanceof` checks from the package root failed at import time.

This PR makes the root package export the full existing SDK error-class surface, including:
- `SandboxError`
- `SessionAlreadyExistsError`
- `SessionDestroyedError`
- `ProcessNotFoundError`

and the rest of the concrete SDK error classes already exposed by the internal errors barrel.

## Changes

- re-export all existing SDK error classes from `@cloudflare/sandbox`
- add a regression test to verify the root exports match the internal errors barrel
- add a patch changeset

## Result

Consumers can now do:

```ts
import { SessionAlreadyExistsError } from "@cloudflare/sandbox";

if (error instanceof SessionAlreadyExistsError) {
  // ...
}
```

## Testing

- npm run check
- npm test -w @cloudflare/sandbox

npm run check still reports two existing Biome warnings in packages/sandbox-container tests, but the command completes successfully.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
