### PR TITLE
Pass metadata into performance tests

### DIFF
--- a/tests/perf/helpers/report-generator.ts
+++ b/tests/perf/helpers/report-generator.ts
@@ -2,14 +2,27 @@
  * Generates console and JSON reports from collected metrics
  */
 
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 import { METRICS, PASS_THRESHOLD, SCENARIOS } from './constants';
 import type {
   GlobalMetricsStore,
   MeasurementStats,
   MetricsCollector
 } from './metrics-collector';
+
+function getSdkVersion(): string {
+  try {
+    const pkgPath = resolve(
+      __dirname,
+      '../../../packages/sandbox/package.json'
+    );
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    return pkg.version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
 
 export interface PerfTestResult {
   version: string;
@@ -170,7 +183,7 @@ export class ReportGenerator {
     const failedCount = scenarios.length - passedCount;
 
     return {
-      version: '1.0.0',
+      version: getSdkVersion(),
       timestamp: new Date().toISOString(),
       runId: `perf-${Date.now()}`,
       environment: {

--- a/turbo.json
+++ b/turbo.json
@@ -93,6 +93,13 @@
         "tests/perf/**/*.ts",
         "vitest.perf.config.ts",
         "packages/sandbox/Dockerfile"
+      ],
+      "env": [
+        "TEST_WORKER_URL",
+        "GITHUB_SHA",
+        "GITHUB_REF_NAME",
+        "GITHUB_EVENT_NAME",
+        "CI"
       ]
     },
     "test:e2e:browser": {


### PR DESCRIPTION
# Summary

When running all performance scenarios (`scenario=all`), branch, commit SHA, and CI metadata were missing from reports. This happened because `npm run test:perf` runs through Turbo, which isolates environment variables, `GITHUB_SHA`, `GITHUB_REF_NAME`, `GITHUB_EVENT_NAME`, and `CI` weren't being passed through. Running a single scenario worked because it invokes vitest directly, bypassing Turbo.

Additionally, the SDK version stored in D1 was always `1.0.0` (a hardcoded report format version) instead of the actual `@cloudflare/sandbox` package version.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
