### PR TITLE
Add capnweb RPC transport

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,21 @@ Turbo handles task orchestration (`turbo.json`) with dependency-aware builds.
 - Use the newly defined type everywhere appropriate for consistency
 - This ensures type safety and catches errors at compile time rather than runtime
 
+### Style Guide
+
+**Uppercase acronyms in identifiers.** When an acronym appears in a camelCase or
+PascalCase identifier, keep it fully uppercase:
+
+| ✅ Do             | ❌ Don't          |
+| ----------------- | ----------------- |
+| `SandboxRPCAPI`   | `SandboxRpcApi`   |
+| `containerURL`    | `containerUrl`    |
+| `parseHTTPHeader` | `parseHttpHeader` |
+| `getAPIKey`       | `getApiKey`       |
+
+This applies to all acronyms: API, URL, HTTP, RPC, SSE, SSH, DNS, ID, etc.
+Exception: library-provided names (e.g. capnweb's `RpcTarget`) keep their original casing.
+
 ### Git Commits
 
 See the **git-commit** skill (`.opencode/skill/git-commit/SKILL.md`) for detailed commit message guidelines.

--- a/bridge/script/integration
+++ b/bridge/script/integration
@@ -3,8 +3,12 @@
 /**
  * Integration tests for the cloudflare-sandbox-bridge Worker.
  *
- * Starts `wrangler dev` (with containers disabled — no Docker required),
- * then exercises every API endpoint via real HTTP requests.
+ * By default, starts `wrangler dev` (with containers disabled — no Docker
+ * required) and exercises every API endpoint via real HTTP requests.
+ *
+ * Set BASE_URL to skip the local server and run against a remote service:
+ *
+ *   BASE_URL=https://bridge.example.com SANDBOX_API_KEY=secret script/integration
  *
  * Uses Bun for:
  *   - Built-in WebSocket client with custom headers support
@@ -20,8 +24,10 @@
  *   - OpenAPI schema availability
  *
  * Usage:
- *   script/integration                        # auth disabled (SANDBOX_API_KEY="")
- *   SANDBOX_API_KEY=secret script/integration    # auth enabled
+ *   script/integration                                              # local, auth disabled
+ *   SANDBOX_API_KEY=secret script/integration                       # local, auth enabled
+ *   BASE_URL=https://bridge.example.com script/integration          # remote, auth disabled
+ *   BASE_URL=https://bridge.example.com SANDBOX_API_KEY=s script/integration  # remote, auth enabled
  */
 
 import { spawn } from 'node:child_process';
@@ -31,10 +37,41 @@ import { setTimeout as sleep } from 'node:timers/promises';
 // Config
 // ---------------------------------------------------------------------------
 
+const REMOTE_BASE = process.env.BASE_URL?.replace(/\/$/, '');
 const PORT = process.env.PORT || 18787;
-const BASE = `http://127.0.0.1:${PORT}`;
+const BASE = REMOTE_BASE || `http://127.0.0.1:${PORT}`;
 const TOKEN = process.env.SANDBOX_API_KEY || '';
-const SANDBOX_ID = 'integration-test';
+let SANDBOX_ID = 'integration-test';
+
+// ---------------------------------------------------------------------------
+// Sandbox lifecycle
+// ---------------------------------------------------------------------------
+
+async function createSandbox(): Promise<string> {
+  const res = await fetch(`${BASE}/v1/sandbox`, {
+    method: 'POST',
+    headers: authHeadersRaw()
+  });
+  if (!res.ok) {
+    throw new Error(`POST /v1/sandbox failed: ${res.status} ${await res.text()}`);
+  }
+  const body: any = await res.json();
+  if (!body.id || typeof body.id !== 'string') {
+    throw new Error(`POST /v1/sandbox returned unexpected body: ${JSON.stringify(body)}`);
+  }
+  return body.id;
+}
+
+async function destroySandbox(id: string): Promise<void> {
+  try {
+    await fetch(`${BASE}/v1/sandbox/${id}`, {
+      method: 'DELETE',
+      headers: authHeadersRaw()
+    });
+  } catch {
+    // Best-effort cleanup
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -155,6 +192,15 @@ function stopServer(child: ReturnType<typeof spawn>) {
 // ---------------------------------------------------------------------------
 
 async function runTests() {
+  // ── Sandbox creation ──────────────────────────────────
+  console.log('\n📋 Sandbox creation');
+
+  await test('POST /v1/sandbox returns a sandbox ID', async () => {
+    SANDBOX_ID = await createSandbox();
+    assert(SANDBOX_ID.length > 0, 'sandbox ID should be non-empty');
+    console.log(`     (using sandbox ID: ${SANDBOX_ID})`);
+  });
+
   // ── Health ──────────────────────────────────────────────
   console.log('\n📋 Health');
 
@@ -380,7 +426,10 @@ async function runTests() {
   console.log('\n📋 DELETE /v1/sandbox/:id');
 
   await test('returns 204 No Content (best-effort)', async () => {
-    const res = await fetch(`${BASE}/v1/sandbox/${SANDBOX_ID}`, {
+    // Create a throwaway sandbox to test deletion without destroying
+    // the main sandbox used by other tests.
+    const throwawayId = await createSandbox();
+    const res = await fetch(`${BASE}/v1/sandbox/${throwawayId}`, {
       method: 'DELETE',
       headers: authHeadersRaw()
     });
@@ -426,7 +475,8 @@ async function runTests() {
     // Without a real container the SDK terminal() will throw,
     // resulting in a 502 or a WS close — but the key assertion is
     // that the route is reached (not a 404).
-    const wsUrl = `ws://127.0.0.1:${PORT}/v1/sandbox/${SANDBOX_ID}/pty?cols=80&rows=24`;
+    const wsBase = BASE.replace(/^http/, 'ws');
+    const wsUrl = `${wsBase}/v1/sandbox/${SANDBOX_ID}/pty?cols=80&rows=24`;
 
     const result = await new Promise<{
       opened: boolean;
@@ -540,29 +590,38 @@ async function runTests() {
 // ---------------------------------------------------------------------------
 
 async function main() {
-  console.log('🚀 Starting wrangler dev on port', PORT, TOKEN ? '(auth enabled)' : '(auth disabled)');
-
   let server: ReturnType<typeof spawn> | undefined;
-  try {
+
+  if (REMOTE_BASE) {
+    console.log(`🌐 Testing remote service at ${REMOTE_BASE}`, TOKEN ? '(auth enabled)' : '(auth disabled)');
+    console.log();
+  } else {
+    console.log('🚀 Starting wrangler dev on port', PORT, TOKEN ? '(auth enabled)' : '(auth disabled)');
     server = await startServer();
     console.log('✅ Server started\n');
+  }
 
+  try {
     await runTests();
-
-    console.log('\n' + '─'.repeat(50));
-    console.log(`\n  Results: ${passed} passed, ${failed} failed\n`);
-
-    if (failures.length > 0) {
-      console.log('  Failed tests:');
-      for (const f of failures) {
-        console.log(`    ❌ ${f.name}`);
-        console.log(`       ${f.error.message}`);
-      }
-      console.log();
-    }
   } finally {
+    // Clean up the test sandbox
+    if (SANDBOX_ID && SANDBOX_ID !== 'integration-test') {
+      await destroySandbox(SANDBOX_ID);
+    }
     if (server) stopServer(server);
-    await sleep(1000);
+    if (server) await sleep(1000);
+  }
+
+  console.log('\n' + '─'.repeat(50));
+  console.log(`\n  Results: ${passed} passed, ${failed} failed\n`);
+
+  if (failures.length > 0) {
+    console.log('  Failed tests:');
+    for (const f of failures) {
+      console.log(`    ❌ ${f.name}`);
+      console.log(`       ${f.error.message}`);
+    }
+    console.log();
   }
 
   process.exit(failed > 0 ? 1 : 0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,8 +116,6 @@
     },
     "examples/code-interpreter/node_modules/zod": {
       "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -188,18 +186,13 @@
       }
     },
     "examples/desktop/node_modules/@cloudflare/kumo": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kumo/-/kumo-1.18.0.tgz",
-      "integrity": "sha512-D1OkzYe6rIPe2CqklE+DDt84YB8Q+gV5PH/Hjco8TO1NEHZkaookdl67YU+HHWCBME6TxSwQRzn72hp/cyOrCw==",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
-        "@shikijs/langs": "^4.0.0",
-        "@shikijs/themes": "^4.0.0",
         "clsx": "^2.1.1",
         "motion": "^12.34.1",
         "react-day-picker": "^9.13.2",
-        "shiki": "^4.0.0",
         "tailwind-merge": "^3.4.0"
       },
       "bin": {
@@ -207,7 +200,6 @@
       },
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.10",
-        "echarts": "^6.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",
         "zod": "^4.0.0"
@@ -220,8 +212,6 @@
     },
     "examples/desktop/node_modules/zod": {
       "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -259,9 +249,7 @@
       }
     },
     "examples/openai-agents/node_modules/nanoid": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
-      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "version": "5.1.6",
       "funding": [
         {
           "type": "github",
@@ -401,9 +389,9 @@
       "license": "MIT"
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.98",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.98.tgz",
-      "integrity": "sha512-Ol+nP8PIlj8FjN8qKlxhE89N0woqAaGi9CUBGp1boe3RafpphJ7WMuq/RErSvxtwTqje03TP+zIdzP113krxRg==",
+      "version": "3.0.102",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.102.tgz",
+      "integrity": "sha512-GrwDpaYJiVafrsA1MTbZtXPcQUI67g5AXiJo7Y1F8b+w+SiYHLk3ZIn1YmpQVoVAh2bjvxjj+Vo0AvfskuGH4g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
@@ -477,6 +465,34 @@
         "typescript": "^5.0.0"
       }
     },
+    "node_modules/@astrojs/check/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@astrojs/compiler": {
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
@@ -484,12 +500,12 @@
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.8.0.tgz",
-      "integrity": "sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.0.tgz",
+      "integrity": "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==",
       "license": "MIT",
       "dependencies": {
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       }
     },
     "node_modules/@astrojs/internal-helpers/node_modules/picomatch": {
@@ -546,12 +562,12 @@
       }
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.0.tgz",
-      "integrity": "sha512-P+HnCsu2js3BoTc8kFmu+E9gOcFeMdPris75g+Zl4sY8+bBRbSQV6xzcBDbZ27eE7yBGEGQoqjpChx+KJYIPYQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.1.tgz",
+      "integrity": "sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.8.0",
+        "@astrojs/internal-helpers": "0.9.0",
         "@astrojs/prism": "4.0.1",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
@@ -572,6 +588,105 @@
         "unist-util-visit": "^5.1.0",
         "unist-util-visit-parents": "^6.0.2",
         "vfile": "^6.0.3"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark/node_modules/@shikijs/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark/node_modules/@shikijs/engine-javascript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark/node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark/node_modules/@shikijs/langs": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark/node_modules/@shikijs/themes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark/node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark/node_modules/shiki": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -608,39 +723,17 @@
         "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@astrojs/react/node_modules/@astrojs/internal-helpers": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.0.tgz",
-      "integrity": "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==",
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^4.0.4"
-      }
-    },
-    "node_modules/@astrojs/react/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@astrojs/telemetry": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
-      "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.1.tgz",
+      "integrity": "sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw==",
       "license": "MIT",
       "dependencies": {
-        "ci-info": "^4.2.0",
-        "debug": "^4.4.0",
+        "ci-info": "^4.4.0",
         "dlv": "^1.1.3",
         "dset": "^3.1.4",
-        "is-docker": "^3.0.0",
-        "is-wsl": "^3.1.0",
+        "is-docker": "^4.0.0",
+        "is-wsl": "^3.1.1",
         "which-pm-runs": "^1.1.0"
       },
       "engines": {
@@ -1089,6 +1182,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1137,60 +1231,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@base-ui/react": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.4.0.tgz",
-      "integrity": "sha512-QcqdVbr/+ba2/RAKJIV1PV6S02Q5+r6a4Eym8ndBw+ZbBILkkmQAyRxXCg/pArrHnkrGeU8goe26aw0h6eE8pg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@base-ui/utils": "0.2.7",
-        "@floating-ui/react-dom": "^2.1.8",
-        "@floating-ui/utils": "^0.2.11",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@date-fns/tz": "^1.2.0",
-        "@types/react": "^17 || ^18 || ^19",
-        "date-fns": "^4.0.0",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@base-ui/utils": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.7.tgz",
-      "integrity": "sha512-nXYKhiL/0JafyJE8PfcflipGftOftlIwKd72rU15iZ1M5yqgg5J9P8NHU71GReDuXco5MJA/eVQqUT5WRqX9sA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@floating-ui/utils": "^0.2.11",
-        "reselect": "^5.1.1",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^17 || ^18 || ^19",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/@biomejs/biome": {
@@ -1688,9 +1728,9 @@
       }
     },
     "node_modules/@cloudflare/containers": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/containers/-/containers-0.3.0.tgz",
-      "integrity": "sha512-8HM1NgXThWCTk7SH28QFxqMNLJwl6RrMkj3qd0KvDA59BALsn3mZXNDT94i1JaGZnP4Bc8sPGs1u9UAl/mVUVg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/containers/-/containers-0.3.2.tgz",
+      "integrity": "sha512-hWobJrpXCgFJ/HYii6E49eegnnlUDWGacjLd0Fb6nQwTD005+T2eHUPI6qOEq9KPJOd7xTWkhkuXEKxDFvfyqQ==",
       "license": "ISC"
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -1986,13 +2026,6 @@
         }
       }
     },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/path-to-regexp": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
       "version": "4.72.0",
       "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.72.0.tgz",
@@ -2109,9 +2142,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260415.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260415.1.tgz",
-      "integrity": "sha512-9sEq9cZzr4s075U/TfjvdSmiX+u2NMOAIcFcCfd24FDtPfR7Iw3SbuQxkcgtpx/Bvg0au9PmQ0ZJfBaIitG0gw==",
+      "version": "4.20260416.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260416.2.tgz",
+      "integrity": "sha512-f7VGuKsHckH5n9KATTPJQ6AGdc2q58eM2waGzzDoCKw+PBtw9j2TWdRz8tLkviv7XcjkcuKy181vQFffXJicrA==",
       "devOptional": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -2136,12 +2169,6 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
-    },
-    "node_modules/@date-fns/tz": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
-      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
-      "license": "MIT"
     },
     "node_modules/@emmetio/abbreviation": {
       "version": "2.3.3",
@@ -2199,9 +2226,9 @@
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2210,30 +2237,15 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@emnapi/core/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@emnapi/runtime/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -2245,14 +2257,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@emnapi/wasi-threads/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
@@ -2679,44 +2683,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.7.5",
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.6"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-      "license": "MIT"
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
@@ -3399,6 +3365,16 @@
         }
       }
     },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -3999,6 +3975,22 @@
         }
       }
     },
+    "node_modules/@react-router/dev/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@react-router/dev/node_modules/confbox": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
@@ -4066,6 +4058,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@react-router/dev/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@react-router/node": {
@@ -4229,9 +4235,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
       "cpu": [
         "ppc64"
       ],
@@ -4246,9 +4252,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
       "cpu": [
         "s390x"
       ],
@@ -4753,58 +4759,45 @@
       ]
     },
     "node_modules/@shikijs/core": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
-      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+      "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/primitive": "4.0.2",
-        "@shikijs/types": "4.0.2",
+        "@shikijs/types": "3.23.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
-      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.0.2",
+        "@shikijs/types": "3.23.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "oniguruma-to-es": "^4.3.4"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
-      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.0.2",
+        "@shikijs/types": "3.23.0",
         "@shikijs/vscode-textmate": "^10.0.2"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
-      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.0.2"
-      },
-      "engines": {
-        "node": ">=20"
+        "@shikijs/types": "3.23.0"
       }
     },
     "node_modules/@shikijs/primitive": {
@@ -4821,19 +4814,7 @@
         "node": ">=20"
       }
     },
-    "node_modules/@shikijs/themes": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
-      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@shikijs/types": {
+    "node_modules/@shikijs/primitive/node_modules/@shikijs/types": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
       "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
@@ -4844,6 +4825,25 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/@shikijs/vscode-textmate": {
@@ -4875,15 +4875,6 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
-    },
-    "node_modules/@tabby_ai/hijri-converter": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
-      "integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
@@ -5265,14 +5256,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@tybys/wasm-util/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/@types/acorn": {
       "version": "4.0.6",
@@ -5766,12 +5749,12 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.161",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.161.tgz",
-      "integrity": "sha512-ufhmijmx2YyWTPAicGgtpLOB/xD7mG8zKs1pT1Trj+JL/3r1rS8fkMi/cHZoChSAQSGB4pgmcWVxDrVTUvK2IQ==",
+      "version": "6.0.165",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.165.tgz",
+      "integrity": "sha512-2Qqd0TZudA6p66W3BcK5eh5S5CrbyPPfmnrX50KhgNFVWFCPJcZdm4lQaYDSFRFz6sK8SawsE6xGsuLVhNSIpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.98",
+        "@ai-sdk/gateway": "3.0.102",
         "@ai-sdk/provider": "3.0.8",
         "@ai-sdk/provider-utils": "4.0.23",
         "@opentelemetry/api": "1.9.0"
@@ -5943,15 +5926,15 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.6.tgz",
-      "integrity": "sha512-pRsz+kYriwCV/AUcY/I9OVKtVHuYFs2DtCszAxprXded/kTE53nMwxfnK0Nf6FPfaX9vcUiLnigcSIhuFoKntA==",
+      "version": "6.1.9",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.9.tgz",
+      "integrity": "sha512-NsAHzMzpznB281g2aM5qnBt2QjfH6ttKiZ3hSZw52If8JJ+62kbnBKbyKhR2glQcJLl7Jfe4GSl0DihFZ36rRQ==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^3.0.1",
-        "@astrojs/internal-helpers": "0.8.0",
-        "@astrojs/markdown-remark": "7.1.0",
-        "@astrojs/telemetry": "3.3.0",
+        "@astrojs/internal-helpers": "0.9.0",
+        "@astrojs/markdown-remark": "7.1.1",
+        "@astrojs/telemetry": "3.3.1",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
         "@oslojs/encoding": "^1.1.0",
@@ -5982,7 +5965,7 @@
         "p-queue": "^9.1.0",
         "package-manager-detector": "^1.6.0",
         "piccolore": "^0.1.3",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.4",
         "rehype": "^13.0.2",
         "semver": "^7.7.4",
         "shiki": "^4.0.2",
@@ -5995,9 +5978,9 @@
         "ultrahtml": "^1.6.0",
         "unifont": "~0.7.4",
         "unist-util-visit": "^5.1.0",
-        "unstorage": "^1.17.4",
+        "unstorage": "^1.17.5",
         "vfile": "^6.0.3",
-        "vite": "^7.3.1",
+        "vite": "^7.3.2",
         "vitefu": "^1.1.2",
         "xxhash-wasm": "^1.1.0",
         "yargs-parser": "^22.0.0",
@@ -6024,6 +6007,86 @@
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-3.0.1.tgz",
       "integrity": "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==",
       "license": "MIT"
+    },
+    "node_modules/astro/node_modules/@shikijs/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/astro/node_modules/@shikijs/engine-javascript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/astro/node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/astro/node_modules/@shikijs/langs": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/astro/node_modules/@shikijs/themes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/astro/node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/astro/node_modules/es-module-lexer": {
       "version": "2.0.0",
@@ -6064,6 +6127,25 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/astro/node_modules/shiki": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/astro/node_modules/yargs-parser": {
       "version": "22.0.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
@@ -6090,12 +6172,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/async-mutex/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/aws4fetch": {
       "version": "1.0.20",
@@ -6348,6 +6424,12 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/capnweb": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/capnweb/-/capnweb-0.6.1.tgz",
+      "integrity": "sha512-fmhV26QPd1ewf5R74h55oVZnGwIcSaRMzbfLQUy8+zOBjuTmT3KXoT8wxHvnp1m9Ht9BoUUS5ZwNLoVLfQTyBg==",
+      "license": "MIT"
+    },
     "node_modules/ccount": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -6423,15 +6505,15 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -6774,22 +6856,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/date-fns-jalali": {
-      "version": "4.1.0-0",
-      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
-      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
-      "license": "MIT"
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -7081,17 +7147,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/echarts": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
-      "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2.3.0",
-        "zrender": "6.0.0"
-      }
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -7100,9 +7155,9 @@
       "optional": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.336",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
-      "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
+      "version": "1.5.339",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz",
+      "integrity": "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==",
       "license": "ISC"
     },
     "node_modules/emmet": {
@@ -7667,39 +7722,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/framer-motion": {
-      "version": "12.38.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
-      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-dom": "^12.38.0",
-        "motion-utils": "^12.36.0",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/framer-motion/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
@@ -8257,15 +8279,15 @@
       }
     },
     "node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
+      "integrity": "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==",
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8316,6 +8338,21 @@
       },
       "engines": {
         "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8402,9 +8439,9 @@
       }
     },
     "node_modules/isbot": {
-      "version": "5.1.38",
-      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.38.tgz",
-      "integrity": "sha512-Cus2702JamTNMEY4zTP+TShgq/3qzjvGcBC4XMOV45BLaxD4iUFENkqu7ZhFeSzwNsCSZLjnGlihDQznnpnEEA==",
+      "version": "5.1.39",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.39.tgz",
+      "integrity": "sha512-obH0yYahGXdzNxo+djmHhBYThUKDkz565cxkIlt2L9hXfv1NlaLKoDBHo6KxXsYrIXx2RK3x5vY36CfZcobxEw==",
       "license": "Unlicense",
       "engines": {
         "node": ">=18"
@@ -8424,16 +8461,6 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -8523,9 +8550,9 @@
       }
     },
     "node_modules/lefthook": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-2.1.5.tgz",
-      "integrity": "sha512-yB9IFWurFllusbPZqvG0EavTmpNXPya2MuO7Li7YT78xAj3uCQ3AgmW9TVUbTTsSMhsegbiAMRpwfEk2TP1P0A==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-2.1.6.tgz",
+      "integrity": "sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -8533,22 +8560,22 @@
         "lefthook": "bin/index.js"
       },
       "optionalDependencies": {
-        "lefthook-darwin-arm64": "2.1.5",
-        "lefthook-darwin-x64": "2.1.5",
-        "lefthook-freebsd-arm64": "2.1.5",
-        "lefthook-freebsd-x64": "2.1.5",
-        "lefthook-linux-arm64": "2.1.5",
-        "lefthook-linux-x64": "2.1.5",
-        "lefthook-openbsd-arm64": "2.1.5",
-        "lefthook-openbsd-x64": "2.1.5",
-        "lefthook-windows-arm64": "2.1.5",
-        "lefthook-windows-x64": "2.1.5"
+        "lefthook-darwin-arm64": "2.1.6",
+        "lefthook-darwin-x64": "2.1.6",
+        "lefthook-freebsd-arm64": "2.1.6",
+        "lefthook-freebsd-x64": "2.1.6",
+        "lefthook-linux-arm64": "2.1.6",
+        "lefthook-linux-x64": "2.1.6",
+        "lefthook-openbsd-arm64": "2.1.6",
+        "lefthook-openbsd-x64": "2.1.6",
+        "lefthook-windows-arm64": "2.1.6",
+        "lefthook-windows-x64": "2.1.6"
       }
     },
     "node_modules/lefthook-darwin-arm64": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-2.1.5.tgz",
-      "integrity": "sha512-VITTaw8PxxyE26gkZ8UcwIa5ZrWnKNRGLeeSrqri40cQdXvLTEoMq2tjjw7eiL9UcB0waRReDdzydevy9GOPUQ==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-2.1.6.tgz",
+      "integrity": "sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==",
       "cpu": [
         "arm64"
       ],
@@ -8560,9 +8587,9 @@
       ]
     },
     "node_modules/lefthook-darwin-x64": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-2.1.5.tgz",
-      "integrity": "sha512-AvtjYiW0BSGHBGrdvL313seUymrW9FxI+6JJwJ+ZSaa2sH81etrTB0wAwlH1L9VfFwK9+gWvatZBvLfF3L4fPw==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-2.1.6.tgz",
+      "integrity": "sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ==",
       "cpu": [
         "x64"
       ],
@@ -8574,9 +8601,9 @@
       ]
     },
     "node_modules/lefthook-freebsd-arm64": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-2.1.5.tgz",
-      "integrity": "sha512-mXjJwe8jKGWGiBYUxfQY1ab3Nn5NhafqT9q3KJz8m5joGGQj4JD0cbWxF1nVBLBWsDGbWZRZunTCMGcIScT2bQ==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-2.1.6.tgz",
+      "integrity": "sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA==",
       "cpu": [
         "arm64"
       ],
