### PR TITLE
Add placement-based runtime identity API

### DIFF
--- a/.changeset/runtime-identity-api.md
+++ b/.changeset/runtime-identity-api.md
@@ -4,6 +4,5 @@
 
 Add `getRuntimeIdentity()` to read a placement-derived `runtimeId`
 for the currently observed sandbox runtime. The value stays stable
-while the same container keeps running, refreshes after SDK-observed
-restarts, and falls back to older container images that do not yet
-expose the dedicated runtime identity endpoint.
+while the same container keeps running and refreshes after
+SDK-observed restarts.

--- a/.changeset/runtime-identity-api.md
+++ b/.changeset/runtime-identity-api.md
@@ -3,6 +3,6 @@
 ---
 
 Add `getRuntimeIdentity()` to detect when a sandbox starts a new
-container runtime. Use the returned `runtimeId` to compare the current
-runtime with the last one you observed and decide when reconciliation
-is needed.
+container runtime. It returns a stable placement-based `runtimeId`
+that stays available after the initial container startup, so callers
+can compare the current runtime with the last one they observed.

--- a/.changeset/runtime-identity-api.md
+++ b/.changeset/runtime-identity-api.md
@@ -1,0 +1,8 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Add `getRuntimeIdentity()` to detect when a sandbox starts a new
+container runtime. Use the returned `runtimeId` to compare the current
+runtime with the last one you observed and decide when reconciliation
+is needed.

--- a/.changeset/runtime-identity-api.md
+++ b/.changeset/runtime-identity-api.md
@@ -2,7 +2,8 @@
 '@cloudflare/sandbox': patch
 ---
 
-Add `getRuntimeIdentity()` to detect when a sandbox starts a new
-container runtime. It returns a stable placement-based `runtimeId`
-that stays available after the initial container startup, so callers
-can compare the current runtime with the last one they observed.
+Add `getRuntimeIdentity()` to read a placement-derived `runtimeId`
+for the currently observed sandbox runtime. The value stays stable
+while the same container keeps running, refreshes after SDK-observed
+restarts, and falls back to older container images that do not yet
+expose the dedicated runtime identity endpoint.

--- a/packages/sandbox-container/src/handlers/misc-handler.ts
+++ b/packages/sandbox-container/src/handlers/misc-handler.ts
@@ -11,6 +11,16 @@ export interface VersionResult {
   timestamp: string;
 }
 
+export interface RuntimeIdentityResult {
+  success: boolean;
+  runtimeId: string;
+  startedAt: string;
+  timestamp: string;
+}
+
+const CONTAINER_RUNTIME_ID = crypto.randomUUID();
+const CONTAINER_STARTED_AT = new Date().toISOString();
+
 export class MiscHandler extends BaseHandler<Request, Response> {
   async handle(request: Request, context: RequestContext): Promise<Response> {
     const url = new URL(request.url);
@@ -27,6 +37,8 @@ export class MiscHandler extends BaseHandler<Request, Response> {
         return await this.handleShutdown(request, context);
       case '/api/version':
         return await this.handleVersion(request, context);
+      case '/api/runtime':
+        return await this.handleRuntime(request, context);
       default:
         return this.createErrorResponse(
           {
@@ -85,6 +97,20 @@ export class MiscHandler extends BaseHandler<Request, Response> {
     const response: VersionResult = {
       success: true,
       version,
+      timestamp: new Date().toISOString()
+    };
+
+    return this.createTypedResponse(response, context);
+  }
+
+  private async handleRuntime(
+    request: Request,
+    context: RequestContext
+  ): Promise<Response> {
+    const response: RuntimeIdentityResult = {
+      success: true,
+      runtimeId: CONTAINER_RUNTIME_ID,
+      startedAt: CONTAINER_STARTED_AT,
       timestamp: new Date().toISOString()
     };
 

--- a/packages/sandbox-container/src/handlers/misc-handler.ts
+++ b/packages/sandbox-container/src/handlers/misc-handler.ts
@@ -11,16 +11,6 @@ export interface VersionResult {
   timestamp: string;
 }
 
-export interface RuntimeIdentityResult {
-  success: boolean;
-  runtimeId: string;
-  startedAt: string;
-  timestamp: string;
-}
-
-const CONTAINER_RUNTIME_ID = crypto.randomUUID();
-const CONTAINER_STARTED_AT = new Date().toISOString();
-
 export class MiscHandler extends BaseHandler<Request, Response> {
   async handle(request: Request, context: RequestContext): Promise<Response> {
     const url = new URL(request.url);
@@ -37,8 +27,6 @@ export class MiscHandler extends BaseHandler<Request, Response> {
         return await this.handleShutdown(request, context);
       case '/api/version':
         return await this.handleVersion(request, context);
-      case '/api/runtime':
-        return await this.handleRuntime(request, context);
       default:
         return this.createErrorResponse(
           {
@@ -97,20 +85,6 @@ export class MiscHandler extends BaseHandler<Request, Response> {
     const response: VersionResult = {
       success: true,
       version,
-      timestamp: new Date().toISOString()
-    };
-
-    return this.createTypedResponse(response, context);
-  }
-
-  private async handleRuntime(
-    request: Request,
-    context: RequestContext
-  ): Promise<Response> {
-    const response: RuntimeIdentityResult = {
-      success: true,
-      runtimeId: CONTAINER_RUNTIME_ID,
-      startedAt: CONTAINER_STARTED_AT,
       timestamp: new Date().toISOString()
     };
 

--- a/packages/sandbox-container/src/handlers/misc-handler.ts
+++ b/packages/sandbox-container/src/handlers/misc-handler.ts
@@ -11,6 +11,12 @@ export interface VersionResult {
   timestamp: string;
 }
 
+export interface RuntimeIdentityResult {
+  success: boolean;
+  runtimeId: string;
+  timestamp: string;
+}
+
 export class MiscHandler extends BaseHandler<Request, Response> {
   async handle(request: Request, context: RequestContext): Promise<Response> {
     const url = new URL(request.url);
@@ -25,6 +31,8 @@ export class MiscHandler extends BaseHandler<Request, Response> {
         return await this.handleHealth(request, context);
       case '/api/shutdown':
         return await this.handleShutdown(request, context);
+      case '/api/runtime/identity':
+        return await this.handleRuntimeIdentity(request, context);
       case '/api/version':
         return await this.handleVersion(request, context);
       default:
@@ -85,6 +93,21 @@ export class MiscHandler extends BaseHandler<Request, Response> {
     const response: VersionResult = {
       success: true,
       version,
+      timestamp: new Date().toISOString()
+    };
+
+    return this.createTypedResponse(response, context);
+  }
+
+  private async handleRuntimeIdentity(
+    request: Request,
+    context: RequestContext
+  ): Promise<Response> {
+    const runtimeId = (process.env.CLOUDFLARE_PLACEMENT_ID || '').trim();
+
+    const response: RuntimeIdentityResult = {
+      success: true,
+      runtimeId,
       timestamp: new Date().toISOString()
     };
 

--- a/packages/sandbox-container/src/routes/setup.ts
+++ b/packages/sandbox-container/src/routes/setup.ts
@@ -478,4 +478,11 @@ export function setupRoutes(router: Router, container: Container): void {
     handler: async (req, ctx) => container.get('miscHandler').handle(req, ctx),
     middleware: [container.get('loggingMiddleware')]
   });
+
+  router.register({
+    method: 'GET',
+    path: '/api/runtime',
+    handler: async (req, ctx) => container.get('miscHandler').handle(req, ctx),
+    middleware: [container.get('loggingMiddleware')]
+  });
 }

--- a/packages/sandbox-container/src/routes/setup.ts
+++ b/packages/sandbox-container/src/routes/setup.ts
@@ -478,11 +478,4 @@ export function setupRoutes(router: Router, container: Container): void {
     handler: async (req, ctx) => container.get('miscHandler').handle(req, ctx),
     middleware: [container.get('loggingMiddleware')]
   });
-
-  router.register({
-    method: 'GET',
-    path: '/api/runtime',
-    handler: async (req, ctx) => container.get('miscHandler').handle(req, ctx),
-    middleware: [container.get('loggingMiddleware')]
-  });
 }

--- a/packages/sandbox-container/src/routes/setup.ts
+++ b/packages/sandbox-container/src/routes/setup.ts
@@ -478,4 +478,11 @@ export function setupRoutes(router: Router, container: Container): void {
     handler: async (req, ctx) => container.get('miscHandler').handle(req, ctx),
     middleware: [container.get('loggingMiddleware')]
   });
+
+  router.register({
+    method: 'GET',
+    path: '/api/runtime/identity',
+    handler: async (req, ctx) => container.get('miscHandler').handle(req, ctx),
+    middleware: [container.get('loggingMiddleware')]
+  });
 }

--- a/packages/sandbox-container/tests/handlers/misc-handler.test.ts
+++ b/packages/sandbox-container/tests/handlers/misc-handler.test.ts
@@ -4,6 +4,7 @@ import type { ErrorResponse } from '@repo/shared/errors';
 import type { RequestContext } from '@sandbox-container/core/types';
 import {
   MiscHandler,
+  type RuntimeIdentityResult,
   type VersionResult
 } from '@sandbox-container/handlers/misc-handler';
 
@@ -221,6 +222,48 @@ describe('MiscHandler', () => {
       expect(response.headers.get('Access-Control-Allow-Headers')).toBe(
         'Content-Type'
       );
+    });
+  });
+
+  describe('handleRuntime - GET /api/runtime', () => {
+    it('should return runtime identity', async () => {
+      const request = new Request('http://localhost:3000/api/runtime', {
+        method: 'GET'
+      });
+
+      const response = await miscHandler.handle(request, mockContext);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toBe('application/json');
+
+      const responseData = (await response.json()) as RuntimeIdentityResult;
+      expect(responseData.success).toBe(true);
+      expect(responseData.runtimeId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      );
+      expect(responseData.startedAt).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+      );
+      expect(responseData.timestamp).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+      );
+    });
+
+    it('should keep runtime identity stable across requests', async () => {
+      const request = new Request('http://localhost:3000/api/runtime', {
+        method: 'GET'
+      });
+
+      const response1 = await miscHandler.handle(request, mockContext);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      const response2 = await miscHandler.handle(request, mockContext);
+
+      const responseData1 = (await response1.json()) as RuntimeIdentityResult;
+      const responseData2 = (await response2.json()) as RuntimeIdentityResult;
+
+      expect(responseData1.runtimeId).toBe(responseData2.runtimeId);
+      expect(responseData1.startedAt).toBe(responseData2.startedAt);
+      expect(responseData1.timestamp).not.toBe(responseData2.timestamp);
     });
   });
 

--- a/packages/sandbox-container/tests/handlers/misc-handler.test.ts
+++ b/packages/sandbox-container/tests/handlers/misc-handler.test.ts
@@ -4,7 +4,6 @@ import type { ErrorResponse } from '@repo/shared/errors';
 import type { RequestContext } from '@sandbox-container/core/types';
 import {
   MiscHandler,
-  type RuntimeIdentityResult,
   type VersionResult
 } from '@sandbox-container/handlers/misc-handler';
 
@@ -222,48 +221,6 @@ describe('MiscHandler', () => {
       expect(response.headers.get('Access-Control-Allow-Headers')).toBe(
         'Content-Type'
       );
-    });
-  });
-
-  describe('handleRuntime - GET /api/runtime', () => {
-    it('should return runtime identity', async () => {
-      const request = new Request('http://localhost:3000/api/runtime', {
-        method: 'GET'
-      });
-
-      const response = await miscHandler.handle(request, mockContext);
-
-      expect(response.status).toBe(200);
-      expect(response.headers.get('Content-Type')).toBe('application/json');
-
-      const responseData = (await response.json()) as RuntimeIdentityResult;
-      expect(responseData.success).toBe(true);
-      expect(responseData.runtimeId).toMatch(
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-      );
-      expect(responseData.startedAt).toMatch(
-        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
-      );
-      expect(responseData.timestamp).toMatch(
-        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
-      );
-    });
-
-    it('should keep runtime identity stable across requests', async () => {
-      const request = new Request('http://localhost:3000/api/runtime', {
-        method: 'GET'
-      });
-
-      const response1 = await miscHandler.handle(request, mockContext);
-      await new Promise((resolve) => setTimeout(resolve, 5));
-      const response2 = await miscHandler.handle(request, mockContext);
-
-      const responseData1 = (await response1.json()) as RuntimeIdentityResult;
-      const responseData2 = (await response2.json()) as RuntimeIdentityResult;
-
-      expect(responseData1.runtimeId).toBe(responseData2.runtimeId);
-      expect(responseData1.startedAt).toBe(responseData2.startedAt);
-      expect(responseData1.timestamp).not.toBe(responseData2.timestamp);
     });
   });
 

--- a/packages/sandbox-container/tests/handlers/misc-handler.test.ts
+++ b/packages/sandbox-container/tests/handlers/misc-handler.test.ts
@@ -4,6 +4,7 @@ import type { ErrorResponse } from '@repo/shared/errors';
 import type { RequestContext } from '@sandbox-container/core/types';
 import {
   MiscHandler,
+  type RuntimeIdentityResult,
   type VersionResult
 } from '@sandbox-container/handlers/misc-handler';
 
@@ -221,6 +222,46 @@ describe('MiscHandler', () => {
       expect(response.headers.get('Access-Control-Allow-Headers')).toBe(
         'Content-Type'
       );
+    });
+  });
+
+  describe('handleRuntimeIdentity - GET /api/runtime/identity', () => {
+    it('should return placement ID from environment variable', async () => {
+      process.env.CLOUDFLARE_PLACEMENT_ID = 'placement-123';
+
+      const request = new Request(
+        'http://localhost:3000/api/runtime/identity',
+        {
+          method: 'GET'
+        }
+      );
+
+      const response = await miscHandler.handle(request, mockContext);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toBe('application/json');
+
+      const responseData = (await response.json()) as RuntimeIdentityResult;
+      expect(responseData.success).toBe(true);
+      expect(responseData.runtimeId).toBe('placement-123');
+      expect(responseData.timestamp).toBeDefined();
+    });
+
+    it('should return empty runtime ID when placement ID is not set', async () => {
+      delete process.env.CLOUDFLARE_PLACEMENT_ID;
+
+      const request = new Request(
+        'http://localhost:3000/api/runtime/identity',
+        {
+          method: 'GET'
+        }
+      );
+
+      const response = await miscHandler.handle(request, mockContext);
+
+      expect(response.status).toBe(200);
+      const responseData = (await response.json()) as RuntimeIdentityResult;
+      expect(responseData.runtimeId).toBe('');
     });
   });
 

--- a/packages/sandbox/src/clients/utility-client.ts
+++ b/packages/sandbox/src/clients/utility-client.ts
@@ -1,4 +1,5 @@
 import type { RuntimeIdentity } from '@repo/shared';
+import { createErrorFromResponse, ErrorCode, SandboxError } from '../errors';
 import { BaseHttpClient } from './base-client';
 import type { BaseApiResponse, HttpClientOptions } from './types';
 
@@ -153,11 +154,30 @@ export class UtilityClient extends BaseHttpClient {
    * `runtimeId` changes when the underlying container boots again.
    */
   async getRuntimeIdentity(): Promise<RuntimeIdentity> {
-    const response = await this.get<RuntimeIdentityResponse>('/api/runtime');
+    try {
+      const response = await this.get<RuntimeIdentityResponse>('/api/runtime');
 
-    return {
-      runtimeId: response.runtimeId,
-      startedAt: response.startedAt
-    };
+      return {
+        runtimeId: response.runtimeId,
+        startedAt: response.startedAt
+      };
+    } catch (error) {
+      if (error instanceof SandboxError && error.httpStatus === 404) {
+        throw createErrorFromResponse({
+          code: ErrorCode.UNKNOWN_ERROR,
+          message:
+            'Runtime identity is not supported by this sandbox container. Recreate the sandbox or upgrade to a newer container image.',
+          context: {
+            endpoint: '/api/runtime'
+          },
+          httpStatus: 404,
+          timestamp: new Date().toISOString(),
+          suggestion:
+            'Recreate the sandbox or upgrade to a newer container image before calling getRuntimeIdentity().'
+        });
+      }
+
+      throw error;
+    }
   }
 }

--- a/packages/sandbox/src/clients/utility-client.ts
+++ b/packages/sandbox/src/clients/utility-client.ts
@@ -1,7 +1,5 @@
-import type { RuntimeIdentity } from '@repo/shared';
-import { createErrorFromResponse, ErrorCode, SandboxError } from '../errors';
 import { BaseHttpClient } from './base-client';
-import type { BaseApiResponse, HttpClientOptions } from './types';
+import type { BaseApiResponse } from './types';
 
 /**
  * Response interface for ping operations
@@ -25,11 +23,6 @@ export interface CommandsResponse extends BaseApiResponse {
 export interface VersionResponse extends BaseApiResponse {
   version: string;
 }
-
-/**
- * Response interface for getting container runtime identity
- */
-interface RuntimeIdentityResponse extends BaseApiResponse, RuntimeIdentity {}
 
 /**
  * Request interface for creating sessions
@@ -146,38 +139,6 @@ export class UtilityClient extends BaseHttpClient {
         { error }
       );
       return 'unknown';
-    }
-  }
-
-  /**
-   * Get the current container runtime identity.
-   * `runtimeId` changes when the underlying container boots again.
-   */
-  async getRuntimeIdentity(): Promise<RuntimeIdentity> {
-    try {
-      const response = await this.get<RuntimeIdentityResponse>('/api/runtime');
-
-      return {
-        runtimeId: response.runtimeId,
-        startedAt: response.startedAt
-      };
-    } catch (error) {
-      if (error instanceof SandboxError && error.httpStatus === 404) {
-        throw createErrorFromResponse({
-          code: ErrorCode.UNKNOWN_ERROR,
-          message:
-            'Runtime identity is not supported by this sandbox container. Recreate the sandbox or upgrade to a newer container image.',
-          context: {
-            endpoint: '/api/runtime'
-          },
-          httpStatus: 404,
-          timestamp: new Date().toISOString(),
-          suggestion:
-            'Recreate the sandbox or upgrade to a newer container image before calling getRuntimeIdentity().'
-        });
-      }
-
-      throw error;
     }
   }
 }

--- a/packages/sandbox/src/clients/utility-client.ts
+++ b/packages/sandbox/src/clients/utility-client.ts
@@ -1,3 +1,4 @@
+import type { RuntimeIdentity } from '@repo/shared';
 import { BaseHttpClient } from './base-client';
 import type { BaseApiResponse, HttpClientOptions } from './types';
 
@@ -23,6 +24,11 @@ export interface CommandsResponse extends BaseApiResponse {
 export interface VersionResponse extends BaseApiResponse {
   version: string;
 }
+
+/**
+ * Response interface for getting container runtime identity
+ */
+interface RuntimeIdentityResponse extends BaseApiResponse, RuntimeIdentity {}
 
 /**
  * Request interface for creating sessions
@@ -140,5 +146,18 @@ export class UtilityClient extends BaseHttpClient {
       );
       return 'unknown';
     }
+  }
+
+  /**
+   * Get the current container runtime identity.
+   * `runtimeId` changes when the underlying container boots again.
+   */
+  async getRuntimeIdentity(): Promise<RuntimeIdentity> {
+    const response = await this.get<RuntimeIdentityResponse>('/api/runtime');
+
+    return {
+      runtimeId: response.runtimeId,
+      startedAt: response.startedAt
+    };
   }
 }

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -52,6 +52,7 @@ export type {
   RemoteMountBucketOptions,
   RestoreBackupResult,
   RunCodeOptions,
+  RuntimeIdentity,
   SandboxOptions,
   SessionOptions,
   StreamOptions,

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1518,12 +1518,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           }
         });
         restartedContainer = true;
