### PR TITLE
Add push permission for library publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
             "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/containers/registries/registry.cloudflare.com/credentials" \
             -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d '{"expiration_minutes": 30, "permissions": ["pull", "library_push"]}')
+            -d '{"expiration_minutes": 30, "permissions": ["pull", "push", "library_push"]}')
           CF_USER=$(echo "$CREDS" | jq -r '.result.username')
           CF_PASS=$(echo "$CREDS" | jq -r '.result.password')
           echo "$CF_PASS" | docker login registry.cloudflare.com -u "$CF_USER" --password-stdin


### PR DESCRIPTION
The library publish step added in #579 failed on its first release with `UNAUTHORIZED` on blob uploads. The `library_push` capability gates authorization to write to the `library/` namespace, but the underlying Docker registry protocol operations (blob uploads via `POST /v2/.../blobs/uploads/`) still require the base `push` permission.

Add `push` to the credentials request alongside `pull` and `library_push`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
