### PR TITLE
Expose container placement ID on the sandbox

### DIFF
--- a/.changeset/placement-id-api.md
+++ b/.changeset/placement-id-api.md
@@ -1,0 +1,32 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Add `sandbox.getContainerPlacementId()` to retrieve the Cloudflare placement ID
+observed for the underlying container.
+
+The placement ID identifies the current container placement and changes when
+the container is replaced by the platform. Compare the returned value against
+a stored value to detect container replacement and trigger reconciliation.
+
+The placement ID is captured during the session-create handshake and cached
+in Durable Object storage, so reads are cheap and do not require a healthy
+container. A fresh placement ID is captured on each subsequent handshake,
+so a replacement is reflected the next time the sandbox is used.
+
+Returns `undefined` when no session-create handshake has been observed yet on
+this sandbox — call any method that triggers session creation (such as
+`exec()`) first. Returns `null` when a handshake has completed but the
+container's `CLOUDFLARE_PLACEMENT_ID` environment variable is not set, such as
+in local development with wrangler.
+
+```ts
+await sandbox.exec('true'); // ensures the handshake has run
+const containerPlacementId = await sandbox.getContainerPlacementId();
+if (
+  typeof containerPlacementId === 'string' &&
+  containerPlacementId !== lastKnownPlacementId
+) {
+  // Container was replaced — reconcile state
+}
+```

--- a/packages/sandbox-container/src/handlers/session-handler.ts
+++ b/packages/sandbox-container/src/handlers/session-handler.ts
@@ -79,11 +79,25 @@ export class SessionHandler extends BaseHandler<Request, Response> {
       const response = {
         success: true,
         data: result.data,
+        containerPlacementId: process.env.CLOUDFLARE_PLACEMENT_ID ?? null,
         timestamp: new Date().toISOString()
       };
 
       return this.createTypedResponse(response, context);
     } else {
+      // Include placement ID on the already-exists path so the DO can capture
+      // it after a DO restart where the container is still the original
+      // placement and the session was created before the DO restarted.
+      if (result.error.code === ErrorCode.SESSION_ALREADY_EXISTS) {
+        const errorWithPlacement = {
+          ...result.error,
+          details: {
+            ...(result.error.details ?? {}),
+            containerPlacementId: process.env.CLOUDFLARE_PLACEMENT_ID ?? null
+          }
+        };
+        return this.createErrorResponse(errorWithPlacement, context);
+      }
       return this.createErrorResponse(result.error, context);
     }
   }

--- a/packages/sandbox-container/src/rpc/sandbox-api.ts
+++ b/packages/sandbox-container/src/rpc/sandbox-api.ts
@@ -26,6 +26,7 @@ import type {
   SandboxAPI as SandboxAPIInterface,
   WatchRequest
 } from '@repo/shared';
+import { ErrorCode } from '@repo/shared/errors';
 import { RpcTarget } from 'capnweb';
 import type {
   CommandResult,
@@ -959,12 +960,30 @@ class UtilsRPCAPI extends RpcTarget {
     cwd?: string;
   }) {
     const result = await this.#mgr.createSession(options);
+    if (
+      !result.success &&
+      result.error.code === ErrorCode.SESSION_ALREADY_EXISTS
+    ) {
+      // Mirror the HTTP handler: surface placement ID on the duplicate-create
+      // path so a restarted DO can capture it from the idempotent retry.
+      throw new RPCError(
+        JSON.stringify({
+          code: result.error.code,
+          message: result.error.message,
+          context: {
+            ...(result.error.details ?? {}),
+            containerPlacementId: process.env.CLOUDFLARE_PLACEMENT_ID ?? null
+          }
+        })
+      );
+    }
     throwIfError(result);
     return {
       success: true,
       id: options.id,
       message: `Session ${options.id} created`,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
+      containerPlacementId: process.env.CLOUDFLARE_PLACEMENT_ID ?? null
     };
   }
 

--- a/packages/sandbox-container/tests/handlers/session-handler.test.ts
+++ b/packages/sandbox-container/tests/handlers/session-handler.test.ts
@@ -152,6 +152,108 @@ describe('SessionHandler', () => {
 
       expect(mockSessionManager.createSession).toHaveBeenCalledTimes(2);
     });
