### PR TITLE
Auto re-expose ports after container restart

### DIFF
--- a/.changeset/auto-reexpose-ports-on-recovery.md
+++ b/.changeset/auto-reexpose-ports-on-recovery.md
@@ -1,0 +1,10 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Automatically re-expose ports on the container runtime after a container
+restart. Port tokens persisted in Durable Object storage are used to restore
+port exposure transparently, so preview URLs keep working across transient
+container restarts without any customer action. Ports that are already
+exposed are skipped, and individual failures are logged but do not block
+restoring the other ports.

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1406,6 +1406,86 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         error instanceof Error ? error : new Error(String(error))
       );
     });
+
+    // Re-expose ports that were exposed before the container restarted.
+    // Tokens persist in DO storage across restarts (see onStop), but the
+    // container runtime has no memory of which ports were exposed. We ask the
+    // container to re-expose each port so preview URLs keep working without
+    // any customer action.
+    this.restoreExposedPorts().catch((error) => {
+      this.logger.error(
+        'Failed to restore exposed ports after container start',
+        error instanceof Error ? error : new Error(String(error))
+      );
+    });
+  }
+
+  /**
+   * Re-expose ports on the container runtime using tokens persisted in DO
+   * storage. Called from onStart() after a container (re)start.
+   *
+   * The DO storage holds the source of truth for which ports should be
+   * exposed and with which tokens. If a port is already exposed on the
+   * container (e.g. first start after exposePort() was just called) this is
+   * a no-op for that port. Individual port failures are logged but do not
+   * abort the overall restore — a transient failure for one port must not
+   * prevent the others from being restored.
+   */
+  private async restoreExposedPorts(): Promise<void> {
+    const savedTokens =
+      await this.ctx.storage.get<Record<string, string>>('portTokens');
+    if (!savedTokens || Object.keys(savedTokens).length === 0) {
+      return;
+    }
+
+    const startTime = Date.now();
+    let restored = 0;
+    let skipped = 0;
+    let failed = 0;
+
+    // Resolving the session ensures the container HTTP API is reachable
+    // before we start firing exposePort requests at it.
+    const sessionId = await this.ensureDefaultSession();
+
+    for (const portStr of Object.keys(savedTokens)) {
+      const port = Number.parseInt(portStr, 10);
+      if (!Number.isFinite(port) || !validatePort(port)) {
+        this.logger.warn('Skipping restore of invalid port in storage', {
+          port: portStr
+        });
+        failed++;
+        continue;
+      }
+
+      try {
+        const alreadyExposed = await this.isPortExposed(port).catch(
+          () => false
+        );
+        if (alreadyExposed) {
+          skipped++;
+          continue;
+        }
+
+        await this.client.ports.exposePort(port, sessionId);
+        restored++;
+      } catch (error) {
+        failed++;
+        this.logger.warn('Failed to re-expose port on container restart', {
+          port,
+          error: error instanceof Error ? error.message : String(error)
+        });
+      }
+    }
+
+    logCanonicalEvent(this.logger, {
+      event: 'port.restore',
+      outcome: failed === 0 ? 'success' : 'error',
+      durationMs: Date.now() - startTime,
+      restored,
+      skipped,
+      failed,
+      total: Object.keys(savedTokens).length
+    });
   }
 
   /**


### PR DESCRIPTION
## Problem

Even with port tokens persisted in Durable Object storage (see #597), customers still lose their preview URLs across container restarts. The container runtime has no memory of which ports were previously exposed, so `isPortExposed()` returns `false` after a restart — and `validatePortToken()`'s live-container check rejects every incoming request until the customer manually calls `exposePort()` again.

## Change

Re-expose ports on the container runtime automatically when the container (re)starts, using the tokens already persisted in DO storage.

The work happens in `Sandbox.onStart()` by calling a new private `restoreExposedPorts()` method that:

1. Reads the `portTokens` map from DO storage.
2. Resolves a session (ensures the container HTTP API is reachable).
3. For each saved port, checks `isPortExposed()` first and skips if already exposed.
4. Calls `this.client.ports.exposePort(port, sessionId)` to re-register on the container runtime. Token stays in storage untouched — no regeneration.
5. Logs per-port failures but never aborts — one bad port must not block restoration of the others.
6. Emits a canonical `port.restore` event with `restored`, `skipped`, `failed`, and `total` counts for observability.

### Why `onStart()` and not `alarm()`?

The task sketched this as an `alarm()` override, but `@cloudflare/containers` explicitly recommends against overriding `alarm` (it's used internally for keep-alive and scheduled tasks) and provides `onStart()` specifically for the "container is running" signal. `onStart()` also removes the need for a manual health check — by contract it fires only when the container is up. Same outcome, cleaner fit with the parent `Container` class.

### No API changes

`exposePort()` already accepts an optional `token` option, so the prerequisite noted in the task is already met. The restore path calls the low-level `this.client.ports.exposePort()` directly because we don't need `hostname`/URL construction — the public `exposePort()` wrapper handles that only on behalf of customer callers.

## Why this is safe

- The restore is bounded by what's already in DO storage — no new ports are exposed, only ports the customer previously opted into.
- Already-exposed ports are detected and skipped, so re-entrant calls (e.g. a restart racing with an in-flight `exposePort()`) are harmless.
- Invalid port entries in storage are defensively rejected and logged.
- Per-port failures are swallowed at warn level; they don't propagate and don't prevent the remaining ports from being restored.
- `validatePortToken()` continues to gate on the live container, so an entry in storage for a port that fails to restore still cannot authorize traffic.

## Combined with #597

This PR builds on #597 (token persistence) — together they deliver the full "preview URLs survive container restarts" behavior end-to-end: tokens stay in storage, and the port is automatically re-exposed on the container when it comes back up.

## User impact

- ✅ Preview URLs just work after transient container restarts — no customer code changes required.
- ✅ Same URL (same port + same token) works before and after a restart.
- ✅ Structured `port.restore` log event for fleet-wide observability of restart recovery.

## Testing

- `npm run typecheck -w @cloudflare/sandbox` — clean
- `npm test -w @cloudflare/sandbox` — 559/559 unit tests pass
- Pre-commit hooks pass (biome, format, changeset validation)

## Changeset

Included: `.changeset/auto-reexpose-ports-on-recovery.md` (`@cloudflare/sandbox`: patch).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