-        await this.captureRuntimeIdentity().catch((error) => {
-          this.logger.warn('runtime.identity.capture', {
-            outcome: 'error',
-            error: error instanceof Error ? error.message : String(error)
-          });
-        });
+        this.runtimeIdentity = null;
       } catch (e) {
         // 1. Provisioning: Container VM not yet available
         if (this.isNoInstanceError(e)) {
@@ -1560,8 +1555,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
             message:
               'Container failed to start due to a permanent error. Check your container configuration.',
             context: {
-              phase: 'startup',
-              error: e instanceof Error ? e.message : String(e)
+              phase: 'startup'
             },
             httpStatus: 500,
             timestamp: new Date().toISOString(),
@@ -1600,8 +1594,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
             code: ErrorCode.INTERNAL_ERROR,
             message: 'Container is starting. Please retry in a moment.',
             context: {
-              phase: 'startup',
-              error: e instanceof Error ? e.message : String(e)
+              phase: 'startup'
             },
             httpStatus: 503,
             timestamp: new Date().toISOString(),
@@ -1628,8 +1621,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           code: ErrorCode.INTERNAL_ERROR,
           message: 'Container is starting. Please retry in a moment.',
           context: {
-            phase: 'startup',
-            error: e instanceof Error ? e.message : String(e)
+            phase: 'startup'
           },
           httpStatus: 503,
           timestamp: new Date().toISOString(),
@@ -1666,8 +1658,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           code: ErrorCode.INTERNAL_ERROR,
           message: 'Container is starting. Please retry in a moment.',
           context: {
-            phase: 'startup',
-            error: error instanceof Error ? error.message : String(error)
+            phase: 'startup'
           },
           httpStatus: 503,
           timestamp: new Date().toISOString(),
@@ -1691,7 +1682,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     const state = await this.getState();
     const containerRunning = this.ctx.container?.running;
     const containerMayNeedRestart =
-      state.status !== 'healthy' || containerRunning === false;
+      state.status !== 'healthy' || containerRunning !== true;
 
     if (!containerMayNeedRestart && this.runtimeIdentity) {
       return this.runtimeIdentity;
@@ -1747,18 +1738,16 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     response: Response,
     operation: string
   ): Promise<never> {
+    let body: unknown;
     try {
-      const errorResponse = (await response.json()) as ErrorResponse;
-      throw createErrorFromResponse(errorResponse);
-    } catch (error) {
-      if (error instanceof Error && error.name !== 'SyntaxError') {
-        throw error;
-      }
-
+      body = await response.json();
+    } catch {
       throw new Error(
         `Failed to ${operation}: HTTP ${response.status} ${response.statusText}`
       );
     }
+
+    throw createErrorFromResponse(body as ErrorResponse);
   }
 
   /**

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1499,6 +1499,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
     const state = await this.getState();
     const containerRunning = this.ctx.container?.running;
+    let restartedContainer = false;
 
     // Start container if persisted state is not healthy OR if runtime reports container is not running.
     // The runtime check catches stale persisted state (e.g., state says 'healthy' after DO recreation
@@ -1516,6 +1517,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
             abort: request.signal
           }
         });
+        restartedContainer = true;
         await this.captureRuntimeIdentity().catch((error) => {
           this.logger.warn('runtime.identity.capture', {
             outcome: 'error',
@@ -1645,7 +1647,44 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
 
     // Delegate to parent for the actual fetch (handles TCP port access internally)
-    return await super.containerFetch(requestOrUrl, portOrInit, portParam);
+    try {
+      return await super.containerFetch(requestOrUrl, portOrInit, portParam);
+    } catch (error) {
+      if (this.isTransientStartupError(error)) {
+        this.logger.warn('container.fetch', {
+          outcome: 'transient_error_after_start',
+          restartedContainer,
+          staleStateDetected,
+          error: error instanceof Error ? error.message : String(error)
+        });
+
+        if (restartedContainer || staleStateDetected) {
+          this.ctx.abort();
+        }
+
+        const errorBody: ErrorResponse = {
+          code: ErrorCode.INTERNAL_ERROR,
+          message: 'Container is starting. Please retry in a moment.',
+          context: {
+            phase: 'startup',
+            error: error instanceof Error ? error.message : String(error)
+          },
+          httpStatus: 503,
+          timestamp: new Date().toISOString(),
+          suggestion:
+            'The container is booting. The SDK will retry automatically.'
+        };
+        return new Response(JSON.stringify(errorBody), {
+          status: 503,
+          headers: {
+            'Content-Type': 'application/json',
+            'Retry-After': '3'
+          }
+        });
+      }
+
+      throw error;
+    }
   }
 
   private async ensureRuntimeIdentity(): Promise<RuntimeIdentity> {

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1700,6 +1700,12 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       );
     }
 
+    // Discard the ping response body so the base class decrements its
+    // inflight-request counter (it only fires in pipeTo's finally callback).
+    // Without this, inflightRequests stays > 0 and the sleepAfter timer
+    // never considers the container idle.
+    await response.body?.cancel();
+
     if (this.runtimeIdentity) {
       return this.runtimeIdentity;
     }

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -232,6 +232,11 @@ const PLACEMENT_ID_COMMAND = 'printf %s "$CLOUDFLARE_PLACEMENT_ID"';
 const MISSING_PLACEMENT_ID_ERROR =
   'Runtime identity is unavailable because CLOUDFLARE_PLACEMENT_ID is not set in the container environment. Recreate the sandbox with a newer container runtime.';
 
+type RuntimeIdentityLookupResponse = RuntimeIdentity & {
+  success: boolean;
+  timestamp: string;
+};
+
 function applySandboxConfiguration(
   stub: ConfigurableSandboxStub,
   configuration: SandboxConfiguration
@@ -1624,7 +1629,12 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   private async ensureRuntimeIdentity(): Promise<RuntimeIdentity> {
-    if (this.runtimeIdentity) {
+    const state = await this.getState();
+    const containerRunning = this.ctx.container?.running;
+    const containerMayNeedRestart =
+      state.status !== 'healthy' || containerRunning === false;
+
+    if (!containerMayNeedRestart && this.runtimeIdentity) {
       return this.runtimeIdentity;
     }
 
@@ -1648,6 +1658,37 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   private async captureRuntimeIdentity(): Promise<RuntimeIdentity> {
+    const response = await super.containerFetch(
+      new Request('http://localhost/api/runtime/identity', {
+        method: 'GET'
+      }),
+      this.defaultPort
+    );
+
+    if (!response.ok) {
+      if (await this.isRuntimeIdentityEndpointUnavailable(response)) {
+        return await this.captureRuntimeIdentityLegacy();
+      }
+
+      await this.throwContainerResponseError(
+        response,
+        'capture runtime identity from the container'
+      );
+    }
+
+    const result = (await response.json()) as RuntimeIdentityLookupResponse;
+    const runtimeId = result.runtimeId.trim();
+    if (!runtimeId) {
+      throw new Error(MISSING_PLACEMENT_ID_ERROR);
+    }
+
+    const runtimeIdentity = { runtimeId };
+    this.runtimeIdentity = runtimeIdentity;
+    await this.ctx.storage.put('runtimeIdentity', runtimeIdentity);
+    return runtimeIdentity;
+  }
+
+  private async captureRuntimeIdentityLegacy(): Promise<RuntimeIdentity> {
     const response = await super.containerFetch(
       new Request('http://localhost/api/execute', {
         method: 'POST',
@@ -1686,6 +1727,24 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     this.runtimeIdentity = runtimeIdentity;
     await this.ctx.storage.put('runtimeIdentity', runtimeIdentity);
     return runtimeIdentity;
+  }
+
+  private async isRuntimeIdentityEndpointUnavailable(
+    response: Response
+  ): Promise<boolean> {
+    if (response.status === 404) {
+      return true;
+    }
+
+    try {
+      const errorResponse = (await response.clone().json()) as ErrorResponse;
+      return (
+        errorResponse.code === ErrorCode.UNKNOWN_ERROR &&
+        errorResponse.message === 'Invalid endpoint'
+      );
+    } catch {
+      return false;
+    }
   }
 
   private async throwContainerResponseError(

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1454,6 +1454,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   override async onStop() {
     this.logger.debug('Sandbox stopped');
 
+    this.client.disconnect();
+
     // Stop local sync managers before clearing the map to avoid leaking timers
     for (const [, m] of this.activeMounts) {
       if (m.mountType === 'local-sync')

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1396,7 +1396,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     let outcome: string;
 
     try {
-      containerVersion = await this.client.utils.getVersion();
+      containerVersion = await this.getContainerVersionForCompatibilityCheck();
 
       if (containerVersion === 'unknown') {
         outcome = 'container_version_unknown';
@@ -1429,6 +1429,26 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       },
       { successLevel }
     );
+  }
+
+  private async getContainerVersionForCompatibilityCheck(): Promise<string> {
+    try {
+      const response = await super.containerFetch(
+        new Request('http://localhost/api/version', {
+          method: 'GET'
+        }),
+        this.defaultPort
+      );
+
+      if (!response.ok) {
+        return 'unknown';
+      }
+
+      const result = (await response.json()) as { version?: unknown };
+      return typeof result.version === 'string' ? result.version : 'unknown';
+    } catch {
+      return 'unknown';
+    }
   }
 
   override async onStop() {

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -25,6 +25,7 @@ import type {
   RemoteMountBucketOptions,
   RestoreBackupResult,
   RunCodeOptions,
+  RuntimeIdentity,
   SandboxOptions,
   SessionOptions,
   StreamOptions,
@@ -2984,6 +2985,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       since: options.since,
       sessionId
     });
+  }
+
+  async getRuntimeIdentity(): Promise<RuntimeIdentity> {
+    return await this.client.utils.getRuntimeIdentity();
   }
 
   /**

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -55,6 +55,7 @@ import {
   BackupNotFoundError,
   BackupRestoreError,
   CustomDomainRequiredError,
+  createErrorFromResponse,
   ErrorCode,
   InvalidBackupConfigError,
   ProcessExitedBeforeReadyError,
@@ -225,6 +226,11 @@ function mergeSandboxConfiguration(
     })
   };
 }
+
+const PLACEMENT_ID_COMMAND = 'printf %s "$CLOUDFLARE_PLACEMENT_ID"';
+
+const MISSING_PLACEMENT_ID_ERROR =
+  'Runtime identity is unavailable because CLOUDFLARE_PLACEMENT_ID is not set in the container environment. Recreate the sandbox with a newer container runtime.';
 
 function applySandboxConfiguration(
   stub: ConfigurableSandboxStub,
@@ -418,6 +424,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   private normalizeId: boolean = false;
   private baseUrl: string | null = null;
   private defaultSession: string | null = null;
+  private runtimeIdentity: RuntimeIdentity | null = null;
   envVars: Record<string, string> = {};
   private logger: ReturnType<typeof createLogger>;
   private keepAliveEnabled: boolean = false;
@@ -622,6 +629,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         (await this.ctx.storage.get<boolean>('normalizeId')) || false;
       this.defaultSession =
         (await this.ctx.storage.get<string>('defaultSession')) || null;
+      this.runtimeIdentity =
+        (await this.ctx.storage.get<RuntimeIdentity>('runtimeIdentity')) ||
+        null;
       this.keepAliveEnabled =
         (await this.ctx.storage.get<boolean>('keepAliveEnabled')) || false;
 
@@ -1428,12 +1438,14 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
 
     this.defaultSession = null;
+    this.runtimeIdentity = null;
     this.activeMounts.clear();
 
     // Persist cleanup to storage so state is clean on next container start
     await Promise.all([
       this.ctx.storage.delete('portTokens'),
-      this.ctx.storage.delete('defaultSession')
+      this.ctx.storage.delete('defaultSession'),
+      this.ctx.storage.delete('runtimeIdentity')
     ]);
   }
 
@@ -1478,6 +1490,12 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
             waitInterval: this.containerTimeouts.waitIntervalMS,
             abort: request.signal
           }
+        });
+        await this.captureRuntimeIdentity().catch((error) => {
+          this.logger.warn('runtime.identity.capture', {
+            outcome: 'error',
+            error: error instanceof Error ? error.message : String(error)
+          });
         });
       } catch (e) {
         // 1. Provisioning: Container VM not yet available
@@ -1603,6 +1621,89 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
     // Delegate to parent for the actual fetch (handles TCP port access internally)
     return await super.containerFetch(requestOrUrl, portOrInit, portParam);
+  }
+
+  private async ensureRuntimeIdentity(): Promise<RuntimeIdentity> {
+    if (this.runtimeIdentity) {
+      return this.runtimeIdentity;
+    }
+
+    const response = await this.containerFetch(
+      new Request('http://localhost/api/ping', { method: 'GET' }),
+      this.defaultPort
+    );
+
+    if (!response.ok) {
+      await this.throwContainerResponseError(
+        response,
+        'start the container for runtime identity lookup'
+      );
+    }
+
+    if (this.runtimeIdentity) {
+      return this.runtimeIdentity;
+    }
+
+    return await this.captureRuntimeIdentity();
+  }
+
+  private async captureRuntimeIdentity(): Promise<RuntimeIdentity> {
+    const response = await super.containerFetch(
+      new Request('http://localhost/api/execute', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          command: PLACEMENT_ID_COMMAND,
+          origin: 'internal'
+        })
+      }),
+      this.defaultPort
+    );
+
+    if (!response.ok) {
+      await this.throwContainerResponseError(
+        response,
+        'capture runtime identity from the container'
+      );
+    }
+
+    const result = (await response.json()) as ExecuteResponse;
+
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Failed to capture runtime identity: ${result.stderr || 'Placement lookup command failed.'}`
+      );
+    }
+
+    const runtimeId = result.stdout.trim();
+    if (!runtimeId) {
+      throw new Error(MISSING_PLACEMENT_ID_ERROR);
+    }
+
+    const runtimeIdentity = { runtimeId };
+    this.runtimeIdentity = runtimeIdentity;
+    await this.ctx.storage.put('runtimeIdentity', runtimeIdentity);
+    return runtimeIdentity;
+  }
+
+  private async throwContainerResponseError(
+    response: Response,
+    operation: string
+  ): Promise<never> {
+    try {
+      const errorResponse = (await response.json()) as ErrorResponse;
+      throw createErrorFromResponse(errorResponse);
+    } catch (error) {
+      if (error instanceof Error && error.name !== 'SyntaxError') {
+        throw error;
+      }
+
+      throw new Error(
+        `Failed to ${operation}: HTTP ${response.status} ${response.statusText}`
+      );
+    }
   }
 
   /**
@@ -2988,7 +3089,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   async getRuntimeIdentity(): Promise<RuntimeIdentity> {
-    return await this.client.utils.getRuntimeIdentity();
+    return await this.ensureRuntimeIdentity();
   }
 
   /**

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -227,8 +227,6 @@ function mergeSandboxConfiguration(
   };
 }
 
-const PLACEMENT_ID_COMMAND = 'printf %s "$CLOUDFLARE_PLACEMENT_ID"';
-
 const MISSING_PLACEMENT_ID_ERROR =
   'Runtime identity is unavailable because CLOUDFLARE_PLACEMENT_ID is not set in the container environment. Recreate the sandbox with a newer container runtime.';
 
@@ -1666,10 +1664,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     );
 
     if (!response.ok) {
-      if (await this.isRuntimeIdentityEndpointUnavailable(response)) {
-        return await this.captureRuntimeIdentityLegacy();
-      }
-
       await this.throwContainerResponseError(
         response,
         'capture runtime identity from the container'
@@ -1686,65 +1680,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     this.runtimeIdentity = runtimeIdentity;
     await this.ctx.storage.put('runtimeIdentity', runtimeIdentity);
     return runtimeIdentity;
-  }
-
-  private async captureRuntimeIdentityLegacy(): Promise<RuntimeIdentity> {
-    const response = await super.containerFetch(
-      new Request('http://localhost/api/execute', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          command: PLACEMENT_ID_COMMAND,
-          origin: 'internal'
-        })
-      }),
-      this.defaultPort
-    );
-
-    if (!response.ok) {
-      await this.throwContainerResponseError(
-        response,
-        'capture runtime identity from the container'
-      );
-    }
-
-    const result = (await response.json()) as ExecuteResponse;
-
-    if (result.exitCode !== 0) {
-      throw new Error(
-        `Failed to capture runtime identity: ${result.stderr || 'Placement lookup command failed.'}`
-      );
-    }
-
-    const runtimeId = result.stdout.trim();
-    if (!runtimeId) {
-      throw new Error(MISSING_PLACEMENT_ID_ERROR);
-    }
-
-    const runtimeIdentity = { runtimeId };
-    this.runtimeIdentity = runtimeIdentity;
-    await this.ctx.storage.put('runtimeIdentity', runtimeIdentity);
-    return runtimeIdentity;
-  }
-
-  private async isRuntimeIdentityEndpointUnavailable(
-    response: Response
-  ): Promise<boolean> {
-    if (response.status === 404) {
-      return true;
-    }
-
-    try {
-      const errorResponse = (await response.clone().json()) as ErrorResponse;
-      return (
-        errorResponse.code === ErrorCode.UNKNOWN_ERROR &&
-        errorResponse.message === 'Invalid endpoint'
-      );
-    } catch {
-      return false;
-    }
   }
 
   private async throwContainerResponseError(

--- a/packages/sandbox/tests/sandbox-error-handling.test.ts
+++ b/packages/sandbox/tests/sandbox-error-handling.test.ts
@@ -329,8 +329,8 @@ describe('Sandbox.containerFetch() error classification', () => {
 
       expect(response.status).toBe(500);
       expect(response.headers.get('Retry-After')).toBeNull();
-      const body = (await response.json()) as { context: { error: string } };
-      expect(body.context.error).toContain('No such image');
+      const body = (await response.json()) as { message: string };
+      expect(body.message).toContain('permanent error');
     });
   });
   describe('unrecognized errors → 503 (safe to retry)', () => {
@@ -563,12 +563,6 @@ describe('Sandbox.containerFetch() error classification', () => {
           Object.getPrototypeOf(Object.getPrototypeOf(sandbox)),
           'containerFetch'
         )
-        .mockResolvedValueOnce(
-          new Response(JSON.stringify({ runtimeId: 'runtime-123' }), {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' }
-          })
-        )
         .mockRejectedValueOnce(new Error('Network connection lost.'));
 
       const response = await sandbox.containerFetch(
@@ -582,7 +576,7 @@ describe('Sandbox.containerFetch() error classification', () => {
       expect(response.headers.get('Retry-After')).toBe('3');
       await expect(response.json()).resolves.toMatchObject({
         message: 'Container is starting. Please retry in a moment.',
-        context: { error: 'Network connection lost.' }
+        context: { phase: 'startup' }
       });
 
       parentContainerFetch.mockRestore();

--- a/packages/sandbox/tests/sandbox-error-handling.test.ts
+++ b/packages/sandbox/tests/sandbox-error-handling.test.ts
@@ -549,5 +549,43 @@ describe('Sandbox.containerFetch() error classification', () => {
       expect(abortSpy).not.toHaveBeenCalled();
       expect(response.status).toBe(503);
     });
+
+    it('returns 503 and aborts when the first fetch after restart loses the network connection', async () => {
+      vi.spyOn(sandbox as any, 'getState').mockResolvedValueOnce({
+        status: 'unhealthy'
+      });
+      const abortSpy = vi.fn();
+      (sandbox as any).ctx.abort = abortSpy;
+      startAndWaitSpy.mockResolvedValueOnce(undefined);
+
+      const parentContainerFetch = vi
+        .spyOn(
+          Object.getPrototypeOf(Object.getPrototypeOf(sandbox)),
+          'containerFetch'
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ runtimeId: 'runtime-123' }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          })
+        )
+        .mockRejectedValueOnce(new Error('Network connection lost.'));
+
+      const response = await sandbox.containerFetch(
+        new Request('http://localhost/test'),
+        {},
+        3000
+      );
+
+      expect(abortSpy).toHaveBeenCalled();
+      expect(response.status).toBe(503);
+      expect(response.headers.get('Retry-After')).toBe('3');
+      await expect(response.json()).resolves.toMatchObject({
+        message: 'Container is starting. Please retry in a moment.',
+        context: { error: 'Network connection lost.' }
+      });
+
+      parentContainerFetch.mockRestore();
+    });
   });
 });

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -466,6 +466,56 @@ describe('Sandbox - Automatic Session Management', () => {
       });
     });
 
+    describe('startup version checking', () => {
+      it('should fetch the container version directly during startup checks', async () => {
+        const getVersionSpy = vi.spyOn(sandbox.client.utils, 'getVersion');
+        const containerFetchSpy = vi
+          .spyOn(Container.prototype as any, 'containerFetch')
+          .mockImplementation((...args: unknown[]) => {
+            const request = args[0] as Request;
+            const url = new URL(request.url);
+
+            if (url.pathname === '/api/version') {
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({
+                    success: true,
+                    version: '1.2.3',
+                    timestamp: new Date().toISOString()
+                  }),
+                  {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' }
+                  }
+                )
+              );
+            }
+
+            return Promise.resolve(new Response('ok'));
+          });
+
+        await (sandbox as any).checkVersionCompatibility();
+
+        expect(getVersionSpy).not.toHaveBeenCalled();
+        expect(containerFetchSpy).toHaveBeenCalledTimes(1);
+
+        const request = containerFetchSpy.mock.calls[0]?.[0] as Request;
+        expect(new URL(request.url).pathname).toBe('/api/version');
+      });
+
+      it('should treat startup version check failures as unknown', async () => {
+        vi.spyOn(sandbox.client.utils, 'getVersion');
+        vi.spyOn(
+          Container.prototype as any,
+          'containerFetch'
+        ).mockResolvedValue(new Response('not available', { status: 500 }));
+
+        await expect(
+          (sandbox as any).checkVersionCompatibility()
+        ).resolves.toBeUndefined();
+      });
+    });
+
     it('should reuse default session across multiple operations', async () => {
       await sandbox.exec('echo test1');
       await sandbox.writeFile('/test.txt', 'content');

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -218,6 +218,20 @@ describe('Sandbox - Automatic Session Management', () => {
       });
     });
 
+    it('should return runtime identity from the utility client', async () => {
+      vi.spyOn(sandbox.client.utils, 'getRuntimeIdentity').mockResolvedValue({
+        runtimeId: 'rt-1',
+        startedAt: '2026-04-07T00:00:00.000Z'
+      });
+
+      const result = await sandbox.getRuntimeIdentity();
+
+      expect(result).toEqual({
+        runtimeId: 'rt-1',
+        startedAt: '2026-04-07T00:00:00.000Z'
+      });
+    });
+
     it('should reuse default session across multiple operations', async () => {
       await sandbox.exec('echo test1');
       await sandbox.writeFile('/test.txt', 'content');

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -293,6 +293,7 @@ describe('Sandbox - Automatic Session Management', () => {
           'containerFetch'
         );
         (sandbox as any).runtimeIdentity = { runtimeId: 'placement-1' };
+        mockCtx.container = { running: true };
 
         const result = await sandbox.getRuntimeIdentity();
 
@@ -359,7 +360,7 @@ describe('Sandbox - Automatic Session Management', () => {
         });
       });
 
-      it('should refresh runtime identity after container startup', async () => {
+      it('should clear cached runtime identity after container startup', async () => {
         (sandbox as any).runtimeIdentity = { runtimeId: 'placement-old' };
         storageState.set('runtimeIdentity', { runtimeId: 'placement-old' });
 
@@ -374,25 +375,6 @@ describe('Sandbox - Automatic Session Management', () => {
           Container.prototype as any,
           'containerFetch'
         ).mockImplementation((...args: unknown[]) => {
-          const request = args[0] as Request;
-          const url = new URL(request.url);
-
-          if (url.pathname === '/api/runtime/identity') {
-            return Promise.resolve(
-              new Response(
-                JSON.stringify({
-                  success: true,
-                  runtimeId: 'placement-new',
-                  timestamp: new Date().toISOString()
-                }),
-                {
-                  status: 200,
-                  headers: { 'Content-Type': 'application/json' }
-                }
-              )
-            );
-          }
-
           return Promise.resolve(
             new Response(
               JSON.stringify({
@@ -413,12 +395,7 @@ describe('Sandbox - Automatic Session Management', () => {
           sandbox.defaultPort
         );
 
-        expect((sandbox as any).runtimeIdentity).toEqual({
-          runtimeId: 'placement-new'
-        });
-        expect(storageState.get('runtimeIdentity')).toEqual({
-          runtimeId: 'placement-new'
-        });
+        expect((sandbox as any).runtimeIdentity).toBeNull();
       });
 
       it('should throw when placement ID is unavailable', async () => {

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1,6 +1,5 @@
 import { Container } from '@cloudflare/containers';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ErrorCode } from '../src/errors';
 import { connect, Sandbox } from '../src/sandbox';
 
 // Mock dependencies before imports
@@ -299,78 +298,6 @@ describe('Sandbox - Automatic Session Management', () => {
 
         expect(result).toEqual({ runtimeId: 'placement-1' });
         expect(containerFetchSpy).not.toHaveBeenCalled();
-      });
-
-      it('should fall back to legacy placement lookup when the new endpoint is unavailable', async () => {
-        const containerFetchSpy = vi
-          .spyOn(Container.prototype as any, 'containerFetch')
-          .mockImplementation((...args: unknown[]) => {
-            const request = args[0] as Request;
-            const url = new URL(request.url);
-
-            if (url.pathname === '/api/ping') {
-              return Promise.resolve(
-                new Response(
-                  JSON.stringify({
-                    success: true,
-                    status: 'healthy',
-                    timestamp: new Date().toISOString()
-                  }),
-                  {
-                    status: 200,
-                    headers: { 'Content-Type': 'application/json' }
-                  }
-                )
-              );
-            }
-
-            if (url.pathname === '/api/runtime/identity') {
-              return Promise.resolve(
-                new Response(
-                  JSON.stringify({
-                    code: ErrorCode.UNKNOWN_ERROR,
-                    message: 'Invalid endpoint',
-                    context: {},
-                    httpStatus: 500,
-                    timestamp: new Date().toISOString()
-                  }),
-                  {
-                    status: 500,
-                    headers: { 'Content-Type': 'application/json' }
-                  }
-                )
-              );
-            }
-
-            if (url.pathname === '/api/execute') {
-              return Promise.resolve(
-                new Response(
-                  JSON.stringify({
-                    success: true,
-                    stdout: 'placement-legacy',
-                    stderr: '',
-                    exitCode: 0,
-                    command: 'printf %s "$CLOUDFLARE_PLACEMENT_ID"',
-                    timestamp: new Date().toISOString()
-                  }),
-                  {
-                    status: 200,
-                    headers: { 'Content-Type': 'application/json' }
-                  }
-                )
-              );
-            }
-
-            return Promise.resolve(new Response('ok'));
-          });
-
-        const result = await sandbox.getRuntimeIdentity();
-
-        expect(result).toEqual({ runtimeId: 'placement-legacy' });
-        expect(mockCtx.storage.put).toHaveBeenCalledWith('runtimeIdentity', {
-          runtimeId: 'placement-legacy'
-        });
-        expect(containerFetchSpy).toHaveBeenCalledTimes(3);
       });
 
       it('should refresh cached runtime identity when the runtime reports the container stopped', async () => {

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -514,6 +514,14 @@ describe('Sandbox - Automatic Session Management', () => {
           (sandbox as any).checkVersionCompatibility()
         ).resolves.toBeUndefined();
       });
+
+      it('should disconnect the client transport when the container stops', async () => {
+        const disconnectSpy = vi.spyOn(sandbox.client, 'disconnect');
+
+        await sandbox.onStop();
+
+        expect(disconnectSpy).toHaveBeenCalledTimes(1);
+      });
     });
 
     it('should reuse default session across multiple operations', async () => {

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1,5 +1,6 @@
 import { Container } from '@cloudflare/containers';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ErrorCode } from '../src/errors';
 import { connect, Sandbox } from '../src/sandbox';
 
 // Mock dependencies before imports
@@ -69,6 +70,9 @@ interface MockCtx {
   storage: MockStorage;
   blockConcurrencyWhile: ReturnType<typeof vi.fn>;
   waitUntil: ReturnType<typeof vi.fn>;
+  container?: {
+    running: boolean;
+  };
   id: {
     toString: () => string;
     equals: ReturnType<typeof vi.fn>;
@@ -256,15 +260,12 @@ describe('Sandbox - Automatic Session Management', () => {
               );
             }
 
-            if (url.pathname === '/api/execute') {
+            if (url.pathname === '/api/runtime/identity') {
               return Promise.resolve(
                 new Response(
                   JSON.stringify({
                     success: true,
-                    stdout: 'placement-1',
-                    stderr: '',
-                    exitCode: 0,
-                    command: 'printf %s "$CLOUDFLARE_PLACEMENT_ID"',
+                    runtimeId: 'placement-1',
                     timestamp: new Date().toISOString()
                   }),
                   {
@@ -300,6 +301,137 @@ describe('Sandbox - Automatic Session Management', () => {
         expect(containerFetchSpy).not.toHaveBeenCalled();
       });
 
+      it('should fall back to legacy placement lookup when the new endpoint is unavailable', async () => {
+        const containerFetchSpy = vi
+          .spyOn(Container.prototype as any, 'containerFetch')
+          .mockImplementation((...args: unknown[]) => {
+            const request = args[0] as Request;
+            const url = new URL(request.url);
+
+            if (url.pathname === '/api/ping') {
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({
+                    success: true,
+                    status: 'healthy',
+                    timestamp: new Date().toISOString()
+                  }),
+                  {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' }
+                  }
+                )
+              );
+            }
+
+            if (url.pathname === '/api/runtime/identity') {
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({
+                    code: ErrorCode.UNKNOWN_ERROR,
+                    message: 'Invalid endpoint',
+                    context: {},
+                    httpStatus: 500,
+                    timestamp: new Date().toISOString()
+                  }),
+                  {
+                    status: 500,
+                    headers: { 'Content-Type': 'application/json' }
+                  }
+                )
+              );
+            }
+
+            if (url.pathname === '/api/execute') {
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({
+                    success: true,
+                    stdout: 'placement-legacy',
+                    stderr: '',
+                    exitCode: 0,
+                    command: 'printf %s "$CLOUDFLARE_PLACEMENT_ID"',
+                    timestamp: new Date().toISOString()
+                  }),
+                  {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' }
+                  }
+                )
+              );
+            }
+
+            return Promise.resolve(new Response('ok'));
+          });
+
+        const result = await sandbox.getRuntimeIdentity();
+
+        expect(result).toEqual({ runtimeId: 'placement-legacy' });
+        expect(mockCtx.storage.put).toHaveBeenCalledWith('runtimeIdentity', {
+          runtimeId: 'placement-legacy'
+        });
+        expect(containerFetchSpy).toHaveBeenCalledTimes(3);
+      });
+
+      it('should refresh cached runtime identity when the runtime reports the container stopped', async () => {
+        (sandbox as any).runtimeIdentity = { runtimeId: 'placement-old' };
+        storageState.set('runtimeIdentity', { runtimeId: 'placement-old' });
+        mockCtx.container = { running: false };
+        (sandbox as any).startAndWaitForPorts = vi
+          .fn()
+          .mockResolvedValue(undefined);
+
+        vi.spyOn(
+          Container.prototype as any,
+          'containerFetch'
+        ).mockImplementation((...args: unknown[]) => {
+          const request = args[0] as Request;
+          const url = new URL(request.url);
+
+          if (url.pathname === '/api/ping') {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  success: true,
+                  status: 'healthy',
+                  timestamp: new Date().toISOString()
+                }),
+                {
+                  status: 200,
+                  headers: { 'Content-Type': 'application/json' }
+                }
+              )
+            );
+          }
+
+          if (url.pathname === '/api/runtime/identity') {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  success: true,
+                  runtimeId: 'placement-new',
+                  timestamp: new Date().toISOString()
+                }),
+                {
+                  status: 200,
+                  headers: { 'Content-Type': 'application/json' }
+                }
+              )
+            );
+          }
+
+          return Promise.resolve(new Response('ok'));
+        });
+
+        const result = await sandbox.getRuntimeIdentity();
+
+        expect(result).toEqual({ runtimeId: 'placement-new' });
+        expect((sandbox as any).startAndWaitForPorts).toHaveBeenCalled();
+        expect(storageState.get('runtimeIdentity')).toEqual({
+          runtimeId: 'placement-new'
+        });
+      });
+
       it('should refresh runtime identity after container startup', async () => {
         (sandbox as any).runtimeIdentity = { runtimeId: 'placement-old' };
         storageState.set('runtimeIdentity', { runtimeId: 'placement-old' });
@@ -318,15 +450,12 @@ describe('Sandbox - Automatic Session Management', () => {
           const request = args[0] as Request;
           const url = new URL(request.url);
 
-          if (url.pathname === '/api/execute') {
+          if (url.pathname === '/api/runtime/identity') {
             return Promise.resolve(
               new Response(
                 JSON.stringify({
                   success: true,
-                  stdout: 'placement-new',
-                  stderr: '',
-                  exitCode: 0,
-                  command: 'printf %s "$CLOUDFLARE_PLACEMENT_ID"',
+                  runtimeId: 'placement-new',
                   timestamp: new Date().toISOString()
                 }),
                 {
@@ -393,10 +522,7 @@ describe('Sandbox - Automatic Session Management', () => {
             new Response(
               JSON.stringify({
                 success: true,
-                stdout: '',
-                stderr: '',
-                exitCode: 0,
-                command: 'printf %s "$CLOUDFLARE_PLACEMENT_ID"',
+                runtimeId: '',
                 timestamp: new Date().toISOString()
               }),
               {

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -80,17 +80,31 @@ describe('Sandbox - Automatic Session Management', () => {
   let sandbox: Sandbox;
   let mockCtx: MockCtx;
   let mockEnv: Record<string, unknown>;
+  let storageState: Map<string, unknown>;
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    storageState = new Map<string, unknown>();
 
     // Mock DurableObjectState
     mockCtx = {
       storage: {
-        get: vi.fn().mockResolvedValue(null),
-        put: vi.fn().mockResolvedValue(undefined),
-        delete: vi.fn().mockResolvedValue(undefined),
-        list: vi.fn().mockResolvedValue(new Map())
+        get: vi
+          .fn()
+          .mockImplementation((key: string) =>
+            Promise.resolve(storageState.get(key) ?? null)
+          ),
+        put: vi.fn().mockImplementation((key: string, value: unknown) => {
+          storageState.set(key, value);
+          return Promise.resolve(undefined);
+        }),
+        delete: vi.fn().mockImplementation((key: string) => {
+          storageState.delete(key);
+          return Promise.resolve(undefined);
+        }),
+        list: vi
+          .fn()
+          .mockImplementation(() => Promise.resolve(new Map(storageState)))
       } as any,
       blockConcurrencyWhile: vi
         .fn()
@@ -218,17 +232,184 @@ describe('Sandbox - Automatic Session Management', () => {
       });
     });
 
-    it('should return runtime identity from the utility client', async () => {
-      vi.spyOn(sandbox.client.utils, 'getRuntimeIdentity').mockResolvedValue({
-        runtimeId: 'rt-1',
-        startedAt: '2026-04-07T00:00:00.000Z'
+    describe('runtime identity', () => {
+      it('should capture runtime identity from placement ID', async () => {
+        const containerFetchSpy = vi
+          .spyOn(Container.prototype as any, 'containerFetch')
+          .mockImplementation((...args: unknown[]) => {
+            const request = args[0] as Request;
+            const url = new URL(request.url);
+
+            if (url.pathname === '/api/ping') {
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({
+                    success: true,
+                    status: 'healthy',
+                    timestamp: new Date().toISOString()
+                  }),
+                  {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' }
+                  }
+                )
+              );
+            }
+
+            if (url.pathname === '/api/execute') {
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({
+                    success: true,
+                    stdout: 'placement-1',
+                    stderr: '',
+                    exitCode: 0,
+                    command: 'printf %s "$CLOUDFLARE_PLACEMENT_ID"',
+                    timestamp: new Date().toISOString()
+                  }),
+                  {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' }
+                  }
+                )
+              );
+            }
+
+            return Promise.resolve(new Response('ok'));
+          });
+
+        const result = await sandbox.getRuntimeIdentity();
+
+        expect(result).toEqual({ runtimeId: 'placement-1' });
+        expect(mockCtx.storage.put).toHaveBeenCalledWith('runtimeIdentity', {
+          runtimeId: 'placement-1'
+        });
+        expect(containerFetchSpy).toHaveBeenCalledTimes(2);
       });
 
-      const result = await sandbox.getRuntimeIdentity();
+      it('should return cached runtime identity without querying the container', async () => {
+        const containerFetchSpy = vi.spyOn(
+          Container.prototype as any,
+          'containerFetch'
+        );
+        (sandbox as any).runtimeIdentity = { runtimeId: 'placement-1' };
 
-      expect(result).toEqual({
-        runtimeId: 'rt-1',
-        startedAt: '2026-04-07T00:00:00.000Z'
+        const result = await sandbox.getRuntimeIdentity();
+
+        expect(result).toEqual({ runtimeId: 'placement-1' });
+        expect(containerFetchSpy).not.toHaveBeenCalled();
+      });
+
+      it('should refresh runtime identity after container startup', async () => {
+        (sandbox as any).runtimeIdentity = { runtimeId: 'placement-old' };
+        storageState.set('runtimeIdentity', { runtimeId: 'placement-old' });
+
+        vi.spyOn(sandbox, 'getState').mockResolvedValue({
+          status: 'unhealthy'
+        } as never);
+        (sandbox as any).startAndWaitForPorts = vi
+          .fn()
+          .mockResolvedValue(undefined);
+
+        vi.spyOn(
+          Container.prototype as any,
+          'containerFetch'
+        ).mockImplementation((...args: unknown[]) => {
+          const request = args[0] as Request;
+          const url = new URL(request.url);
+
+          if (url.pathname === '/api/execute') {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  success: true,
+                  stdout: 'placement-new',
+                  stderr: '',
+                  exitCode: 0,
+                  command: 'printf %s "$CLOUDFLARE_PLACEMENT_ID"',
+                  timestamp: new Date().toISOString()
+                }),
+                {
+                  status: 200,
+                  headers: { 'Content-Type': 'application/json' }
+                }
+              )
+            );
+          }
+
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                success: true,
+                version: '1.2.3',
+                timestamp: new Date().toISOString()
+              }),
+              {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' }
+              }
+            )
+          );
+        });
+
+        await sandbox.containerFetch(
+          new Request('http://localhost/api/version', { method: 'GET' }),
+          sandbox.defaultPort
+        );
+
+        expect((sandbox as any).runtimeIdentity).toEqual({
+          runtimeId: 'placement-new'
+        });
+        expect(storageState.get('runtimeIdentity')).toEqual({
+          runtimeId: 'placement-new'
+        });
+      });
+
+      it('should throw when placement ID is unavailable', async () => {
+        vi.spyOn(
+          Container.prototype as any,
+          'containerFetch'
+        ).mockImplementation((...args: unknown[]) => {
+          const request = args[0] as Request;
+          const url = new URL(request.url);
+
+          if (url.pathname === '/api/ping') {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  success: true,
+                  status: 'healthy',
+                  timestamp: new Date().toISOString()
+                }),
+                {
+                  status: 200,
+                  headers: { 'Content-Type': 'application/json' }
+                }
+              )
+            );
+          }
+
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                success: true,
+                stdout: '',
+                stderr: '',
+                exitCode: 0,
+                command: 'printf %s "$CLOUDFLARE_PLACEMENT_ID"',
+                timestamp: new Date().toISOString()
+              }),
+              {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' }
+              }
+            )
+          );
+        });
+
+        await expect(sandbox.getRuntimeIdentity()).rejects.toThrow(
+          'Runtime identity is unavailable because CLOUDFLARE_PLACEMENT_ID is not set in the container environment. Recreate the sandbox with a newer container runtime.'
+        );
       });
     });
 

--- a/packages/sandbox/tests/utility-client.test.ts
+++ b/packages/sandbox/tests/utility-client.test.ts
@@ -377,6 +377,14 @@ describe('UtilityClient', () => {
 
       await expect(client.getRuntimeIdentity()).rejects.toThrow();
     });
+
+    it('should throw an explicit compatibility error for missing endpoint', async () => {
+      mockFetch.mockResolvedValue(new Response('Not Found', { status: 404 }));
+
+      await expect(client.getRuntimeIdentity()).rejects.toThrow(
+        'Runtime identity is not supported by this sandbox container. Recreate the sandbox or upgrade to a newer container image.'
+      );
+    });
   });
 
   describe('constructor options', () => {

--- a/packages/sandbox/tests/utility-client.test.ts
+++ b/packages/sandbox/tests/utility-client.test.ts
@@ -39,6 +39,21 @@ const mockVersionResponse = (
   ...overrides
 });
 
+const mockRuntimeIdentityResponse = (
+  overrides: Partial<{
+    success: boolean;
+    runtimeId: string;
+    startedAt: string;
+    timestamp: string;
+  }> = {}
+) => ({
+  success: true,
+  runtimeId: 'rt-123',
+  startedAt: '2023-01-01T00:00:00Z',
+  timestamp: '2023-01-01T00:00:01Z',
+  ...overrides
+});
+
 describe('UtilityClient', () => {
   let client: UtilityClient;
   let mockFetch: ReturnType<typeof vi.fn>;
@@ -321,6 +336,46 @@ describe('UtilityClient', () => {
       const result = await client.getVersion();
 
       expect(result).toBe('unknown');
+    });
+  });
+
+  describe('runtime identity', () => {
+    it('should get runtime identity successfully', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(mockRuntimeIdentityResponse()), {
+          status: 200
+        })
+      );
+
+      const result = await client.getRuntimeIdentity();
+
+      expect(result).toEqual({
+        runtimeId: 'rt-123',
+        startedAt: '2023-01-01T00:00:00Z'
+      });
+    });
+
+    it('should request the runtime endpoint', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(mockRuntimeIdentityResponse()), {
+          status: 200
+        })
+      );
+
+      await client.getRuntimeIdentity();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://test.com/api/runtime',
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+
+    it('should surface runtime endpoint failures', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ error: 'Not Found' }), { status: 404 })
+      );
+
+      await expect(client.getRuntimeIdentity()).rejects.toThrow();
     });
   });
 

--- a/packages/sandbox/tests/utility-client.test.ts
+++ b/packages/sandbox/tests/utility-client.test.ts
@@ -39,21 +39,6 @@ const mockVersionResponse = (
   ...overrides
 });
 
-const mockRuntimeIdentityResponse = (
-  overrides: Partial<{
-    success: boolean;
-    runtimeId: string;
-    startedAt: string;
-    timestamp: string;
-  }> = {}
-) => ({
-  success: true,
-  runtimeId: 'rt-123',
-  startedAt: '2023-01-01T00:00:00Z',
-  timestamp: '2023-01-01T00:00:01Z',
-  ...overrides
-});
-
 describe('UtilityClient', () => {
   let client: UtilityClient;
   let mockFetch: ReturnType<typeof vi.fn>;
@@ -336,54 +321,6 @@ describe('UtilityClient', () => {
       const result = await client.getVersion();
 
       expect(result).toBe('unknown');
-    });
-  });
-
-  describe('runtime identity', () => {
-    it('should get runtime identity successfully', async () => {
-      mockFetch.mockResolvedValue(
-        new Response(JSON.stringify(mockRuntimeIdentityResponse()), {
-          status: 200
-        })
-      );
-
-      const result = await client.getRuntimeIdentity();
-
-      expect(result).toEqual({
-        runtimeId: 'rt-123',
-        startedAt: '2023-01-01T00:00:00Z'
-      });
-    });
-
-    it('should request the runtime endpoint', async () => {
-      mockFetch.mockResolvedValue(
-        new Response(JSON.stringify(mockRuntimeIdentityResponse()), {
-          status: 200
-        })
-      );
-
-      await client.getRuntimeIdentity();
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        'http://test.com/api/runtime',
-        expect.objectContaining({ method: 'GET' })
-      );
-    });
-
-    it('should surface runtime endpoint failures', async () => {
-      mockFetch.mockResolvedValue(
-        new Response(JSON.stringify({ error: 'Not Found' }), { status: 404 })
-      );
-
-      await expect(client.getRuntimeIdentity()).rejects.toThrow();
-    });
-
-    it('should throw an explicit compatibility error for missing endpoint', async () => {
-      mockFetch.mockResolvedValue(new Response('Not Found', { status: 404 }));
-
-      await expect(client.getRuntimeIdentity()).rejects.toThrow(
-        'Runtime identity is not supported by this sandbox container. Recreate the sandbox or upgrade to a newer container image.'
-      );
     });
   });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -172,6 +172,7 @@ export type {
   RemoteMountBucketOptions,
   RenameFileResult,
   RestoreBackupResult,
+  RuntimeIdentity,
   // Sandbox configuration options
   SandboxOptions,
   // Session management result types

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1077,10 +1077,8 @@ export interface ExecutionSession {
  * `runtimeId` changes whenever the underlying container boots again.
  */
 export interface RuntimeIdentity {
-  /** Unique identifier for the current container boot. */
+  /** Unique identifier for the current container placement. */
   runtimeId: string;
-  /** When the current container boot started. */
-  startedAt: string;
 }
 
 // Backup types

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1071,6 +1071,18 @@ export interface ExecutionSession {
   terminal(request: Request, options?: PtyOptions): Promise<Response>;
 }
 
+/**
+ * Identity for a single container runtime.
+ *
+ * `runtimeId` changes whenever the underlying container boots again.
+ */
+export interface RuntimeIdentity {
+  /** Unique identifier for the current container boot. */
+  runtimeId: string;
+  /** When the current container boot started. */
+  startedAt: string;
+}
+
 // Backup types
 /**
  * Options for creating a directory backup
@@ -1332,6 +1344,9 @@ export interface ISandbox {
   // Backup operations
   createBackup(options: BackupOptions): Promise<DirectoryBackup>;
   restoreBackup(backup: DirectoryBackup): Promise<RestoreBackupResult>;
+
+  // Runtime lifecycle metadata
+  getRuntimeIdentity(): Promise<RuntimeIdentity>;
 
   // WebSocket connection
   wsConnect(request: Request, port: number): Promise<Response>;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1072,12 +1072,14 @@ export interface ExecutionSession {
 }
 
 /**
- * Identity for a single container runtime.
+ * Placement-derived identity for the currently observed container runtime.
  *
- * `runtimeId` changes whenever the underlying container boots again.
+ * The SDK refreshes this value when it starts a container or detects that the
+ * previously observed container stopped. While a container stays active,
+ * repeated reads return the same value.
  */
 export interface RuntimeIdentity {
-  /** Unique identifier for the current container placement. */
+  /** Placement-derived identifier for the current observed container runtime. */
   runtimeId: string;
 }
 

--- a/tests/e2e/helpers/test-fixtures.ts
+++ b/tests/e2e/helpers/test-fixtures.ts
@@ -133,17 +133,20 @@ export async function waitForCondition<T>(
     options.errorMessage || 'Condition not met within timeout';
 
   const startTime = Date.now();
+  let lastError: unknown;
 
   while (Date.now() - startTime < timeout) {
     try {
       return await condition();
     } catch (error) {
+      lastError = error;
       // Wait before retrying
       await new Promise((resolve) => setTimeout(resolve, interval));
     }
   }
 
-  throw new Error(errorMessage);
+  const suffix = lastError instanceof Error ? `: ${lastError.message}` : '';
+  throw new Error(`${errorMessage}${suffix}`);
 }
 
 /**

--- a/tests/e2e/runtime-identity-workflow.test.ts
+++ b/tests/e2e/runtime-identity-workflow.test.ts
@@ -78,16 +78,26 @@ describe('Runtime Identity E2E', () => {
       const stateHeaders = { ...sandbox.headers() };
       delete stateHeaders['X-Sandbox-Sleep-After'];
 
-      await new Promise((resolve) => setTimeout(resolve, 8000));
+      await waitForCondition(
+        async () => {
+          const stateResponse = await fetch(`${sandbox.workerUrl}/api/state`, {
+            method: 'GET',
+            headers: stateHeaders
+          });
+          expect(stateResponse.ok).toBe(true);
 
-      const stateResponse = await fetch(`${sandbox.workerUrl}/api/state`, {
-        method: 'GET',
-        headers: stateHeaders
-      });
-      expect(stateResponse.ok).toBe(true);
+          const state = (await stateResponse.json()) as SandboxStateResponse;
+          expect(['stopped', 'stopped_with_code']).toContain(state.status);
 
-      const state = (await stateResponse.json()) as SandboxStateResponse;
-      expect(['stopped', 'stopped_with_code']).toContain(state.status);
+          return state;
+        },
+        {
+          timeout: 15000,
+          interval: 500,
+          errorMessage:
+            'Sandbox did not stop before runtime identity restart check'
+        }
+      );
 
       const response2 = await waitForCondition(
         async () => {

--- a/tests/e2e/runtime-identity-workflow.test.ts
+++ b/tests/e2e/runtime-identity-workflow.test.ts
@@ -89,11 +89,29 @@ describe('Runtime Identity E2E', () => {
       const state = (await stateResponse.json()) as SandboxStateResponse;
       expect(['stopped', 'stopped_with_code']).toContain(state.status);
 
-      const response2 = await fetch(
-        `${sandbox.workerUrl}/api/runtime/identity`,
+      const response2 = await waitForCondition(
+        async () => {
+          const response = await fetch(
+            `${sandbox.workerUrl}/api/runtime/identity`,
+            {
+              method: 'GET',
+              headers: sandbox.headers()
+            }
+          );
+
+          if (!response.ok) {
+            throw new Error(
+              `Runtime identity not ready after restart: ${response.status}`
+            );
+          }
+
+          return response;
+        },
         {
-          method: 'GET',
-          headers: sandbox.headers()
+          timeout: 15000,
+          interval: 500,
+          errorMessage:
+            'Runtime identity did not become available after idle restart'
         }
       );
       expect(response2.ok).toBe(true);
@@ -115,5 +133,5 @@ describe('Runtime Identity E2E', () => {
     } finally {
       await cleanupTestSandbox(sandbox);
     }
-  }, 30000);
+  }, 60000);
 });

--- a/tests/e2e/runtime-identity-workflow.test.ts
+++ b/tests/e2e/runtime-identity-workflow.test.ts
@@ -3,6 +3,7 @@ import {
   cleanupTestSandbox,
   createTestSandbox
 } from './helpers/global-sandbox';
+import { waitForCondition } from './helpers/test-fixtures';
 import type { RuntimeIdentityResponse } from './test-worker/types';
 
 interface SandboxStateResponse {
@@ -26,11 +27,27 @@ describe('Runtime Identity E2E', () => {
       const runtime1 = (await response1.json()) as RuntimeIdentityResponse;
       expect(runtime1.runtimeId).not.toBe('');
 
-      const response2 = await fetch(
-        `${sandbox.workerUrl}/api/runtime/identity`,
+      const response2 = await waitForCondition(
+        async () => {
+          const response = await fetch(
+            `${sandbox.workerUrl}/api/runtime/identity`,
+            {
+              method: 'GET',
+              headers: sandbox.headers()
+            }
+          );
+
+          if (!response.ok) {
+            throw new Error(`Runtime identity not ready: ${response.status}`);
+          }
+
+          return response;
+        },
         {
-          method: 'GET',
-          headers: sandbox.headers()
+          timeout: 15000,
+          interval: 500,
+          errorMessage:
+            'Runtime identity did not become available after idle restart'
         }
       );
       expect(response2.ok).toBe(true);

--- a/tests/e2e/runtime-identity-workflow.test.ts
+++ b/tests/e2e/runtime-identity-workflow.test.ts
@@ -1,63 +1,102 @@
-import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import {
   cleanupTestSandbox,
-  createTestSandbox,
-  type TestSandbox
+  createTestSandbox
 } from './helpers/global-sandbox';
 import type { RuntimeIdentityResponse } from './test-worker/types';
 
+interface SandboxStateResponse {
+  status: string;
+}
+
 describe('Runtime Identity E2E', () => {
-  let sandbox: TestSandbox | null = null;
-  let workerUrl: string;
+  test('should keep identity stable while a runtime stays active', async () => {
+    const sandbox = await createTestSandbox();
 
-  beforeAll(async () => {
-    sandbox = await createTestSandbox();
-    workerUrl = sandbox.workerUrl;
-  }, 120000);
+    try {
+      const response1 = await fetch(
+        `${sandbox.workerUrl}/api/runtime/identity`,
+        {
+          method: 'GET',
+          headers: sandbox.headers()
+        }
+      );
+      expect(response1.ok).toBe(true);
 
-  afterAll(async () => {
-    await cleanupTestSandbox(sandbox);
-    sandbox = null;
-  }, 120000);
+      const runtime1 = (await response1.json()) as RuntimeIdentityResponse;
+      expect(runtime1.runtimeId).not.toBe('');
 
-  test('should keep identity stable until the sandbox is recreated', async () => {
-    if (!sandbox) {
-      throw new Error('Sandbox was not initialized');
+      const response2 = await fetch(
+        `${sandbox.workerUrl}/api/runtime/identity`,
+        {
+          method: 'GET',
+          headers: sandbox.headers()
+        }
+      );
+      expect(response2.ok).toBe(true);
+
+      const runtime2 = (await response2.json()) as RuntimeIdentityResponse;
+      expect(runtime2).toEqual(runtime1);
+    } finally {
+      await cleanupTestSandbox(sandbox);
     }
-
-    const response1 = await fetch(`${workerUrl}/api/runtime/identity`, {
-      method: 'GET',
-      headers: sandbox.headers()
-    });
-    expect(response1.ok).toBe(true);
-
-    const runtime1 = (await response1.json()) as RuntimeIdentityResponse;
-
-    const response2 = await fetch(`${workerUrl}/api/runtime/identity`, {
-      method: 'GET',
-      headers: sandbox.headers()
-    });
-    expect(response2.ok).toBe(true);
-
-    const runtime2 = (await response2.json()) as RuntimeIdentityResponse;
-    expect(runtime2).toEqual(runtime1);
-
-    await cleanupTestSandbox(sandbox);
-
-    const recreateResponse = await fetch(`${workerUrl}/api/execute`, {
-      method: 'POST',
-      headers: sandbox.headers(),
-      body: JSON.stringify({ command: 'echo ready' })
-    });
-    expect(recreateResponse.ok).toBe(true);
-
-    const response3 = await fetch(`${workerUrl}/api/runtime/identity`, {
-      method: 'GET',
-      headers: sandbox.headers()
-    });
-    expect(response3.ok).toBe(true);
-
-    const runtime3 = (await response3.json()) as RuntimeIdentityResponse;
-    expect(runtime3.runtimeId).not.toBe(runtime1.runtimeId);
   }, 120000);
+
+  test('should keep returning a stable identity after an idle restart', async () => {
+    const sandbox = await createTestSandbox({ sleepAfter: '3s' });
+
+    try {
+      const response1 = await fetch(
+        `${sandbox.workerUrl}/api/runtime/identity`,
+        {
+          method: 'GET',
+          headers: sandbox.headers()
+        }
+      );
+      expect(response1.ok).toBe(true);
+
+      const runtime1 = (await response1.json()) as RuntimeIdentityResponse;
+      expect(runtime1.runtimeId).not.toBe('');
+
+      const stateHeaders = { ...sandbox.headers() };
+      delete stateHeaders['X-Sandbox-Sleep-After'];
+
+      await new Promise((resolve) => setTimeout(resolve, 8000));
+
+      const stateResponse = await fetch(`${sandbox.workerUrl}/api/state`, {
+        method: 'GET',
+        headers: stateHeaders
+      });
+      expect(stateResponse.ok).toBe(true);
+
+      const state = (await stateResponse.json()) as SandboxStateResponse;
+      expect(['stopped', 'stopped_with_code']).toContain(state.status);
+
+      const response2 = await fetch(
+        `${sandbox.workerUrl}/api/runtime/identity`,
+        {
+          method: 'GET',
+          headers: sandbox.headers()
+        }
+      );
+      expect(response2.ok).toBe(true);
+
+      const restarted1 = (await response2.json()) as RuntimeIdentityResponse;
+      expect(restarted1.runtimeId).not.toBe('');
+
+      const response3 = await fetch(
+        `${sandbox.workerUrl}/api/runtime/identity`,
+        {
+          method: 'GET',
+          headers: sandbox.headers()
+        }
+      );
+      expect(response3.ok).toBe(true);
+
+      const restarted2 = (await response3.json()) as RuntimeIdentityResponse;
+      expect(restarted2).toEqual(restarted1);
+    } finally {
+      await cleanupTestSandbox(sandbox);
+    }
+  }, 30000);
 });

--- a/tests/e2e/runtime-identity-workflow.test.ts
+++ b/tests/e2e/runtime-identity-workflow.test.ts
@@ -59,7 +59,7 @@ describe('Runtime Identity E2E', () => {
     }
   }, 120000);
 
-  test('should keep returning a stable identity after an idle restart', async () => {
+  test('should return a stable runtime identity after restarting from idle sleep', async () => {
     const sandbox = await createTestSandbox({ sleepAfter: '3s' });
 
     try {
@@ -122,7 +122,7 @@ describe('Runtime Identity E2E', () => {
           timeout: 15000,
           interval: 500,
           errorMessage:
-            'Runtime identity did not become available after idle restart'
+            'Runtime identity did not become available after restart from idle sleep'
         }
       );
       expect(response2.ok).toBe(true);

--- a/tests/e2e/runtime-identity-workflow.test.ts
+++ b/tests/e2e/runtime-identity-workflow.test.ts
@@ -92,8 +92,8 @@ describe('Runtime Identity E2E', () => {
           return state;
         },
         {
-          timeout: 15000,
-          interval: 500,
+          timeout: 30000,
+          interval: 1000,
           errorMessage:
             'Sandbox did not stop before runtime identity restart check'
         }

--- a/tests/e2e/runtime-identity-workflow.test.ts
+++ b/tests/e2e/runtime-identity-workflow.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import {
+  cleanupTestSandbox,
+  createTestSandbox,
+  type TestSandbox
+} from './helpers/global-sandbox';
+import type { RuntimeIdentityResponse } from './test-worker/types';
+
+describe('Runtime Identity E2E', () => {
+  let sandbox: TestSandbox | null = null;
+  let workerUrl: string;
+
+  beforeAll(async () => {
+    sandbox = await createTestSandbox();
+    workerUrl = sandbox.workerUrl;
+  }, 120000);
+
+  afterAll(async () => {
+    await cleanupTestSandbox(sandbox);
+    sandbox = null;
+  }, 120000);
+
+  test('should keep identity stable until the sandbox is recreated', async () => {
+    if (!sandbox) {
+      throw new Error('Sandbox was not initialized');
+    }
+
+    const response1 = await fetch(`${workerUrl}/api/runtime/identity`, {
+      method: 'GET',
+      headers: sandbox.headers()
+    });
+    expect(response1.ok).toBe(true);
+
+    const runtime1 = (await response1.json()) as RuntimeIdentityResponse;
+
+    const response2 = await fetch(`${workerUrl}/api/runtime/identity`, {
+      method: 'GET',
+      headers: sandbox.headers()
+    });
+    expect(response2.ok).toBe(true);
+
+    const runtime2 = (await response2.json()) as RuntimeIdentityResponse;
+    expect(runtime2).toEqual(runtime1);
+
+    await cleanupTestSandbox(sandbox);
+
+    const recreateResponse = await fetch(`${workerUrl}/api/execute`, {
+      method: 'POST',
+      headers: sandbox.headers(),
+      body: JSON.stringify({ command: 'echo ready' })
+    });
+    expect(recreateResponse.ok).toBe(true);
+
+    const response3 = await fetch(`${workerUrl}/api/runtime/identity`, {
+      method: 'GET',
+      headers: sandbox.headers()
+    });
+    expect(response3.ok).toBe(true);
+
+    const runtime3 = (await response3.json()) as RuntimeIdentityResponse;
+    expect(runtime3.runtimeId).not.toBe(runtime1.runtimeId);
+  }, 120000);
+});

--- a/tests/e2e/runtime-identity-workflow.test.ts
+++ b/tests/e2e/runtime-identity-workflow.test.ts
@@ -119,8 +119,8 @@ describe('Runtime Identity E2E', () => {
           return response;
         },
         {
-          timeout: 15000,
-          interval: 500,
+          timeout: 30000,
+          interval: 1000,
           errorMessage:
             'Runtime identity did not become available after restart from idle sleep'
         }
@@ -144,5 +144,5 @@ describe('Runtime Identity E2E', () => {
     } finally {
       await cleanupTestSandbox(sandbox);
     }
-  }, 60000);
+  }, 120000);
 });

--- a/tests/e2e/runtime-identity-workflow.test.ts
+++ b/tests/e2e/runtime-identity-workflow.test.ts
@@ -100,8 +100,9 @@ describe('Runtime Identity E2E', () => {
           );
 
           if (!response.ok) {
+            const body = await response.text();
             throw new Error(
-              `Runtime identity not ready after restart: ${response.status}`
+              `Runtime identity not ready after restart: status=${response.status} body=${body}`
             );
           }
 

--- a/tests/e2e/streaming-operations-workflow.test.ts
+++ b/tests/e2e/streaming-operations-workflow.test.ts
@@ -7,6 +7,7 @@ import {
   createUniqueSession,
   type TestSandbox
 } from './helpers/global-sandbox';
+import { waitForCondition } from './helpers/test-fixtures';
 
 interface SandboxStateResponse {
   status: 'healthy' | 'stopped' | 'stopped_with_code' | 'stopping';
@@ -204,22 +205,29 @@ describe('Streaming Operations Edge Cases', () => {
       const stateHeaders = { ...shortSleepSandbox.headers() };
       delete stateHeaders['X-Sandbox-Sleep-After'];
 
-      // Give the alarm loop time to observe idleness and persist the stopped state
-      // before checking it, without issuing repeated requests that can delay delivery.
-      await new Promise((resolve) => setTimeout(resolve, 8000));
+      await waitForCondition(
+        async () => {
+          const stateResponse = await fetch(
+            `${shortSleepSandbox.workerUrl}/api/state`,
+            {
+              method: 'GET',
+              headers: stateHeaders
+            }
+          );
 
-      const stateResponse = await fetch(
-        `${shortSleepSandbox.workerUrl}/api/state`,
+          expect(stateResponse.status).toBe(200);
+
+          const state = (await stateResponse.json()) as SandboxStateResponse;
+          expect(['stopped', 'stopped_with_code']).toContain(state.status);
+
+          return state;
+        },
         {
-          method: 'GET',
-          headers: stateHeaders
+          timeout: 15000,
+          interval: 500,
+          errorMessage: 'Sandbox did not stop after sleepAfter'
         }
       );
-
-      expect(stateResponse.status).toBe(200);
-
-      const state = (await stateResponse.json()) as SandboxStateResponse;
-      expect(['stopped', 'stopped_with_code']).toContain(state.status);
     } finally {
       await cleanupTestSandbox(shortSleepSandbox);
     }

--- a/tests/e2e/test-worker/index.ts
+++ b/tests/e2e/test-worker/index.ts
@@ -28,6 +28,7 @@ import type {
   ErrorResponse,
   HealthResponse,
   PortUnexposeResponse,
+  RuntimeIdentityResponse,
   SessionCreateResponse,
   SuccessResponse,
   SuccessWithMessageResponse,
@@ -490,6 +491,18 @@ console.log('Terminal server on port ' + port);
       if (url.pathname === '/api/state' && request.method === 'GET') {
         const state = await sandbox.getState();
         return new Response(JSON.stringify(state), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      if (
+        url.pathname === '/api/runtime/identity' &&
+        request.method === 'GET'
+      ) {
+        const runtimeIdentity = await sandbox.getRuntimeIdentity();
+        const response: RuntimeIdentityResponse = runtimeIdentity;
+
+        return new Response(JSON.stringify(response), {
           headers: { 'Content-Type': 'application/json' }
         });
       }

--- a/tests/e2e/test-worker/types.ts
+++ b/tests/e2e/test-worker/types.ts
@@ -31,6 +31,11 @@ export interface SuccessWithMessageResponse {
   message: string;
 }
 
+export interface RuntimeIdentityResponse {
+  runtimeId: string;
+  startedAt: string;
+}
+
 // R2 bucket operations
 export interface BucketPutResponse {
   success: boolean;

--- a/tests/e2e/test-worker/types.ts
+++ b/tests/e2e/test-worker/types.ts
@@ -33,7 +33,6 @@ export interface SuccessWithMessageResponse {
 
 export interface RuntimeIdentityResponse {
   runtimeId: string;
-  startedAt: string;
 }
 
 // R2 bucket operations


### PR DESCRIPTION
## Summary
- add `sandbox.getRuntimeIdentity()` and export `RuntimeIdentity` so callers can detect when the currently observed sandbox runtime has changed
- persist the placement-derived runtime ID in Durable Object storage, refresh it when the SDK starts a container or detects that the previous runtime stopped, and clear it when the sandbox stops
- expose `CLOUDFLARE_PLACEMENT_ID` through a lightweight container endpoint so the SDK can retrieve runtime identity through a dedicated API instead of shelling into the container
- add unit and E2E coverage for stable identity reads, refresh after restart, cache invalidation when the runtime stops, and test-worker wiring

## Updates since last revision
Addressed Devin Review flags and CodeQL finding:

- **Lazy identity capture**: removed the eager `captureRuntimeIdentity()` call from `containerFetch` that added an extra HTTP roundtrip on every container startup. The cached identity is now invalidated (`this.runtimeIdentity = null`) on restart and captured lazily when `getRuntimeIdentity()` is first called via `ensureRuntimeIdentity`.
- **Safer undefined-container handling**: changed `containerRunning === false` → `containerRunning !== true` in `ensureRuntimeIdentity` so that an undefined container binding (e.g. binding not yet available) correctly triggers a refresh instead of returning a potentially stale cached identity.
- **Robust error parsing in `throwContainerResponseError`**: separated JSON parsing from `createErrorFromResponse` into distinct try/catch blocks, replacing the fragile `error.name !== 'SyntaxError'` check that could swallow unrelated `SyntaxError` exceptions.
- **No stack-trace exposure (CodeQL fix)**: removed raw `error.message` from all `context.error` fields in HTTP error response bodies returned by `containerFetch`. Error details are still logged server-side via the logger.

## Why
This change gives SDK users a first-class API for that flow so they can compare the current runtime identity with the last one they observed without managing their own marker file.

## Reviewer Notes
- `runtimeId` is intentionally documented as placement-derived, not as an official monotonic generation counter. The SDK promise here is stable identity while the same container stays active, plus refresh after SDK-observed restart paths.
- `getRuntimeIdentity()` no longer trusts a cached value when the runtime reports that the container stopped. It refreshes after the next startup path instead of returning stale identity.
- The container implementation reads `process.env.CLOUDFLARE_PLACEMENT_ID` directly via `/api/runtime/identity`.
- The idle-restart E2E test now retries across the cold-start window because the first request after sleep can race with container startup.
- This supersedes the earlier approach from closed PR #564.

## Testing
- `npm run check` (passes with the existing `sherif` workspace warnings about example directories missing `package.json`)
- `npm test -w @cloudflare/sandbox -- tests/sandbox.test.ts -t "runtime identity"`
- `npm test -w @repo/sandbox-container -- --filter "handleRuntimeIdentity"`
- `npm run typecheck:e2e`

## Review & Testing Checklist for Human
- [ ] **Lazy capture correctness**: verify that callers who rely on `getRuntimeIdentity()` after a container restart still get a fresh identity — the capture now happens inside `ensureRuntimeIdentity` rather than eagerly in `containerFetch`. Check that no code path depends on `this.runtimeIdentity` being populated immediately after startup.
- [ ] **`containerRunning !== true` semantics**: confirm that treating `undefined` as "may need restart" is the desired behavior across all call sites. In `containerFetch`, the existing `=== false` checks for `staleStateDetected` are intentionally kept — only `ensureRuntimeIdentity` was changed.
- [ ] **Error response body change**: the `context.error` field was removed from all error responses in `containerFetch`. Verify no downstream consumers (monitoring dashboards, client-side error handling) depend on this field being present.
- [ ] **Run the E2E runtime identity tests** against a deployed environment to confirm identity stability across idle-sleep restarts: `npm run typecheck:e2e` and the runtime-identity-workflow E2E suite.

### Notes
- Three pre-existing test failures (keepAlive/sleepAfter) are unrelated to this PR and reproduce on the base branch.
- Seven pre-existing PTY test failures in `sandbox-container` are also unrelated.

Link to Devin session: https://app.devin.ai/sessions/77dbbcb4df434b458768a72c8ff8903c
Requested by: @whoiskatrin