@@ -8588,9 +8615,9 @@
       ]
     },
     "node_modules/lefthook-freebsd-x64": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-2.1.5.tgz",
-      "integrity": "sha512-exD69dCjc1K45BxatDPGoH4NmEvgLKPm4kJLOWn1fTeHRKZwWiFPwnjknEoG2OemlCDHmCU++5X40kMEG0WBlA==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-2.1.6.tgz",
+      "integrity": "sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg==",
       "cpu": [
         "x64"
       ],
@@ -8602,9 +8629,9 @@
       ]
     },
     "node_modules/lefthook-linux-arm64": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-2.1.5.tgz",
-      "integrity": "sha512-57TDKC5ewWpsCLZQKIJMHumFEObYKVundmPpiWhX491hINRZYYOL/26yrnVnNcidThRzTiTC+HLcuplLcaXtbA==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-2.1.6.tgz",
+      "integrity": "sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g==",
       "cpu": [
         "arm64"
       ],
@@ -8616,9 +8643,9 @@
       ]
     },
     "node_modules/lefthook-linux-x64": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-2.1.5.tgz",
-      "integrity": "sha512-bqK3LrAB5l5YaCaoHk6qRWlITrGWzP4FbwRxA31elbxjd0wgNWZ2Sn3zEfSEcxz442g7/PPkEwqqsTx0kSFzpg==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-2.1.6.tgz",
+      "integrity": "sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw==",
       "cpu": [
         "x64"
       ],
@@ -8630,9 +8657,9 @@
       ]
     },
     "node_modules/lefthook-openbsd-arm64": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-2.1.5.tgz",
-      "integrity": "sha512-5aSwK7vV3A6t0w9PnxCMiVjQlcvopBP50BtmnnLnNJyAYHnFbZ0Baq5M0WkE9IsUkWSux0fe6fd0jDkuG711MA==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-2.1.6.tgz",
+      "integrity": "sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A==",
       "cpu": [
         "arm64"
       ],
@@ -8644,9 +8671,9 @@
       ]
     },
     "node_modules/lefthook-openbsd-x64": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-2.1.5.tgz",
-      "integrity": "sha512-Y+pPdDuENJ8qWnUgL02xxhpjblc0WnwXvWGfqnl3WZrAgHzQpwx3G6469RID/wlNVdHYAlw3a8UkFSMYsTzXvA==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-2.1.6.tgz",
+      "integrity": "sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg==",
       "cpu": [
         "x64"
       ],
@@ -8658,9 +8685,9 @@
       ]
     },
     "node_modules/lefthook-windows-arm64": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-2.1.5.tgz",
-      "integrity": "sha512-2PlcFBjTzJaMufw0c28kfhB/0zmaRCU0TRPPsil/HU2YNOExod4upPGLk9qjgsOmb2YVWFz6zq6u7+D1yqmzTQ==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-2.1.6.tgz",
+      "integrity": "sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw==",
       "cpu": [
         "arm64"
       ],
@@ -8672,9 +8699,9 @@
       ]
     },
     "node_modules/lefthook-windows-x64": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-2.1.5.tgz",
-      "integrity": "sha512-yiAh8qxml6uqy10jDxOdN9fOQpyLxBFY1fgCEAhn7sVJYmJKRhjqSBwZX6LG5MQjzr29KStrIdw7TR3lf3rT7Q==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-2.1.6.tgz",
+      "integrity": "sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A==",
       "cpu": [
         "x64"
       ],
@@ -9952,53 +9979,6 @@
         "ufo": "^1.6.3"
       }
     },
-    "node_modules/motion": {
-      "version": "12.38.0",
-      "resolved": "https://registry.npmjs.org/motion/-/motion-12.38.0.tgz",
-      "integrity": "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==",
-      "license": "MIT",
-      "dependencies": {
-        "framer-motion": "^12.38.0",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/motion-dom": {
-      "version": "12.38.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
-      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-utils": "^12.36.0"
-      }
-    },
-    "node_modules/motion-utils": {
-      "version": "12.36.0",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
-      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
-      "license": "MIT"
-    },
-    "node_modules/motion/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -10436,15 +10416,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -10813,28 +10788,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-day-picker": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
-      "integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@date-fns/tz": "^1.4.1",
-        "@tabby_ai/hijri-converter": "1.0.5",
-        "date-fns": "^4.1.0",
-        "date-fns-jalali": "4.1.0-0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/gpbl"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
     "node_modules/react-dom": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
@@ -10919,12 +10872,12 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
@@ -11120,12 +11073,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/reselect": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
-      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
@@ -11363,6 +11310,17 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/run-parallel": {
@@ -11681,22 +11639,19 @@
       ]
     },
     "node_modules/shiki": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
-      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+      "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "4.0.2",
-        "@shikijs/engine-javascript": "4.0.2",
-        "@shikijs/engine-oniguruma": "4.0.2",
-        "@shikijs/langs": "4.0.2",
-        "@shikijs/themes": "4.0.2",
-        "@shikijs/types": "4.0.2",
+        "@shikijs/core": "3.23.0",
+        "@shikijs/engine-javascript": "3.23.0",
+        "@shikijs/engine-oniguruma": "3.23.0",
+        "@shikijs/langs": "3.23.0",
+        "@shikijs/themes": "3.23.0",
+        "@shikijs/types": "3.23.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/side-channel": {
@@ -12015,16 +11970,6 @@
         "url": "https://opencollective.com/svgo"
       }
     },
-    "node_modules/tailwind-merge": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
-      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/dcastil"
-      }
-    },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
@@ -12316,40 +12261,10 @@
         }
       }
     },
-    "node_modules/tsdown/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/tsdown/node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/tsx": {
@@ -12722,13 +12637,13 @@
       }
     },
     "node_modules/unrun": {
-      "version": "0.2.35",
-      "resolved": "https://registry.npmjs.org/unrun/-/unrun-0.2.35.tgz",
-      "integrity": "sha512-nDP7mA4Fu5owDarQtLiiN3lq7tJZHFEAVIchnwP8U3wMeEkLoUNT37Hva85H05Rdw8CArpGmtY+lBjpk9fruVQ==",
+      "version": "0.2.36",
+      "resolved": "https://registry.npmjs.org/unrun/-/unrun-0.2.36.tgz",
+      "integrity": "sha512-ICAGv44LHSKjCdI4B4rk99lJLHXBweutO4MUwu3cavMlYtXID0Tn5e1Kwe/Uj6BSAuHHXfi1JheFVCYhcXHfAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "rolldown": "1.0.0-rc.15"
+        "rolldown": "1.0.0-rc.16"
       },
       "bin": {
         "unrun": "dist/cli.mjs"
@@ -12748,10 +12663,33 @@
         }
       }
     },
+    "node_modules/unrun/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/unrun/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/unrun/node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
+      "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -12759,9 +12697,9 @@
       }
     },
     "node_modules/unrun/node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
       "cpu": [
         "arm64"
       ],
@@ -12776,9 +12714,9 @@
       }
     },
     "node_modules/unrun/node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
       "cpu": [
         "arm64"
       ],
@@ -12793,9 +12731,9 @@
       }
     },
     "node_modules/unrun/node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
       "cpu": [
         "x64"
       ],
@@ -12810,9 +12748,9 @@
       }
     },
     "node_modules/unrun/node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
       "cpu": [
         "x64"
       ],
@@ -12827,9 +12765,9 @@
       }
     },
     "node_modules/unrun/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
+      "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
       "cpu": [
         "arm"
       ],
@@ -12844,9 +12782,9 @@
       }
     },
     "node_modules/unrun/node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
       "cpu": [
         "arm64"
       ],
@@ -12861,9 +12799,9 @@
       }
     },
     "node_modules/unrun/node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
+      "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
       "cpu": [
         "arm64"
       ],
@@ -12878,9 +12816,9 @@
       }
     },
     "node_modules/unrun/node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
       "cpu": [
         "x64"
       ],
@@ -12895,9 +12833,9 @@
       }
     },
     "node_modules/unrun/node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
+      "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
       "cpu": [
         "x64"
       ],
@@ -12912,9 +12850,9 @@
       }
     },
     "node_modules/unrun/node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
       "cpu": [
         "arm64"
       ],
@@ -12929,9 +12867,9 @@
       }
     },
     "node_modules/unrun/node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
+      "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
       "cpu": [
         "wasm32"
       ],
@@ -12941,16 +12879,16 @@
       "dependencies": {
         "@emnapi/core": "1.9.2",
         "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/unrun/node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
+      "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
       "cpu": [
         "arm64"
       ],
@@ -12965,9 +12903,9 @@
       }
     },
     "node_modules/unrun/node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
+      "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
       "cpu": [
         "x64"
       ],
@@ -12982,21 +12920,21 @@
       }
     },
     "node_modules/unrun/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
+      "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/unrun/node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.126.0",
+        "@rolldown/pluginutils": "1.0.0-rc.16"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -13005,21 +12943,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
       }
     },
     "node_modules/unstorage": {
@@ -13118,21 +13056,6 @@
         }
       }
     },
-    "node_modules/unstorage/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/unstorage/node_modules/lru-cache": {
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
@@ -13140,19 +13063,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/unstorage/node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -13193,15 +13103,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/valibot": {
@@ -13891,9 +13792,9 @@
       }
     },
     "node_modules/workers-ai-provider": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/workers-ai-provider/-/workers-ai-provider-3.1.10.tgz",
-      "integrity": "sha512-PEf+eijYbeZD5kfWO6uWOmWshq99H3mOtx6nCDhSfBOYv90qfkec2QqsGM3+c5gpP0YU8+gPq7v7KUplwf8mug==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/workers-ai-provider/-/workers-ai-provider-3.1.11.tgz",
+      "integrity": "sha512-+J2dfbSs3r/DUEzo2buhBuomTrz/kHd063vqz3qsZjZFmnprlE82TLqWfB1jb+AGBCiygQ1J4EimCLy9ZU7QMQ==",
       "license": "MIT",
       "peerDependencies": {
         "@ai-sdk/provider": "^3.0.0",
@@ -14033,12 +13934,6 @@
       "engines": {
         "node": ">=18.0.0"
       }
-    },
-    "node_modules/wrangler/node_modules/path-to-regexp": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "license": "MIT"
     },
     "node_modules/wrangler/node_modules/undici": {
       "version": "7.24.8",
@@ -14308,16 +14203,6 @@
         "zod": "^3.25.28 || ^4"
       }
     },
-    "node_modules/zrender": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
-      "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2.3.0"
-      }
-    },
     "node_modules/zwitch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