+
+    it('should include containerPlacementId from CLOUDFLARE_PLACEMENT_ID env var on success', async () => {
+      process.env.CLOUDFLARE_PLACEMENT_ID = 'placement-abc-123';
+
+      (mockSessionManager.createSession as any).mockResolvedValue({
+        success: true,
+        data: {} as Session
+      });
+
+      const request = new Request('http://localhost:3000/api/session/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      });
+
+      const response = await sessionHandler.handle(request, mockContext);
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as SessionCreateResultGeneric & {
+        containerPlacementId: string | null;
+      };
+      expect(body.containerPlacementId).toBe('placement-abc-123');
+
+      delete process.env.CLOUDFLARE_PLACEMENT_ID;
+    });
+
+    it('should return containerPlacementId: null when CLOUDFLARE_PLACEMENT_ID is not set', async () => {
+      delete process.env.CLOUDFLARE_PLACEMENT_ID;
+
+      (mockSessionManager.createSession as any).mockResolvedValue({
+        success: true,
+        data: {} as Session
+      });
+
+      const request = new Request('http://localhost:3000/api/session/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      });
+
+      const response = await sessionHandler.handle(request, mockContext);
+
+      const body = (await response.json()) as SessionCreateResultGeneric & {
+        containerPlacementId: string | null;
+      };
+      expect(body.containerPlacementId).toBeNull();
+    });
+
+    it('should include containerPlacementId in error details when session already exists', async () => {
+      process.env.CLOUDFLARE_PLACEMENT_ID = 'placement-xyz-789';
+
+      (mockSessionManager.createSession as any).mockResolvedValue({
+        success: false,
+        error: {
+          message: "Session 'foo' already exists",
+          code: ErrorCode.SESSION_ALREADY_EXISTS,
+          details: { sessionId: 'foo' }
+        }
+      });
+
+      const request = new Request('http://localhost:3000/api/session/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: 'foo' })
+      });
+
+      const response = await sessionHandler.handle(request, mockContext);
+
+      const body = (await response.json()) as ErrorResponse;
+      expect(body.code).toBe(ErrorCode.SESSION_ALREADY_EXISTS);
+      expect(body.context).toEqual({
+        sessionId: 'foo',
+        containerPlacementId: 'placement-xyz-789'
+      });
+
+      delete process.env.CLOUDFLARE_PLACEMENT_ID;
+    });
+
+    it('should not add containerPlacementId to unrelated error codes', async () => {
+      process.env.CLOUDFLARE_PLACEMENT_ID = 'placement-should-not-appear';
+
+      (mockSessionManager.createSession as any).mockResolvedValue({
+        success: false,
+        error: {
+          message: 'Some other failure',
+          code: ErrorCode.UNKNOWN_ERROR,
+          details: { foo: 'bar' }
+        }
+      });
+
+      const request = new Request('http://localhost:3000/api/session/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      });
+
+      const response = await sessionHandler.handle(request, mockContext);
+      const body = (await response.json()) as ErrorResponse;
+      expect(body.context).toEqual({ foo: 'bar' });
+      expect(
+        (body.context as Record<string, unknown>).containerPlacementId
+      ).toBeUndefined();
+
+      delete process.env.CLOUDFLARE_PLACEMENT_ID;
+    });
   });
 
   describe('handleDelete - POST /api/session/delete', () => {

--- a/packages/sandbox-container/tests/rpc/sandbox-api-utils.test.ts
+++ b/packages/sandbox-container/tests/rpc/sandbox-api-utils.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
+import type { Logger } from '@repo/shared';
+import { ErrorCode } from '@repo/shared/errors';
+import {
+  SandboxAPI,
+  type SandboxAPIDeps
+} from '@sandbox-container/rpc/sandbox-api';
+import type { SessionManager } from '@sandbox-container/services/session-manager';
+import type { Session } from '@sandbox-container/session';
+
+const mockLogger = {
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  child: vi.fn()
+} as Logger;
+mockLogger.child = vi.fn(() => mockLogger);
+
+function buildApi(sessionManager: SessionManager): SandboxAPI {
+  // Domains other than sessionManager are unused by utils.createSession; cast
+  // through unknown so the test does not have to construct real services.
+  return new SandboxAPI({
+    sessionManager,
+    logger: mockLogger
+  } as unknown as SandboxAPIDeps);
+}
+
+describe('SandboxAPI utils.createSession', () => {
+  let mockSessionManager: SessionManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSessionManager = {
+      createSession: vi.fn(),
+      deleteSession: vi.fn(),
+      listSessions: vi.fn()
+    } as unknown as SessionManager;
+  });
+
+  afterEach(() => {
+    delete process.env.CLOUDFLARE_PLACEMENT_ID;
+  });
+
+  it('returns containerPlacementId from CLOUDFLARE_PLACEMENT_ID on success', async () => {
+    process.env.CLOUDFLARE_PLACEMENT_ID = 'placement-rpc-123';
+    (mockSessionManager.createSession as any).mockResolvedValue({
+      success: true,
+      data: {} as Session
+    });
+
+    const api = buildApi(mockSessionManager);
+    const result = await api.utils.createSession({ id: 'sess-1' });
+
+    expect(result).toMatchObject({
+      success: true,
+      id: 'sess-1',
+      containerPlacementId: 'placement-rpc-123'
+    });
+    expect(typeof result.timestamp).toBe('string');
+  });
+
+  it('returns containerPlacementId: null when CLOUDFLARE_PLACEMENT_ID is unset', async () => {
+    delete process.env.CLOUDFLARE_PLACEMENT_ID;
+    (mockSessionManager.createSession as any).mockResolvedValue({
+      success: true,
+      data: {} as Session
+    });
+
+    const api = buildApi(mockSessionManager);
+    const result = await api.utils.createSession({ id: 'sess-2' });
+
+    expect(result.containerPlacementId).toBeNull();
+  });
+
+  it('includes containerPlacementId in error context on SESSION_ALREADY_EXISTS', async () => {
+    process.env.CLOUDFLARE_PLACEMENT_ID = 'placement-rpc-already';
+    (mockSessionManager.createSession as any).mockResolvedValue({
+      success: false,
+      error: {
+        message: "Session 'sess-3' already exists",
+        code: ErrorCode.SESSION_ALREADY_EXISTS,
+        details: { sessionId: 'sess-3' }
+      }
+    });
+
+    const api = buildApi(mockSessionManager);
+
+    let caught: Error | undefined;
+    try {
+      await api.utils.createSession({ id: 'sess-3' });
+    } catch (err) {
+      caught = err as Error;
+    }
+
+    expect(caught).toBeDefined();
+    const payload = JSON.parse(caught!.message) as {
+      code: string;
+      message: string;
+      context: Record<string, unknown>;
+    };
+    expect(payload.code).toBe(ErrorCode.SESSION_ALREADY_EXISTS);
+    expect(payload.context).toEqual({
+      sessionId: 'sess-3',
+      containerPlacementId: 'placement-rpc-already'
+    });
+  });
+
+  it('does not add containerPlacementId to unrelated error codes', async () => {
+    process.env.CLOUDFLARE_PLACEMENT_ID = 'placement-should-not-appear';
+    (mockSessionManager.createSession as any).mockResolvedValue({
+      success: false,
+      error: {
+        message: 'Some other failure',
+        code: ErrorCode.UNKNOWN_ERROR,
+        details: { foo: 'bar' }
+      }
+    });
+
+    const api = buildApi(mockSessionManager);
+
+    let caught: Error | undefined;
+    try {
+      await api.utils.createSession({ id: 'sess-4' });
+    } catch (err) {
+      caught = err as Error;
+    }
+
+    expect(caught).toBeDefined();
+    const payload = JSON.parse(caught!.message) as {
+      code: string;
+      context: Record<string, unknown>;
+    };
+    expect(payload.code).toBe(ErrorCode.UNKNOWN_ERROR);
+    expect(payload.context).toEqual({ foo: 'bar' });
+    expect(payload.context.containerPlacementId).toBeUndefined();
+  });
+});

