### PR TITLE
Fix local R2 mounts prefix handling

### DIFF
--- a/.changeset/fix-local-mount-prefix.md
+++ b/.changeset/fix-local-mount-prefix.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Fix `localBucket: true` mount silently syncing nothing when prefix starts with `/`

--- a/packages/sandbox/Dockerfile
+++ b/packages/sandbox/Dockerfile
@@ -1,7 +1,5 @@
 # Bun version — override via --build-arg BUN_VERSION=$(cat .bun-version)
 ARG BUN_VERSION=1
-ARG UBUNTU_MIRROR=http://mirrors.edge.kernel.org/ubuntu
-ARG UBUNTU_PORTS_MIRROR=http://mirrors.edge.kernel.org/ubuntu-ports
 FROM oven/bun:${BUN_VERSION} AS bun-binary
 
 # Sandbox container images (default and python variants)
@@ -53,9 +51,6 @@ RUN npx turbo run build
 # ============================================================================
 FROM ubuntu:22.04 AS python-builder
 
-ARG UBUNTU_MIRROR
-ARG UBUNTU_PORTS_MIRROR
-
 # Prevent interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -67,15 +62,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache && \
-    if [ "$(dpkg --print-architecture)" = "amd64" ] || [ "$(dpkg --print-architecture)" = "i386" ]; then \
-        M=$UBUNTU_MIRROR; \
-    else \
-        M=$UBUNTU_PORTS_MIRROR; \
-    fi && \
-    echo "deb $M jammy main restricted universe multiverse" > /etc/apt/sources.list && \
-    echo "deb $M jammy-updates main restricted universe multiverse" >> /etc/apt/sources.list && \
-    echo "deb $M jammy-backports main restricted universe multiverse" >> /etc/apt/sources.list && \
-    echo "deb $M jammy-security main restricted universe multiverse" >> /etc/apt/sources.list && \
     apt-get update && apt-get install -y --no-install-recommends \
     wget ca-certificates
 
@@ -107,9 +93,6 @@ RUN --mount=type=cache,target=/tmp/python-cache \
 # ============================================================================
 FROM ubuntu:22.04 AS runtime-base
 
-ARG UBUNTU_MIRROR
-ARG UBUNTU_PORTS_MIRROR
-
 # Accept version as build argument (passed from npm_package_version)
 ARG SANDBOX_VERSION=unknown
 