@@ -14335,6 +14220,7 @@
       "dependencies": {
         "@cloudflare/containers": "^0.3.0",
         "aws4fetch": "^1.0.20",
+        "capnweb": "^0.6.1",
         "hono": "^4.7.11"
       },
       "devDependencies": {
@@ -14367,7 +14253,8 @@
       "dependencies": {
         "@repo/shared": "*",
         "acorn": "^8.14.0",
-        "async-mutex": "^0.5.0"
+        "async-mutex": "^0.5.0",
+        "capnweb": "^0.6.1"
       },
       "devDependencies": {
         "@repo/typescript-config": "*",
@@ -14407,83 +14294,6 @@
         "tailwindcss": "^4.1.17",
         "typescript": "^5.9.3",
         "wrangler": "^4.76.0"
-      }
-    },
-    "sites/sandbox/node_modules/@shikijs/core": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
-      "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4",
-        "hast-util-to-html": "^9.0.5"
-      }
-    },
-    "sites/sandbox/node_modules/@shikijs/engine-javascript": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
-      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "oniguruma-to-es": "^4.3.4"
-      }
-    },
-    "sites/sandbox/node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
-      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2"
-      }
-    },
-    "sites/sandbox/node_modules/@shikijs/langs": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
-      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0"
-      }
-    },
-    "sites/sandbox/node_modules/@shikijs/themes": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
-      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0"
-      }
-    },
-    "sites/sandbox/node_modules/@shikijs/types": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
-      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      }
-    },
-    "sites/sandbox/node_modules/shiki": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
-      "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/core": "3.23.0",
-        "@shikijs/engine-javascript": "3.23.0",
-        "@shikijs/engine-oniguruma": "3.23.0",
-        "@shikijs/langs": "3.23.0",
-        "@shikijs/themes": "3.23.0",
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
       }
     },
     "tooling/typescript-config": {

--- a/packages/sandbox-container/package.json
+++ b/packages/sandbox-container/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "@repo/shared": "*",
     "acorn": "^8.14.0",
-    "async-mutex": "^0.5.0"
+    "async-mutex": "^0.5.0",
+    "capnweb": "^0.6.1"
   },
   "devDependencies": {
     "@repo/typescript-config": "*",

--- a/packages/sandbox-container/src/core/container.ts
+++ b/packages/sandbox-container/src/core/container.ts
@@ -41,6 +41,7 @@ export interface Dependencies {
   // Infrastructure
   logger: Logger;
   security: SecurityService;
+  sessionManager: SessionManager;
 
   // Handlers
   backupHandler: BackupHandler;
@@ -166,6 +167,7 @@ export class Container {
       // Infrastructure
       logger,
       security,
+      sessionManager,
 
       // Handlers
       backupHandler,

--- a/packages/sandbox-container/src/handlers/desktop-handler.ts
+++ b/packages/sandbox-container/src/handlers/desktop-handler.ts
@@ -108,7 +108,7 @@ export class DesktopHandler extends BaseHandler<Request, Response> {
   ): Promise<Response> {
     const result = await this.desktopService.status();
     if (!result.success) return this.createErrorResponse(result.error, context);
-    return this.createTypedResponse({ success: true, ...result.data }, context);
+    return this.createTypedResponse(result.data, context);
   }
 
   private async handleScreenshot(
@@ -118,7 +118,7 @@ export class DesktopHandler extends BaseHandler<Request, Response> {
     const body = await this.parseRequestBody<DesktopScreenshotRequest>(request);
     const result = await this.desktopService.screenshot(body);
     if (!result.success) return this.createErrorResponse(result.error, context);
-    return this.createTypedResponse({ success: true, ...result.data }, context);
+    return this.createTypedResponse(result.data, context);
   }
 
   private async handleScreenshotRegion(
@@ -129,7 +129,7 @@ export class DesktopHandler extends BaseHandler<Request, Response> {
       await this.parseRequestBody<DesktopScreenshotRegionRequest>(request);
     const result = await this.desktopService.screenshotRegion(body);
     if (!result.success) return this.createErrorResponse(result.error, context);
-    return this.createTypedResponse({ success: true, ...result.data }, context);
+    return this.createTypedResponse(result.data, context);
   }
 
   private async handleMouseClick(
@@ -199,7 +199,7 @@ export class DesktopHandler extends BaseHandler<Request, Response> {
   ): Promise<Response> {
     const result = await this.desktopService.getCursorPosition();
     if (!result.success) return this.createErrorResponse(result.error, context);
-    return this.createTypedResponse({ success: true, ...result.data }, context);
+    return this.createTypedResponse(result.data, context);
   }
 
   private async handleKeyboardType(
@@ -248,7 +248,7 @@ export class DesktopHandler extends BaseHandler<Request, Response> {
   ): Promise<Response> {
     const result = await this.desktopService.getScreenSize();
     if (!result.success) return this.createErrorResponse(result.error, context);
-    return this.createTypedResponse({ success: true, ...result.data }, context);
+    return this.createTypedResponse(result.data, context);
   }
 
   private async handleProcessStatus(

--- a/packages/sandbox-container/src/handlers/interpreter-handler.ts
+++ b/packages/sandbox-container/src/handlers/interpreter-handler.ts
@@ -6,11 +6,12 @@ import type {
   InterpreterHealthResult,
   Logger
 } from '@repo/shared';
-import { ErrorCode } from '@repo/shared/errors';
+import { ErrorCode, getHttpStatus } from '@repo/shared/errors';
 
 import type { RequestContext } from '../core/types';
 import type {
   CreateContextRequest,
+  ExecutionEvent,
   InterpreterService
 } from '../services/interpreter-service';
 import { BaseHandler } from './base-handler';
@@ -169,14 +170,53 @@ export class InterpreterHandler extends BaseHandler<Request, Response> {
       language?: string;
     }>(request);
 
-    // The service returns a Response directly for streaming
-    // No need to wrap with ServiceResult as it's already handled
-    const response = await this.interpreterService.executeCode(
+    const result = await this.interpreterService.executeCodeEvents(
       body.context_id,
       body.code,
       body.language
     );
 
-    return response;
+    if (!result.success) {
+      const status = getHttpStatus(result.error.code as ErrorCode);
+      return new Response(
+        JSON.stringify({
+          error: result.error.message,
+          code: result.error.code,
+          details: result.error.details
+        }),
+        {
+          status,
+          headers: {
+            'Content-Type': 'application/json',
+            ...context.corsHeaders
+          }
+        }
+      );
+    }
+
+    const stream = new ReadableStream({
+      start(controller) {
+        const encoder = new TextEncoder();
+        for (const event of result.data) {
+          controller.enqueue(
+            encoder.encode(InterpreterHandler.formatSSE(event))
+          );
+        }
+        controller.close();
+      }
+    });
+
+    return new Response(stream, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        ...context.corsHeaders
+      }
+    });
+  }
+
+  private static formatSSE(event: ExecutionEvent): string {
+    return `data: ${JSON.stringify(event)}\n\n`;
   }
 }

--- a/packages/sandbox-container/src/lib/capnweb-bun.ts
+++ b/packages/sandbox-container/src/lib/capnweb-bun.ts
@@ -1,0 +1,146 @@
+// Vendored from https://github.com/cloudflare/capnweb/pull/159
+// Remove this file once capnweb publishes a release with Bun support.
+//
+// Copyright (c) 2026 Cloudflare, Inc.
+// Licensed under the MIT license found in the LICENSE.txt file or at:
+//     https://opensource.org/license/mit
+
+import type { ServerWebSocket } from 'bun';
+import { RpcSession, type RpcSessionOptions, type RpcTransport } from 'capnweb';
+
+/**
+ * Start an RPC session over a Bun ServerWebSocket.
+ *
+ * Returns both the stub and the transport. The transport must be wired to Bun's
+ * `WebSocketHandler` callbacks (`message`, `close`, `error`) by calling its
+ * `dispatchMessage`, `dispatchClose`, and `dispatchError` methods.
+ *
+ * For a zero-wiring alternative, see `newBunWebSocketRpcHandler`.
+ */
+export function newBunWebSocketRpcSession<T>(
+  ws: ServerWebSocket<T>,
+  localMain?: any,
+  options?: RpcSessionOptions
+): { stub: any; transport: BunWebSocketTransport<T> } {
+  const transport = new BunWebSocketTransport<T>(ws);
+  const rpc = new RpcSession(transport, localMain, options);
+  return { stub: rpc.getRemoteMain(), transport };
+}
+
+/**
+ * Create a Bun `WebSocketHandler` object that manages RPC sessions automatically.
+ *
+ * The returned object can be passed directly as the `websocket` option to `Bun.serve()`.
+ * A fresh `localMain` is created for each connection via the `createMain` callback.
+ * The transport is stored on `ws.data.__capnwebTransport`.
+ *
+ * @param createMain Called once per connection to create the main RPC interface for that client.
+ * @param options Optional RPC session options applied to every connection.
+ */
+function newBunWebSocketRpcHandler(
+  createMain: () => any,
+  options?: RpcSessionOptions
+) {
+  type WsData = {
+    __capnwebTransport: BunWebSocketTransport<WsData>;
+    __capnwebStub: any;
+  };
+
+  return {
+    open(ws: ServerWebSocket<WsData>) {
+      const transport = new BunWebSocketTransport<WsData>(ws);
+      const rpc = new RpcSession(transport, createMain(), options);
+      ws.data = {
+        __capnwebTransport: transport,
+        __capnwebStub: rpc.getRemoteMain()
+      };
+    },
+    message(ws: ServerWebSocket<WsData>, message: string | Buffer) {
+      ws.data.__capnwebTransport.dispatchMessage(message);
+    },
+    close(ws: ServerWebSocket<WsData>, code: number, reason: string) {
+      ws.data.__capnwebTransport.dispatchClose(code, reason);
+    },
+    error(ws: ServerWebSocket<WsData>, error: Error) {
+      ws.data.__capnwebTransport.dispatchError(error);
+    }
+  };
+}
+
+export class BunWebSocketTransport<T = undefined> implements RpcTransport {
+  #ws: ServerWebSocket<T>;
+  #receiveResolver?: (message: string) => void;
+  #receiveRejecter?: (err: any) => void;
+  #receiveQueue: string[] = [];
+  #error?: any;
+
+  constructor(ws: ServerWebSocket<T>) {
+    this.#ws = ws;
+  }
+
+  async send(message: string): Promise<void> {
+    this.#ws.send(message);
+  }
+
+  async receive(): Promise<string> {
+    if (this.#receiveQueue.length > 0) {
+      return this.#receiveQueue.shift()!;
+    }
+    if (this.#error) {
+      throw this.#error;
+    }
+    return new Promise<string>((resolve, reject) => {
+      this.#receiveResolver = resolve;
+      this.#receiveRejecter = reject;
+    });
+  }
+
+  abort?(reason: any): void {
+    let message: string;
+    if (reason instanceof Error) {
+      message = reason.message;
+    } else {
+      message = `${reason}`;
+    }
+    this.#ws.close(3000, message);
+
+    if (!this.#error) {
+      this.#error = reason;
+    }
+  }
+
+  dispatchMessage(data: string | Buffer): void {
+    if (this.#error) {
+      return;
+    }
+
+    const strData = typeof data === 'string' ? data : data.toString('utf-8');
+
+    if (this.#receiveResolver) {
+      this.#receiveResolver(strData);
+      this.#receiveResolver = undefined;
+      this.#receiveRejecter = undefined;
+    } else {
+      this.#receiveQueue.push(strData);
+    }
+  }
+
+  dispatchClose(code: number, reason: string): void {
+    this.#receivedError(new Error(`Peer closed WebSocket: ${code} ${reason}`));
+  }
+
+  dispatchError(_error: Error): void {
+    this.#receivedError(new Error('WebSocket connection failed.'));
+  }
+
+  #receivedError(reason: any) {
+    if (!this.#error) {
+      this.#error = reason;
+      if (this.#receiveRejecter) {
+        this.#receiveRejecter(reason);
+        this.#receiveResolver = undefined;
+        this.#receiveRejecter = undefined;
+      }
+    }
+  }
+}

--- a/packages/sandbox-container/src/rpc/sandbox-api.ts
+++ b/packages/sandbox-container/src/rpc/sandbox-api.ts
@@ -1,0 +1,1195 @@
+import type {
+  CheckChangesRequest,
+  CheckChangesResult,
+  DesktopCursorPosition,
+  DesktopMouseButton,
+  DesktopMouseClickRequest,
+  DesktopMouseDownRequest,
+  DesktopMouseDragRequest,
+  DesktopMouseScrollRequest,
+  DesktopMouseUpRequest,
+  DesktopScreenSize,
+  DesktopScreenshotRegionRequest,
+  DesktopScreenshotRequest,
+  DesktopScreenshotResult,
+  DesktopScrollDirection,
+  DesktopStartRequest,
+  DesktopStartResult,
+  DesktopStatusResult,
+  DesktopStopResult,
+  ExecutionError,
+  FileInfo,
+  ListFilesOptions,
+  Logger,
+  OutputMessage,
+  Result,
+  SandboxAPI as SandboxAPIInterface,
+  WatchRequest
+} from '@repo/shared';
+import { RpcTarget } from 'capnweb';
+import type {
+  CommandResult,
+  ProcessRecord,
+  ServiceError,
+  ServiceResult
+} from '../core/types';
+import type { BackupService } from '../services/backup-service';
+import type { DesktopService } from '../services/desktop-service';
+import type { FileService } from '../services/file-service';
+import type { GitService } from '../services/git-service';
+import type {
+  Context,
+  ExecutionEvent,
+  InterpreterService
+} from '../services/interpreter-service';
+import type { PortService } from '../services/port-service';
+import type { ProcessService } from '../services/process-service';
+import type { SessionManager } from '../services/session-manager';
+import type { WatchService } from '../services/watch-service';
+
+export interface SandboxAPIDeps {
+  processService: ProcessService;
+  fileService: FileService;
+  portService: PortService;
+  gitService: GitService;
+  interpreterService: InterpreterService;
+  backupService: BackupService;
+  desktopService: DesktopService;
+  watchService: WatchService;
+  sessionManager: SessionManager;
+  logger: Logger;
+}
+
+// ---------------------------------------------------------------------------
+// RPC error wrapper
+// ---------------------------------------------------------------------------
+
+class RPCError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any ServiceResult variant
+function throwIfError(result: ServiceResult<any, any>): void {
+  if (!result.success) {
+    const err = result.error;
+    throw new RPCError(`[${err.code}] ${err.message}`);
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any ServiceResult variant
+function extractData<T>(result: ServiceResult<any, any>): T {
+  throwIfError(result);
+  return (result as { data: T }).data;
+}
+
+/**
+ * Native RPC API exposed to capnweb clients.
+ *
+ * Each domain is exposed as a nested RpcTarget so the client can access
+ * them directly as `rpc.commands`, `rpc.files`, etc. Top-level methods
+ * handle utility and session management.
+ */
+export class SandboxAPI extends RpcTarget implements SandboxAPIInterface {
+  #deps: SandboxAPIDeps;
+
+  constructor(deps: SandboxAPIDeps) {
+    super();
+    this.#deps = deps;
+  }
+
+  // --- Domain sub-stubs (nested RpcTargets) --------------------------------
+
+  get commands() {
+    return new CommandsRPCAPI(this.#deps.processService);
+  }
+  get files() {
+    return new FilesRPCAPI(this.#deps.fileService);
+  }
+  get processes() {
+    return new ProcessesRPCAPI(this.#deps.processService);
+  }
+  get ports() {
+    return new PortsRPCAPI(this.#deps.portService, this.#deps.processService);
+  }
+  get git() {
+    return new GitRPCAPI(this.#deps.gitService);
+  }
+  get interpreter() {
+    return new InterpreterRPCAPI(this.#deps.interpreterService);
+  }
+  get utils() {
+    return new UtilsRPCAPI(this.#deps.sessionManager);
+  }
+  get backup() {
+    return new BackupRPCAPI(this.#deps.backupService);
+  }
+  get desktop() {
+    return new DesktopRPCAPI(this.#deps.desktopService);
+  }
+  get watch() {
+    return new WatchRPCAPI(this.#deps.watchService);
+  }
+}
+
+// ===========================================================================
+// Commands
+// ===========================================================================
+
+class CommandsRPCAPI extends RpcTarget {
+  #svc: ProcessService;
+  constructor(svc: ProcessService) {
+    super();
+    this.#svc = svc;
+  }
+
+  async execute(
+    command: string,
+    sessionId: string,
+    options?: {
+      timeoutMs?: number;
+      env?: Record<string, string | undefined>;
+      cwd?: string;
+    }
+  ): Promise<{
+    success: boolean;
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+    command: string;
+    timestamp: string;
+  }> {
+    const result = await this.#svc.executeCommand(command, {
+      sessionId,
+      timeoutMs: options?.timeoutMs,
+      env: options?.env,
+      cwd: options?.cwd
+    });
+    const data = extractData<CommandResult>(result);
+    return {
+      success: data.success,
+      exitCode: data.exitCode,
+      stdout: data.stdout,
+      stderr: data.stderr,
+      command,
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  async executeStream(
+    command: string,
+    sessionId: string,
+    options?: {
+      timeoutMs?: number;
+      env?: Record<string, string | undefined>;
+      cwd?: string;
+    }
+  ): Promise<ReadableStream<Uint8Array>> {
+    const encoder = new TextEncoder();
+    const result = await this.#svc.startProcess(command, {
+      sessionId,
+      timeoutMs: options?.timeoutMs,
+      env: options?.env,
+      cwd: options?.cwd
+    });
+
+    if (!result.success) {
+      return new ReadableStream({
+        start(controller) {
+          const event = {
+            type: 'error',
+            error: result.error.message,
+            timestamp: new Date().toISOString()
+          };
+          controller.enqueue(
+            encoder.encode(`event: error\ndata: ${JSON.stringify(event)}\n\n`)
+          );
+          controller.close();
+        }
+      });
+    }
+
+    const proc: ProcessRecord = result.data;
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            `event: start\ndata: ${JSON.stringify({ type: 'start', command, sessionId, pid: proc.pid, timestamp: new Date().toISOString() })}\n\n`
+          )
+        );
+        if (proc.stdout) {
+          controller.enqueue(
+            encoder.encode(
+              `event: stdout\ndata: ${JSON.stringify({ type: 'stdout', data: proc.stdout, timestamp: new Date().toISOString() })}\n\n`
+            )
+          );
+        }
+        if (proc.stderr) {
+          controller.enqueue(
+            encoder.encode(
+              `event: stderr\ndata: ${JSON.stringify({ type: 'stderr', data: proc.stderr, timestamp: new Date().toISOString() })}\n\n`
+            )
+          );
+        }
+
+        const outputListener = (stream: 'stdout' | 'stderr', data: string) => {
+          try {
+            controller.enqueue(
+              encoder.encode(
+                `event: ${stream}\ndata: ${JSON.stringify({ type: stream, data, timestamp: new Date().toISOString() })}\n\n`
+              )
+            );
+          } catch {
+            /* Stream closed */
+          }
+        };
+
+        const statusListener = (status: string) => {
+          if (['completed', 'failed', 'killed', 'error'].includes(status)) {
+            try {
+              controller.enqueue(
+                encoder.encode(
+                  `event: complete\ndata: ${JSON.stringify({ type: 'complete', exitCode: proc.exitCode, timestamp: new Date().toISOString() })}\n\n`
+                )
+              );
+              controller.close();
+            } catch {
+              /* Stream closed */
+            }
+            proc.outputListeners.delete(outputListener);
+            proc.statusListeners.delete(statusListener);
+          }
+        };
+
+        proc.outputListeners.add(outputListener);
+        proc.statusListeners.add(statusListener);
+        if (['completed', 'failed', 'killed', 'error'].includes(proc.status)) {
+          statusListener(proc.status);
+        }
+      }
+    });
+  }
+}
+
+// ===========================================================================
+// Files
+// ===========================================================================
+
+class FilesRPCAPI extends RpcTarget {
+  #svc: FileService;
+  constructor(svc: FileService) {
+    super();
+    this.#svc = svc;
+  }
+
+  async readFile(
+    path: string,
+    sessionId: string,
+    options?: { encoding?: string }
+  ) {
+    const result = await this.#svc.readFile(path, options, sessionId);
+    const content = extractData<string>(result);
+    const metadata = (
+      result as {
+        metadata?: {
+          encoding?: string;
+          isBinary?: boolean;
+          mimeType?: string;
+          size?: number;
+        };
+      }
+    ).metadata;
+    return {
+      success: true,
+      content,
+      path,
+      encoding: (metadata?.encoding ?? (options?.encoding || 'utf-8')) as
+        | 'utf-8'
+        | 'base64',
+      isBinary: metadata?.isBinary,
+      size: metadata?.size ?? content.length,
+      mimeType: metadata?.mimeType ?? 'text/plain',
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  async readFileStream(
+    path: string,
+    sessionId: string
+  ): Promise<ReadableStream<Uint8Array>> {
+    return this.#svc.readFileStreamOperation(path, sessionId);
+  }
+
+  async writeFile(
+    path: string,
+    content: string,
+    sessionId: string,
+    options?: { encoding?: string; permissions?: string }
+  ) {
+    const result = await this.#svc.writeFile(path, content, options, sessionId);
+    throwIfError(result);
+    return {
+      success: true,
+      path,
+      bytesWritten: new TextEncoder().encode(content).byteLength,
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  async writeFileStream(
+    path: string,
+    stream: ReadableStream<Uint8Array>,
+    sessionId: string
+  ) {
+    const result = await this.#svc.writeFileStream(path, stream, sessionId);
+    throwIfError(result);
+    const data = (result as { data?: { bytesWritten: number } }).data;
+    return {
+      success: true,
+      path,
+      bytesWritten: data?.bytesWritten ?? 0,
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  async deleteFile(path: string, sessionId: string) {
+    const result = await this.#svc.deleteFile(path, sessionId);
+    throwIfError(result);
+    return { success: true, path, timestamp: new Date().toISOString() };
+  }
+
+  async renameFile(oldPath: string, newPath: string, sessionId: string) {
+    const result = await this.#svc.renameFile(oldPath, newPath, sessionId);
+    throwIfError(result);
+    return {
+      success: true,
+      path: oldPath,
+      /** @deprecated */ oldPath,
+      newPath,
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  async moveFile(
+    sourcePath: string,
+    destinationPath: string,
+    sessionId: string
+  ) {
+    const result = await this.#svc.moveFile(
+      sourcePath,
+      destinationPath,
+      sessionId
+    );
+    throwIfError(result);
+    return {
+      success: true,
+      path: sourcePath,
+      newPath: destinationPath,
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  async mkdir(
+    path: string,
+    sessionId: string,
+    options?: { recursive?: boolean }
+  ) {
+    const result = await this.#svc.createDirectory(path, options, sessionId);
+    throwIfError(result);
+    return {
+      success: true,
+      path,
+      recursive: options?.recursive ?? false,
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  async listFiles(
+    path: string,
+    sessionId: string,
+    options?: ListFilesOptions
+  ): Promise<{
+    success: boolean;
+    files: FileInfo[];
+    count: number;
+    path: string;
+    timestamp: string;
+  }> {
+    const result = await this.#svc.listFiles(path, options, sessionId);
+    const files = extractData<FileInfo[]>(result);
+    return {
+      success: true,
+      files,
+      count: files.length,
+      path,
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  async exists(path: string, sessionId: string) {
+    const result = await this.#svc.exists(path, sessionId);
+    const exists = extractData<boolean>(result);
+    return { success: true, exists, path, timestamp: new Date().toISOString() };
+  }
+}
+
+// ===========================================================================
+// Processes
+// ===========================================================================
+
+class ProcessesRPCAPI extends RpcTarget {
+  #svc: ProcessService;
+  constructor(svc: ProcessService) {
+    super();
+    this.#svc = svc;
+  }
+
+  async startProcess(
+    command: string,
+    sessionId: string,
+    options?: { processId?: string; timeoutMs?: number }
+  ) {
+    const result = await this.#svc.startProcess(command, {
+      sessionId,
+      ...options
+    });
+    const proc = extractData<ProcessRecord>(result);
+    return {
+      success: true,
+      processId: proc.id,
+      pid: proc.pid,
+      command: proc.command,
+      timestamp: proc.startTime.toISOString()
+    };
+  }
+
+  async listProcesses() {
+    const result = await this.#svc.listProcesses();
+    const procs = extractData<ProcessRecord[]>(result);
+    return {
+      success: true,
+      processes: procs.map((p) => ({
+        id: p.id,
+        pid: p.pid,
+        command: p.command,
+        status: p.status,
+        startTime: p.startTime.toISOString(),
+        exitCode: p.exitCode
+      })),
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  async getProcess(id: string) {
+    const result = await this.#svc.getProcess(id);
+    const proc = extractData<ProcessRecord>(result);
+    return {
+      success: true,
+      process: {
+        id: proc.id,
+        pid: proc.pid,
+        command: proc.command,
+        status: proc.status,
+        startTime: proc.startTime.toISOString(),
+        exitCode: proc.exitCode
+      },
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  async killProcess(id: string) {
+    const result = await this.#svc.killProcess(id);
+    throwIfError(result);
+    return {
+      success: true,
+      processId: id,
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  async killAllProcesses() {
+    const result = await this.#svc.killAllProcesses();
+    const count = extractData<number>(result);
+    return {
+      success: true,
+      cleanedCount: count,
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  async getProcessLogs(id: string) {
+    const result = await this.#svc.getProcess(id);
+    const proc = extractData<ProcessRecord>(result);
+    return {
+      success: true,
+      processId: id,
+      stdout: proc.stdout,
+      stderr: proc.stderr,
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  async streamProcessLogs(id: string): Promise<ReadableStream<Uint8Array>> {
+    const encoder = new TextEncoder();
+    const result = await this.#svc.getProcess(id);
+    const proc = extractData<ProcessRecord>(result);
+
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        if (proc.stdout) {
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({ type: 'stdout', data: proc.stdout, processId: id, timestamp: new Date().toISOString() })}\n\n`
+            )
+          );
+        }
+        if (proc.stderr) {
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({ type: 'stderr', data: proc.stderr, processId: id, timestamp: new Date().toISOString() })}\n\n`
+            )
+          );
+        }
+        if (proc.status !== 'running') {
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({ type: 'exit', exitCode: proc.exitCode, processId: id, timestamp: new Date().toISOString() })}\n\n`
+            )
+          );
+          controller.close();
+          return;
+        }
+
+        const listener = (type: 'stdout' | 'stderr', data: string) => {
+          try {
+            controller.enqueue(
+              encoder.encode(
+                `data: ${JSON.stringify({ type, data, processId: id, timestamp: new Date().toISOString() })}\n\n`
+              )
+            );
+          } catch {
+            /* Stream closed */
+          }
+        };
+        proc.outputListeners.add(listener);
+
+        const statusListener = (status: string) => {
+          if (['completed', 'failed', 'killed', 'error'].includes(status)) {
+            try {
+              controller.enqueue(
+                encoder.encode(
+                  `data: ${JSON.stringify({ type: 'exit', exitCode: proc.exitCode, processId: id, timestamp: new Date().toISOString() })}\n\n`
+                )
+              );
+              controller.close();
+            } catch {
+              /* Stream closed */
+            }
+            proc.outputListeners.delete(listener);
+            proc.statusListeners.delete(statusListener);
+          }
+        };
+        proc.statusListeners.add(statusListener);
+      }
+    });
+  }
+}
+
+// ===========================================================================
+// Ports
+// ===========================================================================
+
+class PortsRPCAPI extends RpcTarget {
+  #portSvc: PortService;
+  #procSvc: ProcessService;
+  constructor(portSvc: PortService, procSvc: ProcessService) {
+    super();
+    this.#portSvc = portSvc;
+    this.#procSvc = procSvc;
+  }
+
+  async exposePort(port: number, _sessionId: string, name?: string) {
+    const result = await this.#portSvc.exposePort(port, name);
+    throwIfError(result);
+    return {
+      success: true,
+      port,
+      url: '',
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  async getExposedPorts(_sessionId: string) {
+    const result = await this.#portSvc.getExposedPorts();
+    const ports = extractData<Array<{ port: number; name?: string }>>(result);
+    return {
+      success: true,
+      ports: ports.map((p) => ({
+        port: p.port,
+        url: '',
+        status: 'active' as const
+      })),
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  async unexposePort(port: number, _sessionId: string) {
+    const result = await this.#portSvc.unexposePort(port);
+    throwIfError(result);
+    return { success: true, port, timestamp: new Date().toISOString() };
+  }
+
+  async watchPort(request: {
+    port: number;
+    mode: 'http' | 'tcp';
+    path?: string;
+    statusMin?: number;
+    statusMax?: number;
+    processId?: string;
+    interval?: number;
+  }): Promise<ReadableStream<Uint8Array>> {
+    const encoder = new TextEncoder();
+    const {
+      port,
+      mode,
+      path,
+      statusMin,
+      statusMax,
+      processId,
+      interval = 500
+    } = request;
+    const portSvc = this.#portSvc;
+    const procSvc = this.#procSvc;
+    let cancelled = false;
+    const clampedInterval = Math.max(100, Math.min(interval, 10000));
+
+    return new ReadableStream<Uint8Array>({
+      async start(controller) {
+        const emit = (event: Record<string, unknown>) => {
+          controller.enqueue(
+            encoder.encode(`data: ${JSON.stringify(event)}\n\n`)
+          );
+        };
+        emit({ type: 'watching', port });
+        try {
+          while (!cancelled) {
+            if (processId) {
+              const processResult = await procSvc.getProcess(processId);
+              if (!processResult.success) {
+                emit({ type: 'error', port, error: 'Process not found' });
+                return;
+              }
+              const proc = processResult.data;
+              if (
+                ['completed', 'failed', 'killed', 'error'].includes(proc.status)
+              ) {
+                emit({
+                  type: 'process_exited',
+                  port,
+                  exitCode: proc.exitCode ?? undefined
+                });
+                return;
+              }
+            }
+            const result = await portSvc.checkPortReady({
+              port,
+              mode,
+              path,
+              statusMin,
+              statusMax
+            });
+            if (result.ready) {
+              emit({ type: 'ready', port, statusCode: result.statusCode });
+              return;
+            }
+            await new Promise((resolve) =>
+              setTimeout(resolve, clampedInterval)
+            );
+          }
+        } catch (error) {
+          emit({
+            type: 'error',
+            port,
+            error: error instanceof Error ? error.message : 'Unknown error'
+          });
+        } finally {
+          controller.close();
+        }
+      },
+      cancel() {
+        cancelled = true;
+      }
+    });
+  }
+}
+
+// ===========================================================================
+// Git
+// ===========================================================================
+
+class GitRPCAPI extends RpcTarget {
+  #svc: GitService;
+  constructor(svc: GitService) {
+    super();
+    this.#svc = svc;
+  }
+
+  async checkout(
+    repoUrl: string,
+    sessionId: string,
+    options?: {
+      branch?: string;
+      targetDir?: string;
+      depth?: number;
+      timeoutMs?: number;
+    }
+  ) {
+    const result = await this.#svc.cloneRepository(repoUrl, {
+      branch: options?.branch,
+      targetDir: options?.targetDir,
+      depth: options?.depth,
+      timeoutMs: options?.timeoutMs,
+      sessionId
+    });
+    const data = extractData<{ path: string; branch: string }>(result);
+    return {
+      success: true,
+      repoUrl,
+      branch: data.branch ?? '',
+      targetDir: data.path,
+      timestamp: new Date().toISOString()
+    };
+  }
+}
+
+// ===========================================================================
+// Code Interpreter
+// ===========================================================================
+
+class InterpreterRPCAPI extends RpcTarget {
+  #svc: InterpreterService;
+  constructor(svc: InterpreterService) {
+    super();
+    this.#svc = svc;
+  }
+
+  async createCodeContext(options?: {
+    language?: string;
+    cwd?: string;
+  }): Promise<{
+    id: string;
+    language: string;
+    cwd: string;
+    createdAt: Date;
+    lastUsed: Date;
+  }> {
+    const result = await this.#svc.createContext(options || {});
+    const ctx = extractData<Context>(result);
+    return {
+      id: ctx.id,
+      language: ctx.language,
+      cwd: ctx.cwd,
+      createdAt: new Date(ctx.createdAt),
+      lastUsed: new Date(ctx.lastUsed)
+    };
+  }
+
+  async streamCode(
+    contextId: string,
+    code: string,
+    language?: string
+  ): Promise<ReadableStream<Uint8Array>> {
+    const result = await this.#svc.executeCodeEvents(contextId, code, language);
+    const events = extractData<ExecutionEvent[]>(result);
+    const encoder = new TextEncoder();
+
+    return new ReadableStream({
+      start(controller) {
+        for (const event of events) {
+          controller.enqueue(
+            encoder.encode(`data: ${JSON.stringify(event)}\n\n`)
+          );
+        }
+        controller.close();
+      }
+    });
+  }
+
+  /**
+   * Execute code and dispatch results via callbacks.
+   *
+   * capnweb stubs the callback functions so calls route back to the
+   * caller transparently.
+   */
+  async runCodeStream(
+    contextId: string | undefined,
+    code: string,
+    language: string | undefined,
+    callbacks: {
+      onStdout?: (output: OutputMessage) => void | Promise<void>;
+      onStderr?: (output: OutputMessage) => void | Promise<void>;
+      onResult?: (result: Result) => void | Promise<void>;
+      onError?: (error: ExecutionError) => void | Promise<void>;
+    },
+    _timeoutMs?: number
+  ): Promise<void> {
+    const result = await this.#svc.executeCodeEvents(
+      contextId ?? '',
+      code,
+      language
+    );
+    const events = extractData<ExecutionEvent[]>(result);
+
+    for (const event of events) {
+      await this.#dispatchEvent(event, callbacks);
+    }
+  }
+
+  async #dispatchEvent(
+    event: ExecutionEvent,
+    cb: {
+      onStdout?: (output: OutputMessage) => void | Promise<void>;
+      onStderr?: (output: OutputMessage) => void | Promise<void>;
+      onResult?: (result: Result) => void | Promise<void>;
+      onError?: (error: ExecutionError) => void | Promise<void>;
+    }
+  ): Promise<void> {
+    switch (event.type) {
+      case 'stdout':
+        await cb.onStdout?.({
+          text: event.text,
+          timestamp: Date.now()
+        });
+        break;
+      case 'stderr':
+        await cb.onStderr?.({
+          text: event.text,
+          timestamp: Date.now()
+        });
+        break;
+      case 'result':
+        // Send as a plain object — capnweb cannot serialize class instances.
+        await cb.onResult?.({
+          text: event.text as string | undefined,
+          html: event.html as string | undefined,
+          png: event.png as string | undefined,
+          jpeg: event.jpeg as string | undefined,
+          svg: event.svg as string | undefined,
+          latex: event.latex as string | undefined,
+          markdown: event.markdown as string | undefined,
+          javascript: event.javascript as string | undefined,
+          json: event.json as string | undefined,
+          data: event.data as Record<string, unknown> | undefined
+        } as Result);
+        break;
+      case 'error':
+        await cb.onError?.({
+          name: event.ename,
+          message: event.evalue,
+          traceback: event.traceback
+        });
+        break;
+    }
+  }
+
+  async listCodeContexts(): Promise<
+    Array<{
+      id: string;
+      language: string;
+      cwd: string;
+      createdAt: Date;
+      lastUsed: Date;
+    }>
+  > {
+    const result = await this.#svc.listContexts();
+    const contexts = extractData<Context[]>(result);
+    return contexts.map((c) => ({
+      id: c.id,
+      language: c.language,
+      cwd: c.cwd,
+      createdAt: new Date(c.createdAt),
+      lastUsed: new Date(c.lastUsed)
+    }));
+  }
+
+  async deleteCodeContext(contextId: string): Promise<void> {
+    const result = await this.#svc.deleteContext(contextId);
+    throwIfError(result);
+  }
+}
+
+// ===========================================================================
+// Utility
+// ===========================================================================
+
+class UtilsRPCAPI extends RpcTarget {
+  #mgr: SessionManager;
+  constructor(mgr: SessionManager) {
+    super();
+    this.#mgr = mgr;
+  }
+
+  async ping(): Promise<string> {
+    return 'healthy';
+  }
+
+  async getVersion(): Promise<string> {
+    try {
+      return process.env.SANDBOX_VERSION || 'unknown';
+    } catch {
+      return 'unknown';
+    }
+  }
+
+  /** Currently empty — the container does not maintain a command registry. */
+  async getCommands(): Promise<string[]> {
+    return [];
+  }
+
+  async createSession(options: {
+    id: string;
+    env?: Record<string, string | undefined>;
+    cwd?: string;
+  }) {
+    const result = await this.#mgr.createSession(options);
+    throwIfError(result);
+    return {
+      success: true,
+      id: options.id,
+      message: `Session ${options.id} created`,
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  async deleteSession(sessionId: string) {
+    const result = await this.#mgr.deleteSession(sessionId);
+    throwIfError(result);
+    return { success: true, sessionId, timestamp: new Date().toISOString() };
+  }
+
+  async listSessions() {
+    const result = await this.#mgr.listSessions();
+    const sessions = extractData<string[]>(result);
+    return { sessions };
+  }
+}
+
+// ===========================================================================
+// Backup
+// ===========================================================================
+
+class BackupRPCAPI extends RpcTarget {
+  #svc: BackupService;
+  constructor(svc: BackupService) {
+    super();
+    this.#svc = svc;
+  }
+
+  async createArchive(
+    dir: string,
+    archivePath: string,
+    sessionId: string,
+    options?: { excludes?: string[]; gitignore?: boolean }
+  ) {
+    const result = await this.#svc.createArchive(
+      dir,
+      archivePath,
+      sessionId,
+      options?.gitignore ?? false,
+      options?.excludes ?? []
+    );
+    const data = extractData<{ sizeBytes: number; archivePath: string }>(
+      result
+    );
+    return {
+      success: true,
+      sizeBytes: data.sizeBytes,
+      archivePath: data.archivePath
+    };
+  }
+
+  async restoreArchive(dir: string, archivePath: string, sessionId: string) {
+    const result = await this.#svc.restoreArchive(dir, archivePath, sessionId);
+    throwIfError(result);
+    return { success: true, dir };
+  }
+}
+
+// ===========================================================================
+// Desktop
+// ===========================================================================
+
+class DesktopRPCAPI extends RpcTarget {
+  #svc: DesktopService;
+  constructor(svc: DesktopService) {
+    super();
+    this.#svc = svc;
+  }
+
+  async start(options?: {
+    resolution?: [number, number];
+    dpi?: number;
+  }): Promise<DesktopStartResult> {
+    return extractData<DesktopStartResult>(
+      await this.#svc.start(options as DesktopStartRequest)
+    );
+  }
+  async stop(): Promise<DesktopStopResult> {
+    return extractData<DesktopStopResult>(await this.#svc.stop());
+  }
+  async status(): Promise<DesktopStatusResult> {
+    return extractData<DesktopStatusResult>(await this.#svc.status());
+  }
+  async screenshot(
+    options?: DesktopScreenshotRequest
+  ): Promise<DesktopScreenshotResult> {
+    return extractData<DesktopScreenshotResult>(
+      await this.#svc.screenshot(options)
+    );
+  }
+  async screenshotRegion(
+    request: DesktopScreenshotRegionRequest
+  ): Promise<DesktopScreenshotResult> {
+    return extractData<DesktopScreenshotResult>(
+      await this.#svc.screenshotRegion(request)
+    );
+  }
+
+  async click(
+    x: number,
+    y: number,
+    options?: { button?: DesktopMouseButton; clickCount?: number }
+  ): Promise<void> {
+    throwIfError(
+      await this.#svc.click({ x, y, ...options } as DesktopMouseClickRequest)
+    );
+  }
+  async doubleClick(x: number, y: number): Promise<void> {
+    await this.click(x, y, { clickCount: 2 });
+  }
+  async tripleClick(x: number, y: number): Promise<void> {
+    await this.click(x, y, { clickCount: 3 });
+  }
+  async rightClick(x: number, y: number): Promise<void> {
+    await this.click(x, y, { button: 'right' });
+  }
+  async middleClick(x: number, y: number): Promise<void> {
+    await this.click(x, y, { button: 'middle' });
+  }
+
+  async mouseDown(
+    x?: number,
+    y?: number,
+    options?: { button?: DesktopMouseButton }
+  ): Promise<void> {
+    throwIfError(
+      await this.#svc.mouseDown({ x, y, ...options } as DesktopMouseDownRequest)
+    );
+  }
+  async mouseUp(
+    x?: number,
+    y?: number,
+    options?: { button?: DesktopMouseButton }
+  ): Promise<void> {
+    throwIfError(
+      await this.#svc.mouseUp({ x, y, ...options } as DesktopMouseUpRequest)
+    );
+  }
+  async moveMouse(x: number, y: number): Promise<void> {
+    throwIfError(await this.#svc.moveMouse({ x, y }));
+  }
+  async drag(
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+    options?: { button?: DesktopMouseButton }
+  ): Promise<void> {
+    throwIfError(
+      await this.#svc.drag({
+        startX,
+        startY,
+        endX,
+        endY,
+        ...options
+      } as DesktopMouseDragRequest)
+    );
+  }
+  async scroll(
+    x: number,
+    y: number,
+    direction: DesktopScrollDirection,
+    amount?: number
+  ): Promise<void> {
+    throwIfError(
+      await this.#svc.scroll({
+        x,
+        y,
+        direction,
+        amount
+      } as DesktopMouseScrollRequest)
+    );
+  }
+
+  async getCursorPosition(): Promise<DesktopCursorPosition> {
+    return extractData<DesktopCursorPosition>(
+      await this.#svc.getCursorPosition()
+    );
+  }
+  async type(text: string, options?: { delay?: number }): Promise<void> {
+    throwIfError(await this.#svc.typeText({ text, ...options }));
+  }
+  async press(key: string): Promise<void> {
+    throwIfError(await this.#svc.keyPress({ key }));
+  }
+  async keyDown(key: string): Promise<void> {
+    throwIfError(await this.#svc.keyDown({ key }));
+  }
+  async keyUp(key: string): Promise<void> {
+    throwIfError(await this.#svc.keyUp({ key }));
+  }
+  async getScreenSize(): Promise<DesktopScreenSize> {
+    return extractData<DesktopScreenSize>(await this.#svc.getScreenSize());
+  }
+  async getProcessStatus(_name: string): Promise<DesktopStatusResult> {
+    return this.status();
+  }
+}
+
+// ===========================================================================
+// Watch
+// ===========================================================================
+
+class WatchRPCAPI extends RpcTarget {
+  #svc: WatchService;
+  constructor(svc: WatchService) {
+    super();
+    this.#svc = svc;
+  }
+
+  async watch(request: WatchRequest): Promise<ReadableStream<Uint8Array>> {
+    const result = await this.#svc.watchDirectory(request.path, {
+      path: request.path,
+      sessionId: request.sessionId ?? 'default',
+      recursive: request.recursive,
+      include: request.include,
+      exclude: request.exclude
+    });
+    return extractData<ReadableStream<Uint8Array>>(result);
+  }
+
+  async checkChanges(
+    request: CheckChangesRequest
+  ): Promise<CheckChangesResult> {
+    const result = await this.#svc.checkChanges(request.path, {
+      path: request.path,
+      sessionId: request.sessionId ?? 'default',
+      recursive: request.recursive,
+      include: request.include,
+      exclude: request.exclude,
+      since: request.since
+    });
+    return extractData<CheckChangesResult>(result);
+  }
+}

--- a/packages/sandbox-container/src/rpc/sandbox-api.ts
+++ b/packages/sandbox-container/src/rpc/sandbox-api.ts
@@ -74,7 +74,13 @@ class RPCError extends Error {
 function throwIfError(result: ServiceResult<any, any>): void {
   if (!result.success) {
     const err = result.error;
-    throw new RPCError(`[${err.code}] ${err.message}`);
+    throw new RPCError(
+      JSON.stringify({
+        code: err.code,
+        message: err.message,
+        context: err.details ?? {}
+      })
+    );
   }
 }
 

--- a/packages/sandbox-container/src/server.ts
+++ b/packages/sandbox-container/src/server.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@repo/shared';
 import type { ServerWebSocket } from 'bun';
 import { serve } from 'bun';
 import { trustRuntimeCert } from './cert';
+import { CONFIG } from './config';
 import { Container } from './core/container';
 import { Router } from './core/router';
 import type { PtyWSData } from './handlers/pty-ws-handler';
@@ -10,9 +11,23 @@ import {
   generateConnectionId,
   WebSocketAdapter
 } from './handlers/ws-adapter';
+import {
+  type BunWebSocketTransport,
+  newBunWebSocketRpcSession
+} from './lib/capnweb-bun';
 import { setupRoutes } from './routes/setup';
+import { SandboxAPI } from './rpc/sandbox-api';
 
-export type WSData = (ControlWSData & { type: 'control' }) | PtyWSData;
+export type CapnwebWSData = {
+  type: 'capnweb';
+  connectionId: string;
+  transport?: BunWebSocketTransport<WSData>;
+};
+
+export type WSData =
+  | (ControlWSData & { type: 'control' })
+  | PtyWSData
+  | CapnwebWSData;
 
 const logger = createLogger({ component: 'container' });
 const SERVER_PORT = 3000;
@@ -45,6 +60,7 @@ async function createApplication(): Promise<{
   ) => Promise<Response>;
   container: Container;
   wsAdapter: WebSocketAdapter;
+  rpcAPI: SandboxAPI;
 }> {
   const container = new Container();
   await container.initialize();
@@ -55,6 +71,20 @@ async function createApplication(): Promise<{
 
   // Create WebSocket adapter with the router for control plane multiplexing
   const wsAdapter = new WebSocketAdapter(router, logger);
+
+  // Create native RPC API that calls services directly (bypasses HTTP routing)
+  const rpcAPI = new SandboxAPI({
+    processService: container.get('processService'),
+    fileService: container.get('fileService'),
+    portService: container.get('portService'),
+    gitService: container.get('gitService'),
+    interpreterService: container.get('interpreterService'),
+    backupService: container.get('backupService'),
+    desktopService: container.get('desktopService'),
+    watchService: container.get('watchService'),
+    sessionManager: container.get('sessionManager'),
+    logger
+  });
 
   return {
     fetch: async (
@@ -88,6 +118,10 @@ async function createApplication(): Promise<{
             }
           });
           if (upgraded) {
+            // Bun's server.upgrade() handles the response internally — at runtime the
+            // fetch handler returns `undefined` to signal a successful upgrade. The Bun
+            // type signature requires `MaybePromise<Response>` (no `undefined`), so we
+            // cast through `unknown`. See: https://bun.sh/docs/api/websockets#upgrade
             return undefined as unknown as Response;
           }
           return new Response('WebSocket upgrade failed', { status: 500 });
@@ -105,13 +139,28 @@ async function createApplication(): Promise<{
           }
           return new Response('WebSocket upgrade failed', { status: 500 });
         }
+
+        if (url.pathname === '/rpc') {
+          logger.info('Establishing capnweb connection');
+          const upgraded = server.upgrade(req, {
+            data: {
+              type: 'capnweb' as const,
+              connectionId: generateConnectionId()
+            }
+          });
+          if (upgraded) {
+            return undefined as unknown as Response;
+          }
+          return new Response('WebSocket upgrade failed', { status: 500 });
+        }
       }
 
       // Regular HTTP request
       return router.route(req);
     },
     container,
-    wsAdapter
+    wsAdapter,
+    rpcAPI
   };
 }
 
@@ -150,6 +199,12 @@ export async function startServer(): Promise<ServerInstance> {
                   ws.close(1011, 'Internal error');
                 } catch {}
               });
+          } else if (ws.data.type === 'capnweb') {
+            const { transport } = newBunWebSocketRpcSession(ws, app.rpcAPI);
+            ws.data.transport = transport;
+            logger.debug('capnweb session initialized', {
+              connectionId: ws.data.connectionId
+            });
           } else {
             app.wsAdapter.onOpen(ws);
           }
@@ -166,6 +221,8 @@ export async function startServer(): Promise<ServerInstance> {
             app.container
               .get('ptyWsHandler')
               .onClose(ws as ServerWebSocket<PtyWSData>, code, reason);
+          } else if (ws.data.type === 'capnweb') {
+            ws.data.transport?.dispatchClose(code, reason);
           } else {
             app.wsAdapter.onClose(ws, code, reason);
           }
@@ -182,6 +239,8 @@ export async function startServer(): Promise<ServerInstance> {
             app.container
               .get('ptyWsHandler')
               .onMessage(ws as ServerWebSocket<PtyWSData>, message);
+          } else if (ws.data.type === 'capnweb') {
+            ws.data.transport?.dispatchMessage(message);
           } else {
             await app.wsAdapter.onMessage(ws, message);
           }

--- a/packages/sandbox-container/src/services/desktop-service.ts
+++ b/packages/sandbox-container/src/services/desktop-service.ts
@@ -88,6 +88,7 @@ export class DesktopService {
   async status(): Promise<ServiceResult<DesktopStatusResult>> {
     const managerStatus = this.manager.getStatus();
     return serviceSuccess<DesktopStatusResult>({
+      success: true,
       status: managerStatus.status,
       processes: managerStatus.processes,
       resolution: this.manager.getResolution(),
@@ -121,6 +122,7 @@ export class DesktopService {
       } catch {}
 
       return serviceSuccess<DesktopScreenshotResult>({
+        success: true,
         data,
         imageFormat,
         width: resolution[0],
@@ -152,6 +154,7 @@ export class DesktopService {
       } catch {}
 
       return serviceSuccess<DesktopScreenshotResult>({
+        success: true,
         data,
         imageFormat,
         width: w,
@@ -282,6 +285,7 @@ export class DesktopService {
         y: number;
       };
       return serviceSuccess<DesktopCursorPosition>({
+        success: true,
         x: result.x,
         y: result.y
       });
@@ -348,6 +352,7 @@ export class DesktopService {
         height: number;
       };
       return serviceSuccess<DesktopScreenSize>({
+        success: true,
         width: result.width,
         height: result.height
       });

--- a/packages/sandbox-container/src/services/file-service.ts
+++ b/packages/sandbox-container/src/services/file-service.ts
@@ -1,3 +1,4 @@
+import { chmod, rename, stat, unlink } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import type { FileInfo, ListFilesOptions, Logger } from '@repo/shared';
 import { logCanonicalEvent, shellEscape } from '@repo/shared';
@@ -1118,6 +1119,130 @@ export class FileService implements FileSystemOperations {
     sessionId?: string
   ): Promise<ServiceResult<void>> {
     return await this.write(path, content, options, sessionId);
+  }
+
+  /**
+   * Write a file from a ReadableStream.
+   * Streams bytes directly to disk without buffering the entire file in memory.
+   */
+  async writeFileStream(
+    path: string,
+    stream: ReadableStream<Uint8Array>,
+    sessionId = 'default'
+  ): Promise<ServiceResult<{ bytesWritten: number }>> {
+    try {
+      const validation = this.security.validatePath(path);
+      if (!validation.isValid) {
+        return {
+          success: false,
+          error: {
+            message: `Invalid path format for '${path}': ${validation.errors.join(', ')}`,
+            code: ErrorCode.VALIDATION_FAILED,
+            details: {
+              validationErrors: validation.errors.map((e) => ({
+                field: 'path',
+                message: e,
+                code: 'INVALID_PATH'
+              }))
+            } satisfies ValidationFailedContext
+          }
+        };
+      }
+
+      const writeResult = await this.sessionManager.withSession(
+        sessionId,
+        async (exec) => {
+          let targetPath = path;
+
+          if (!path.startsWith('/')) {
+            const pwdResult = await exec('pwd');
+            if (pwdResult.exitCode !== 0) {
+              throw {
+                code: ErrorCode.FILESYSTEM_ERROR,
+                message: `Failed to resolve working directory for '${path}'`,
+                details: {
+                  path,
+                  operation: Operation.FILE_WRITE,
+                  exitCode: pwdResult.exitCode,
+                  stderr: pwdResult.stderr
+                } satisfies FileSystemContext
+              };
+            }
+            const cwd = pwdResult.stdout.trim();
+            targetPath = resolve(cwd, path);
+          }
+
+          // Ensure parent directory exists
+          const dir = targetPath.substring(0, targetPath.lastIndexOf('/'));
+          if (dir) {
+            await exec(`mkdir -p ${shellEscape(dir)}`);
+          }
+
+          // Atomic write: stream to a temporary file, then rename into place.
+          // Prevents partial reads if another process opens the file mid-write.
+          // Preserves the original file's permission bits (e.g. executables).
+          const tmpPath = `${targetPath}.tmp.${crypto.randomUUID()}`;
+          const existingMode = await stat(targetPath)
+            .then((s) => s.mode)
+            .catch(() => null);
+          const writer = Bun.file(tmpPath).writer();
+          let bytesWritten = 0;
+          const reader = stream.getReader();
+          try {
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              writer.write(value);
+              bytesWritten += value.byteLength;
+            }
+            await writer.flush();
+            writer.end();
+            reader.releaseLock();
+            if (existingMode !== null) {
+              await chmod(tmpPath, existingMode);
+            }
+            await rename(tmpPath, targetPath);
+          } catch (err) {
+            writer.end();
+            reader.releaseLock();
+            await stream.cancel().catch(() => {});
+            await unlink(tmpPath).catch(() => {});
+            throw err;
+          }
+          return { bytesWritten };
+        }
+      );
+
+      if (!writeResult.success) {
+        return writeResult as ServiceResult<{ bytesWritten: number }>;
+      }
+
+      return {
+        success: true,
+        data: writeResult.data as { bytesWritten: number }
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(
+        'Failed to stream-write file',
+        error instanceof Error ? error : undefined,
+        { path }
+      );
+
+      return {
+        success: false,
+        error: {
+          message: `Failed to write file '${path}': ${errorMessage}`,
+          code: ErrorCode.FILESYSTEM_ERROR,
+          details: {
+            path,
+            operation: Operation.FILE_WRITE,
+            stderr: errorMessage
+          } satisfies FileSystemContext
+        }
+      };
+    }
   }
 
   async deleteFile(

--- a/packages/sandbox-container/src/services/interpreter-service.ts
+++ b/packages/sandbox-container/src/services/interpreter-service.ts
@@ -33,6 +33,17 @@ export interface HealthStatus {
   progress: number;
 }
 
+export type ExecutionEvent =
+  | { type: 'stdout'; text: string }
+  | { type: 'stderr'; text: string }
+  | {
+      type: 'result';
+      metadata: Record<string, unknown>;
+      [key: string]: unknown;
+    }
+  | { type: 'execution_complete'; execution_count: number }
+  | { type: 'error'; ename: string; evalue: string; traceback: string[] };
+
 export class InterpreterNotReadyError extends Error {
   progress: number;
   retryAfter: number;
@@ -258,53 +269,48 @@ export class InterpreterService {
   }
 
   /**
-   * Execute code in a context
-   * Returns a Response with streaming output (SSE format)
+   * Execute code in a context and return typed execution events.
    *
-   * Note: This method returns Response directly rather than ServiceResult<Response>
-   * because streaming responses need special handling. Error responses are still
-   * returned as Response objects with appropriate status codes.
+   * Callers decide how to serialize these events (SSE for HTTP, direct
+   * dispatch for RPC).
    */
-  async executeCode(
+  async executeCodeEvents(
     contextId: string,
     code: string,
     language?: string
-  ): Promise<Response> {
+  ): Promise<ServiceResult<ExecutionEvent[]>> {
     try {
       const context = this.contexts.get(contextId);
       if (!context) {
-        return new Response(
-          JSON.stringify({
-            error: `Context ${contextId} not found`
-          }),
-          {
-            status: 404,
-            headers: { 'Content-Type': 'application/json' }
+        return {
+          success: false,
+          error: {
+            message: `Context ${contextId} not found`,
+            code: ErrorCode.CONTEXT_NOT_FOUND,
+            details: {
+              contextId
+            } satisfies ContextNotFoundContext
           }
-        );
+        };
       }
 
       context.lastUsed = new Date().toISOString();
 
-      // Check if executor is healthy
       if (!processPool.isContextExecutorHealthy(contextId)) {
-        return new Response(
-          JSON.stringify({
-            error: `Context executor has terminated. Please delete and recreate the context.`,
+        return {
+          success: false,
+          error: {
+            message:
+              'Context executor has terminated. Please delete and recreate the context.',
             code: ErrorCode.INTERNAL_ERROR,
             details: {
               contextId
-            }
-          }),
-          {
-            status: 410,
-            headers: { 'Content-Type': 'application/json' }
+            } satisfies ContextNotFoundContext
           }
-        );
+        };
       }
 
       const execLanguage = this.mapLanguage(language || context.language);
-      const self = this;
 
       const result = await processPool.execute(
         execLanguage,
@@ -313,134 +319,61 @@ export class InterpreterService {
         undefined
       );
 
-      const stream = new ReadableStream({
-        start(controller) {
-          const encoder = new TextEncoder();
+      const events: ExecutionEvent[] = [];
 
-          try {
-            if (result.stdout) {
-              controller.enqueue(
-                encoder.encode(
-                  self.formatSSE({
-                    type: 'stdout',
-                    text: result.stdout
-                  })
-                )
-              );
-            }
+      if (result.stdout) {
+        events.push({ type: 'stdout', text: result.stdout });
+      }
 
-            if (result.stderr) {
-              controller.enqueue(
-                encoder.encode(
-                  self.formatSSE({
-                    type: 'stderr',
-                    text: result.stderr
-                  })
-                )
-              );
-            }
+      if (result.stderr) {
+        events.push({ type: 'stderr', text: result.stderr });
+      }
 
-            if (result.outputs && result.outputs.length > 0) {
-              for (const output of result.outputs) {
-                const outputData = self.formatOutputData(output);
-                controller.enqueue(
-                  encoder.encode(
-                    self.formatSSE({
-                      type: 'result',
-                      ...outputData,
-                      metadata: output.metadata || {}
-                    })
-                  )
-                );
-              }
-            }
-
-            if (result.success) {
-              controller.enqueue(
-                encoder.encode(
-                  self.formatSSE({
-                    type: 'execution_complete',
-                    execution_count: 1
-                  })
-                )
-              );
-            } else if (result.error) {
-              controller.enqueue(
-                encoder.encode(
-                  self.formatSSE({
-                    type: 'error',
-                    ename: result.error.type || 'ExecutionError',
-                    evalue: result.error.message || 'Code execution failed',
-                    traceback: result.error.traceback
-                      ? result.error.traceback.split('\n')
-                      : []
-                  })
-                )
-              );
-            } else {
-              controller.enqueue(
-                encoder.encode(
-                  self.formatSSE({
-                    type: 'error',
-                    ename: 'ExecutionError',
-                    evalue: result.stderr || 'Code execution failed',
-                    traceback: []
-                  })
-                )
-              );
-            }
-
-            controller.close();
-          } catch (error) {
-            self.logger.error('Code execution failed', error as Error, {
-              contextId,
-              language: execLanguage
-            });
-
-            controller.enqueue(
-              encoder.encode(
-                self.formatSSE({
-                  type: 'error',
-                  ename: 'InternalError',
-                  evalue:
-                    error instanceof Error ? error.message : String(error),
-                  traceback: []
-                })
-              )
-            );
-
-            controller.close();
-          }
+      if (result.outputs && result.outputs.length > 0) {
+        for (const output of result.outputs) {
+          events.push({
+            type: 'result',
+            ...InterpreterService.formatOutputData(output),
+            metadata: output.metadata || {}
+          });
         }
-      });
+      }
 
-      return new Response(stream, {
-        headers: {
-          'Content-Type': 'text/event-stream',
-          'Cache-Control': 'no-cache',
-          Connection: 'keep-alive'
-        }
-      });
+      if (result.success) {
+        events.push({ type: 'execution_complete', execution_count: 1 });
+      } else if (result.error) {
+        events.push({
+          type: 'error',
+          ename: result.error.type || 'ExecutionError',
+          evalue: result.error.message || 'Code execution failed',
+          traceback: result.error.traceback
+            ? result.error.traceback.split('\n')
+            : []
+        });
+      } else {
+        events.push({
+          type: 'error',
+          ename: 'ExecutionError',
+          evalue: result.stderr || 'Code execution failed',
+          traceback: []
+        });
+      }
+
+      return { success: true, data: events };
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      // Return error as JSON response
-      return new Response(
-        JSON.stringify({
-          error: {
-            message: `Failed to execute code in context '${contextId}': ${errorMessage}`,
-            code: ErrorCode.CODE_EXECUTION_ERROR,
-            details: {
-              contextId,
-              evalue: errorMessage
-            } satisfies CodeExecutionContext
-          }
-        }),
-        {
-          status: 500,
-          headers: { 'Content-Type': 'application/json' }
+      return {
+        success: false,
+        error: {
+          message: `Failed to execute code in context '${contextId}': ${errorMessage}`,
+          code: ErrorCode.CODE_EXECUTION_ERROR,
+          details: {
+            contextId,
+            evalue: errorMessage
+          } satisfies CodeExecutionContext
         }
-      );
+      };
     }
   }
 
@@ -463,7 +396,7 @@ export class InterpreterService {
     }
   }
 
-  private formatOutputData(output: RichOutput): Record<string, unknown> {
+  static formatOutputData(output: RichOutput): Record<string, unknown> {
     const result: Record<string, unknown> = {};
 
     switch (output.type) {
@@ -502,15 +435,5 @@ export class InterpreterService {
     }
 
     return result;
-  }
-
-  /**
-   * Format event as SSE (Server-Sent Events)
-   * SSE format requires "data: " prefix and double newline separator
-   * @param event - Event object to send
-   * @returns SSE-formatted string
-   */
-  private formatSSE(event: Record<string, unknown>): string {
-    return `data: ${JSON.stringify(event)}\n\n`;
   }
 }

--- a/packages/sandbox-container/src/workers/desktop-worker.ts
+++ b/packages/sandbox-container/src/workers/desktop-worker.ts
@@ -192,8 +192,8 @@ const handlers: { [Op in DesktopWorkerOp]: Handler<Op> } = {
     checkError(bindings.keyTap!(msg.key, msg.modifiers ?? ''), 'KeyTap');
     return { success: true };
   },
-  getScreenSize: () => bindings.getScreenSize!(),
-  getMousePos: () => bindings.getMousePos!(),
+  getScreenSize: () => ({ success: true, ...bindings.getScreenSize!() }),
+  getMousePos: () => ({ success: true, ...bindings.getMousePos!() }),
   mouseDown: (msg) => {
     if (msg.x !== undefined && msg.y !== undefined) {
       checkError(bindings.move!(Math.trunc(msg.x), Math.trunc(msg.y)), 'Move');

--- a/packages/sandbox-container/tests/handlers/desktop-handler.test.ts
+++ b/packages/sandbox-container/tests/handlers/desktop-handler.test.ts
@@ -58,6 +58,7 @@ describe('DesktopHandler', () => {
         Promise.resolve({
           success: true,
           data: {
+            success: true,
             status: 'active',
             processes: {},
             resolution: [1920, 1080],
@@ -69,6 +70,7 @@ describe('DesktopHandler', () => {
         Promise.resolve({
           success: true,
           data: {
+            success: true,
             data: 'base64-image',
             imageFormat: 'png',
             width: 1920,
@@ -80,6 +82,7 @@ describe('DesktopHandler', () => {
         Promise.resolve({
           success: true,
           data: {
+            success: true,
             data: 'base64-image',
             imageFormat: 'png',
             width: 400,
@@ -94,14 +97,20 @@ describe('DesktopHandler', () => {
       drag: mock(() => Promise.resolve({ success: true })),
       scroll: mock(() => Promise.resolve({ success: true })),
       getCursorPosition: mock(() =>
-        Promise.resolve({ success: true, data: { x: 120, y: 300 } })
+        Promise.resolve({
+          success: true,
+          data: { success: true, x: 120, y: 300 }
+        })
       ),
       typeText: mock(() => Promise.resolve({ success: true })),
       keyPress: mock(() => Promise.resolve({ success: true })),
       keyDown: mock(() => Promise.resolve({ success: true })),
       keyUp: mock(() => Promise.resolve({ success: true })),
       getScreenSize: mock(() =>
-        Promise.resolve({ success: true, data: { width: 1920, height: 1080 } })
+        Promise.resolve({
+          success: true,
+          data: { success: true, width: 1920, height: 1080 }
+        })
       ),
       getProcessStatus: mock(() =>
         Promise.resolve({

--- a/packages/sandbox-container/tests/handlers/interpreter-handler.test.ts
+++ b/packages/sandbox-container/tests/handlers/interpreter-handler.test.ts
@@ -16,6 +16,7 @@ import { InterpreterHandler } from '@sandbox-container/handlers/interpreter-hand
 import type {
   Context,
   CreateContextRequest,
+  ExecutionEvent,
   HealthStatus,
   InterpreterService
 } from '@sandbox-container/services/interpreter-service';
@@ -27,7 +28,7 @@ const mockInterpreterService = {
   createContext: vi.fn(),
   listContexts: vi.fn(),
   deleteContext: vi.fn(),
-  executeCode: vi.fn()
+  executeCodeEvents: vi.fn()
 } as unknown as InterpreterService;
 
 const mockLogger = {
@@ -406,33 +407,15 @@ describe('InterpreterHandler', () => {
 
   describe('handle - Execute Code', () => {
     it('should execute code and return streaming response', async () => {
-      // Mock streaming response from service
-      const mockStream = new ReadableStream({
-        start(controller) {
-          controller.enqueue(
-            'data: {"type":"start","timestamp":"2023-01-01T00:00:00Z"}\n\n'
-          );
-          controller.enqueue(
-            'data: {"type":"stdout","data":"Hello World\\n","timestamp":"2023-01-01T00:00:01Z"}\n\n'
-          );
-          controller.enqueue(
-            'data: {"type":"complete","exitCode":0,"timestamp":"2023-01-01T00:00:02Z"}\n\n'
-          );
-          controller.close();
-        }
-      });
+      const mockEvents: ExecutionEvent[] = [
+        { type: 'stdout', text: 'Hello World\n' },
+        { type: 'execution_complete', execution_count: 1 }
+      ];
 
-      const mockStreamResponse = new Response(mockStream, {
-        status: 200,
-        headers: {
-          'Content-Type': 'text/event-stream',
-          'Cache-Control': 'no-cache'
-        }
+      mocked(mockInterpreterService.executeCodeEvents).mockResolvedValue({
+        success: true,
+        data: mockEvents
       });
-
-      mocked(mockInterpreterService.executeCode).mockResolvedValue(
-        mockStreamResponse
-      );
 
       const executeRequest = {
         context_id: 'ctx-123',
@@ -448,14 +431,12 @@ describe('InterpreterHandler', () => {
 
       const response = await interpreterHandler.handle(request, mockContext);
 
-      // Verify streaming response
       expect(response.status).toBe(200);
       expect(response.headers.get('Content-Type')).toBe('text/event-stream');
       expect(response.headers.get('Cache-Control')).toBe('no-cache');
       expect(response.body).toBeDefined();
 
-      // Verify service was called correctly
-      expect(mockInterpreterService.executeCode).toHaveBeenCalledWith(
+      expect(mockInterpreterService.executeCodeEvents).toHaveBeenCalledWith(
         'ctx-123',
         'print("Hello World")',
         'python'
@@ -463,24 +444,14 @@ describe('InterpreterHandler', () => {
     });
 
     it('should handle execute code errors', async () => {
-      // Mock error response from service
-      const mockErrorResponse = new Response(
-        JSON.stringify({
-          code: ErrorCode.CONTEXT_NOT_FOUND,
+      mocked(mockInterpreterService.executeCodeEvents).mockResolvedValue({
+        success: false,
+        error: {
           message: 'Context not found',
-          context: { contextId: 'ctx-invalid' },
-          httpStatus: 404,
-          timestamp: new Date().toISOString()
-        }),
-        {
-          status: 404,
-          headers: { 'Content-Type': 'application/json' }
+          code: ErrorCode.CONTEXT_NOT_FOUND,
+          details: { contextId: 'ctx-invalid' }
         }
-      );
-
-      mocked(mockInterpreterService.executeCode).mockResolvedValue(
-        mockErrorResponse
-      );
+      });
 
       const executeRequest = {
         context_id: 'ctx-invalid',
@@ -496,14 +467,15 @@ describe('InterpreterHandler', () => {
 
       const response = await interpreterHandler.handle(request, mockContext);
 
-      // Verify error response: {code, message, context, httpStatus, timestamp}
       expect(response.status).toBe(404);
-      const responseData = (await response.json()) as ErrorResponse;
+      const responseData = (await response.json()) as {
+        error: string;
+        code: string;
+        details: { contextId: string };
+      };
       expect(responseData.code).toBe(ErrorCode.CONTEXT_NOT_FOUND);
-      expect(responseData.message).toBe('Context not found');
-      expect(responseData.context).toMatchObject({ contextId: 'ctx-invalid' });
-      expect(responseData.httpStatus).toBe(404);
-      expect(responseData.timestamp).toBeDefined();
+      expect(responseData.error).toBe('Context not found');
+      expect(responseData.details).toMatchObject({ contextId: 'ctx-invalid' });
     });
   });
 

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@cloudflare/containers": "^0.3.0",
     "aws4fetch": "^1.0.20",
+    "capnweb": "^0.6.1",
     "hono": "^4.7.11"
   },
   "devDependencies": {

--- a/packages/sandbox/src/clients/rpc-sandbox-client.ts
+++ b/packages/sandbox/src/clients/rpc-sandbox-client.ts
@@ -1,0 +1,411 @@
+/**
+ * SandboxClient implementation backed by direct capnweb RPC calls.
+ *
+ * The server exposes each domain (commands, files, processes, etc.) as a
+ * nested RpcTarget. capnweb returns typed stubs for these so the client
+ * can use `rpc.commands`, `rpc.files`, etc. directly without any
+ * per-method boilerplate.
+ *
+ * Manages its own connection lifecycle: creates a fresh ContainerConnection
+ * on demand and disconnects it after a configurable idle period. Idle
+ * detection uses capnweb's `RpcSession.getStats()` which naturally tracks
+ * all in-flight RPC calls, streams, and peer-held references — no manual
+ * operation counting required.
+ */
+
+import type {
+  Logger,
+  SandboxBackupAPI,
+  SandboxCommandsAPI,
+  SandboxDesktopAPI,
+  SandboxFilesAPI,
+  SandboxGitAPI,
+  SandboxInterpreterAPI,
+  SandboxPortsAPI,
+  SandboxProcessesAPI,
+  SandboxUtilsAPI,
+  SandboxWatchAPI
+} from '@repo/shared';
+import { createNoOpLogger } from '@repo/shared';
+import {
+  type ErrorCode,
+  type ErrorResponse,
+  getHttpStatus
+} from '@repo/shared/errors';
+import {
+  ContainerConnection,
+  type ContainerConnectionOptions
+} from '../container-connection';
+import { createErrorFromResponse } from '../errors/adapter';
+import type { SandboxClient } from './sandbox-client';
+import type { TransportMode } from './transport';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Close the idle capnweb WebSocket promptly so the DO can sleep. */
+const DEFAULT_IDLE_DISCONNECT_MS = 1_000;
+
+/**
+ * Baseline getStats() values for an idle session. The bootstrap stub on each
+ * side accounts for 1 import and 1 export.
+ */
+const IDLE_IMPORT_THRESHOLD = 1;
+const IDLE_EXPORT_THRESHOLD = 1;
+
+// ---------------------------------------------------------------------------
+// Error translation
+// ---------------------------------------------------------------------------
+
+interface RPCErrorPayload {
+  code: string;
+  message: string;
+  context?: Record<string, unknown>;
+}
+
+/**
+ * Translate a capnweb-propagated error into a typed SandboxError.
+ *
+ * capnweb only preserves `error.name` and `error.message` across the wire.
+ * The container encodes the full error as a JSON object in the message
+ * string: `{"code":"...","message":"...","context":{...}}`.
+ */
+function translateRPCError(error: unknown): never {
+  if (error instanceof Error) {
+    try {
+      const payload = JSON.parse(error.message) as RPCErrorPayload;
+      if (
+        typeof payload.code === 'string' &&
+        typeof payload.message === 'string'
+      ) {
+        throw createErrorFromResponse({
+          code: payload.code as ErrorCode,
+          message: payload.message,
+          context: payload.context ?? {},
+          httpStatus: getHttpStatus(payload.code as ErrorCode),
+          timestamp: new Date().toISOString()
+        });
+      }
+    } catch (e) {
+      if (e instanceof Error && e !== error) throw e;
+    }
+  }
+  throw error;
+}
+
+/**
+ * Wrap a capnweb RPC stub so that every method call translates errors
+ * from the `[CODE] message` wire format into typed SandboxError instances.
+ *
+ * `onCallStarted` fires synchronously when an RPC method is invoked.
+ * `onCallSettled` fires after each promise-returning call resolves or
+ * rejects. The RPCSandboxClient uses these to renew the DO activity
+ * timeout (start) and check for idle disconnect (settle).
+ */
+function wrapStub<T extends object>(
+  stub: T,
+  onCallStarted?: () => void,
+  onCallSettled?: () => void
+): T {
+  return new Proxy(stub, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== 'function') return value;
+      // Return a wrapper that catches errors from the RPC call.
+      // Use Reflect.apply instead of value.apply() because capnweb
+      // stubs are Proxies that interpret .apply as an RPC property access.
+      return (...args: unknown[]) => {
+        onCallStarted?.();
+        try {
+          const result = Reflect.apply(
+            value as (...a: unknown[]) => unknown,
+            target,
+            args
+          );
+          // capnweb RpcPromise is a Proxy with typeof 'function',
+          // so check for .then directly rather than typeof 'object'.
+          if (
+            result != null &&
+            typeof (result as { then?: unknown }).then === 'function'
+          ) {
+            return (result as Promise<unknown>)
+              .catch(translateRPCError)
+              .finally(() => onCallSettled?.());
+          }
+          // Non-promise return: settle immediately so the inflight
+          // counter doesn't drift.
+          onCallSettled?.();
+          return result;
+        } catch (err) {
+          // Synchronous throw: settle before re-throwing so the
+          // inflight counter doesn't drift.
+          onCallSettled?.();
+          translateRPCError(err);
+        }
+      };
+    }
+  });
+}
+// ---------------------------------------------------------------------------
+// Public client
+// ---------------------------------------------------------------------------
+
+export interface RPCSandboxClientOptions extends ContainerConnectionOptions {
+  /** Idle timeout before disconnecting the WebSocket (ms). Defaults to 1 000. */
+  idleDisconnectMs?: number;
+  /**
+   * Fires at the start of each RPC call. The Sandbox DO wires this to
+   * increment inflightRequests and renew the activity timeout, matching
+   * what containerFetch() does for the HTTP transport.
+   */
+  onActivity?: () => void;
+  /**
+   * Fires after each RPC call settles. The Sandbox DO wires this to
+   * decrement inflightRequests and renew the activity timeout when the
+   * count reaches zero, matching containerFetch's finally block.
+   */
+  onIdle?: () => void;
+}
+
+/**
+ * SandboxClient backed by direct capnweb RPC.
+ *
+ * Drop-in replacement for SandboxClient when the capnweb transport is active.
+ * All operations call the container's SandboxRPCAPI directly over capnweb,
+ * bypassing the HTTP handler/router layer entirely.
+ *
+ * Manages its own WebSocket lifecycle: a fresh `ContainerConnection` is
+ * created on demand and torn down after `idleDisconnectMs` of inactivity.
+ * Idle detection relies on `RpcSession.getStats()` which tracks all in-flight
+ * RPC calls and streams — including long-lived streaming RPCs that would be
+ * invisible to a simple request counter.
+ */
+export class RPCSandboxClient {
+  private readonly connOptions: ContainerConnectionOptions;
+  private readonly idleDisconnectMs: number;
+  private readonly logger: Logger;
+  private readonly onActivity: (() => void) | undefined;
+  private readonly onIdle: (() => void) | undefined;
+
+  private conn: ContainerConnection | null = null;
+  private idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(options: RPCSandboxClientOptions) {
+    this.connOptions = {
+      stub: options.stub,
+      port: options.port,
+      logger: options.logger
+    };
+    this.idleDisconnectMs =
+      options.idleDisconnectMs ?? DEFAULT_IDLE_DISCONNECT_MS;
+    this.logger = options.logger ?? createNoOpLogger();
+    this.onActivity = options.onActivity;
+    this.onIdle = options.onIdle;
+  }
+
+  // -------------------------------------------------------------------------
+  // Connection factory
+  // -------------------------------------------------------------------------
+
+  /**
+   * Return the current connection, creating a new one if none exists or the
+   * previous one was torn down by an idle disconnect.
+   */
+  private getConnection(): ContainerConnection {
+    if (!this.conn) {
+      this.conn = new ContainerConnection(this.connOptions);
+    }
+    return this.conn;
+  }
+
+  // -------------------------------------------------------------------------
+  // Idle disconnect
+  // -------------------------------------------------------------------------
+
+  /**
+   * Called synchronously at the start of each RPC method invocation.
+   * Renews the DO activity timeout so the sleepAfter alarm is pushed
+   * forward before the container processes the call.
+   */
+  private renewActivity = (): void => {
+    this.onActivity?.();
+  };
+
+  /**
+   * Called after each RPC promise settles. Decrements the DO's inflight
+   * counter via onIdle, then checks whether the capnweb session is idle
+   * enough to disconnect the WebSocket.
+   */
+  private checkIdle = (): void => {
+    this.onIdle?.();
+    const conn = this.conn;
+    if (!conn || !conn.isConnected()) return;
+
+    const { imports, exports } = conn.getStats();
+    if (imports <= IDLE_IMPORT_THRESHOLD && exports <= IDLE_EXPORT_THRESHOLD) {
+      this.scheduleIdleDisconnect();
+    } else {
+      // Still busy — clear any pending timer and wait for the next settle.
+      this.clearIdleTimer();
+    }
+  };
+
+  private scheduleIdleDisconnect(): void {
+    this.clearIdleTimer();
+    this.idleTimer = setTimeout(() => {
+      this.idleTimer = null;
+      // Re-check before disconnecting — a new call may have started.
+      const conn = this.conn;
+      if (!conn || !conn.isConnected()) return;
+
+      const { imports, exports } = conn.getStats();
+      if (
+        imports <= IDLE_IMPORT_THRESHOLD &&
+        exports <= IDLE_EXPORT_THRESHOLD
+      ) {
+        this.logger.debug('Disconnecting idle capnweb connection');
+        this.destroyConnection();
+      }
+    }, this.idleDisconnectMs);
+  }
+
+  private clearIdleTimer(): void {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+  }
+
+  private destroyConnection(): void {
+    if (this.conn) {
+      this.conn.disconnect();
+      this.conn = null;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Sub-client getters
+  // -------------------------------------------------------------------------
+
+  // Each getter returns the corresponding nested RpcTarget stub
+  // wrapped in a Proxy that translates RPC errors into SandboxError
+  // subclasses. Explicit return types prevent capnweb's recursive
+  // type machinery from expanding in .d.ts output (causes OOM).
+
+  get commands(): SandboxCommandsAPI {
+    return wrapStub(
+      this.getConnection().rpc().commands,
+      this.renewActivity,
+      this.checkIdle
+    );
+  }
+  get files(): SandboxFilesAPI {
+    return wrapStub(
+      this.getConnection().rpc().files,
+      this.renewActivity,
+      this.checkIdle
+    );
+  }
+  get processes(): SandboxProcessesAPI {
+    return wrapStub(
+      this.getConnection().rpc().processes,
+      this.renewActivity,
+      this.checkIdle
+    );
+  }
+  get ports(): SandboxPortsAPI {
+    return wrapStub(
+      this.getConnection().rpc().ports,
+      this.renewActivity,
+      this.checkIdle
+    );
+  }
+  get git(): SandboxGitAPI {
+    return wrapStub(
+      this.getConnection().rpc().git,
+      this.renewActivity,
+      this.checkIdle
+    );
+  }
+  get utils(): SandboxUtilsAPI {
+    return wrapStub(
+      this.getConnection().rpc().utils,
+      this.renewActivity,
+      this.checkIdle
+    );
+  }
+  get backup(): SandboxBackupAPI {
+    return wrapStub(
+      this.getConnection().rpc().backup,
+      this.renewActivity,
+      this.checkIdle
+    );
+  }
+  get desktop(): SandboxDesktopAPI {
+    return wrapStub(
+      this.getConnection().rpc().desktop,
+      this.renewActivity,
+      this.checkIdle
+    );
+  }
+  get watch(): SandboxWatchAPI {
+    return wrapStub(
+      this.getConnection().rpc().watch,
+      this.renewActivity,
+      this.checkIdle
+    );
+  }
+  get interpreter(): SandboxInterpreterAPI {
+    return wrapStub(
+      this.getConnection().rpc().interpreter,
+      this.renewActivity,
+      this.checkIdle
+    );
+  }
+
+  setRetryTimeoutMs(_ms: number): void {
+    // RPC transport does not use HTTP retry budgets
+  }
+
+  getTransportMode(): TransportMode {
+    return 'rpc';
+  }
+
+  isWebSocketConnected(): boolean {
+    return this.conn?.isConnected() ?? false;
+  }
+
+  async connect(): Promise<void> {
+    await this.getConnection().connect();
+  }
+
+  disconnect(): void {
+    this.clearIdleTimer();
+    this.destroyConnection();
+  }
+
+  async writeFileStream(
+    path: string,
+    stream: ReadableStream<Uint8Array>,
+    sessionId: string
+  ): Promise<{
+    success: boolean;
+    path: string;
+    bytesWritten: number;
+    timestamp: string;
+  }> {
+    return this.files.writeFileStream(path, stream, sessionId);
+  }
+}
+
+/**
+ * Extracts the public key set of a type. Used to verify that
+ * RPCSandboxClient exposes the same top-level properties and methods
+ * as SandboxClient without requiring deep structural compatibility
+ * (sub-clients are capnweb stubs, not HTTP client class instances).
+ */
+type PublicKeys<T> = { [K in keyof T]: unknown };
+
+// Compile-time check: RPCSandboxClient has every public key that SandboxClient has.
+void (0 as unknown as PublicKeys<RPCSandboxClient> satisfies PublicKeys<SandboxClient>);

--- a/packages/sandbox/src/clients/sandbox-client.ts
+++ b/packages/sandbox/src/clients/sandbox-client.ts
@@ -1,3 +1,4 @@
+import type { SandboxAPI } from '@repo/shared';
 import { BackupClient } from './backup-client';
 import { CommandClient } from './command-client';
 import { DesktopClient } from './desktop-client';
@@ -16,14 +17,13 @@ import { UtilityClient } from './utility-client';
 import { WatchClient } from './watch-client';
 
 /**
- * Main sandbox client that composes all domain-specific clients
- * Provides organized access to all sandbox functionality
+ * Main sandbox client that composes all domain-specific clients.
+ * Provides organized access to all sandbox functionality.
  *
  * Supports two transport modes:
  * - HTTP (default): Each request is a separate HTTP call
- * - WebSocket: All requests multiplexed over a single connection
- *
- * WebSocket mode reduces sub-request count when running inside Workers/Durable Objects.
+ * - WebSocket: All requests multiplexed over a single connection,
+ *   reducing sub-request count inside Workers/Durable Objects
  */
 export class SandboxClient {
   public readonly backup: BackupClient;
@@ -43,7 +43,7 @@ export class SandboxClient {
     // Create shared transport if WebSocket mode is enabled
     if (options.transportMode === 'websocket' && options.wsUrl) {
       this.transport = createTransport({
-        mode: 'websocket',
+        mode: options.transportMode,
         wsUrl: options.wsUrl,
         baseUrl: options.baseUrl,
         logger: options.logger,
@@ -115,6 +115,28 @@ export class SandboxClient {
   }
 
   /**
+   * Stream a file directly to the container over a binary RPC channel.
+   *
+   * Requires the capnweb transport (`useWebSocket: 'rpc'`). Calling this
+   * method with the HTTP or WebSocket transports throws an error because those
+   * transports do not support binary streaming.
+   */
+  writeFileStream(
+    _path: string,
+    _content: ReadableStream<Uint8Array>,
+    _sessionId: string
+  ): Promise<{
+    success: boolean;
+    path: string;
+    bytesWritten: number;
+    timestamp: string;
+  }> {
+    throw new Error(
+      'writeFileStream requires the RPC transport. Enable it with transport: "rpc" in sandbox options.'
+    );
+  }
+
+  /**
    * Connect WebSocket transport (no-op in HTTP mode)
    * Called automatically on first request, but can be called explicitly
    * to establish connection upfront.
@@ -135,3 +157,9 @@ export class SandboxClient {
     }
   }
 }
+
+// Compile-time check: SandboxClient exposes every top-level field that SandboxAPI requires.
+// Deep structural compatibility is not enforced because the HTTP sub-clients
+// (e.g. FileClient) lack streaming methods only available via capnweb.
+type PublicKeys<T> = { [K in keyof T]: unknown };
+void (0 as unknown as PublicKeys<SandboxClient> satisfies PublicKeys<SandboxAPI>);

--- a/packages/sandbox/src/clients/transport/types.ts
+++ b/packages/sandbox/src/clients/transport/types.ts
@@ -4,7 +4,7 @@ import type { ContainerStub } from '../types';
 /**
  * Transport mode for SDK communication
  */
-export type TransportMode = 'http' | 'websocket';
+export type TransportMode = 'http' | 'websocket' | 'rpc';
 
 /**
  * Configuration options for creating a transport

--- a/packages/sandbox/src/container-connection.ts
+++ b/packages/sandbox/src/container-connection.ts
@@ -189,6 +189,7 @@ export class ContainerConnection {
     } catch (error) {
       clearTimeout(timeout);
       this.connected = false;
+      this.transport.abort(error);
       this.logger.error(
         'ContainerConnection failed',
         error instanceof Error ? error : new Error(String(error))
@@ -264,6 +265,7 @@ class DeferredTransport implements RpcTransport {
   }
 
   abort(reason: unknown): void {
+    this.#fail(reason instanceof Error ? reason : new Error(String(reason)));
     if (this.#ws) {
       const message = reason instanceof Error ? reason.message : String(reason);
       this.#ws.close(3000, message);

--- a/packages/sandbox/src/container-connection.ts
+++ b/packages/sandbox/src/container-connection.ts
@@ -1,0 +1,280 @@
+/**
+ * Capnweb RPC connection to the container.
+ *
+ * Manages a single WebSocket session and exposes typed methods that map
+ * 1:1 to the container's SandboxAPI. The Sandbox DO calls these
+ * directly instead of going through the HTTP client layer.
+ */
+
+import type {
+  Logger,
+  SandboxAPI,
+  SandboxBackupAPI,
+  SandboxCommandsAPI,
+  SandboxDesktopAPI,
+  SandboxFilesAPI,
+  SandboxGitAPI,
+  SandboxInterpreterAPI,
+  SandboxPortsAPI,
+  SandboxProcessesAPI,
+  SandboxUtilsAPI,
+  SandboxWatchAPI
+} from '@repo/shared';
+import { createNoOpLogger } from '@repo/shared';
+import { RpcSession, type RpcStub, type RpcTransport } from 'capnweb';
+
+// ---------------------------------------------------------------------------
+// Connection manager
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
+
+/** Stub that can issue a WebSocket-upgrade fetch through the DO's Container base class. */
+export interface ContainerFetchStub {
+  fetch(request: Request): Promise<Response>;
+}
+
+export interface ContainerConnectionOptions {
+  stub: ContainerFetchStub;
+  port?: number;
+  logger?: Logger;
+}
+
+/**
+ * Manages a capnweb WebSocket RPC session to the container.
+ *
+ * The RPC stub is created eagerly in the constructor using a deferred
+ * transport. Calls made before `connect()` completes are queued in the
+ * transport and flushed once the WebSocket is established.
+ */
+export class ContainerConnection {
+  private readonly stub: RpcStub<SandboxAPI>;
+  private readonly session: RpcSession<SandboxAPI>;
+  private readonly transport: DeferredTransport;
+  private ws: WebSocket | null = null;
+  private connected = false;
+  private connectPromise: Promise<void> | null = null;
+  private readonly containerStub: ContainerFetchStub;
+  private readonly port: number;
+  private readonly logger: Logger;
+
+  constructor(options: ContainerConnectionOptions) {
+    this.containerStub = options.stub;
+    this.port = options.port ?? 3000;
+    this.logger = options.logger ?? createNoOpLogger();
+
+    this.transport = new DeferredTransport();
+    this.session = new RpcSession<SandboxAPI>(this.transport);
+    this.stub = this.session.getRemoteMain();
+  }
+
+  /**
+   * Get the typed RPC stub.
+   *
+   * The stub is available immediately — calls made before connect()
+   * completes are queued in the deferred transport and flushed once
+   * the WebSocket is established.
+   */
+  rpc(): RpcStub<SandboxAPI> {
+    if (!this.connected && !this.connectPromise) {
+      this.connect().catch(() => {});
+    }
+    return this.stub;
+  }
+
+  /**
+   * Return capnweb session statistics. The `imports` and `exports` counts
+   * reflect all in-flight RPC calls, streams, and peer-held references.
+   * An idle session has imports <= 1 && exports <= 1 (the bootstrap stubs).
+   */
+  getStats(): { imports: number; exports: number } {
+    return this.session.getStats();
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  async connect(): Promise<void> {
+    if (this.connected) return;
+
+    if (this.connectPromise) {
+      return this.connectPromise;
+    }
+
+    this.connectPromise = this.doConnect();
+    try {
+      await this.connectPromise;
+    } finally {
+      this.connectPromise = null;
+    }
+  }
+
+  disconnect(): void {
+    try {
+      (this.stub as unknown as Disposable)[Symbol.dispose]?.();
+    } catch {
+      // Stub may already be disposed
+    }
+    if (this.ws) {
+      try {
+        this.ws.close();
+      } catch {
+        // WebSocket may already be closed
+      }
+      this.ws = null;
+    }
+    this.connected = false;
+    this.connectPromise = null;
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal
+  // -----------------------------------------------------------------------
+
+  private async doConnect(): Promise<void> {
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(),
+      DEFAULT_CONNECT_TIMEOUT_MS
+    );
+
+    try {
+      const url = `http://localhost:${this.port}/rpc`;
+      const request = new Request(url, {
+        headers: {
+          Upgrade: 'websocket',
+          Connection: 'Upgrade'
+        },
+        signal: controller.signal
+      });
+
+      const response = await this.containerStub.fetch(request);
+      clearTimeout(timeout);
+
+      if (response.status !== 101) {
+        throw new Error(
+          `WebSocket upgrade failed: ${response.status} ${response.statusText}`
+        );
+      }
+
+      // The Container base class returns the WebSocket on the response object
+      // (Cloudflare Workers runtime convention, not standard fetch)
+      const ws = (response as unknown as { webSocket?: WebSocket }).webSocket;
+      if (!ws) {
+        throw new Error('No WebSocket in upgrade response');
+      }
+
+      // Workers WebSockets require explicit accept() before use
+      (ws as unknown as { accept: () => void }).accept();
+
+      ws.addEventListener('close', () => {
+        this.connected = false;
+        this.ws = null;
+        this.logger.debug('ContainerConnection WebSocket closed');
+      });
+
+      ws.addEventListener('error', () => {
+        this.connected = false;
+        this.ws = null;
+      });
+
+      this.ws = ws;
+      this.transport.activate(ws);
+      this.connected = true;
+
+      this.logger.debug('ContainerConnection established', {
+        port: this.port
+      });
+    } catch (error) {
+      clearTimeout(timeout);
+      this.connected = false;
+      this.logger.error(
+        'ContainerConnection failed',
+        error instanceof Error ? error : new Error(String(error))
+      );
+      throw error;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Deferred WebSocket transport
+// ---------------------------------------------------------------------------
+
+/**
+ * RPC transport that queues sends and blocks receives until a WebSocket
+ * is provided via `activate()`. Allows the RPC stub to be created before
+ * the connection is established — queued calls flush automatically.
+ */
+class DeferredTransport implements RpcTransport {
+  #ws: WebSocket | null = null;
+  #sendQueue: string[] = [];
+  #receiveQueue: string[] = [];
+  #receiveResolver?: (msg: string) => void;
+  #receiveRejecter?: (err: unknown) => void;
+  #error?: unknown;
+
+  activate(ws: WebSocket): void {
+    this.#ws = ws;
+
+    ws.addEventListener('message', (event: MessageEvent) => {
+      if (this.#error) return;
+      if (typeof event.data === 'string') {
+        if (this.#receiveResolver) {
+          this.#receiveResolver(event.data);
+          this.#receiveResolver = undefined;
+          this.#receiveRejecter = undefined;
+        } else {
+          this.#receiveQueue.push(event.data);
+        }
+      }
+    });
+    ws.addEventListener('close', (event: CloseEvent) => {
+      this.#fail(
+        new Error(`Peer closed WebSocket: ${event.code} ${event.reason}`)
+      );
+    });
+    ws.addEventListener('error', () => {
+      this.#fail(new Error('WebSocket connection failed'));
+    });
+
+    // Flush queued sends
+    for (const msg of this.#sendQueue) {
+      ws.send(msg);
+    }
+    this.#sendQueue = [];
+  }
+
+  async send(message: string): Promise<void> {
+    if (this.#ws) {
+      this.#ws.send(message);
+    } else {
+      this.#sendQueue.push(message);
+    }
+  }
+
+  async receive(): Promise<string> {
+    if (this.#receiveQueue.length > 0) return this.#receiveQueue.shift()!;
+    if (this.#error) throw this.#error;
+    return new Promise<string>((resolve, reject) => {
+      this.#receiveResolver = resolve;
+      this.#receiveRejecter = reject;
+    });
+  }
+
+  abort(reason: unknown): void {
+    if (this.#ws) {
+      const message = reason instanceof Error ? reason.message : String(reason);
+      this.#ws.close(3000, message);
+    }
+  }
+
+  #fail(err: unknown): void {
+    if (this.#error) return;
+    this.#error = err;
+    this.#receiveRejecter?.(err);
+    this.#receiveResolver = undefined;
+    this.#receiveRejecter = undefined;
+  }
+}

--- a/packages/sandbox/src/interpreter.ts
+++ b/packages/sandbox/src/interpreter.ts
@@ -6,20 +6,22 @@ import {
   type OutputMessage,
   type Result,
   ResultImpl,
-  type RunCodeOptions
+  type RunCodeOptions,
+  type SandboxInterpreterAPI
 } from '@repo/shared';
-import type { InterpreterClient } from './clients/interpreter-client.js';
-import type { Sandbox } from './sandbox.js';
 import { validateLanguage } from './security.js';
 
 export class CodeInterpreter {
-  private interpreterClient: InterpreterClient;
+  private getInterpreterClient: () => SandboxInterpreterAPI;
   private contexts = new Map<string, CodeContext>();
 
-  constructor(sandbox: Sandbox) {
-    // In init-testing architecture, client is a SandboxClient with an interpreter property
-    this.interpreterClient = (sandbox.client as any)
-      .interpreter as InterpreterClient;
+  constructor(
+    interpreterClient: SandboxInterpreterAPI | (() => SandboxInterpreterAPI)
+  ) {
+    this.getInterpreterClient =
+      typeof interpreterClient === 'function'
+        ? interpreterClient
+        : () => interpreterClient;
   }
 
   /**
@@ -31,7 +33,8 @@ export class CodeInterpreter {
     // Validate language before sending to container
     validateLanguage(options.language);
 
-    const context = await this.interpreterClient.createCodeContext(options);
+    const context =
+      await this.getInterpreterClient().createCodeContext(options);
     this.contexts.set(context.id, context);
     return context;
   }
@@ -55,7 +58,7 @@ export class CodeInterpreter {
     const execution = new Execution(code, context);
 
     // Stream execution
-    await this.interpreterClient.runCodeStream(
+    await this.getInterpreterClient().runCodeStream(
       context.id,
       code,
       options.language,
@@ -97,7 +100,7 @@ export class CodeInterpreter {
     }
 
     // Use streamCode which handles both HTTP and WebSocket streaming
-    return this.interpreterClient.streamCode(
+    return this.getInterpreterClient().streamCode(
       context.id,
       code,
       options.language
@@ -108,7 +111,7 @@ export class CodeInterpreter {
    * List all code contexts
    */
   async listCodeContexts(): Promise<CodeContext[]> {
-    const contexts = await this.interpreterClient.listCodeContexts();
+    const contexts = await this.getInterpreterClient().listCodeContexts();
 
     // Update local cache
     for (const context of contexts) {
@@ -122,7 +125,7 @@ export class CodeInterpreter {
    * Delete a code context
    */
   async deleteCodeContext(contextId: string): Promise<void> {
-    await this.interpreterClient.deleteCodeContext(contextId);
+    await this.getInterpreterClient().deleteCodeContext(contextId);
     this.contexts.delete(contextId);
   }
 

--- a/packages/sandbox/src/local-mount-sync.ts
+++ b/packages/sandbox/src/local-mount-sync.ts
@@ -1,6 +1,7 @@
 import path from 'node:path/posix';
 import type { FileWatchSSEEvent, Logger } from '@repo/shared';
 import type { SandboxClient } from './clients';
+import type { RPCSandboxClient } from './clients/rpc-sandbox-client';
 import { parseSSEStream } from './sse-parser';
 import { validatePrefix } from './storage-mount';
 
@@ -19,7 +20,7 @@ interface LocalMountSyncOptions {
   mountPath: string;
   prefix: string | undefined;
   readOnly: boolean;
-  client: SandboxClient;
+  client: SandboxClient | RPCSandboxClient;
   sessionId: string;
   logger: Logger;
   pollIntervalMs?: number;
@@ -37,7 +38,7 @@ export class LocalMountSyncManager {
   private readonly mountPath: string;
   private readonly prefix: string | undefined;
   private readonly readOnly: boolean;
-  private readonly client: SandboxClient;
+  private readonly client: SandboxClient | RPCSandboxClient;
   private readonly sessionId: string;
   private readonly logger: Logger;
   private readonly pollIntervalMs: number;

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -37,7 +37,6 @@ import {
   createLogger,
   filterEnvVars,
   getEnvString,
-  isTerminalStatus,
   logCanonicalEvent,
   partitionEnvVars,
   type SessionDeleteResult,
@@ -47,6 +46,7 @@ import {
 import { BACKUP_ALLOWED_PREFIXES } from '@repo/shared/backup';
 import { AwsClient } from 'aws4fetch';
 import { type Desktop, type ExecuteResponse, SandboxClient } from './clients';
+import { RPCSandboxClient } from './clients/rpc-sandbox-client';
 import type { ErrorResponse } from './errors';
 import {
   BackupCreateError,
@@ -66,7 +66,11 @@ import { CodeInterpreter } from './interpreter';
 import { LocalMountSyncManager } from './local-mount-sync';
 import { proxyTerminal } from './pty';
 import { isLocalhostPattern } from './request-handler';
-import { SecurityError, sanitizeSandboxId, validatePort } from './security';
+import {
+  SandboxSecurityError,
+  sanitizeSandboxId,
+  validatePort
+} from './security';
 import { parseSSEStream } from './sse-parser';
 import {
   buildS3fsSource,
@@ -106,7 +110,7 @@ type SandboxConfiguration = {
   sleepAfter?: string | number;
   keepAlive?: boolean;
   containerTimeouts?: NonNullable<SandboxOptions['containerTimeouts']>;
-  transport?: 'http' | 'websocket';
+  transport?: 'http' | 'websocket' | 'rpc';
 };
 
 type CachedSandboxConfiguration = {
@@ -115,7 +119,7 @@ type CachedSandboxConfiguration = {
   sleepAfter?: string | number;
   keepAlive?: boolean;
   containerTimeouts?: NonNullable<SandboxOptions['containerTimeouts']>;
-  transport?: 'http' | 'websocket';
+  transport?: 'http' | 'websocket' | 'rpc';
 };
 
 type ConfigurableSandboxStub = {
@@ -126,7 +130,7 @@ type ConfigurableSandboxStub = {
   setContainerTimeouts?: (
     timeouts: NonNullable<SandboxOptions['containerTimeouts']>
   ) => Promise<void>;
-  setTransport?: (transport: 'http' | 'websocket') => Promise<void>;
+  setTransport?: (transport: 'http' | 'websocket' | 'rpc') => Promise<void>;
 };
 
 const sandboxConfigurationCache = new WeakMap<
@@ -402,7 +406,7 @@ export function connect(stub: {
 }) {
   return async (request: Request, port: number) => {
     if (!validatePort(port)) {
-      throw new SecurityError(
+      throw new SandboxSecurityError(
         `Invalid port number: ${port}. Must be 1024-65535, excluding 3000 (sandbox control plane).`
       );
     }
@@ -434,7 +438,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   defaultPort = 3000; // Default port for the container's Bun server
   sleepAfter: string | number = '10m'; // Sleep the sandbox if no requests are made in this timeframe
 
-  client: SandboxClient;
+  client: SandboxClient | RPCSandboxClient;
+
   private codeInterpreter: CodeInterpreter;
   private sandboxName: string | null = null;
   private normalizeId: boolean = false;
@@ -452,7 +457,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   private logger: ReturnType<typeof createLogger>;
   private keepAliveEnabled: boolean = false;
   private activeMounts: Map<string, MountInfo> = new Map();
-  private transport: 'http' | 'websocket' = 'http';
+  private transport: 'http' | 'websocket' | 'rpc' = 'http';
 
   /**
    * True once transport has been written to storage at least once (either
@@ -607,6 +612,50 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     });
   }
 
+  /**
+   * Create the appropriate client for a given transport protocol.
+   */
+  private createClientForTransport(
+    transport: 'http' | 'websocket' | 'rpc'
+  ): SandboxClient | RPCSandboxClient {
+    if (transport === 'rpc') {
+      // Access the base Container's private inflightRequests counter so
+      // the alarm loop's isActivityExpired() check sees active work and
+      // skips the sleepAfterMs comparison while RPC calls are in flight.
+      const self = this as unknown as { inflightRequests: number };
+      return new RPCSandboxClient({
+        stub: this,
+        port: 3000,
+        logger: this.logger,
+        // Mirrors containerFetch()'s request lifecycle for the RPC transport.
+        // The HTTP transport increments inflightRequests at the start of each
+        // containerFetch() call and renews the activity timeout so the alarm
+        // loop sees active work and pushes sleepAfter forward. The RPC
+        // transport bypasses containerFetch() entirely (all calls multiplex
+        // over a single WebSocket), so we replicate the same bookkeeping here.
+        onActivity: () => {
+          // Called at the start of each RPC method invocation.
+          // Equivalent to the top of containerFetch(): mark the DO as busy
+          // so isActivityExpired() returns false, and push the sleepAfter
+          // deadline forward.
+          self.inflightRequests++;
+          this.renewActivityTimeout();
+        },
+        onIdle: () => {
+          // Called when an RPC method promise settles.
+          // Equivalent to containerFetch()'s finally block: decrement the
+          // inflight counter, and when it reaches zero restart the inactivity
+          // window from now — the same behavior as decrementInflight().
+          self.inflightRequests = Math.max(0, self.inflightRequests - 1);
+          if (self.inflightRequests === 0) {
+            this.renewActivityTimeout();
+          }
+        }
+      });
+    }
+    return this.createSandboxClient();
+  }
+
   constructor(ctx: DurableObjectState<{}>, env: Env) {
     super(ctx, env);
 
@@ -628,13 +677,15 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
     // Read transport setting from env var
     const transportEnv = envObj?.SANDBOX_TRANSPORT;
-    if (transportEnv === 'websocket') {
-      this.transport = 'websocket';
+    if (transportEnv === 'websocket' || transportEnv === 'rpc') {
+      this.transport = transportEnv;
     } else if (transportEnv != null && transportEnv !== 'http') {
       this.logger.warn(
-        `Invalid SANDBOX_TRANSPORT value: "${transportEnv}". Must be "http" or "websocket". Defaulting to "http".`
+        `Invalid SANDBOX_TRANSPORT value: "${transportEnv}". Must be "http", "websocket", or "rpc". Defaulting to "http".`
       );
     }
+
+    this.logger.info(`Using ${this.transport} transport`);
 
     // Read R2 backup bucket binding if configured
     const backupBucket = envObj?.BACKUP_BUCKET;
@@ -656,12 +707,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       });
     }
 
-    // Create client with transport based on env var (may be updated from storage)
-    this.client = this.createSandboxClient();
+    this.client = this.createClientForTransport(this.transport);
 
-    // Initialize code interpreter - pass 'this' after client is ready
-    // The CodeInterpreter extracts client.interpreter from the sandbox
-    this.codeInterpreter = new CodeInterpreter(this);
+    this.codeInterpreter = new CodeInterpreter(() => this.client.interpreter);
 
     this.ctx.blockConcurrencyWhile(async () => {
       this.sandboxName =
@@ -698,14 +746,16 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       }
 
       // Restore transport setting from storage (overrides env var default)
-      const storedTransport = await this.ctx.storage.get<'http' | 'websocket'>(
-        'transport'
-      );
+      const storedTransport = await this.ctx.storage.get<
+        'http' | 'websocket' | 'rpc'
+      >('transport');
       if (storedTransport && storedTransport !== this.transport) {
         this.transport = storedTransport;
         const previousClient = this.client;
-        this.client = this.createSandboxClient();
-        this.codeInterpreter = new CodeInterpreter(this);
+        this.client = this.createClientForTransport(storedTransport);
+        this.codeInterpreter = new CodeInterpreter(
+          () => this.client.interpreter
+        );
         previousClient.disconnect();
       }
       if (storedTransport) {
@@ -901,10 +951,14 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    * has been persisted: re-applying the same transport is a no-op.
    * Storage is written before the in-memory state and client are updated.
    */
-  async setTransport(transport: 'http' | 'websocket'): Promise<void> {
-    if (transport !== 'http' && transport !== 'websocket') {
+  async setTransport(transport: 'http' | 'websocket' | 'rpc'): Promise<void> {
+    if (
+      transport !== 'http' &&
+      transport !== 'websocket' &&
+      transport !== 'rpc'
+    ) {
       this.logger.warn(
-        `Invalid transport value: "${transport}". Must be "http" or "websocket". Ignoring.`
+        `Invalid transport value: "${transport}". Must be "http", "websocket", or "rpc". Ignoring.`
       );
       return;
     }
@@ -918,9 +972,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     const previousClient = this.client;
     this.transport = transport;
     this.hasStoredTransport = true;
-    this.client = this.createSandboxClient();
-    this.codeInterpreter = new CodeInterpreter(this);
+    this.client = this.createClientForTransport(transport);
+    this.codeInterpreter = new CodeInterpreter(() => this.client.interpreter);
     previousClient.disconnect();
+    this.renewActivityTimeout();
     this.logger.debug('Transport updated', { transport });
   }
 
@@ -1450,10 +1505,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         }
       }
 
-      // Disconnect WebSocket transport if active
-      this.client.disconnect();
-
-      // Unmount all mounted buckets and cleanup
+      // Unmount all mounted buckets and cleanup (requires an active connection
+      // for execInternal calls, so this runs before disconnecting the transport)
       for (const [mountPath, mountInfo] of this.activeMounts.entries()) {
         mountsProcessed++;
         if (mountInfo.mountType === 'local-sync') {
@@ -1502,6 +1555,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       // still not atomic against concurrent writers, but the preview URL
       // authorization path is race-free.
       await this.ctx.storage.delete('portTokens');
+
+      // Disconnect transport after all cleanup commands have completed
+      this.client.disconnect();
 
       outcome = 'success';
       await super.destroy();
@@ -1704,6 +1760,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     this.containerGeneration++;
     this.defaultSession = null;
     this.defaultSessionInit = null;
+
+    // Disconnect capnweb transport so the WebSocket doesn't hold the DO alive
+    this.client.disconnect();
 
     // Stop local sync managers before clearing the map.
     for (const [, m] of this.activeMounts) {
@@ -3124,10 +3183,15 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
   async writeFile(
     path: string,
-    content: string,
+    content: string | ReadableStream<Uint8Array>,
     options: { encoding?: string; sessionId?: string } = {}
   ) {
     const session = options.sessionId ?? (await this.ensureDefaultSession());
+
+    if (content instanceof ReadableStream) {
+      return this.client.writeFileStream(path, content, session);
+    }
+
     return this.client.files.writeFile(path, content, session, {
       encoding: options.encoding
     });
@@ -3348,7 +3412,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     let caughtError: Error | undefined;
     try {
       if (!validatePort(port)) {
-        throw new SecurityError(
+        throw new SandboxSecurityError(
           `Invalid port number: ${port}. Must be 1024-65535, excluding 3000 (sandbox control plane).`
         );
       }
@@ -3386,7 +3450,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         ([p, entry]) => entry.token === token && p !== port.toString()
       );
       if (existingPort) {
-        throw new SecurityError(
+        throw new SandboxSecurityError(
           `Token '${token}' is already in use by port ${existingPort[0]}. Please use a different token.`
         );
       }
@@ -3432,7 +3496,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     let caughtError: Error | undefined;
     try {
       if (!validatePort(port)) {
-        throw new SecurityError(
+        throw new SandboxSecurityError(
           `Invalid port number: ${port}. Must be 1024-65535, excluding 3000 (sandbox control plane).`
         );
       }
@@ -3569,17 +3633,17 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
   private validateCustomToken(token: string): void {
     if (token.length === 0) {
-      throw new SecurityError(`Custom token cannot be empty.`);
+      throw new SandboxSecurityError(`Custom token cannot be empty.`);
     }
 
     if (token.length > 16) {
-      throw new SecurityError(
+      throw new SandboxSecurityError(
         `Custom token too long. Maximum 16 characters allowed. Received: ${token.length} characters.`
       );
     }
 
     if (!/^[a-z0-9_]+$/.test(token)) {
-      throw new SecurityError(
+      throw new SandboxSecurityError(
         `Custom token must contain only lowercase letters (a-z), numbers (0-9), and underscores (_). Invalid token provided.`
       );
     }
@@ -3606,7 +3670,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     token: string
   ): string {
     if (!validatePort(port)) {
-      throw new SecurityError(
+      throw new SandboxSecurityError(
         `Invalid port number: ${port}. Must be 1024-65535, excluding 3000 (sandbox control plane).`
       );
     }
@@ -3615,7 +3679,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     const effectiveId = this.sandboxName || sandboxId;
     const hasUppercase = /[A-Z]/.test(effectiveId);
     if (!this.normalizeId && hasUppercase) {
-      throw new SecurityError(
+      throw new SandboxSecurityError(
         `Preview URLs require lowercase sandbox IDs. Your ID "${effectiveId}" contains uppercase letters.\n\n` +
           `To fix this:\n` +
           `1. Create a new sandbox with: getSandbox(ns, "${effectiveId}", { normalizeId: true })\n` +
@@ -3639,7 +3703,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
         return baseUrl.toString();
       } catch (error) {
-        throw new SecurityError(
+        throw new SandboxSecurityError(
           `Failed to construct preview URL: ${
             error instanceof Error ? error.message : 'Unknown error'
           }`
@@ -3654,7 +3718,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
       return baseUrl.toString();
     } catch (error) {
-      throw new SecurityError(
+      throw new SandboxSecurityError(
         `Failed to construct preview URL: ${
           error instanceof Error ? error.message : 'Unknown error'
         }`

--- a/packages/sandbox/src/security.ts
+++ b/packages/sandbox/src/security.ts
@@ -9,13 +9,13 @@
  * - Open redirect vulnerabilities
  */
 
-export class SecurityError extends Error {
+export class SandboxSecurityError extends Error {
   constructor(
     message: string,
     public readonly code?: string
   ) {
     super(message);
-    this.name = 'SecurityError';
+    this.name = 'SandboxSecurityError';
   }
 }
 
@@ -53,7 +53,7 @@ export function validatePort(port: number): boolean {
 export function sanitizeSandboxId(id: string): string {
   // Basic validation: not empty, reasonable length limit (DNS subdomain limit is 63 chars)
   if (!id || id.length > 63) {
-    throw new SecurityError(
+    throw new SandboxSecurityError(
       'Sandbox ID must be 1-63 characters long.',
       'INVALID_SANDBOX_ID_LENGTH'
     );
@@ -61,7 +61,7 @@ export function sanitizeSandboxId(id: string): string {
 
   // DNS compliance: cannot start or end with hyphens (RFC requirement)
   if (id.startsWith('-') || id.endsWith('-')) {
-    throw new SecurityError(
+    throw new SandboxSecurityError(
       'Sandbox ID cannot start or end with hyphens (DNS requirement).',
       'INVALID_SANDBOX_ID_HYPHENS'
     );
@@ -80,7 +80,7 @@ export function sanitizeSandboxId(id: string): string {
 
   const lowerCaseId = id.toLowerCase();
   if (reservedNames.includes(lowerCaseId)) {
-    throw new SecurityError(
+    throw new SandboxSecurityError(
       `Reserved sandbox ID '${id}' is not allowed.`,
       'RESERVED_SANDBOX_ID'
     );
@@ -110,7 +110,7 @@ export function validateLanguage(language: string | undefined): void {
   const normalized = language.toLowerCase();
 
   if (!supportedLanguages.includes(normalized)) {
-    throw new SecurityError(
+    throw new SandboxSecurityError(
       `Unsupported language '${language}'. Supported languages: python, javascript, typescript`,
       'INVALID_LANGUAGE'
     );

--- a/packages/sandbox/tests/container-connection.test.ts
+++ b/packages/sandbox/tests/container-connection.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ContainerConnection } from '../src/container-connection';
+
+/**
+ * Tests for ContainerConnection — the capnweb RPC connection manager.
+ *
+ * These tests verify connection lifecycle and RPC stub access.
+ * The actual RPC methods are tested via E2E tests against a real container.
+ */
+describe('ContainerConnection', () => {
+  describe('initial state', () => {
+    it('should not be connected after construction', () => {
+      const conn = new ContainerConnection({
+        stub: { fetch: vi.fn() }
+      });
+      expect(conn.isConnected()).toBe(false);
+    });
+
+    it('should have a stub available immediately after construction', () => {
+      const conn = new ContainerConnection({
+        stub: { fetch: vi.fn() }
+      });
+      expect(conn.rpc()).toBeDefined();
+    });
+  });
+
+  describe('disconnect', () => {
+    it('should be safe to call disconnect when not connected', () => {
+      const conn = new ContainerConnection({
+        stub: { fetch: vi.fn() }
+      });
+      conn.disconnect();
+      expect(conn.isConnected()).toBe(false);
+    });
+
+    it('should be safe to call disconnect multiple times', () => {
+      const conn = new ContainerConnection({
+        stub: { fetch: vi.fn() }
+      });
+      conn.disconnect();
+      conn.disconnect();
+      conn.disconnect();
+      expect(conn.isConnected()).toBe(false);
+    });
+  });
+
+  describe('connect', () => {
+    it('should fail when WebSocket upgrade is rejected', async () => {
+      const conn = new ContainerConnection({
+        stub: {
+          fetch: vi
+            .fn()
+            .mockResolvedValue(new Response('Not Found', { status: 404 }))
+        }
+      });
+
+      await expect(conn.connect()).rejects.toThrow(
+        'WebSocket upgrade failed: 404'
+      );
+      expect(conn.isConnected()).toBe(false);
+    });
+
+    it('should reject pending RPC calls when connection fails', async () => {
+      const conn = new ContainerConnection({
+        stub: {
+          fetch: vi
+            .fn()
+            .mockResolvedValue(new Response('Not Found', { status: 404 }))
+        }
+      });
+
+      // rpc() triggers connect() in the background and returns the stub.
+      const stub = conn.rpc();
+
+      // Calling a method on the stub queues a send and starts a receive().
+      // Without the fix, this would hang forever because doConnect()'s
+      // failure never propagated to the transport.
+      const rpcCall = stub.utils.ping();
+
+      await expect(rpcCall).rejects.toThrow();
+    }, 5000);
+  });
+
+  describe('rpc', () => {
+    it('should trigger connect lazily when calling rpc()', () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(new Response('Not Found', { status: 404 }));
+      const conn = new ContainerConnection({
+        stub: { fetch: fetchMock }
+      });
+
+      // rpc() returns the stub immediately and triggers connect in the background
+      const stub = conn.rpc();
+      expect(stub).toBeDefined();
+      expect(fetchMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('connection lifecycle with mocked internals', () => {
+    it('should return connected after successful connect', async () => {
+      const conn = new ContainerConnection({
+        stub: { fetch: vi.fn() }
+      });
+      const internals = conn as unknown as {
+        connected: boolean;
+        ws: unknown;
+        doConnect: () => Promise<void>;
+      };
+
+      vi.spyOn(internals, 'doConnect').mockImplementation(async () => {
+        internals.connected = true;
+        internals.ws = { close: vi.fn() };
+      });
+
+      await conn.connect();
+      expect(conn.isConnected()).toBe(true);
+    });
+
+    it('should return the same stub before and after connect', async () => {
+      const conn = new ContainerConnection({
+        stub: { fetch: vi.fn() }
+      });
+      const internals = conn as unknown as {
+        connected: boolean;
+        ws: unknown;
+        doConnect: () => Promise<void>;
+      };
+
+      vi.spyOn(internals, 'doConnect').mockImplementation(async () => {
+        internals.connected = true;
+        internals.ws = { close: vi.fn() };
+      });
+
+      // rpc() returns the stub immediately — same reference before and after connect
+      const stubBefore = conn.rpc();
+      await conn.connect();
+      const stubAfter = conn.rpc();
+      expect(stubAfter).toBe(stubBefore);
+    });
+
+    it('should disconnect and reconnect', async () => {
+      const conn = new ContainerConnection({
+        stub: { fetch: vi.fn() }
+      });
+      const internals = conn as unknown as {
+        connected: boolean;
+        ws: unknown;
+        doConnect: () => Promise<void>;
+      };
+
+      const doConnect = vi
+        .spyOn(internals, 'doConnect')
+        .mockImplementation(async () => {
+          internals.connected = true;
+          internals.ws = { close: vi.fn() };
+        });
+
+      await conn.connect();
+      expect(doConnect).toHaveBeenCalledTimes(1);
+
+      conn.disconnect();
+      expect(conn.isConnected()).toBe(false);
+
+      await conn.connect();
+      expect(doConnect).toHaveBeenCalledTimes(2);
+    });
+
+    it('should share connection across concurrent connect() calls', async () => {
+      const conn = new ContainerConnection({
+        stub: { fetch: vi.fn() }
+      });
+      const internals = conn as unknown as {
+        connected: boolean;
+        ws: unknown;
+        doConnect: () => Promise<void>;
+      };
+
+      const doConnect = vi
+        .spyOn(internals, 'doConnect')
+        .mockImplementation(async () => {
+          internals.connected = true;
+          internals.ws = { close: vi.fn() };
+        });
+
+      await Promise.all([conn.connect(), conn.connect()]);
+      expect(doConnect).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -2142,5 +2142,157 @@ describe('Sandbox - Automatic Session Management', () => {
       expect((instance as any).hasStoredTransport).toBe(true);
       expect(instance.client.getTransportMode()).toBe('websocket');
     });
+
+    it('reads rpc transport from SANDBOX_TRANSPORT env var', async () => {
+      const rpcCtx = {
+        ...mockCtx,
+        blockConcurrencyWhile: vi
+          .fn()
+          .mockImplementation(
+            <T>(callback: () => Promise<T>): Promise<T> => callback()
+          ),
+        storage: {
+          get: vi.fn().mockResolvedValue(null),
+          put: vi.fn().mockResolvedValue(undefined),
+          delete: vi.fn().mockResolvedValue(undefined),
+          list: vi.fn().mockResolvedValue(new Map())
+        } as any
+      };
+
+      const instance = new Sandbox(
+        rpcCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+        { SANDBOX_TRANSPORT: 'rpc' }
+      );
+
+      await vi.waitFor(() => {
+        expect(rpcCtx.blockConcurrencyWhile).toHaveBeenCalled();
+      });
+
+      expect((instance as any).transport).toBe('rpc');
+      expect(instance.client.getTransportMode()).toBe('rpc');
+    });
+
+    it('setTransport switches from http to rpc', async () => {
+      await vi.waitFor(() => {
+        expect(mockCtx.blockConcurrencyWhile).toHaveBeenCalled();
+      });
+
+      expect((sandbox as any).transport).toBe('http');
+
+      await sandbox.setTransport('rpc');
+
+      expect((sandbox as any).transport).toBe('rpc');
+      expect(sandbox.client.getTransportMode()).toBe('rpc');
+    });
+
+    it('setTransport switches from rpc to http', async () => {
+      const rpcCtx = {
+        ...mockCtx,
+        blockConcurrencyWhile: vi
+          .fn()
+          .mockImplementation(
+            <T>(callback: () => Promise<T>): Promise<T> => callback()
+          ),
+        storage: {
+          get: vi.fn().mockResolvedValue(null),
+          put: vi.fn().mockResolvedValue(undefined),
+          delete: vi.fn().mockResolvedValue(undefined),
+          list: vi.fn().mockResolvedValue(new Map())
+        } as any
+      };
+
+      const instance = new Sandbox(
+        rpcCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+        { SANDBOX_TRANSPORT: 'rpc' }
+      );
+
+      await vi.waitFor(() => {
+        expect(rpcCtx.blockConcurrencyWhile).toHaveBeenCalled();
+      });
+
+      expect((instance as any).transport).toBe('rpc');
+
+      await instance.setTransport('http');
+
+      expect((instance as any).transport).toBe('http');
+      expect(instance.client.getTransportMode()).toBe('http');
+    });
+
+    it('restores rpc transport from storage on cold start', async () => {
+      const coldCtx = {
+        ...mockCtx,
+        blockConcurrencyWhile: vi
+          .fn()
+          .mockImplementation(
+            <T>(callback: () => Promise<T>): Promise<T> => callback()
+          ),
+        storage: {
+          get: vi.fn().mockImplementation(async (key: string) => {
+            if (key === 'transport') return 'rpc';
+            return null;
+          }),
+          put: vi.fn().mockResolvedValue(undefined),
+          delete: vi.fn().mockResolvedValue(undefined),
+          list: vi.fn().mockResolvedValue(new Map())
+        } as any
+      };
+
+      const instance = new Sandbox(
+        coldCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+        {}
+      );
+
+      await vi.waitFor(() => {
+        expect(coldCtx.blockConcurrencyWhile).toHaveBeenCalled();
+      });
+      await Promise.all(
+        (coldCtx.blockConcurrencyWhile as any).mock.results.map(
+          (r: { value: unknown }) => r.value
+        )
+      );
+
+      expect((instance as any).transport).toBe('rpc');
+      expect((instance as any).hasStoredTransport).toBe(true);
+      expect(instance.client.getTransportMode()).toBe('rpc');
+    });
+
+    it('storage restore does not override env-derived rpc with stored http', async () => {
+      const coldCtx = {
+        ...mockCtx,
+        blockConcurrencyWhile: vi
+          .fn()
+          .mockImplementation(
+            <T>(callback: () => Promise<T>): Promise<T> => callback()
+          ),
+        storage: {
+          get: vi.fn().mockImplementation(async (key: string) => {
+            // Storage has 'http' but env says 'rpc'
+            if (key === 'transport') return 'http';
+            return null;
+          }),
+          put: vi.fn().mockResolvedValue(undefined),
+          delete: vi.fn().mockResolvedValue(undefined),
+          list: vi.fn().mockResolvedValue(new Map())
+        } as any
+      };
+
+      const instance = new Sandbox(
+        coldCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+        { SANDBOX_TRANSPORT: 'rpc' }
+      );
+
+      await vi.waitFor(() => {
+        expect(coldCtx.blockConcurrencyWhile).toHaveBeenCalled();
+      });
+      await Promise.all(
+        (coldCtx.blockConcurrencyWhile as any).mock.results.map(
+          (r: { value: unknown }) => r.value
+        )
+      );
+
+      // Storage says 'http' which differs from env 'rpc', so storage wins
+      expect((instance as any).transport).toBe('http');
+      expect((instance as any).hasStoredTransport).toBe(true);
+    });
   });
 });

--- a/packages/sandbox/tests/security.test.ts
+++ b/packages/sandbox/tests/security.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
-  SecurityError,
+  SandboxSecurityError,
   sanitizeSandboxId,
   validatePort
 } from '../src/security';
@@ -44,17 +44,19 @@ describe('sanitizeSandboxId', () => {
   });
 
   it('rejects invalid lengths', () => {
-    expect(() => sanitizeSandboxId('')).toThrow(SecurityError);
-    expect(() => sanitizeSandboxId('a'.repeat(64))).toThrow(SecurityError);
+    expect(() => sanitizeSandboxId('')).toThrow(SandboxSecurityError);
+    expect(() => sanitizeSandboxId('a'.repeat(64))).toThrow(
+      SandboxSecurityError
+    );
   });
 
   it('rejects leading/trailing hyphens (DNS requirement)', () => {
-    expect(() => sanitizeSandboxId('-myproject')).toThrow(SecurityError);
-    expect(() => sanitizeSandboxId('myproject-')).toThrow(SecurityError);
+    expect(() => sanitizeSandboxId('-myproject')).toThrow(SandboxSecurityError);
+    expect(() => sanitizeSandboxId('myproject-')).toThrow(SandboxSecurityError);
   });
 
   it('rejects reserved names case-insensitively', () => {
-    expect(() => sanitizeSandboxId('www')).toThrow(SecurityError);
-    expect(() => sanitizeSandboxId('API')).toThrow(SecurityError);
+    expect(() => sanitizeSandboxId('www')).toThrow(SandboxSecurityError);
+    expect(() => sanitizeSandboxId('API')).toThrow(SandboxSecurityError);
   });
 });

--- a/packages/sandbox/tsconfig.json
+++ b/packages/sandbox/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "types": ["node", "@cloudflare/workers-types"],
-    "lib": ["ES2022"],
+    "lib": ["ES2024"],
     "resolveJsonModule": true,
     "paths": {
       "@repo/shared/backup": ["../shared/src/backup.ts"]

--- a/packages/shared/src/desktop-types.ts
+++ b/packages/shared/src/desktop-types.ts
@@ -24,6 +24,7 @@ export interface DesktopStopResult {
 }
 
 export interface DesktopStatusResult {
+  success: boolean;
   status: 'active' | 'partial' | 'inactive';
   processes: Record<string, DesktopProcessHealth>;
   resolution: [number, number] | null;
@@ -47,8 +48,7 @@ export interface DesktopScreenshotRequest {
   showCursor?: boolean;
 }
 
-export interface DesktopScreenshotRegionRequest
-  extends DesktopScreenshotRequest {
+export interface DesktopScreenshotRegionRequest extends DesktopScreenshotRequest {
   region: DesktopScreenshotRegion;
 }
 
@@ -60,6 +60,7 @@ export interface DesktopScreenshotRegion {
 }
 
 export interface DesktopScreenshotResult {
+  success: boolean;
   data: string;
   imageFormat: DesktopImageFormat;
   width: number;
@@ -111,6 +112,7 @@ export interface DesktopMouseScrollRequest {
 }
 
 export interface DesktopCursorPosition {
+  success: boolean;
   x: number;
   y: number;
 }
@@ -142,6 +144,7 @@ export interface DesktopTypeRequest {
 // === Screen Info ===
 
 export interface DesktopScreenSize {
+  success: boolean;
   width: number;
   height: number;
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -107,6 +107,20 @@ export type {
   StartProcessRequest,
   WriteFileRequest
 } from './request-types.js';
+// RPC interface types (shared between SDK and container)
+export type {
+  SandboxAPI,
+  SandboxBackupAPI,
+  SandboxCommandsAPI,
+  SandboxDesktopAPI,
+  SandboxFilesAPI,
+  SandboxGitAPI,
+  SandboxInterpreterAPI,
+  SandboxPortsAPI,
+  SandboxProcessesAPI,
+  SandboxUtilsAPI,
+  SandboxWatchAPI
+} from './rpc-types.js';
 // Export shell utilities
 export { shellEscape } from './shell-escape.js';
 // Export SSE utilities

--- a/packages/shared/src/interpreter-types.ts
+++ b/packages/shared/src/interpreter-types.ts
@@ -329,64 +329,45 @@ export class Execution {
 
 // Implementation of Result
 export class ResultImpl implements Result {
-  constructor(private raw: any) {}
+  text?: string;
+  html?: string;
+  png?: string;
+  jpeg?: string;
+  svg?: string;
+  latex?: string;
+  markdown?: string;
+  javascript?: string;
+  json?: any;
+  chart?: ChartData;
+  data?: any;
 
-  get text(): string | undefined {
-    return this.raw.text || this.raw.data?.['text/plain'];
-  }
-
-  get html(): string | undefined {
-    return this.raw.html || this.raw.data?.['text/html'];
-  }
-
-  get png(): string | undefined {
-    return this.raw.png || this.raw.data?.['image/png'];
-  }
-
-  get jpeg(): string | undefined {
-    return this.raw.jpeg || this.raw.data?.['image/jpeg'];
-  }
-
-  get svg(): string | undefined {
-    return this.raw.svg || this.raw.data?.['image/svg+xml'];
-  }
-
-  get latex(): string | undefined {
-    return this.raw.latex || this.raw.data?.['text/latex'];
-  }
-
-  get markdown(): string | undefined {
-    return this.raw.markdown || this.raw.data?.['text/markdown'];
-  }
-
-  get javascript(): string | undefined {
-    return this.raw.javascript || this.raw.data?.['application/javascript'];
-  }
-
-  get json(): any {
-    return this.raw.json || this.raw.data?.['application/json'];
-  }
-
-  get chart(): ChartData | undefined {
-    return this.raw.chart;
-  }
-
-  get data(): any {
-    return this.raw.data;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- raw SSE data has dynamic shape
+  constructor(raw: any) {
+    this.text = raw.text || raw.data?.['text/plain'];
+    this.html = raw.html || raw.data?.['text/html'];
+    this.png = raw.png || raw.data?.['image/png'];
+    this.jpeg = raw.jpeg || raw.data?.['image/jpeg'];
+    this.svg = raw.svg || raw.data?.['image/svg+xml'];
+    this.latex = raw.latex || raw.data?.['text/latex'];
+    this.markdown = raw.markdown || raw.data?.['text/markdown'];
+    this.javascript = raw.javascript || raw.data?.['application/javascript'];
+    this.json = raw.json || raw.data?.['application/json'];
+    this.chart = raw.chart;
+    this.data = raw.data;
   }
 
   formats(): string[] {
-    const formats: string[] = [];
-    if (this.text) formats.push('text');
-    if (this.html) formats.push('html');
-    if (this.png) formats.push('png');
-    if (this.jpeg) formats.push('jpeg');
-    if (this.svg) formats.push('svg');
-    if (this.latex) formats.push('latex');
-    if (this.markdown) formats.push('markdown');
-    if (this.javascript) formats.push('javascript');
-    if (this.json) formats.push('json');
-    if (this.chart) formats.push('chart');
-    return formats;
+    const fmts: string[] = [];
+    if (this.text) fmts.push('text');
+    if (this.html) fmts.push('html');
+    if (this.png) fmts.push('png');
+    if (this.jpeg) fmts.push('jpeg');
+    if (this.svg) fmts.push('svg');
+    if (this.latex) fmts.push('latex');
+    if (this.markdown) fmts.push('markdown');
+    if (this.javascript) fmts.push('javascript');
+    if (this.json) fmts.push('json');
+    if (this.chart) fmts.push('chart');
+    return fmts;
   }
 }

--- a/packages/shared/src/rpc-types.ts
+++ b/packages/shared/src/rpc-types.ts
@@ -1,0 +1,302 @@
+/**
+ * Shared RPC interface types for the capnweb transport layer.
+ *
+ * Defines the contract between the SDK client (ContainerConnection) and the
+ * container server (SandboxAPI). Both sides must implement or satisfy
+ * these interfaces to ensure type-safe communication.
+ */
+
+import type {
+  DesktopCursorPosition,
+  DesktopMouseButton,
+  DesktopScreenSize,
+  DesktopScreenshotRegionRequest,
+  DesktopScreenshotRequest,
+  DesktopScreenshotResult,
+  DesktopScrollDirection,
+  DesktopStartResult,
+  DesktopStatusResult,
+  DesktopStopResult
+} from './desktop-types.js';
+import type {
+  CodeContext,
+  CreateContextOptions,
+  ExecutionError,
+  OutputMessage,
+  Result
+} from './interpreter-types.js';
+import type {
+  CreateBackupResponse,
+  RestoreBackupResponse
+} from './request-types.js';
+import type {
+  CheckChangesRequest,
+  CheckChangesResult,
+  DeleteFileResult,
+  FileExistsResult,
+  GitCheckoutResult,
+  ListFilesOptions,
+  ListFilesResult,
+  MkdirResult,
+  MoveFileResult,
+  PortCloseResult,
+  PortExposeResult,
+  PortListResult,
+  PortWatchRequest,
+  ProcessCleanupResult,
+  ProcessInfoResult,
+  ProcessKillResult,
+  ProcessListResult,
+  ProcessLogsResult,
+  ProcessStartResult,
+  ReadFileResult,
+  RenameFileResult,
+  WatchRequest,
+  WriteFileResult
+} from './types.js';
+
+export interface SandboxAPI {
+  commands: SandboxCommandsAPI;
+  files: SandboxFilesAPI;
+  processes: SandboxProcessesAPI;
+  ports: SandboxPortsAPI;
+  git: SandboxGitAPI;
+  interpreter: SandboxInterpreterAPI;
+  utils: SandboxUtilsAPI;
+  backup: SandboxBackupAPI;
+  desktop: SandboxDesktopAPI;
+  watch: SandboxWatchAPI;
+}
+
+export interface SandboxCommandsAPI {
+  execute(
+    command: string,
+    sessionId: string,
+    options?: {
+      timeoutMs?: number;
+      env?: Record<string, string | undefined>;
+      cwd?: string;
+    }
+  ): Promise<{
+    success: boolean;
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+    command: string;
+    timestamp: string;
+  }>;
+  executeStream(
+    command: string,
+    sessionId: string,
+    options?: {
+      timeoutMs?: number;
+      env?: Record<string, string | undefined>;
+      cwd?: string;
+    }
+  ): Promise<ReadableStream<Uint8Array>>;
+}
+
+export interface SandboxFilesAPI {
+  readFile(
+    path: string,
+    sessionId: string,
+    options?: { encoding?: string }
+  ): Promise<ReadFileResult>;
+  readFileStream(
+    path: string,
+    sessionId: string
+  ): Promise<ReadableStream<Uint8Array>>;
+  writeFile(
+    path: string,
+    content: string,
+    sessionId: string,
+    options?: { encoding?: string; permissions?: string }
+  ): Promise<WriteFileResult>;
+  writeFileStream(
+    path: string,
+    stream: ReadableStream<Uint8Array>,
+    sessionId: string
+  ): Promise<{
+    success: boolean;
+    path: string;
+    bytesWritten: number;
+    timestamp: string;
+  }>;
+  deleteFile(path: string, sessionId: string): Promise<DeleteFileResult>;
+  renameFile(
+    oldPath: string,
+    newPath: string,
+    sessionId: string
+  ): Promise<RenameFileResult>;
+  moveFile(
+    sourcePath: string,
+    destinationPath: string,
+    sessionId: string
+  ): Promise<MoveFileResult>;
+  mkdir(
+    path: string,
+    sessionId: string,
+    options?: { recursive?: boolean }
+  ): Promise<MkdirResult>;
+  listFiles(
+    path: string,
+    sessionId: string,
+    options?: ListFilesOptions
+  ): Promise<ListFilesResult>;
+  exists(path: string, sessionId: string): Promise<FileExistsResult>;
+}
+
+export interface SandboxProcessesAPI {
+  startProcess(
+    command: string,
+    sessionId: string,
+    options?: { processId?: string; timeoutMs?: number }
+  ): Promise<ProcessStartResult>;
+  listProcesses(): Promise<ProcessListResult>;
+  getProcess(id: string): Promise<ProcessInfoResult>;
+  killProcess(id: string): Promise<ProcessKillResult>;
+  killAllProcesses(): Promise<ProcessCleanupResult>;
+  getProcessLogs(id: string): Promise<ProcessLogsResult>;
+  streamProcessLogs(id: string): Promise<ReadableStream<Uint8Array>>;
+}
+
+export interface SandboxPortsAPI {
+  exposePort(
+    port: number,
+    sessionId: string,
+    name?: string
+  ): Promise<PortExposeResult>;
+  getExposedPorts(sessionId: string): Promise<PortListResult>;
+  unexposePort(port: number, sessionId: string): Promise<PortCloseResult>;
+  watchPort(request: PortWatchRequest): Promise<ReadableStream<Uint8Array>>;
+}
+
+export interface SandboxGitAPI {
+  checkout(
+    repoUrl: string,
+    sessionId: string,
+    options?: {
+      branch?: string;
+      targetDir?: string;
+      depth?: number;
+      timeoutMs?: number;
+    }
+  ): Promise<GitCheckoutResult>;
+}
+
+export interface SandboxInterpreterAPI {
+  createCodeContext(options?: CreateContextOptions): Promise<CodeContext>;
+  streamCode(
+    contextId: string,
+    code: string,
+    language?: string
+  ): Promise<ReadableStream<Uint8Array>>;
+  runCodeStream(
+    contextId: string | undefined,
+    code: string,
+    language: string | undefined,
+    callbacks: {
+      onStdout?: (output: OutputMessage) => void | Promise<void>;
+      onStderr?: (output: OutputMessage) => void | Promise<void>;
+      onResult?: (result: Result) => void | Promise<void>;
+      onError?: (error: ExecutionError) => void | Promise<void>;
+    },
+    timeoutMs?: number
+  ): Promise<void>;
+  listCodeContexts(): Promise<CodeContext[]>;
+  deleteCodeContext(contextId: string): Promise<void>;
+}
+
+export interface SandboxUtilsAPI {
+  ping(): Promise<string>;
+  getVersion(): Promise<string>;
+  getCommands(): Promise<string[]>;
+  createSession(options: {
+    id: string;
+    env?: Record<string, string | undefined>;
+    cwd?: string;
+  }): Promise<{
+    success: boolean;
+    id: string;
+    message: string;
+    timestamp: string;
+  }>;
+  deleteSession(
+    sessionId: string
+  ): Promise<{ success: boolean; sessionId: string; timestamp: string }>;
+  listSessions(): Promise<{ sessions: string[] }>;
+}
+
+export interface SandboxBackupAPI {
+  createArchive(
+    dir: string,
+    archivePath: string,
+    sessionId: string,
+    options?: { excludes?: string[]; gitignore?: boolean }
+  ): Promise<CreateBackupResponse>;
+  restoreArchive(
+    dir: string,
+    archivePath: string,
+    sessionId: string
+  ): Promise<RestoreBackupResponse>;
+}
+
+export interface SandboxDesktopAPI {
+  start(options?: {
+    resolution?: [number, number];
+    dpi?: number;
+  }): Promise<DesktopStartResult>;
+  stop(): Promise<DesktopStopResult>;
+  status(): Promise<DesktopStatusResult>;
+  screenshot(
+    options?: DesktopScreenshotRequest
+  ): Promise<DesktopScreenshotResult>;
+  screenshotRegion(
+    request: DesktopScreenshotRegionRequest
+  ): Promise<DesktopScreenshotResult>;
+  click(
+    x: number,
+    y: number,
+    options?: { button?: DesktopMouseButton; clickCount?: number }
+  ): Promise<void>;
+  doubleClick(x: number, y: number): Promise<void>;
+  tripleClick(x: number, y: number): Promise<void>;
+  rightClick(x: number, y: number): Promise<void>;
+  middleClick(x: number, y: number): Promise<void>;
+  mouseDown(
+    x?: number,
+    y?: number,
+    options?: { button?: DesktopMouseButton }
+  ): Promise<void>;
+  mouseUp(
+    x?: number,
+    y?: number,
+    options?: { button?: DesktopMouseButton }
+  ): Promise<void>;
+  moveMouse(x: number, y: number): Promise<void>;
+  drag(
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+    options?: { button?: DesktopMouseButton }
+  ): Promise<void>;
+  scroll(
+    x: number,
+    y: number,
+    direction: DesktopScrollDirection,
+    amount?: number
+  ): Promise<void>;
+  getCursorPosition(): Promise<DesktopCursorPosition>;
+  type(text: string, options?: { delay?: number }): Promise<void>;
+  press(key: string): Promise<void>;
+  keyDown(key: string): Promise<void>;
+  keyUp(key: string): Promise<void>;
+  getScreenSize(): Promise<DesktopScreenSize>;
+  getProcessStatus(name: string): Promise<DesktopStatusResult>;
+}
+
+export interface SandboxWatchAPI {
+  watch(request: WatchRequest): Promise<ReadableStream<Uint8Array>>;
+  checkChanges(request: CheckChangesRequest): Promise<CheckChangesResult>;
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -538,6 +538,8 @@ export interface SandboxOptions {
    * - `"http"` (default): Standard HTTP request/response. Works everywhere.
    * - `"websocket"`: Multiplexes requests over a single WebSocket connection,
    *   avoiding sub-request limits in Workers and Durable Objects.
+   * - `"capnweb"`: Direct RPC over a single WebSocket using the capnweb protocol.
+   *   Lowest latency; automatically disconnects when idle to respect `sleepAfter`.
    *
    * When set via `getSandbox()` options, this overrides the `SANDBOX_TRANSPORT` env var.
    *
@@ -548,7 +550,7 @@ export interface SandboxOptions {
    *
    * @default "http"
    */
-  transport?: 'http' | 'websocket';
+  transport?: 'http' | 'websocket' | 'rpc';
 }
 
 /**
@@ -1018,7 +1020,7 @@ export interface ExecutionSession {
   // File operations
   writeFile(
     path: string,
-    content: string,
+    content: string | ReadableStream<Uint8Array>,
     options?: { encoding?: string }
   ): Promise<WriteFileResult>;
   readFile(
@@ -1290,7 +1292,7 @@ export interface ISandbox {
   // File operations
   writeFile(
     path: string,
-    content: string,
+    content: string | ReadableStream<Uint8Array>,
     options?: { encoding?: string }
   ): Promise<WriteFileResult>;
   readFile(

--- a/tests/e2e/capnweb-transport.test.ts
+++ b/tests/e2e/capnweb-transport.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Cap'n Web Transport E2E Tests
+ *
+ * Validates core sandbox operations work end-to-end through the capnweb
+ * transport layer. These tests exercise:
+ * - Command execution (exec)
+ * - Streaming output (execStream)
+ * - File operations (write, read, list, delete)
+ * - Session isolation
+ *
+ * Skipped unless TEST_TRANSPORT=capnweb. Transport selection flows through
+ * the X-Sandbox-Transport header to the test worker, which passes it to
+ * getSandbox() as a per-instance transport option.
+ */
+
+import type {
+  ExecEvent,
+  ExecResult,
+  ListFilesResult,
+  ReadFileResult
+} from '@repo/shared';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { parseSSEStream } from '../../packages/sandbox/src/sse-parser';
+import {
+  cleanupTestSandbox,
+  createTestSandbox,
+  createUniqueSession,
+  type TestSandbox
+} from './helpers/global-sandbox';
+
+const isCapnweb = process.env.TEST_TRANSPORT === 'rpc';
+
+describe.skipIf(!isCapnweb)("Cap'n Web Transport", () => {
+  let sandbox: TestSandbox | null = null;
+  let workerUrl: string;
+  let headers: Record<string, string>;
+
+  beforeAll(async () => {
+    sandbox = await createTestSandbox();
+    workerUrl = sandbox.workerUrl;
+    headers = sandbox.headers(createUniqueSession());
+  }, 120000);
+
+  afterAll(async () => {
+    await cleanupTestSandbox(sandbox);
+    sandbox = null;
+  }, 120000);
+
+  test('should execute a command and return stdout', async () => {
+    const response = await fetch(`${workerUrl}/api/execute`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ command: 'echo hello-capnweb' })
+    });
+
+    expect(response.status).toBe(200);
+    const result = (await response.json()) as ExecResult;
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('hello-capnweb');
+  });
+
+  test('should handle command with non-zero exit code', async () => {
+    const response = await fetch(`${workerUrl}/api/execute`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ command: 'sh -c "exit 42"' })
+    });
+
+    expect(response.status).toBe(200);
+    const result = (await response.json()) as ExecResult;
+    expect(result.exitCode).toBe(42);
+  });
+
+  test('should write and read a file', async () => {
+    const testPath = sandbox!.uniquePath('capnweb-test.txt');
+    const testContent = 'Hello from capnweb transport! 🚀';
+
+    // Write
+    const writeResponse = await fetch(`${workerUrl}/api/file/write`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ path: testPath, content: testContent })
+    });
+    expect(writeResponse.status).toBe(200);
+
+    // Read
+    const readResponse = await fetch(`${workerUrl}/api/file/read`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ path: testPath })
+    });
+    expect(readResponse.status).toBe(200);
+    const readResult = (await readResponse.json()) as ReadFileResult;
+    expect(readResult.content).toBe(testContent);
+  });
+
+  test('should list files in a directory', async () => {
+    const testDir = sandbox!.uniquePath('capnweb-list');
+
+    // Create directory with files
+    await fetch(`${workerUrl}/api/execute`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        command: `mkdir -p ${testDir} && touch ${testDir}/a.txt ${testDir}/b.txt`
+      })
+    });
+
+    const response = await fetch(`${workerUrl}/api/list-files`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ path: testDir })
+    });
+
+    expect(response.status).toBe(200);
+    const result = (await response.json()) as ListFilesResult;
+    expect(result.files.length).toBeGreaterThanOrEqual(2);
+    const names = result.files.map((f) => f.name);
+    expect(names).toContain('a.txt');
+    expect(names).toContain('b.txt');
+  });
+
+  test('should stream command output via execStream', async () => {
+    const abortController = new AbortController();
+    const response = await fetch(`${workerUrl}/api/execStream`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        command: 'echo line1 && echo line2 && echo line3'
+      }),
+      signal: abortController.signal
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBeTruthy();
+
+    const events: ExecEvent[] = [];
+    for await (const event of parseSSEStream<ExecEvent>(
+      response.body!,
+      abortController.signal
+    )) {
+      events.push(event);
+      if (event.type === 'complete' || event.type === 'error') {
+        break;
+      }
+    }
+
+    // Should have stdout events and a complete event
+    const stdoutEvents = events.filter((e) => e.type === 'stdout');
+    const completeEvents = events.filter((e) => e.type === 'complete');
+
+    expect(stdoutEvents.length).toBeGreaterThan(0);
+    expect(completeEvents.length).toBe(1);
+
+    // Combine all stdout output
+    const allOutput = stdoutEvents.map((e) => e.data ?? '').join('');
+    expect(allOutput).toContain('line1');
+    expect(allOutput).toContain('line2');
+    expect(allOutput).toContain('line3');
+
+    // Complete event should show success
+    const complete = completeEvents[0];
+    expect(complete.exitCode).toBe(0);
+  });
+
+  test('should delete a file', async () => {
+    const testPath = sandbox!.uniquePath('capnweb-delete.txt');
+
+    // Create file
+    await fetch(`${workerUrl}/api/file/write`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        path: testPath,
+        content: 'to be deleted'
+      })
+    });
+
+    // Delete
+    const deleteResponse = await fetch(`${workerUrl}/api/file/delete`, {
+      method: 'DELETE',
+      headers,
+      body: JSON.stringify({ path: testPath })
+    });
+    expect(deleteResponse.status).toBe(200);
+
+    // Verify gone
+    const existsResponse = await fetch(`${workerUrl}/api/file/exists`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ path: testPath })
+    });
+    expect(existsResponse.status).toBe(200);
+    const existsResult = (await existsResponse.json()) as {
+      exists: boolean;
+    };
+    expect(existsResult.exists).toBe(false);
+  });
+
+  test('should create and use a separate session with isolated env', async () => {
+    const sessionId = createUniqueSession();
+
+    // Create session with custom env
+    const createResponse = await fetch(`${workerUrl}/api/session/create`, {
+      method: 'POST',
+      headers: sandbox!.headers(),
+      body: JSON.stringify({
+        id: sessionId,
+        env: { CAPNWEB_TEST: 'transport-works' }
+      })
+    });
+    expect(createResponse.status).toBe(200);
+
+    // Execute in that session to verify env
+    const sessionHeaders = sandbox!.headers(sessionId);
+    const execResponse = await fetch(`${workerUrl}/api/execute`, {
+      method: 'POST',
+      headers: sessionHeaders,
+      body: JSON.stringify({ command: 'echo $CAPNWEB_TEST' })
+    });
+    expect(execResponse.status).toBe(200);
+    const result = (await execResponse.json()) as ExecResult;
+    expect(result.stdout.trim()).toBe('transport-works');
+
+    // The original session should NOT have this env var
+    const defaultExecResponse = await fetch(`${workerUrl}/api/execute`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ command: 'echo $CAPNWEB_TEST' })
+    });
+    const defaultResult = (await defaultExecResponse.json()) as ExecResult;
+    expect(defaultResult.stdout.trim()).toBe('');
+  });
+});

--- a/tests/e2e/file-operations-workflow.test.ts
+++ b/tests/e2e/file-operations-workflow.test.ts
@@ -311,3 +311,106 @@ describe('File Operations Error Handling', () => {
     expect(readData.content).toMatch(/^[A-Za-z0-9+/=]+$/);
   }, 90000);
 });
+
+const isCapnweb = process.env.TEST_TRANSPORT === 'rpc';
+
+describe.skipIf(!isCapnweb)('File Streaming Write (capnweb)', () => {
+  let sandbox: TestSandbox | null = null;
+  let workerUrl: string;
+  let headers: Record<string, string>;
+
+  beforeAll(async () => {
+    sandbox = await createTestSandbox();
+    workerUrl = sandbox.workerUrl;
+    headers = sandbox.headers(createUniqueSession());
+  }, 120000);
+
+  afterAll(async () => {
+    await cleanupTestSandbox(sandbox);
+    sandbox = null;
+  }, 120000);
+
+  test('should stream-write a file and read it back', async () => {
+    const testPath = sandbox!.uniquePath('stream-write.txt');
+    const testContent = 'Streamed content for capnweb transport ✨';
+    const body = new TextEncoder().encode(testContent);
+
+    const writeResponse = await fetch(`${workerUrl}/api/file/write-stream`, {
+      method: 'PUT',
+      headers: { ...headers, 'X-File-Path': testPath },
+      body
+    });
+    expect(writeResponse.status).toBe(200);
+
+    const readResponse = await fetch(`${workerUrl}/api/file/read`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ path: testPath })
+    });
+    expect(readResponse.status).toBe(200);
+    const readResult = (await readResponse.json()) as ReadFileResult;
+    expect(readResult.content).toBe(testContent);
+  });
+
+  test('should preserve executable permissions on stream-write', async () => {
+    const testPath = sandbox!.uniquePath('stream-exec.sh');
+
+    // Create an executable file
+    await fetch(`${workerUrl}/api/execute`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        command: `mkdir -p $(dirname ${testPath}) && printf '#!/bin/sh\necho original' > ${testPath} && chmod +x ${testPath}`
+      })
+    });
+
+    // Overwrite via streaming
+    const newContent = '#!/bin/sh\necho updated';
+    const body = new TextEncoder().encode(newContent);
+    const writeResponse = await fetch(`${workerUrl}/api/file/write-stream`, {
+      method: 'PUT',
+      headers: { ...headers, 'X-File-Path': testPath },
+      body
+    });
+    expect(writeResponse.status).toBe(200);
+
+    // Verify file is still executable
+    const execResponse = await fetch(`${workerUrl}/api/execute`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        command: `test -x ${testPath} && echo executable`
+      })
+    });
+    expect(execResponse.status).toBe(200);
+    const result = (await execResponse.json()) as { stdout: string };
+    expect(result.stdout.trim()).toBe('executable');
+  });
+
+  test('should stream-write a large file', async () => {
+    const testPath = sandbox!.uniquePath('stream-large.bin');
+    // 256KB of data
+    const chunk = new Uint8Array(1024).fill(0x42);
+    const chunks: Uint8Array[] = [];
+    for (let i = 0; i < 256; i++) chunks.push(chunk);
+    const blob = new Blob(chunks);
+
+    const writeResponse = await fetch(`${workerUrl}/api/file/write-stream`, {
+      method: 'PUT',
+      headers: { ...headers, 'X-File-Path': testPath },
+      body: blob.stream(),
+      duplex: 'half'
+    } as RequestInit);
+    expect(writeResponse.status).toBe(200);
+
+    // Verify size
+    const execResponse = await fetch(`${workerUrl}/api/execute`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ command: `stat -c %s ${testPath}` })
+    });
+    expect(execResponse.status).toBe(200);
+    const result = (await execResponse.json()) as { stdout: string };
+    expect(Number.parseInt(result.stdout.trim(), 10)).toBe(256 * 1024);
+  });
+});

--- a/tests/e2e/git-clone-workflow.test.ts
+++ b/tests/e2e/git-clone-workflow.test.ts
@@ -79,9 +79,13 @@ describe('Git Clone Error Handling', () => {
       })
     });
 
-    expect(cloneResponse.status).toBe(500);
+    expect(cloneResponse.status).toBeGreaterThanOrEqual(400);
     const errorData = (await cloneResponse.json()) as ErrorResponse;
-    expect(errorData.error).toMatch(/Invalid timeout value: 0/i);
+    // "Invalid timeout value" comes from the HTTP handler's validation;
+    // "Invalid clone timeout" comes from the git service itself.
+    expect(errorData.error).toMatch(
+      /Invalid (timeout value|clone timeout).*0/i
+    );
   });
 });
 

--- a/tests/e2e/process-lifecycle-workflow.test.ts
+++ b/tests/e2e/process-lifecycle-workflow.test.ts
@@ -508,7 +508,7 @@ console.log("Line 3");
       }
 
       const killAllResponse = await fetch(`${workerUrl}/api/process/kill-all`, {
-        method: 'DELETE',
+        method: 'POST',
         headers
       });
       expect(killAllResponse.status).toBe(200);

--- a/tests/e2e/test-worker/index.ts
+++ b/tests/e2e/test-worker/index.ts
@@ -154,6 +154,8 @@ const ERROR_NAME_MAP: Record<string, { status: number; code: string }> = {
   PortError: { status: 500, code: 'PORT_OPERATION_ERROR' },
   // Git errors (generic)
   GitError: { status: 500, code: 'GIT_OPERATION_FAILED' },
+  // Security errors
+  SandboxSecurityError: { status: 400, code: 'SECURITY_ERROR' },
   // Validation errors
   ValidationFailedError: { status: 400, code: 'VALIDATION_FAILED' },
   DesktopNotStartedError: { status: 400, code: 'DESKTOP_NOT_STARTED' },
@@ -185,7 +187,10 @@ export default {
     if (proxyResponse) return proxyResponse;
 
     const url = new URL(request.url);
-    const body = await parseBody(request);
+    // Skip JSON body parsing for streaming endpoints to preserve request.body
+    const isStreamingUpload =
+      url.pathname === '/api/file/write-stream' && request.method === 'PUT';
+    const body = isStreamingUpload ? {} : await parseBody(request);
 
     // Get sandbox ID from header or query param (WebSocket can't send headers)
     // Sandbox ID determines which container instance (Durable Object)
@@ -194,9 +199,10 @@ export default {
       url.searchParams.get('sandboxId') ||
       'default-test-sandbox';
 
-    const transport: 'http' | 'websocket' =
-      request.headers.get('X-Sandbox-Transport') === 'websocket'
-        ? 'websocket'
+    const transportHeader = request.headers.get('X-Sandbox-Transport');
+    const transport: 'http' | 'websocket' | 'rpc' =
+      transportHeader === 'websocket' || transportHeader === 'rpc'
+        ? transportHeader
         : 'http';
 
     // Suffix sandbox ID with transport so each transport gets its own DO instance
@@ -661,6 +667,24 @@ console.log('Terminal server on port ' + port);
       if (url.pathname === '/api/file/write' && request.method === 'POST') {
         await executor.writeFile(body.path, body.content);
         return new Response(JSON.stringify({ success: true }), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      // File write via streaming (request body piped directly as a ReadableStream)
+      if (
+        url.pathname === '/api/file/write-stream' &&
+        request.method === 'PUT'
+      ) {
+        const filePath = request.headers.get('X-File-Path');
+        if (!filePath || !request.body) {
+          return new Response(
+            JSON.stringify({ error: 'X-File-Path header and body required' }),
+            { status: 400, headers: { 'Content-Type': 'application/json' } }
+          );
+        }
+        const result = await executor.writeFile(filePath, request.body);
+        return new Response(JSON.stringify(result), {
           headers: { 'Content-Type': 'application/json' }
         });
       }

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@repo/typescript-config/base.json",
   "compilerOptions": {
-    "types": ["node", "vitest"],
+    "types": ["node", "vitest", "@cloudflare/workers-types"],
     "lib": ["ES2022"]
   },
   "include": ["**/*.ts"],

--- a/tooling/typescript-config/bun.json
+++ b/tooling/typescript-config/bun.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./base.json",
   "compilerOptions": {
+    "customConditions": ["bun"],
     "noEmit": false,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
The Sandbox SDK currently offers two transports — HTTP and WebSocket — for communication between the Durable Object and the Bun container runtime. Both serialize every operation as an HTTP request; WebSocket just multiplexes them over a single connection to reduce sub-request count.

This PR introduces a third `rpc` transport built on [capnweb](https://github.com/cloudflare/capnweb), a Cap'n Proto-inspired RPC library that runs over WebSocket. capnweb replaces request/response serialization with typed RPC calls, which brings two immediate benefits:

- **Native streaming with backpressure** — `ReadableStream` values flow directly through the RPC layer without SSE encoding or base64 overhead.
- **Direct service calls** — the container exposes a typed `SandboxRPCAPI` that calls services directly, bypassing the HTTP handler/router layer entirely.

When `SANDBOX_TRANSPORT: rpc`, all sandbox operations — commands, files, processes, ports, git, code interpreter, desktop, backups, and file watching — go through native RPC. The HTTP handler/router layer is not involved.

> [!NOTE]
> This introduces some undesirable duplication right now, but makes it _much_ easier to remove the other two transports later.
>
> The changeset is huge because the `SandboxAPI` has been implemented again in a separate file. This duplication is intended to make it easier to remove the `http` and `websocket` transports if this experiment is successful.

The first operation to exploit native streaming is `writeFile`, which now accepts `string | ReadableStream<Uint8Array>`. Passing a stream pipes bytes to disk with automatic backpressure, removing the previous 32 MiB buffering constraint.

To run locally with worker:

```bash
npm i https://pkg.pr.new/cloudflare/sandbox-sdk/@cloudflare/sandbox@538
```
And update your Dockerfile to use the new sandbox client.

```Dockerfile
FROM cloudflare/sandbox:0.0.0-pr-538-<hash>
```

Then:

```bash
npx wrangler dev --var SANDBOX_TRANSPORT:rpc
```

## How it works

**Container side:** The Bun server gains a `/rpc` WebSocket upgrade endpoint. Each connection gets its own capnweb RPC session backed by `SandboxRPCAPI extends RpcTarget`, which has a typed method per operation. Service errors are thrown as exceptions; capnweb propagates them back to the caller automatically.

**SDK side:** `ContainerConnection` manages the capnweb WebSocket session and exposes a typed `rpc()` handle — the client-side mirror of `SandboxRPCAPI`. `RPCSandboxClient` wraps `ContainerConnection` and exposes the same sub-client fields as the existing `SandboxClient` (`commands`, `files`, `processes`, `ports`, `git`, `utils`, `interpreter`, `backup`, `desktop`, `watch`), so `sandbox.ts` switches between the two at construction time with no changes needed at call sites.

Transport selection is controlled by the existing `SANDBOX_TRANSPORT` environment variable or `transport` option, now accepting `"rpc"` in addition to `"http"` and `"websocket"`.

## Testing

**Unit tests** cover `ContainerConnection` in isolation — initial state, safe/repeated disconnect, connection failure propagation, and concurrent `connect()` deduplication.

**Existing unit tests** were updated to access the internal client through the `__client` accessor instead of casting through `any`. No behavioral changes. This makes the client itself private on the DO to avoid people depending on it.

**E2E tests** deploy a real worker with `TEST_TRANSPORT=rpc` and exercise command execution, streaming output, file write/read, directory listing, and session isolation through the full DO → container RPC path.

I've also manually tested against the bridge worker integration tests.

## Other changes

- `CodeInterpreter` constructor now takes `SandboxInterpreterAPI` directly instead of extracting it from the `Sandbox` instance.
-  In order to make the DO <> Bun client interactions RPC-able most of the logic has been pushed into the Bun server. THis means moving fields like `success` and other formatting into bun rather than sitting in a layer in the DO. We can do an audit on this once the web & http transports are gone.

## Follow-up

The HTTP transport, domain client classes (`CommandClient`, `FileClient`, etc.), HTTP handlers, and router remain in place for the `http` and `websocket` transport modes. A follow-up PR can remove them (~8 000 lines) once those modes are fully retired.

See https://github.com/cloudflare/sandbox-sdk/pull/539 for a first pass.