--- a/packages/sandbox/src/clients/utility-client.ts
+++ b/packages/sandbox/src/clients/utility-client.ts
@@ -35,11 +35,16 @@ export interface CreateSessionRequest {
 }
 
 /**
- * Response interface for creating sessions
+ * Response interface for creating sessions.
+ *
+ * `containerPlacementId` carries the container's `CLOUDFLARE_PLACEMENT_ID` at session
+ * creation time so the DO can capture it without a separate request. It is
+ * `null` when the environment variable is not set, such as in local dev.
  */
 export interface CreateSessionResponse extends BaseApiResponse {
   id: string;
   message: string;
+  containerPlacementId?: string | null;
 }
 
 /**

--- a/packages/sandbox/src/errors/classes.ts
+++ b/packages/sandbox/src/errors/classes.ts
@@ -279,6 +279,10 @@ export class SessionAlreadyExistsError extends SandboxError<SessionAlreadyExists
   get sessionId() {
     return this.context.sessionId;
   }
+
+  get containerPlacementId(): string | null | undefined {
+    return this.context.containerPlacementId;
+  }
 }
 
 /**

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -2227,18 +2227,21 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     sessionId: string,
     generation: number
   ): Promise<string> {
+    let placementId: string | null | undefined;
     try {
-      await this.client.utils.createSession({
+      const response = await this.client.utils.createSession({
         id: sessionId,
         env: this.envVars || {},
         cwd: '/workspace'
       });
+      placementId = response.containerPlacementId;
     } catch (error: unknown) {
       // The container can outlive this DO instance, so an existing session
       // means the container is already in the state we need.
       if (!(error instanceof SessionAlreadyExistsError)) {
         throw error;
       }
+      placementId = error.containerPlacementId;
       this.logger.debug(
         'Session exists in container but not in DO state, syncing',
         { sessionId }
@@ -2258,9 +2261,31 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     // Durable storage is the cross-eviction source of truth for the default
     // session identity. Update the in-memory cache only after persistence.
     await this.ctx.storage.put('defaultSession', sessionId);
+    await this.capturePlacementId(placementId);
     this.defaultSession = sessionId;
     this.logger.debug('Default session initialized', { sessionId });
     return sessionId;
+  }
+
+  /**
+   * Persist the container's placement ID in DO storage.
+   *
+   * Called from the session-create handshake so subsequent reads via
+   * `getContainerPlacementId()` do not require a round-trip to the container. The value
+   * is overwritten on every handshake so that container replacements (which
+   * assign a new placement ID) are reflected on the next session-create.
+   *
+   * A value of `undefined` means the handshake response omitted the field
+   * (older container, unexpected error shape) and the stored value is left
+   * untouched. `null` means the env var is not set in the container and is
+   * stored as-is so callers can distinguish "observed and absent" from "not
+   * yet observed."
+   */
+  private async capturePlacementId(
+    containerPlacementId: string | null | undefined
+  ): Promise<void> {
+    if (containerPlacementId === undefined) return;
+    await this.ctx.storage.put('containerPlacementId', containerPlacementId);
   }
 
   // Enhanced exec method - always returns ExecResult with optional streaming