@@ -129,15 +112,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/* && \
-    if [ "$(dpkg --print-architecture)" = "amd64" ] || [ "$(dpkg --print-architecture)" = "i386" ]; then \
-        M=$UBUNTU_MIRROR; \
-    else \
-        M=$UBUNTU_PORTS_MIRROR; \
-    fi && \
-    echo "deb $M jammy main restricted universe multiverse" > /etc/apt/sources.list && \
-    echo "deb $M jammy-updates main restricted universe multiverse" >> /etc/apt/sources.list && \
-    echo "deb $M jammy-backports main restricted universe multiverse" >> /etc/apt/sources.list && \
-    echo "deb $M jammy-security main restricted universe multiverse" >> /etc/apt/sources.list && \
     apt-get update && apt-get install -y --no-install-recommends \
     s3fs fuse3 squashfs-tools squashfuse fuse-overlayfs \
     ca-certificates curl wget procps git unzip zip jq file \
@@ -272,23 +246,11 @@ RUN go mod tidy && go build -buildmode=c-shared -o /usr/lib/desktop.so .
 
 FROM runtime-base AS desktop
 
-ARG UBUNTU_MIRROR
-ARG UBUNTU_PORTS_MIRROR
-
 # Install display stack
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache && \
-    if [ "$(dpkg --print-architecture)" = "amd64" ] || [ "$(dpkg --print-architecture)" = "i386" ]; then \
-        M=$UBUNTU_MIRROR; \
-    else \
-        M=$UBUNTU_PORTS_MIRROR; \
-    fi && \
-    echo "deb $M jammy main restricted universe multiverse" > /etc/apt/sources.list && \
-    echo "deb $M jammy-updates main restricted universe multiverse" >> /etc/apt/sources.list && \
-    echo "deb $M jammy-backports main restricted universe multiverse" >> /etc/apt/sources.list && \
-    echo "deb $M jammy-security main restricted universe multiverse" >> /etc/apt/sources.list && \
     apt-get update && apt-get install -y --no-install-recommends \
     xvfb x11vnc novnc websockify \
     xfce4 xfce4-terminal dbus-x11 \

--- a/packages/sandbox/Dockerfile
+++ b/packages/sandbox/Dockerfile
@@ -1,5 +1,7 @@
 # Bun version — override via --build-arg BUN_VERSION=$(cat .bun-version)
 ARG BUN_VERSION=1
+ARG UBUNTU_MIRROR=http://mirrors.edge.kernel.org/ubuntu
+ARG UBUNTU_PORTS_MIRROR=http://mirrors.edge.kernel.org/ubuntu-ports
 FROM oven/bun:${BUN_VERSION} AS bun-binary
 
 # Sandbox container images (default and python variants)
@@ -51,6 +53,9 @@ RUN npx turbo run build
 # ============================================================================
 FROM ubuntu:22.04 AS python-builder
 
+ARG UBUNTU_MIRROR
+ARG UBUNTU_PORTS_MIRROR
+
 # Prevent interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -62,6 +67,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache && \
+    if [ "$(dpkg --print-architecture)" = "amd64" ] || [ "$(dpkg --print-architecture)" = "i386" ]; then \
+        M=$UBUNTU_MIRROR; \
+    else \
+        M=$UBUNTU_PORTS_MIRROR; \
+    fi && \
+    echo "deb $M jammy main restricted universe multiverse" > /etc/apt/sources.list && \
+    echo "deb $M jammy-updates main restricted universe multiverse" >> /etc/apt/sources.list && \
+    echo "deb $M jammy-backports main restricted universe multiverse" >> /etc/apt/sources.list && \
+    echo "deb $M jammy-security main restricted universe multiverse" >> /etc/apt/sources.list && \
     apt-get update && apt-get install -y --no-install-recommends \
     wget ca-certificates
 
@@ -93,6 +107,9 @@ RUN --mount=type=cache,target=/tmp/python-cache \
 # ============================================================================
 FROM ubuntu:22.04 AS runtime-base
 
+ARG UBUNTU_MIRROR
+ARG UBUNTU_PORTS_MIRROR
+
 # Accept version as build argument (passed from npm_package_version)
 ARG SANDBOX_VERSION=unknown
 
@@ -112,6 +129,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/* && \
+    if [ "$(dpkg --print-architecture)" = "amd64" ] || [ "$(dpkg --print-architecture)" = "i386" ]; then \
+        M=$UBUNTU_MIRROR; \
+    else \
+        M=$UBUNTU_PORTS_MIRROR; \
+    fi && \
+    echo "deb $M jammy main restricted universe multiverse" > /etc/apt/sources.list && \
+    echo "deb $M jammy-updates main restricted universe multiverse" >> /etc/apt/sources.list && \
+    echo "deb $M jammy-backports main restricted universe multiverse" >> /etc/apt/sources.list && \
+    echo "deb $M jammy-security main restricted universe multiverse" >> /etc/apt/sources.list && \
     apt-get update && apt-get install -y --no-install-recommends \
     s3fs fuse3 squashfs-tools squashfuse fuse-overlayfs \
     ca-certificates curl wget procps git unzip zip jq file \
@@ -246,11 +272,23 @@ RUN go mod tidy && go build -buildmode=c-shared -o /usr/lib/desktop.so .
 
 FROM runtime-base AS desktop
 
+ARG UBUNTU_MIRROR
+ARG UBUNTU_PORTS_MIRROR
+
 # Install display stack
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache && \
+    if [ "$(dpkg --print-architecture)" = "amd64" ] || [ "$(dpkg --print-architecture)" = "i386" ]; then \
+        M=$UBUNTU_MIRROR; \
+    else \
+        M=$UBUNTU_PORTS_MIRROR; \
+    fi && \
+    echo "deb $M jammy main restricted universe multiverse" > /etc/apt/sources.list && \
+    echo "deb $M jammy-updates main restricted universe multiverse" >> /etc/apt/sources.list && \
+    echo "deb $M jammy-backports main restricted universe multiverse" >> /etc/apt/sources.list && \
+    echo "deb $M jammy-security main restricted universe multiverse" >> /etc/apt/sources.list && \
     apt-get update && apt-get install -y --no-install-recommends \
     xvfb x11vnc novnc websockify \
     xfce4 xfce4-terminal dbus-x11 \

--- a/packages/sandbox/src/local-mount-sync.ts
+++ b/packages/sandbox/src/local-mount-sync.ts
@@ -2,6 +2,7 @@ import path from 'node:path/posix';
 import type { FileWatchSSEEvent, Logger } from '@repo/shared';
 import type { SandboxClient } from './clients';
 import { parseSSEStream } from './sse-parser';
+import { validatePrefix } from './storage-mount';
 
 const DEFAULT_POLL_INTERVAL_MS = 1000;
 const DEFAULT_ECHO_SUPPRESS_TTL_MS = 2000;
@@ -55,7 +56,12 @@ export class LocalMountSyncManager {
   constructor(options: LocalMountSyncOptions) {
     this.bucket = options.bucket;
     this.mountPath = options.mountPath;
-    this.prefix = options.prefix;
+    if (options.prefix !== undefined) {
+      validatePrefix(options.prefix);
+    }
+    // R2 keys never have leading slashes. Convert the validated '/'-prefixed
+    // value into bare R2 key format for list() and put().
+    this.prefix = options.prefix?.replace(/^\//, '') || undefined;
     this.readOnly = options.readOnly;
     this.client = options.client;
     this.sessionId = options.sessionId;

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -955,6 +955,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         );
       }
 
+      if (options.prefix !== undefined) {
+        validatePrefix(options.prefix);
+      }
+
       if (this.activeMounts.has(mountPath)) {
         throw new InvalidMountConfigError(
           `Mount path already in use: ${mountPath}`

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -915,6 +915,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     mountPath: string,
     options: MountBucketOptions
   ): Promise<void> {
+    if (options.prefix !== undefined) {
+      validatePrefix(options.prefix);
+    }
+
     if ('localBucket' in options && options.localBucket) {
       await this.mountBucketLocal(bucket, mountPath, options);
       return;
@@ -953,10 +957,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         throw new InvalidMountConfigError(
           `Invalid mount path: "${mountPath}". Must be an absolute path starting with /`
         );
-      }
-
-      if (options.prefix !== undefined) {
-        validatePrefix(options.prefix);
       }
 
       if (this.activeMounts.has(mountPath)) {
@@ -1228,10 +1228,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       );
     }
 
-    // Validate prefix format if provided
-    if (options.prefix !== undefined) {
-      validatePrefix(options.prefix);
-    }
+    // Prefix validation is handled centrally in mountBucket()
   }
 
   /**

--- a/packages/sandbox/tests/local-mount-sync.test.ts
+++ b/packages/sandbox/tests/local-mount-sync.test.ts
@@ -462,7 +462,7 @@ describe('LocalMountSyncManager', () => {
       const manager = new LocalMountSyncManager({
         bucket: bucket as unknown as R2Bucket,
         mountPath: '/mnt/data',
-        prefix: 'data/',
+        prefix: '/data/',
         readOnly: true,
         client,
         sessionId: 'test-session',
@@ -471,7 +471,7 @@ describe('LocalMountSyncManager', () => {
 
       await manager.start();
 
-      // Should list with prefix
+      // Leading slash stripped for R2 key semantics
       expect(bucket.list).toHaveBeenCalledWith(
         expect.objectContaining({ prefix: 'data/' })
       );
@@ -487,6 +487,141 @@ describe('LocalMountSyncManager', () => {
       await manager.stop();
     });
 
+    it('should normalize leading-slash prefix for R2 list and path mapping', async () => {
+      const r2Objects = new Map([
+        ['some/prefix/file.txt', { body: 'content', etag: 'etag1' }]
+      ]);
+      const bucket = createMockR2Bucket(r2Objects);
+      const fileClient = createMockFileClient();
+      const watchClient = createMockWatchClient();
+      const client = createMockSandboxClient(fileClient, watchClient);
+
+      const manager = new LocalMountSyncManager({
+        bucket: bucket as unknown as R2Bucket,
+        mountPath: '/mnt/data',
+        prefix: '/some/prefix/',
+        readOnly: true,
+        client,
+        sessionId: 'test-session',
+        logger
+      });
+
+      await manager.start();
+
+      // Leading slash must be stripped before passing to R2
+      expect(bucket.list).toHaveBeenCalledWith(
+        expect.objectContaining({ prefix: 'some/prefix/' })
+      );
+
+      // Container path should have prefix stripped
+      expect(fileClient.writeFile).toHaveBeenCalledWith(
+        '/mnt/data/file.txt',
+        expect.any(String),
+        'test-session',
+        { encoding: 'base64' }
+      );
+
+      await manager.stop();
+    });
+
+    it('should normalize leading-slash prefix for Container→R2 uploads', async () => {
+      const r2Objects = new Map<string, { body: string; etag: string }>();
+      const bucket = createMockR2Bucket(r2Objects);
+      const fileClient = createMockFileClient();
+      const {
+        client: watchClient,
+        emit,
+        close
+      } = createControllableWatchClient();
+      const client = createMockSandboxClient(fileClient, watchClient);
+
+      const manager = new LocalMountSyncManager({
+        bucket: bucket as unknown as R2Bucket,
+        mountPath: '/mnt/data',
+        prefix: '/some/prefix/',
+        readOnly: false,
+        client,
+        sessionId: 'test-session',
+        logger,
+        pollIntervalMs: 60_000
+      });
+
+      await manager.start();
+
+      emit({
+        type: 'event',
+        eventType: 'create',
+        path: '/mnt/data/foo.txt',
+        isDirectory: false,
+        timestamp: new Date().toISOString()
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      // R2 key must NOT have a leading slash
+      expect(bucket.put).toHaveBeenCalledWith(
+        'some/prefix/foo.txt',
+        expect.any(Uint8Array)
+      );
+
+      close();
+      await manager.stop();
+    });
+
+    it('should treat a bare slash prefix as no prefix', async () => {
+      const r2Objects = new Map([
+        ['file.txt', { body: 'content', etag: 'etag1' }]
+      ]);
+      const bucket = createMockR2Bucket(r2Objects);
+      const fileClient = createMockFileClient();
+      const watchClient = createMockWatchClient();
+      const client = createMockSandboxClient(fileClient, watchClient);
+
+      const manager = new LocalMountSyncManager({
+        bucket: bucket as unknown as R2Bucket,
+        mountPath: '/mnt/data',
+        prefix: '/',
+        readOnly: true,
+        client,
+        sessionId: 'test-session',
+        logger
+      });
+
+      await manager.start();
+
+      // Bare '/' stripped to empty string → treated as undefined (no prefix filter)
+      expect(bucket.list).toHaveBeenCalledWith({});
+
+      expect(fileClient.writeFile).toHaveBeenCalledWith(
+        '/mnt/data/file.txt',
+        expect.any(String),
+        'test-session',
+        { encoding: 'base64' }
+      );
+
+      await manager.stop();
+    });
+
+    it('should reject prefix without leading slash (matches production)', async () => {
+      const bucket = createMockR2Bucket(new Map());
+      const fileClient = createMockFileClient();
+      const watchClient = createMockWatchClient();
+      const client = createMockSandboxClient(fileClient, watchClient);
+
+      expect(
+        () =>
+          new LocalMountSyncManager({
+            bucket: bucket as unknown as R2Bucket,
+            mountPath: '/mnt/data',
+            prefix: 'data/',
+            readOnly: true,
+            client,
+            sessionId: 'test-session',
+            logger
+          })
+      ).toThrow(/Prefix must start with/);
+    });
+
     it('should handle prefix without trailing slash', async () => {
       const r2Objects = new Map([
         ['uploads/photo.jpg', { body: 'img', etag: 'etag1' }]
@@ -499,7 +634,7 @@ describe('LocalMountSyncManager', () => {
       const manager = new LocalMountSyncManager({
         bucket: bucket as unknown as R2Bucket,
         mountPath: '/mnt/data',
-        prefix: 'uploads',
+        prefix: '/uploads',
         readOnly: true,
         client,
         sessionId: 'test-session',
@@ -821,7 +956,7 @@ describe('LocalMountSyncManager', () => {
       const manager = new LocalMountSyncManager({
         bucket: bucket as unknown as R2Bucket,
         mountPath: '/mnt/data',
-        prefix: 'uploads/',
+        prefix: '/uploads/',
         readOnly: false,
         client,
         sessionId: 'test-session',
@@ -841,7 +976,7 @@ describe('LocalMountSyncManager', () => {
 
       await flush();
 
-      // R2 key should include prefix
+      // R2 key should include prefix (leading slash stripped)
       expect(bucket.put).toHaveBeenCalledWith(
         'uploads/photo.jpg',
         expect.any(Uint8Array)


### PR DESCRIPTION
# Summary

`LocalMountSyncManager` passed the prefix verbatim to R2 APIs (`bucket.list()`, `bucket.put()`), but R2 object keys never have leading slashes. Since the docs and the production FUSE path both require prefixes to start with `/`, following the documented convention caused `list()` to match zero objects — the mount appeared healthy but the directory was always empty. Writes from inside the container also landed under malformed R2 keys with a leading `/`.

Additionally, `validatePrefix()` was only called from the FUSE path, so the local dev path silently accepted prefixes that production would reject.

# Changes

- **packages/sandbox/src/local-mount-sync.ts** - Constructor now calls `validatePrefix()` (matching production) then strips the leading `/` for R2 key compatibility
- **packages/sandbox/src/sandbox.ts** - `mountBucketLocal()` also calls `validatePrefix()` for defence in depth
- **packages/sandbox/tests/local-mount-sync.test.ts** - Updated all prefix tests to use `/`-prefixed values matching production; added tests for leading-slash normalisation in both sync directions, bare `/` handling, and rejection of non-leading-slash prefixes

Closes #590 