### PR TITLE
Persist port tokens across container restarts

### DIFF
--- a/.changeset/persist-port-tokens-across-restarts.md
+++ b/.changeset/persist-port-tokens-across-restarts.md
@@ -1,0 +1,11 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Preserve port tokens across container restarts so preview URLs remain valid
+when a container stops or loses connectivity temporarily. Tokens are now only
+removed on explicit `unexposePort()` calls or full sandbox `destroy()`.
+Previously, `onStop()` deleted all port tokens from storage, invalidating every
+preview URL on any restart — including transient ones. If a port isn't
+actually exposed on the container after restart, token validation still fails
+via the existing `isPortExposed()` check, so security is unchanged.

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1465,11 +1465,13 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     this.defaultSession = null;
     this.activeMounts.clear();
 
-    // Persist cleanup to storage so state is clean on next container start
-    await Promise.all([
-      this.ctx.storage.delete('portTokens'),
-      this.ctx.storage.delete('defaultSession')
-    ]);
+    // Persist cleanup to storage so state is clean on next container start.
+    // Port tokens are intentionally preserved so preview URLs survive container
+    // restarts. Tokens are only removed on explicit unexposePort() or full
+    // sandbox destroy(). If a port isn't actually exposed on the container
+    // after restart, validatePortToken()'s isPortExposed() check rejects the
+    // request regardless of what's in storage.
+    await this.ctx.storage.delete('defaultSession');
   }
 
   override onError(error: unknown) {


### PR DESCRIPTION
## Problem

Preview URLs were being invalidated on every container stop — including transient restarts caused by idle eviction, redeploys, or temporary connectivity loss. `Sandbox.onStop()` unconditionally deleted `portTokens` from Durable Object storage:

```ts
override async onStop() {
  this.defaultSession = null;
  this.activeMounts.clear();
  await Promise.all([
    this.ctx.storage.delete('portTokens'),    // ← wipes every preview URL token
    this.ctx.storage.delete('defaultSession')
  ]);
}
```

This was especially painful for customers using **deterministic tokens**, where the token is reproducible but the stored entry was gone — `validatePortToken()` would bail out at the "port is exposed but has no token" check after the port was re-exposed on restart.

## Change

Stop deleting `portTokens` in `onStop()`. Tokens are now cleared only on the two events that semantically invalidate them:

1. **Explicit `unexposePort(port)`** — per-port token removal (existing behavior, unchanged).
2. **Full `destroy()`** — the whole sandbox is torn down via `super.destroy()`, which cleans DO storage.

`defaultSession` cleanup in `onStop()` is preserved — that one is legitimately tied to container lifetime.

## Why this is safe

Token validation is **not** solely gated by DO storage. `validatePortToken()` first calls `isPortExposed()`, which queries the live container runtime:

```ts
async validatePortToken(port: number, token: string): Promise<boolean> {
  const isExposed = await this.isPortExposed(port);
  if (!isExposed) return false;   // ← live container check
  // ... then compare token from storage
}
```

So a stale token in storage cannot authorize traffic to a port that isn't actually exposed on the current container. The worst case is an unused storage entry that gets overwritten or ignored the next time that port is exposed.

## User impact

- ✅ Preview URLs survive transient container restarts for customers with deterministic tokens — they just work after the port is re-exposed.
- ✅ For customers using the SDK's default random tokens, the persisted entry remains valid as long as the same port gets re-exposed with the same token; otherwise it's harmlessly replaced.
- ✅ No security regression — live-container gating is unchanged.

## Testing

- `npm run check -w @cloudflare/sandbox` — typecheck clean
- `npm test -w @cloudflare/sandbox` — 559/559 unit tests pass
- Pre-commit hooks pass (biome, format, changeset validation)

## Changeset

Included: `.changeset/persist-port-tokens-across-restarts.md` (`@cloudflare/sandbox`: patch).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