@@ -3758,7 +3783,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       Object.keys(filteredEnv).length > 0 ? filteredEnv : undefined;
 
     // Create session in container
-    await this.client.utils.createSession({
+    const response = await this.client.utils.createSession({
       id: sessionId,
       ...(envPayload && { env: envPayload }),
       ...(options?.cwd && { cwd: options.cwd }),
@@ -3766,6 +3791,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         commandTimeoutMs: options.commandTimeoutMs
       })
     });
+
+    await this.capturePlacementId(response.containerPlacementId);
 
     // Return wrapper that binds sessionId to all operations
     return this.getSessionWrapper(sessionId);
@@ -3812,6 +3839,27 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       sessionId: response.sessionId,
       timestamp: response.timestamp
     };
+  }
+
+  /**
+   * Get the Cloudflare placement ID observed for the underlying container.
+   *
+   * The placement ID is captured during the first session-create handshake
+   * after a container start and stored in Durable Object storage, so this
+   * method returns the cached value without contacting the container. A new
+   * placement ID is captured on each subsequent session-create handshake,
+   * which occurs whenever the container has been replaced.
+   *
+   * Returns `null` when a handshake has completed but the container's
+   * `CLOUDFLARE_PLACEMENT_ID` environment variable is not set (for example,
+   * in local development).
+   *
+   * Returns `undefined` when no handshake has been observed yet on this
+   * sandbox. Call any method that triggers session creation (such as
+   * `exec()`) to populate the value.
+   */
+  async getContainerPlacementId(): Promise<string | null | undefined> {
+    return this.ctx.storage.get<string | null>('containerPlacementId');
   }
 
   private getSessionWrapper(sessionId: string): ExecutionSession {

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -582,6 +582,72 @@ describe('Sandbox - Automatic Session Management', () => {
     });
   });
 
