### PR TITLE
Fix git clone timeout controls

### DIFF
--- a/.changeset/git-clone-timeout.md
+++ b/.changeset/git-clone-timeout.md
@@ -1,0 +1,6 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Increase the default `gitCheckout()` clone timeout to 10 minutes so larger repositories and slower Git remotes do not fail after 2 minutes by default.
+You can now override the git clone subprocess timeout per call with the `cloneTimeoutMs` option when a checkout needs more time.

--- a/packages/sandbox-container/src/core/types.ts
+++ b/packages/sandbox-container/src/core/types.ts
@@ -341,6 +341,8 @@ export interface CloneOptions {
   sessionId?: string;
   /** Clone depth for shallow clones (e.g., 1 for latest commit only) */
   depth?: number;
+  /** Maximum wall-clock time for the git clone subprocess in milliseconds */
+  timeoutMs?: number;
 }
 
 export interface ExecuteResponse {

--- a/packages/sandbox-container/src/handlers/git-handler.ts
+++ b/packages/sandbox-container/src/handlers/git-handler.ts
@@ -47,7 +47,8 @@ export class GitHandler extends BaseHandler<Request, Response> {
       branch: body.branch,
       targetDir: body.targetDir,
       sessionId,
-      depth: body.depth
+      depth: body.depth,
+      timeoutMs: body.timeoutMs
     });
 
     if (result.success) {

--- a/packages/sandbox-container/src/managers/git-manager.ts
+++ b/packages/sandbox-container/src/managers/git-manager.ts
@@ -14,12 +14,23 @@
  * NO I/O operations - all infrastructure delegated to SessionManager via GitService
  */
 
-import { extractRepoName } from '@repo/shared';
+import { DEFAULT_GIT_CLONE_TIMEOUT_MS, extractRepoName } from '@repo/shared';
 import { ErrorCode } from '@repo/shared/errors';
 import type { CloneOptions } from '../core/types';
 
-/** Wall-clock timeout in seconds for git clone operations. */
-export const GIT_CLONE_TIMEOUT_SECONDS = 120;
+export { DEFAULT_GIT_CLONE_TIMEOUT_MS } from '@repo/shared';
+
+const GIT_CLONE_KILL_GRACE_SECONDS = 5;
+
+export function gitCloneTimeoutSeconds(timeoutMs: number): string {
+  const timeoutSeconds = timeoutMs / 1000;
+  return Number.isInteger(timeoutSeconds)
+    ? String(timeoutSeconds)
+    : timeoutSeconds
+        .toFixed(3)
+        .replace(/\.0+$/, '')
+        .replace(/(\.\d*?)0+$/, '$1');
+}
 
 /**
  * GitManager contains pure business logic for git operations.
@@ -40,7 +51,7 @@ export class GitManager {
   /**
    * Build git clone command arguments
    *
-   * Wraps the command with `timeout -k 5 120` to enforce a 2-minute wall-clock
+   * Wraps the command with `timeout -k 5 <seconds>` to enforce a wall-clock
    * limit, and configures git's own stalled-transfer detection via
    * http.lowSpeedLimit and http.lowSpeedTime.
    */
@@ -49,11 +60,13 @@ export class GitManager {
     targetDir: string,
     options: CloneOptions = {}
   ): string[] {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_GIT_CLONE_TIMEOUT_MS;
+    const timeoutSeconds = gitCloneTimeoutSeconds(timeoutMs);
     const args = [
       'timeout',
       '-k',
-      '5',
-      String(GIT_CLONE_TIMEOUT_SECONDS),
+      String(GIT_CLONE_KILL_GRACE_SECONDS),
+      String(timeoutSeconds),
       'git',
       '-c',
       'http.lowSpeedLimit=1024',

--- a/packages/sandbox-container/src/services/git-service.ts
+++ b/packages/sandbox-container/src/services/git-service.ts
@@ -1,6 +1,7 @@
 // Git Operations Service
 
 import {
+  DEFAULT_GIT_CLONE_TIMEOUT_MS,
   type Logger,
   logCanonicalEvent,
   redactCommand,
@@ -13,7 +14,7 @@ import type {
 } from '@repo/shared/errors';
 import { ErrorCode } from '@repo/shared/errors';
 import type { CloneOptions, ServiceError, ServiceResult } from '../core/types';
-import { GIT_CLONE_TIMEOUT_SECONDS, GitManager } from '../managers/git-manager';
+import { GitManager, gitCloneTimeoutSeconds } from '../managers/git-manager';
 import type { SessionManager } from './session-manager';
 
 export interface SecurityService {
@@ -91,6 +92,25 @@ export class GitService {
       // Generate target directory if not provided
       const targetDirectory =
         options.targetDir || this.manager.generateTargetDirectory(repoUrl);
+      const cloneTimeoutMs = options.timeoutMs ?? DEFAULT_GIT_CLONE_TIMEOUT_MS;
+
+      if (!Number.isInteger(cloneTimeoutMs) || cloneTimeoutMs <= 0) {
+        errorMessage = `Invalid clone timeout '${options.timeoutMs}'. Must be a positive integer number of milliseconds.`;
+        return this.returnError({
+          message: errorMessage,
+          code: ErrorCode.VALIDATION_FAILED,
+          details: {
+            validationErrors: [
+              {
+                field: 'timeoutMs',
+                message:
+                  'Clone timeout must be a positive integer number of milliseconds',
+                code: 'INVALID_TIMEOUT'
+              }
+            ]
+          } satisfies ValidationFailedContext
+        });
+      }
 
       // Validate target directory path
       const pathValidation = this.security.validatePath(targetDirectory);
@@ -125,7 +145,9 @@ export class GitService {
           if (cloneResult.exitCode !== 0) {
             if (cloneResult.exitCode === 124) {
               throw {
-                message: `Git clone timed out after ${GIT_CLONE_TIMEOUT_SECONDS} seconds for '${redactCommand(repoUrl)}'`,
+                message: `Git clone timed out after ${gitCloneTimeoutSeconds(
+                  cloneTimeoutMs
+                )} seconds for '${redactCommand(repoUrl)}'`,
                 code: ErrorCode.GIT_NETWORK_ERROR,
                 details: {
                   repository: redactCommand(repoUrl),
@@ -213,6 +235,7 @@ export class GitService {
         repoUrl: redactCommand(repoUrl),
         targetDir: options.targetDir,
         branch: options.branch,
+        timeoutMs: options.timeoutMs ?? DEFAULT_GIT_CLONE_TIMEOUT_MS,
         sessionId,
         errorMessage,
         error: caughtError

--- a/packages/sandbox-container/src/services/git-service.ts
+++ b/packages/sandbox-container/src/services/git-service.ts
@@ -95,7 +95,7 @@ export class GitService {
       const cloneTimeoutMs = options.timeoutMs ?? DEFAULT_GIT_CLONE_TIMEOUT_MS;
 
       if (!Number.isInteger(cloneTimeoutMs) || cloneTimeoutMs <= 0) {
-        errorMessage = `Invalid clone timeout '${options.timeoutMs}'. Must be a positive integer number of milliseconds.`;
+        errorMessage = `Invalid clone timeout '${options.timeoutMs}'. Must be a positive integer representing milliseconds.`;
         return this.returnError({
           message: errorMessage,
           code: ErrorCode.VALIDATION_FAILED,

--- a/packages/sandbox-container/src/services/git-service.ts
+++ b/packages/sandbox-container/src/services/git-service.ts
@@ -104,7 +104,7 @@ export class GitService {
               {
                 field: 'timeoutMs',
                 message:
-                  'Clone timeout must be a positive integer number of milliseconds',
+                  'Clone timeout must be a positive integer representing milliseconds',
                 code: 'INVALID_TIMEOUT'
               }
             ]

--- a/packages/sandbox-container/tests/handlers/git-handler.test.ts
+++ b/packages/sandbox-container/tests/handlers/git-handler.test.ts
@@ -50,7 +50,8 @@ describe('GitHandler', () => {
         repoUrl: 'https://github.com/user/awesome-repo.git',
         branch: 'develop',
         targetDir: '/tmp/my-project',
-        sessionId: 'session-456'
+        sessionId: 'session-456',
+        timeoutMs: 90_000
       };
 
       const mockGitResult = {
@@ -87,7 +88,8 @@ describe('GitHandler', () => {
         {
           branch: 'develop',
           targetDir: '/tmp/my-project',
-          sessionId: 'session-456'
+          sessionId: 'session-456',
+          timeoutMs: 90_000
         }
       );
     });
@@ -134,7 +136,9 @@ describe('GitHandler', () => {
         {
           branch: undefined,
           targetDir: undefined,
-          sessionId: 'session-456' // From mockContext
+          sessionId: 'session-456', // From mockContext
+          depth: undefined,
+          timeoutMs: undefined
         }
       );
     });

--- a/packages/sandbox-container/tests/managers/git-manager.test.ts
+++ b/packages/sandbox-container/tests/managers/git-manager.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { ErrorCode } from '@repo/shared/errors';
-import { GitManager } from '@sandbox-container/managers/git-manager';
+import {
+  DEFAULT_GIT_CLONE_TIMEOUT_MS,
+  GitManager
+} from '@sandbox-container/managers/git-manager';
 
 describe('GitManager', () => {
   let manager: GitManager;
@@ -37,7 +40,12 @@ describe('GitManager', () => {
   });
 
   describe('buildCloneArgs', () => {
-    const timeoutPrefix = ['timeout', '-k', '5', '120'];
+    const timeoutPrefix = [
+      'timeout',
+      '-k',
+      '5',
+      String(DEFAULT_GIT_CLONE_TIMEOUT_MS / 1000)
+    ];
     const gitConfig = [
       'git',
       '-c',
@@ -131,6 +139,45 @@ describe('GitManager', () => {
         '--filter=blob:none',
         '--depth',
         '5',
+        'https://github.com/user/repo.git',
+        '/tmp/target'
+      ]);
+    });
+
+    it('should build clone args with custom timeout', () => {
+      const args = manager.buildCloneArgs(
+        'https://github.com/user/repo.git',
+        '/tmp/target',
+        { timeoutMs: 90_000 }
+      );
+      expect(args).toEqual([
+        'timeout',
+        '-k',
+        '5',
+        '90',
+        ...gitConfig,
+        'clone',
+        '--filter=blob:none',
+        'https://github.com/user/repo.git',
+        '/tmp/target'
+      ]);
+    });
+
+    it('should preserve millisecond precision for sub-second clone timeouts', () => {
+      const args = manager.buildCloneArgs(
+        'https://github.com/user/repo.git',
+        '/tmp/target',
+        { timeoutMs: 1_500 }
+      );
+
+      expect(args).toEqual([
+        'timeout',
+        '-k',
+        '5',
+        '1.5',
+        ...gitConfig,
+        'clone',
+        '--filter=blob:none',
         'https://github.com/user/repo.git',
         '/tmp/target'
       ]);

--- a/packages/sandbox-container/tests/services/git-service.test.ts
+++ b/packages/sandbox-container/tests/services/git-service.test.ts
@@ -5,6 +5,7 @@ import type {
   CloneOptions,
   ServiceResult
 } from '@sandbox-container/core/types';
+import { DEFAULT_GIT_CLONE_TIMEOUT_MS } from '@sandbox-container/managers/git-manager';
 import {
   GitService,
   type SecurityService
@@ -151,7 +152,7 @@ describe('GitService', () => {
       expect(mockSessionManager.executeInSession).toHaveBeenNthCalledWith(
         1,
         'default',
-        "'timeout' '-k' '5' '120' 'git' '-c' 'http.lowSpeedLimit=1024' '-c' 'http.lowSpeedTime=30' 'clone' '--filter=blob:none' 'https://github.com/user/repo.git' '/workspace/repo'"
+        "'timeout' '-k' '5' '600' 'git' '-c' 'http.lowSpeedLimit=1024' '-c' 'http.lowSpeedTime=30' 'clone' '--filter=blob:none' 'https://github.com/user/repo.git' '/workspace/repo'"
       );
 
       // Verify SessionManager was called for getting current branch
@@ -203,7 +204,39 @@ describe('GitService', () => {
       expect(mockSessionManager.executeInSession).toHaveBeenNthCalledWith(
         1,
         'session-123',
-        "'timeout' '-k' '5' '120' 'git' '-c' 'http.lowSpeedLimit=1024' '-c' 'http.lowSpeedTime=30' 'clone' '--filter=blob:none' '--branch' 'develop' 'https://github.com/user/repo.git' '/tmp/custom-target'"
+        "'timeout' '-k' '5' '600' 'git' '-c' 'http.lowSpeedLimit=1024' '-c' 'http.lowSpeedTime=30' 'clone' '--filter=blob:none' '--branch' 'develop' 'https://github.com/user/repo.git' '/tmp/custom-target'"
+      );
+    });
+
+    it('should clone repository with custom timeout', async () => {
+      mocked(mockSessionManager.executeInSession)
+        .mockResolvedValueOnce({
+          success: true,
+          data: {
+            exitCode: 0,
+            stdout: 'Cloning...',
+            stderr: ''
+          }
+        } as ServiceResult<RawExecResult>)
+        .mockResolvedValueOnce({
+          success: true,
+          data: {
+            exitCode: 0,
+            stdout: 'main\n',
+            stderr: ''
+          }
+        } as ServiceResult<RawExecResult>);
+
+      const result = await gitService.cloneRepository(
+        'https://github.com/user/repo.git',
+        { timeoutMs: 90_000 }
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockSessionManager.executeInSession).toHaveBeenNthCalledWith(
+        1,
+        'default',
+        "'timeout' '-k' '5' '90' 'git' '-c' 'http.lowSpeedLimit=1024' '-c' 'http.lowSpeedTime=30' 'clone' '--filter=blob:none' 'https://github.com/user/repo.git' '/workspace/repo'"
       );
     });
 
@@ -297,9 +330,26 @@ describe('GitService', () => {
       if (!result.success) {
         expect(result.error.code).toBe(ErrorCode.GIT_NETWORK_ERROR);
         expect(result.error.message).toContain('timed out');
-        expect(result.error.message).toContain('120 seconds');
+        expect(result.error.message).toContain(
+          `${DEFAULT_GIT_CLONE_TIMEOUT_MS / 1000} seconds`
+        );
         expect(result.error.details?.exitCode).toBe(124);
       }
+    });
+
+    it('should return validation error when timeout is invalid', async () => {
+      const result = await gitService.cloneRepository(
+        'https://github.com/user/repo.git',
+        { timeoutMs: 0 }
+      );
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe(ErrorCode.VALIDATION_FAILED);
+        expect(result.error.message).toContain('Invalid clone timeout');
+      }
+
+      expect(mockSessionManager.executeInSession).not.toHaveBeenCalled();
     });
 
     it('should sanitize credentials in timeout error messages', async () => {

--- a/packages/sandbox/src/clients/base-client.ts
+++ b/packages/sandbox/src/clients/base-client.ts
@@ -2,7 +2,11 @@ import type { Logger } from '@repo/shared';
 import { createNoOpLogger } from '@repo/shared';
 import type { ErrorResponse as NewErrorResponse } from '../errors';
 import { createErrorFromResponse, ErrorCode } from '../errors';
-import { createTransport, type ITransport } from './transport';
+import {
+  createTransport,
+  type ITransport,
+  type TransportRequestInit
+} from './transport';
 import type { HttpClientOptions, ResponseHandler } from './types';
 
 /**
@@ -61,7 +65,7 @@ export abstract class BaseHttpClient {
    */
   protected async doFetch(
     path: string,
-    options?: RequestInit
+    options?: TransportRequestInit
   ): Promise<Response> {
     const { defaultHeaders } = this.options;
     if (defaultHeaders) {
@@ -82,14 +86,16 @@ export abstract class BaseHttpClient {
   protected async post<T>(
     endpoint: string,
     data: unknown,
-    responseHandler?: ResponseHandler<T>
+    responseHandler?: ResponseHandler<T>,
+    requestOptions?: Pick<TransportRequestInit, 'requestTimeoutMs'>
   ): Promise<T> {
     const response = await this.doFetch(endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify(data)
+      body: JSON.stringify(data),
+      ...requestOptions
     });
 
     return this.handleResponse(response, responseHandler);

--- a/packages/sandbox/src/clients/git-client.ts
+++ b/packages/sandbox/src/clients/git-client.ts
@@ -1,5 +1,9 @@
 import type { GitCheckoutResult } from '@repo/shared';
-import { extractRepoName, GitLogger } from '@repo/shared';
+import {
+  DEFAULT_GIT_CLONE_TIMEOUT_MS,
+  extractRepoName,
+  GitLogger
+} from '@repo/shared';
 import { BaseHttpClient } from './base-client';
 import type { HttpClientOptions, SessionRequest } from './types';
 
@@ -15,12 +19,16 @@ export interface GitCheckoutRequest extends SessionRequest {
   targetDir?: string;
   /** Clone depth for shallow clones (e.g., 1 for latest commit only) */
   depth?: number;
+  /** Maximum wall-clock time for the git clone subprocess in milliseconds */
+  timeoutMs?: number;
 }
 
 /**
  * Client for Git repository operations
  */
 export class GitClient extends BaseHttpClient {
+  private static readonly REQUEST_TIMEOUT_BUFFER_MS = 30_000;
+
   constructor(options: HttpClientOptions = {}) {
     super(options);
     // Wrap logger with GitLogger to auto-redact credentials
@@ -31,7 +39,7 @@ export class GitClient extends BaseHttpClient {
    * Clone a Git repository
    * @param repoUrl - URL of the Git repository to clone
    * @param sessionId - The session ID for this operation
-   * @param options - Optional settings (branch, targetDir, depth)
+   * @param options - Optional settings (branch, targetDir, depth, timeoutMs)
    */
   async checkout(
     repoUrl: string,
@@ -41,9 +49,13 @@ export class GitClient extends BaseHttpClient {
       targetDir?: string;
       /** Clone depth for shallow clones (e.g., 1 for latest commit only) */
       depth?: number;
+      /** Maximum wall-clock time for the git clone subprocess in milliseconds */
+      timeoutMs?: number;
     }
   ): Promise<GitCheckoutResult> {
     try {
+      const timeoutMs = options?.timeoutMs ?? DEFAULT_GIT_CLONE_TIMEOUT_MS;
+
       // Determine target directory - use provided path or generate from repo name
       let targetDir = options?.targetDir;
       if (!targetDir) {
@@ -71,9 +83,21 @@ export class GitClient extends BaseHttpClient {
         data.depth = options.depth;
       }
 
+      if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+        throw new Error(
+          `Invalid timeout value: ${timeoutMs}. Must be a positive integer number of milliseconds.`
+        );
+      }
+
+      data.timeoutMs = timeoutMs;
+
       const response = await this.post<GitCheckoutResult>(
         '/api/git/checkout',
-        data
+        data,
+        undefined,
+        {
+          requestTimeoutMs: timeoutMs + GitClient.REQUEST_TIMEOUT_BUFFER_MS
+        }
       );
 
       return response;

--- a/packages/sandbox/src/clients/transport/base-transport.ts
+++ b/packages/sandbox/src/clients/transport/base-transport.ts
@@ -1,6 +1,11 @@
 import type { Logger } from '@repo/shared';
 import { createNoOpLogger } from '@repo/shared';
-import type { ITransport, TransportConfig, TransportMode } from './types';
+import type {
+  ITransport,
+  TransportConfig,
+  TransportMode,
+  TransportRequestInit
+} from './types';
 
 /**
  * Container startup retry configuration
@@ -44,7 +49,7 @@ export abstract class BaseTransport implements ITransport {
    * This is the primary entry point for making requests. It wraps the
    * transport-specific doFetch() with retry logic for container startup.
    */
-  async fetch(path: string, options?: RequestInit): Promise<Response> {
+  async fetch(path: string, options?: TransportRequestInit): Promise<Response> {
     const startTime = Date.now();
     let attempt = 0;
 
@@ -90,7 +95,7 @@ export abstract class BaseTransport implements ITransport {
    */
   protected abstract doFetch(
     path: string,
-    options?: RequestInit
+    options?: TransportRequestInit
   ): Promise<Response>;
 
   /**

--- a/packages/sandbox/src/clients/transport/http-transport.ts
+++ b/packages/sandbox/src/clients/transport/http-transport.ts
@@ -1,5 +1,5 @@
 import { BaseTransport } from './base-transport';
-import type { TransportMode } from './types';
+import type { TransportMode, TransportRequestInit } from './types';
 
 /**
  * HTTP transport implementation
@@ -30,7 +30,7 @@ export class HttpTransport extends BaseTransport {
 
   protected async doFetch(
     path: string,
-    options?: RequestInit
+    options?: TransportRequestInit
   ): Promise<Response> {
     return this.httpFetch(path, options);
   }

--- a/packages/sandbox/src/clients/transport/index.ts
+++ b/packages/sandbox/src/clients/transport/index.ts
@@ -3,7 +3,12 @@
 // =============================================================================
 
 export type { TransportOptions } from './factory';
-export type { ITransport, TransportConfig, TransportMode } from './types';
+export type {
+  ITransport,
+  TransportConfig,
+  TransportMode,
+  TransportRequestInit
+} from './types';
 
 // =============================================================================
 // Implementations (for advanced use cases)

--- a/packages/sandbox/src/clients/transport/types.ts
+++ b/packages/sandbox/src/clients/transport/types.ts
@@ -46,6 +46,11 @@ export interface TransportConfig {
   retryTimeoutMs?: number;
 }
 
+export interface TransportRequestInit extends RequestInit {
+  /** Override the non-streaming request timeout for this single request. */
+  requestTimeoutMs?: number;
+}
+
 /**
  * Transport interface - all transports must implement this
  *
@@ -57,7 +62,7 @@ export interface ITransport {
    * Make a fetch-compatible request
    * @returns Standard Response object
    */
-  fetch(path: string, options?: RequestInit): Promise<Response>;
+  fetch(path: string, options?: TransportRequestInit): Promise<Response>;
 
   /**
    * Make a streaming request

--- a/packages/sandbox/src/clients/transport/ws-transport.ts
+++ b/packages/sandbox/src/clients/transport/ws-transport.ts
@@ -10,7 +10,11 @@ import {
   type WSStreamChunk
 } from '@repo/shared';
 import { BaseTransport } from './base-transport';
-import type { TransportConfig, TransportMode } from './types';
+import type {
+  TransportConfig,
+  TransportMode,
+  TransportRequestInit
+} from './types';
 
 /**
  * Default timeout values (all in milliseconds)
@@ -144,7 +148,7 @@ export class WebSocketTransport extends BaseTransport {
    */
   protected async doFetch(
     path: string,
-    options?: RequestInit
+    options?: TransportRequestInit
   ): Promise<Response> {
     if (this.isWebSocketConnecting()) {
       return this.httpFetch(path, options);
@@ -156,7 +160,13 @@ export class WebSocketTransport extends BaseTransport {
     const body = this.parseBody(options?.body);
     const headers = this.normalizeHeaders(options?.headers);
 
-    const result = await this.request(method, path, body, headers);
+    const result = await this.request(
+      method,
+      path,
+      body,
+      headers,
+      options?.requestTimeoutMs
+    );
 
     return new Response(JSON.stringify(result.body), {
       status: result.status,
@@ -408,7 +418,8 @@ export class WebSocketTransport extends BaseTransport {
     method: WSMethod,
     path: string,
     body?: unknown,
-    headers?: Record<string, string>
+    headers?: Record<string, string>,
+    requestTimeoutMs?: number
   ): Promise<{ status: number; body: T }> {
     await this.connect();
     this.clearIdleDisconnectTimer();
@@ -425,7 +436,9 @@ export class WebSocketTransport extends BaseTransport {
 
     return new Promise((resolve, reject) => {
       const timeoutMs =
-        this.config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+        requestTimeoutMs ??
+        this.config.requestTimeoutMs ??
+        DEFAULT_REQUEST_TIMEOUT_MS;
       const timeoutId = setTimeout(() => {
         this.pendingRequests.delete(id);
         this.scheduleIdleDisconnect();

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -2777,13 +2777,16 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       sessionId?: string;
       /** Clone depth for shallow clones (e.g., 1 for latest commit only) */
       depth?: number;
+      /** Maximum wall-clock time for the git clone subprocess in milliseconds */
+      cloneTimeoutMs?: number;
     }
   ) {
     const session = options?.sessionId ?? (await this.ensureDefaultSession());
     return this.client.git.checkout(repoUrl, session, {
       branch: options?.branch,
       targetDir: options?.targetDir,
-      depth: options?.depth
+      depth: options?.depth,
+      timeoutMs: options?.cloneTimeoutMs
     });
   }
 

--- a/packages/sandbox/tests/git-client.test.ts
+++ b/packages/sandbox/tests/git-client.test.ts
@@ -1,4 +1,7 @@
-import type { GitCheckoutResult } from '@repo/shared';
+import {
+  DEFAULT_GIT_CLONE_TIMEOUT_MS,
+  type GitCheckoutResult
+} from '@repo/shared';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GitClient } from '../src/clients/git-client';
 import {
@@ -55,6 +58,10 @@ describe('GitClient', () => {
       expect(result.success).toBe(true);
       expect(result.repoUrl).toBe('https://github.com/facebook/react.git');
       expect(result.branch).toBe('main');
+
+      const fetchCall = mockFetch.mock.calls[0];
+      const requestBody = JSON.parse(fetchCall[1].body as string);
+      expect(requestBody.timeoutMs).toBe(DEFAULT_GIT_CLONE_TIMEOUT_MS);
     });
 
     it('should clone repositories to specific branches', async () => {
@@ -180,6 +187,32 @@ describe('GitClient', () => {
       expect(requestBody.depth).toBe(10);
     });
 
+    it('should clone repositories with custom timeout', async () => {
+      const mockResponse: GitCheckoutResult = {
+        success: true,
+        repoUrl: 'https://github.com/company/project.git',
+        branch: 'main',
+        targetDir: '/workspace/project',
+        timestamp: '2023-01-01T00:00:00Z'
+      };
+
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(mockResponse), { status: 200 })
+      );
+
+      const result = await client.checkout(
+        'https://github.com/company/project.git',
+        'test-session',
+        { timeoutMs: 90_000 }
+      );
+
+      expect(result.success).toBe(true);
+
+      const fetchCall = mockFetch.mock.calls[0];
+      const requestBody = JSON.parse(fetchCall[1].body as string);
+      expect(requestBody.timeoutMs).toBe(90_000);
+    });
+
     it('should reject depth of zero', async () => {
       await expect(
         client.checkout('https://github.com/user/repo.git', 'test-session', {
@@ -206,6 +239,16 @@ describe('GitClient', () => {
           depth: 1.5
         })
       ).rejects.toThrow('Invalid depth value: 1.5');
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should reject invalid timeout values', async () => {
+      await expect(
+        client.checkout('https://github.com/user/repo.git', 'test-session', {
+          timeoutMs: 0
+        })
+      ).rejects.toThrow('Invalid timeout value: 0');
 
       expect(mockFetch).not.toHaveBeenCalled();
     });

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -292,14 +292,20 @@ describe('Sandbox - Automatic Session Management', () => {
       } as any);
 
       await sandbox.gitCheckout('https://github.com/test/repo.git', {
-        branch: 'main'
+        branch: 'main',
+        cloneTimeoutMs: 90_000
       });
 
       expect(sandbox.client.utils.createSession).toHaveBeenCalledTimes(1);
       expect(sandbox.client.git.checkout).toHaveBeenCalledWith(
         'https://github.com/test/repo.git',
         expect.stringMatching(/^sandbox-/),
-        { branch: 'main', targetDir: undefined }
+        {
+          branch: 'main',
+          targetDir: undefined,
+          depth: undefined,
+          timeoutMs: 90_000
+        }
       );
     });
 
@@ -514,12 +520,20 @@ describe('Sandbox - Automatic Session Management', () => {
         timestamp: new Date().toISOString()
       } as any);
 
-      await session.gitCheckout('https://github.com/test/repo.git');
+      await session.gitCheckout('https://github.com/test/repo.git', {
+        depth: 1,
+        cloneTimeoutMs: 90_000
+      });
 
       expect(sandbox.client.git.checkout).toHaveBeenCalledWith(
         'https://github.com/test/repo.git',
         'test-session',
-        { branch: undefined, targetDir: undefined }
+        {
+          branch: undefined,
+          targetDir: undefined,
+          depth: 1,
+          timeoutMs: 90_000
+        }
       );
     });
   });

--- a/packages/sandbox/tests/ws-transport.test.ts
+++ b/packages/sandbox/tests/ws-transport.test.ts
@@ -188,6 +188,57 @@ describe('WebSocket Protocol Types', () => {
   });
 
   describe('request headers', () => {
+    it('should honor per-request timeout overrides for websocket requests', async () => {
+      vi.useFakeTimers();
+      try {
+        const transport = new WebSocketTransport({
+          wsUrl: 'ws://localhost:3000/ws',
+          requestTimeoutMs: 1000
+        });
+
+        (transport as any).connect = vi.fn().mockResolvedValue(undefined);
+        const wsSend = vi.fn();
+        (transport as any).ws = {
+          readyState: WebSocket.OPEN,
+          send: wsSend,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          close: vi.fn()
+        };
+
+        const requestPromise = (transport as any).request(
+          'GET',
+          '/api/health',
+          undefined,
+          undefined,
+          3000
+        ) as Promise<{ status: number; body: { ok: boolean } }>;
+
+        await Promise.resolve();
+        expect(wsSend).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(1500);
+
+        const pendingIds = Array.from(
+          ((transport as any).pendingRequests as Map<string, unknown>).keys()
+        );
+        expect(pendingIds).toHaveLength(1);
+
+        (transport as any).handleResponse({
+          type: 'response',
+          id: pendingIds[0],
+          status: 200,
+          body: { ok: true },
+          done: true
+        });
+
+        const response = await requestPromise;
+        expect(response.status).toBe(200);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('should include headers in websocket requests', async () => {
       const transport = new WebSocketTransport({
         wsUrl: 'ws://localhost:3000/ws',

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -6,6 +6,9 @@ import { redactCommand } from './logger/sanitize.js';
  */
 export const FALLBACK_REPO_NAME = 'repository';
 
+/** Default wall-clock timeout in milliseconds for git clone operations. */
+export const DEFAULT_GIT_CLONE_TIMEOUT_MS = 600_000;
+
 /**
  * Extract repository name from a Git URL
  *

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -33,6 +33,7 @@ export type {
 export { filterEnvVars, getEnvString, partitionEnvVars } from './env.js';
 // Export git utilities
 export {
+  DEFAULT_GIT_CLONE_TIMEOUT_MS,
   extractRepoName,
   FALLBACK_REPO_NAME,
   GitLogger,

--- a/packages/shared/src/request-types.ts
+++ b/packages/shared/src/request-types.ts
@@ -112,6 +112,8 @@ export interface GitCheckoutRequest {
   sessionId?: string;
   /** Clone depth for shallow clones (e.g., 1 for latest commit only) */
   depth?: number;
+  /** Maximum wall-clock time for the git clone subprocess in milliseconds */
+  timeoutMs?: number;
 }
 
 /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1039,6 +1039,8 @@ export interface ExecutionSession {
       targetDir?: string;
       /** Clone depth for shallow clones (e.g., 1 for latest commit only) */
       depth?: number;
+      /** Maximum wall-clock time for the git clone subprocess in milliseconds */
+      cloneTimeoutMs?: number;
     }
   ): Promise<GitCheckoutResult>;
 
@@ -1299,8 +1301,11 @@ export interface ISandbox {
     options?: {
       branch?: string;
       targetDir?: string;
+      sessionId?: string;
       /** Clone depth for shallow clones (e.g., 1 for latest commit only) */
       depth?: number;
+      /** Maximum wall-clock time for the git clone subprocess in milliseconds */
+      cloneTimeoutMs?: number;
     }
   ): Promise<GitCheckoutResult>;
 

--- a/tests/e2e/git-clone-workflow.test.ts
+++ b/tests/e2e/git-clone-workflow.test.ts
@@ -68,6 +68,21 @@ describe('Git Clone Error Handling', () => {
       /authentication|permission|access|denied|fatal|not found/i
     );
   }, 90000);
+
+  test('should reject invalid git clone timeout values before cloning', async () => {
+    const cloneResponse = await fetch(`${workerUrl}/api/git/clone`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        repoUrl: 'https://github.com/octocat/Spoon-Knife',
+        cloneTimeoutMs: 0
+      })
+    });
+
+    expect(cloneResponse.status).toBe(500);
+    const errorData = (await cloneResponse.json()) as ErrorResponse;
+    expect(errorData.error).toMatch(/Invalid timeout value: 0/i);
+  });
 });
 
 /**

--- a/tests/e2e/test-worker/index.ts
+++ b/tests/e2e/test-worker/index.ts
@@ -539,7 +539,8 @@ console.log('Terminal server on port ' + port);
         const result = await executor.gitCheckout(body.repoUrl, {
           branch: body.branch,
           targetDir: body.targetDir,
-          depth: body.depth
+          depth: body.depth,
+          cloneTimeoutMs: body.cloneTimeoutMs
         });
         return new Response(JSON.stringify(result), {
           headers: { 'Content-Type': 'application/json' }


### PR DESCRIPTION
## Summary
- raise the default `gitCheckout()` clone timeout from 2 minutes to 10 minutes so larger or slower repositories stop failing on the current hard limit
- add an explicit `cloneTimeoutMs` override that is threaded through the SDK, transport layer, request types, container handler, and git service
- validate timeout input early and preserve sub-second precision when formatting the underlying `timeout` command so the API matches what the subprocess actually does

## Why
Users on `0.8.7` and `0.8.8` can hit a hardcoded 120 second timeout in the clone path behind `gitCheckout()`, even with `depth: 1`. This change fixes the immediate product issue and makes the timeout user-controlled without broadening the API beyond the existing checkout primitive.

## Testing
- `npm test -w @cloudflare/sandbox -- git-client.test.ts sandbox.test.ts`
- `bun test tests/handlers/git-handler.test.ts tests/services/git-service.test.ts tests/managers/git-manager.test.ts`
- `npm run typecheck:e2e`
- `git push` pre-push hook: `npm run typecheck`

## Reviewer Notes
- `cloneTimeoutMs` is intentionally scoped to the `git clone` subprocess. It does not try to represent total wall-clock time including cold start or container readiness retries, which keeps the API semantics explicit.
- The transport changes are there to support per-request request timeouts, especially in WebSocket mode, so clone requests can outlive the old 120 second client timeout without changing global request behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