+  describe('placement id capture', () => {
+    it('should store containerPlacementId from session-create response', async () => {
+      vi.mocked(sandbox.client.utils.createSession).mockResolvedValueOnce({
+        success: true,
+        id: 'sandbox-default',
+        message: 'Created',
+        containerPlacementId: 'placement-abc-123'
+      } as any);
+
+      await sandbox.exec('echo hi');
+
+      expect(mockCtx.storage.put).toHaveBeenCalledWith(
+        'containerPlacementId',
+        'placement-abc-123'
+      );
+    });
+
+    it('should store null when container reports containerPlacementId as null', async () => {
+      vi.mocked(sandbox.client.utils.createSession).mockResolvedValueOnce({
+        success: true,
+        id: 'sandbox-default',
+        message: 'Created',
+        containerPlacementId: null
+      } as any);
+
+      await sandbox.exec('echo hi');
+
+      expect(mockCtx.storage.put).toHaveBeenCalledWith(
+        'containerPlacementId',
+        null
+      );
+    });
+
+    it('should not touch containerPlacementId storage when response omits the field', async () => {
+      vi.mocked(sandbox.client.utils.createSession).mockResolvedValueOnce({
+        success: true,
+        id: 'sandbox-default',
+        message: 'Created'
+      } as any);
+
+      await sandbox.exec('echo hi');
+
+      const placementCalls = mockCtx.storage.put.mock.calls.filter(
+        (call: unknown[]) => call[0] === 'containerPlacementId'
+      );
+      expect(placementCalls).toHaveLength(0);
+    });
+
+    it('getContainerPlacementId returns stored value', async () => {
+      mockCtx.storage.get.mockImplementation(async (key: string) => {
+        if (key === 'containerPlacementId') return 'placement-stored-xyz';
+        return null;
+      });
+
+      await expect(sandbox.getContainerPlacementId()).resolves.toBe(
+        'placement-stored-xyz'
+      );
+    });
+
+    it('getContainerPlacementId returns undefined when no handshake has occurred', async () => {
+      mockCtx.storage.get.mockResolvedValue(undefined);
+
+      await expect(sandbox.getContainerPlacementId()).resolves.toBeUndefined();
+    });
+  });
+
   describe('ExecutionSession operations', () => {
     let session: any;
 

--- a/packages/shared/src/errors/contexts.ts
+++ b/packages/shared/src/errors/contexts.ts
@@ -57,6 +57,13 @@ export interface ProcessErrorContext {
 
 export interface SessionAlreadyExistsContext {
   sessionId: string;
+  /**
+   * `CLOUDFLARE_PLACEMENT_ID` captured from the container at the moment the
+   * duplicate create was detected. Included so a restarted DO can learn the
+   * container's placement ID from an idempotent session-create. `null` when
+   * the env var is not set (for example, in local development).
+   */
+  containerPlacementId?: string | null;
 }
 
 export interface SessionDestroyedContext {

--- a/packages/shared/src/rpc-types.ts
+++ b/packages/shared/src/rpc-types.ts
@@ -220,6 +220,7 @@ export interface SandboxUtilsAPI {
     id: string;
     message: string;
     timestamp: string;
+    containerPlacementId?: string | null;
   }>;
   deleteSession(
     sessionId: string

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1347,6 +1347,15 @@ export interface ISandbox {
   createSession(options?: SessionOptions): Promise<ExecutionSession>;
   deleteSession(sessionId: string): Promise<SessionDeleteResult>;
 
+  // Container metadata
+  /**
+   * Returns the Cloudflare placement ID observed during the most recent
+   * session-create handshake with the container. `null` when the container
+   * does not expose `CLOUDFLARE_PLACEMENT_ID` (local development). `undefined`
+   * when no handshake has been observed yet on this sandbox.
+   */
+  getContainerPlacementId(): Promise<string | null | undefined>;
+
   // Code interpreter methods
   createCodeContext(options?: CreateContextOptions): Promise<CodeContext>;
   runCode(code: string, options?: RunCodeOptions): Promise<ExecutionResult>;

--- a/tests/e2e/capnweb-transport.test.ts
+++ b/tests/e2e/capnweb-transport.test.ts
@@ -231,4 +231,29 @@ describe.skipIf(!isCapnweb)("Cap'n Web Transport", () => {
     const defaultResult = (await defaultExecResponse.json()) as ExecResult;
     expect(defaultResult.stdout.trim()).toBe('');
   });
+
+  test('should expose container placement ID after a session handshake', async () => {
+    // Trigger a handshake so the DO captures CLOUDFLARE_PLACEMENT_ID from
+    // the createSession response.
+    const execResponse = await fetch(`${workerUrl}/api/execute`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ command: 'true' })
+    });
+    expect(execResponse.status).toBe(200);
+
+    const placementResponse = await fetch(`${workerUrl}/api/placement-id`, {
+      method: 'GET',
+      headers
+    });
+    expect(placementResponse.status).toBe(200);
+    const { placementId } = (await placementResponse.json()) as {
+      placementId: string | null | undefined;
+    };
+
+    // After a handshake the DO must have stored a value (string when
+    // CLOUDFLARE_PLACEMENT_ID is set, null when running locally) but not
+    // undefined, which would mean the RPC transport dropped the field.
+    expect(placementId === null || typeof placementId === 'string').toBe(true);
+  });
 });

--- a/tests/e2e/test-worker/index.ts
+++ b/tests/e2e/test-worker/index.ts
@@ -518,6 +518,13 @@ console.log('Terminal server on port ' + port);
         });
       }
 
+      if (url.pathname === '/api/placement-id' && request.method === 'GET') {
+        const placementId = await sandbox.getContainerPlacementId();
+        return new Response(JSON.stringify({ placementId }), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
       // Command execution
       if (url.pathname === '/api/execute' && request.method === 'POST') {
         const result = await executor.exec(body.command, {


### PR DESCRIPTION
## Summary

Adds `sandbox.getContainerPlacementId()` so callers can detect when the underlying container has been replaced by the platform.

The placement ID (`CLOUDFLARE_PLACEMENT_ID`) identifies a specific container placement and changes whenever the platform replaces the container. Today, detecting replacement requires writing a sentinel file into the container and reading it back — which breaks the moment the container is unhealthy, exactly when you most need to know.

This change piggybacks on the existing session-create handshake: the container reports its placement ID in the response, the Durable Object caches it in storage, and subsequent reads return the cached value without contacting the container.

```ts
await sandbox.exec('true'); // ensures the handshake has run
const placementId = await sandbox.getContainerPlacementId();
if (typeof placementId === 'string' && placementId !== lastKnownPlacementId) {
  // Container was replaced — reconcile state
}
```

## Design

### Push on handshake, not pull on demand

The natural alternative was a dedicated `GET /api/placement` endpoint. Rejected because:

- Every read would require a healthy container — defeats the primary use case (detecting replacement when things go wrong).
- It duplicates a round-trip when the SDK already does a handshake on first use.

Instead, the placement ID travels inside `CreateSessionResponse`. The DO captures it in `ensureDefaultSession()` and writes it to `ctx.storage`. Reads go to DO storage directly — no container wake, no HTTP.

### Capture on both success and already-exists paths

`ensureDefaultSession()` has two outcomes: the session gets created, or the container reports `SESSION_ALREADY_EXISTS` (common after DO restart while the container lives on). The placement ID must be captured in **both** cases, otherwise a restarted DO would permanently lose the value until the container itself restarts.

- Success path: `CreateSessionResponse.placementId`
- Already-exists path: `SessionAlreadyExistsContext.placementId`, surfaced via `SessionAlreadyExistsError.placementId`. This flows through the standard `ServiceError.details → ErrorResponse.context` pipeline in `BaseHandler.enrichServiceError()`.

### Return type: `string | null | undefined`

Three distinct states, each meaningful:

| Value       | Meaning                                                                        |
| ----------- | ------------------------------------------------------------------------------ |
| `string`    | Handshake observed; placement ID captured.                                     |
| `null`      | Handshake observed; `CLOUDFLARE_PLACEMENT_ID` env var not set (e.g. local dev).|
| `undefined` | No handshake has occurred yet on this sandbox — call `exec()` or similar first.|

Collapsing `undefined` into `null` would hide a real distinction: "the env var is absent" vs "we have not yet looked."

### Overwrite on every handshake

A fresh placement is written on each session-create. Container replacement triggers a new handshake (the old session no longer exists in the new container), so the stored value is naturally kept current without any TTL or explicit invalidation.

## Changes

**Container (`@repo/sandbox-container`)**
- `handlers/session-handler.ts`: include `placementId: process.env.CLOUDFLARE_PLACEMENT_ID ?? null` in the success response; add `placementId` to the `details` of the `SESSION_ALREADY_EXISTS` error path.

**SDK (`@cloudflare/sandbox`)**
- `clients/utility-client.ts`: extend `CreateSessionResponse` with optional `placementId`.
- `errors/classes.ts`: `SessionAlreadyExistsError` gains a `placementId` accessor.
- `sandbox.ts`:
  - `ensureDefaultSession()` calls a new private `capturePlacementId()` on both the success and already-exists branches.
  - `capturePlacementId()` writes to `ctx.storage.put('placementId', ...)`, skipping writes when the field is absent from the response (forward-compat with older containers).
  - Public `getPlacementId()` reads from `ctx.storage.get('placementId')`.

**Shared (`@repo/shared`)**
- `errors/contexts.ts`: `SessionAlreadyExistsContext` gains optional `placementId`.
- `types.ts`: `getPlacementId()` added to the `ISandbox` interface.

## Reviewer notes

Main places worth a closer look:

- **`packages/sandbox/src/sandbox.ts`** — `ensureDefaultSession()` (~L1872) and `capturePlacementId()` (~L1924). Verify both branches capture, and that `undefined` is correctly treated as "no information" rather than a write-through.
- **`packages/sandbox-container/src/handlers/session-handler.ts`** — confirm the already-exists error path carries `placementId` in `details` (not just in the success response).
- **Return type semantics** — the `string | null | undefined` tri-state is deliberate. If a reviewer prefers `string | null` with a separate "is initialized" flag, happy to discuss, but callers lose information.
- **`.changeset/placement-id-api.md`** — user-facing description; please sanity-check the wording and the example.

Places that intentionally did **not** change:

- No `/api/placement` endpoint. We considered one and rejected it (see Design above).
- No `PlacementResponse` or `PlacementResult` type exported from the SDK — the wire DTO is internal to the session-create handshake.
- No public change to `CreateSessionResponse` shape beyond the new optional field — existing callers are unaffected.

## Tests

- **SDK unit (`packages/sandbox/tests/sandbox.test.ts`)** — new `describe('placement id capture', ...)` covers: stores a string, stores `null`, skips write when the field is omitted, `getPlacementId()` returns the stored value, `getPlacementId()` returns `undefined` pre-handshake.
- **Container unit (`packages/sandbox-container/tests/handlers/session-handler.test.ts`)** — new cases cover the success response, `null` when the env var is unset, the already-exists error path surfacing `placementId` in `details`, and that unrelated error codes are not polluted.
- **Results**: `@cloudflare/sandbox` 560/560 pass; `@repo/sandbox-container` 622/622 pass; all three target packages typecheck clean.
