### PR TITLE
Cache preview URL token validation at the Worker level

### DIFF
--- a/.changeset/cache-token-validation.md
+++ b/.changeset/cache-token-validation.md
@@ -1,5 +1,5 @@
 ---
-'@cloudflare/sandbox': minor
+'@cloudflare/sandbox': patch
 ---
 
 Cache successful preview URL token validations at the Worker level so page

--- a/.changeset/cache-token-validation.md
+++ b/.changeset/cache-token-validation.md
@@ -1,11 +1,16 @@
 ---
-'@cloudflare/sandbox': patch
+'@cloudflare/sandbox': minor
 ---
 
-Cache successful preview URL token validations at the Worker level to avoid
-calling the Sandbox Durable Object on every preview request. Page loads that
-previously triggered 20+ RPCs to the DO for the same port and token now
-trigger one, with the rest served from a per-isolate, TTL-bounded cache.
-Failed validations are never cached, so transient "port not exposed" states
-recover immediately once the port is re-exposed. A `clearTokenValidationCache`
-helper is exported for callers that need to force re-validation.
+Cache successful preview URL token validations at the Worker level so page
+loads on preview URLs stop saturating the Sandbox Durable Object. Page loads
+that previously made 20+ RPCs for the same port and token now make one per
+cache window (10 s by default), with the rest served from a per-isolate,
+TTL- and size-bounded cache. Failed validations are never cached, so
+transient "port not exposed" states recover on the next request. Exports
+`TokenValidationCache`, `proxyToSandbox` accepts an optional
+`tokenValidationCache` so operators can tune TTL and size limits or share
+one instance across handlers, and `clearTokenValidationCache()` is exposed
+for tests and forced re-validation. This is a bridge toward signed (HMAC)
+tokens that can be verified locally with zero RPCs; the cache unblocks
+customers today without requiring a token-format change.

--- a/.changeset/cache-token-validation.md
+++ b/.changeset/cache-token-validation.md
@@ -1,0 +1,11 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Cache successful preview URL token validations at the Worker level to avoid
+calling the Sandbox Durable Object on every preview request. Page loads that
+previously triggered 20+ RPCs to the DO for the same port and token now
+trigger one, with the rest served from a per-isolate, TTL-bounded cache.
+Failed validations are never cached, so transient "port not exposed" states
+recover immediately once the port is re-exposed. A `clearTokenValidationCache`
+helper is exported for callers that need to force re-validation.

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -153,9 +153,13 @@ export { CodeInterpreter } from './interpreter.js';
 export { proxyTerminal } from './pty';
 // Re-export request handler utilities
 export {
+  clearTokenValidationCache,
+  type ProxyToSandboxOptions,
   proxyToSandbox,
   type RouteInfo,
-  type SandboxEnv
+  type SandboxEnv,
+  TokenValidationCache,
+  type TokenValidationCacheOptions
 } from './request-handler';
 // Export SSE parser for converting ReadableStream to AsyncIterable
 export {

--- a/packages/sandbox/src/request-handler.ts
+++ b/packages/sandbox/src/request-handler.ts
@@ -14,6 +14,56 @@ export interface RouteInfo {
   token: string;
 }
 
+// Per-isolate cache of successful token validations. Preview URLs are hit many
+// times per page load (20+ for a Vite dev page), and every miss goes over RPC
+// to the Sandbox Durable Object. Caching successes collapses those to a single
+// RPC per {sandboxId, port, token} triple within the TTL window.
+//
+// - Successes only: a failed validation during a transient window (e.g. while
+//   the container is restarting and ports have not yet been re-exposed) must
+//   be retried on the next request, never cached.
+// - TTL-bounded: limits how long a revoked token can keep working after
+//   unexposePort(). 30s is short enough to feel responsive, long enough to
+//   absorb a page load burst.
+// - Size-bounded: a Map with a hard cap protects against adversarial traffic
+//   that rotates tokens on every request. Oldest entries are evicted first
+//   (insertion order, which Map preserves).
+// - Per-isolate: lost on Worker eviction, which is fine — the next request
+//   simply re-validates.
+const TOKEN_CACHE_TTL_MS = 30_000;
+const TOKEN_CACHE_MAX_ENTRIES = 10_000;
+const tokenValidationCache = new Map<string, number>();
+
+function getCachedTokenValidation(key: string): boolean {
+  const timestamp = tokenValidationCache.get(key);
+  if (timestamp === undefined) return false;
+  if (Date.now() - timestamp >= TOKEN_CACHE_TTL_MS) {
+    tokenValidationCache.delete(key);
+    return false;
+  }
+  return true;
+}
+
+function rememberTokenValidation(key: string): void {
+  // Refresh insertion order so recently validated entries survive eviction.
+  if (tokenValidationCache.has(key)) {
+    tokenValidationCache.delete(key);
+  } else if (tokenValidationCache.size >= TOKEN_CACHE_MAX_ENTRIES) {
+    // Evict the oldest entry (first key by insertion order).
+    const oldest = tokenValidationCache.keys().next().value;
+    if (oldest !== undefined) tokenValidationCache.delete(oldest);
+  }
+  tokenValidationCache.set(key, Date.now());
+}
+
+/**
+ * Clear the token validation cache. Exposed for tests and for callers that
+ * need to force re-validation (e.g. after an out-of-band token rotation).
+ */
+export function clearTokenValidationCache(): void {
+  tokenValidationCache.clear();
+}
+
 export async function proxyToSandbox<
   T extends Sandbox<any>,
   E extends SandboxEnv<T>
@@ -42,8 +92,21 @@ export async function proxyToSandbox<
     // Critical security check: Validate token (mandatory for all user ports)
     // Skip check for control plane port 3000
     if (port !== 3000) {
-      // Validate the token matches the port
-      const isValidToken = await sandbox.validatePortToken(port, token);
+      const cacheKey = `${sandboxId}:${port}:${token}`;
+
+      // Fast path: recent successful validation for this exact triple.
+      let isValidToken = getCachedTokenValidation(cacheKey);
+
+      if (!isValidToken) {
+        // Slow path: ask the Durable Object. Only successes are cached —
+        // failures must re-check on every request so a transient "not
+        // exposed" state does not get pinned as permanently invalid.
+        isValidToken = await sandbox.validatePortToken(port, token);
+        if (isValidToken) {
+          rememberTokenValidation(cacheKey);
+        }
+      }
+
       if (!isValidToken) {
         logger.warn('Invalid token access blocked', {
           port,

--- a/packages/sandbox/src/request-handler.ts
+++ b/packages/sandbox/src/request-handler.ts
@@ -14,60 +14,123 @@ export interface RouteInfo {
   token: string;
 }
 
-// Per-isolate cache of successful token validations. Preview URLs are hit many
-// times per page load (20+ for a Vite dev page), and every miss goes over RPC
-// to the Sandbox Durable Object. Caching successes collapses those to a single
-// RPC per {sandboxId, port, token} triple within the TTL window.
-//
-// - Successes only: a failed validation during a transient window (e.g. while
-//   the container is restarting and ports have not yet been re-exposed) must
-//   be retried on the next request, never cached.
-// - TTL-bounded: limits how long a revoked token can keep working after
-//   unexposePort(). 30s is short enough to feel responsive, long enough to
-//   absorb a page load burst.
-// - Size-bounded: a Map with a hard cap protects against adversarial traffic
-//   that rotates tokens on every request. Oldest entries are evicted first
-//   (insertion order, which Map preserves).
-// - Per-isolate: lost on Worker eviction, which is fine — the next request
-//   simply re-validates.
-const TOKEN_CACHE_TTL_MS = 30_000;
-const TOKEN_CACHE_MAX_ENTRIES = 10_000;
-const tokenValidationCache = new Map<string, number>();
-
-function getCachedTokenValidation(key: string): boolean {
-  const timestamp = tokenValidationCache.get(key);
-  if (timestamp === undefined) return false;
-  if (Date.now() - timestamp >= TOKEN_CACHE_TTL_MS) {
-    tokenValidationCache.delete(key);
-    return false;
-  }
-  return true;
+/**
+ * Options that tune the per-isolate token validation cache.
+ *
+ * The cache turns preview URL traffic from one DO RPC per request into one
+ * RPC per {sandboxId, port, token} triple per TTL window. It is intentionally
+ * a bridge toward signed (HMAC) tokens that can be verified locally with
+ * zero RPCs; until that lands, caching is the cheapest way to keep DO load
+ * proportional to unique previews rather than unique requests.
+ */
+export interface TokenValidationCacheOptions {
+  /**
+   * How long a successful validation is trusted before re-checking with the
+   * Durable Object. This directly bounds how long a token revoked via
+   * `unexposePort()` can continue to authorize traffic in other isolates.
+   *
+   * Defaults to 10 seconds: long enough to absorb a page-load burst (which
+   * happens in sub-second), short enough that revocation feels responsive.
+   * Set to 0 to disable caching entirely.
+   */
+  ttlMs?: number;
+  /**
+   * Maximum number of entries held per isolate. When exceeded, the oldest
+   * entry is evicted first. Protects against adversarial traffic that rotates
+   * tokens on every request. Defaults to 10,000.
+   */
+  maxEntries?: number;
 }
 
-function rememberTokenValidation(key: string): void {
-  // Refresh insertion order so recently validated entries survive eviction.
-  if (tokenValidationCache.has(key)) {
-    tokenValidationCache.delete(key);
-  } else if (tokenValidationCache.size >= TOKEN_CACHE_MAX_ENTRIES) {
-    // Evict the oldest entry (first key by insertion order).
-    const oldest = tokenValidationCache.keys().next().value;
-    if (oldest !== undefined) tokenValidationCache.delete(oldest);
-  }
-  tokenValidationCache.set(key, Date.now());
-}
+const DEFAULT_TOKEN_CACHE_TTL_MS = 10_000;
+const DEFAULT_TOKEN_CACHE_MAX_ENTRIES = 10_000;
 
 /**
- * Clear the token validation cache. Exposed for tests and for callers that
- * need to force re-validation (e.g. after an out-of-band token rotation).
+ * Per-isolate cache of successful token validations. Invariants:
+ *
+ * - Only successes are stored. A `false` result must never be cached so a
+ *   transient "port not exposed" state (e.g. mid-restart) recovers on the
+ *   next request rather than being pinned as invalid.
+ * - TTL-bounded. Caps the revocation-propagation window.
+ * - Size-bounded. Oldest entries evicted first; hits refresh insertion
+ *   order so recently validated triples survive.
+ * - Per-isolate. Lost on Worker eviction, which is fine — the next request
+ *   simply re-validates.
+ */
+export class TokenValidationCache {
+  private readonly entries = new Map<string, number>();
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+
+  constructor(options: TokenValidationCacheOptions = {}) {
+    this.ttlMs = options.ttlMs ?? DEFAULT_TOKEN_CACHE_TTL_MS;
+    this.maxEntries = options.maxEntries ?? DEFAULT_TOKEN_CACHE_MAX_ENTRIES;
+  }
+
+  has(key: string): boolean {
+    if (this.ttlMs <= 0) return false;
+    const timestamp = this.entries.get(key);
+    if (timestamp === undefined) return false;
+    if (Date.now() - timestamp >= this.ttlMs) {
+      this.entries.delete(key);
+      return false;
+    }
+    // Refresh insertion order so hot entries survive size-cap eviction.
+    this.entries.delete(key);
+    this.entries.set(key, timestamp);
+    return true;
+  }
+
+  remember(key: string): void {
+    if (this.ttlMs <= 0) return;
+    if (this.entries.has(key)) {
+      this.entries.delete(key);
+    } else if (this.entries.size >= this.maxEntries) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest !== undefined) this.entries.delete(oldest);
+    }
+    this.entries.set(key, Date.now());
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+}
+
+// Default per-isolate cache used by the simple `proxyToSandbox(request, env)`
+// call path. Callers that need custom TTL or size limits can pass options.
+const defaultTokenValidationCache = new TokenValidationCache();
+
+/**
+ * Clear the default token validation cache. Useful in tests and for callers
+ * that need to force re-validation after an out-of-band token change.
  */
 export function clearTokenValidationCache(): void {
-  tokenValidationCache.clear();
+  defaultTokenValidationCache.clear();
+}
+
+export interface ProxyToSandboxOptions {
+  /**
+   * Override the per-isolate token validation cache. Pass a long-lived
+   * `TokenValidationCache` instance to use tuned TTL/size limits; omit to
+   * share the module-level default (10 s TTL, 10,000 entries).
+   */
+  tokenValidationCache?: TokenValidationCache;
 }
 
 export async function proxyToSandbox<
   T extends Sandbox<any>,
   E extends SandboxEnv<T>
->(request: Request, env: E): Promise<Response | null> {
+>(
+  request: Request,
+  env: E,
+  options?: ProxyToSandboxOptions
+): Promise<Response | null> {
+  const cache = options?.tokenValidationCache ?? defaultTokenValidationCache;
   // Create logger context for this request
   const traceId =
     TraceContext.fromHeaders(request.headers) || TraceContext.generate();
@@ -95,7 +158,7 @@ export async function proxyToSandbox<
       const cacheKey = `${sandboxId}:${port}:${token}`;
 
       // Fast path: recent successful validation for this exact triple.
-      let isValidToken = getCachedTokenValidation(cacheKey);
+      let isValidToken = cache.has(cacheKey);
 
       if (!isValidToken) {
         // Slow path: ask the Durable Object. Only successes are cached —
@@ -103,7 +166,7 @@ export async function proxyToSandbox<
         // exposed" state does not get pinned as permanently invalid.
         isValidToken = await sandbox.validatePortToken(port, token);
         if (isValidToken) {
-          rememberTokenValidation(cacheKey);
+          cache.remember(cacheKey);
         }
       }
 

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -3312,7 +3312,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   /**
    * Expose a port and get a preview URL for accessing services running in the sandbox
    *
-Preview URLs survive transient container restarts: the token and any
+   * Preview URLs survive transient container restarts: the token and any
    * friendly name are persisted in Durable Object storage, and the port is
    * automatically re-exposed on the container when it comes back up. Tokens
    * are cleared only on explicit `unexposePort()` or full sandbox

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -3312,11 +3312,17 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   /**
    * Expose a port and get a preview URL for accessing services running in the sandbox
    *
-   * Preview URLs survive transient container restarts: the token and any
+Preview URLs survive transient container restarts: the token and any
    * friendly name are persisted in Durable Object storage, and the port is
    * automatically re-exposed on the container when it comes back up. Tokens
    * are cleared only on explicit `unexposePort()` or full sandbox
    * `destroy()`.
+   *
+   * At the Worker level, successful preview URL token validations are cached
+   * for a short window (10 s by default) to avoid an RPC per preview
+   * request. This means `unexposePort()` can take up to one cache TTL to
+   * propagate to other Worker isolates. See `TokenValidationCache` for
+   * tuning or disabling that cache.
    *
    * @param port - Port number to expose (1024-65535)
    * @param options - Configuration options

--- a/packages/sandbox/tests/request-handler.test.ts
+++ b/packages/sandbox/tests/request-handler.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { proxyToSandbox, type SandboxEnv } from '../src/request-handler';
+import {
+  clearTokenValidationCache,
+  proxyToSandbox,
+  type SandboxEnv
+} from '../src/request-handler';
 import type { Sandbox } from '../src/sandbox';
 
 // Mock getSandbox from sandbox.ts
@@ -20,6 +24,7 @@ describe('proxyToSandbox - WebSocket Support', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    clearTokenValidationCache();
 
     // Mock Sandbox with necessary methods
     mockSandbox = {
@@ -151,7 +156,7 @@ describe('proxyToSandbox - WebSocket Support', () => {
   describe('Token validation', () => {
     it('should validate token for both WebSocket and HTTP requests', async () => {
       const wsRequest = new Request(
-        'https://8080-sandbox-token12345678901.example.com/ws',
+        'https://8080-sandbox-wstoken123456789a.example.com/ws',
         {
           headers: { Upgrade: 'websocket' }
         }
@@ -160,18 +165,19 @@ describe('proxyToSandbox - WebSocket Support', () => {
       await proxyToSandbox(wsRequest, mockEnv);
       expect(mockSandbox.validatePortToken).toHaveBeenCalledWith(
         8080,
-        'token12345678901'
+        'wstoken123456789a'
       );
 
       vi.clearAllMocks();
-
+      // Use a different token so we bypass the validation cache and confirm
+      // HTTP requests also trigger validation.
       const httpRequest = new Request(
-        'https://8080-sandbox-token12345678901.example.com/api'
+        'https://8080-sandbox-httptoken12345678.example.com/api'
       );
       await proxyToSandbox(httpRequest, mockEnv);
       expect(mockSandbox.validatePortToken).toHaveBeenCalledWith(
         8080,
-        'token12345678901'
+        'httptoken12345678'
       );
     });
 
@@ -212,6 +218,71 @@ describe('proxyToSandbox - WebSocket Support', () => {
       expect(response).toBeNull();
       expect(mockSandbox.validatePortToken).not.toHaveBeenCalled();
       expect(mockSandbox.containerFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Token validation cache', () => {
+    it('should not re-validate the same sandbox+port+token on subsequent requests', async () => {
+      const url = 'https://8080-sandbox-cachedtoken12345.example.com/';
+
+      await proxyToSandbox(new Request(url), mockEnv);
+      await proxyToSandbox(new Request(url), mockEnv);
+      await proxyToSandbox(new Request(url), mockEnv);
+
+      expect(mockSandbox.validatePortToken).toHaveBeenCalledTimes(1);
+      expect(mockSandbox.containerFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('should validate separately for different tokens on the same port', async () => {
+      await proxyToSandbox(
+        new Request('https://8080-sandbox-tokenaaaaaaaaaaaa.example.com/'),
+        mockEnv
+      );
+      await proxyToSandbox(
+        new Request('https://8080-sandbox-tokenbbbbbbbbbbbb.example.com/'),
+        mockEnv
+      );
+
+      expect(mockSandbox.validatePortToken).toHaveBeenCalledTimes(2);
+    });
+
+    it('should validate separately for different ports with the same token', async () => {
+      await proxyToSandbox(
+        new Request('https://8080-sandbox-sharedtoken1234567.example.com/'),
+        mockEnv
+      );
+      await proxyToSandbox(
+        new Request('https://9090-sandbox-sharedtoken1234567.example.com/'),
+        mockEnv
+      );
+
+      expect(mockSandbox.validatePortToken).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not cache failed validations', async () => {
+      vi.mocked(mockSandbox.validatePortToken as any).mockResolvedValue(false);
+
+      const url = 'https://8080-sandbox-badtoken1234567890.example.com/';
+      const first = await proxyToSandbox(new Request(url), mockEnv);
+      const second = await proxyToSandbox(new Request(url), mockEnv);
+
+      expect(first?.status).toBe(404);
+      expect(second?.status).toBe(404);
+      // Each request re-checks with the DO so a later successful
+      // re-exposure of the port starts working immediately.
+      expect(mockSandbox.validatePortToken).toHaveBeenCalledTimes(2);
+    });
+
+    it('should re-validate after the cache is cleared', async () => {
+      const url = 'https://8080-sandbox-recheckedtoken12.example.com/';
+
+      await proxyToSandbox(new Request(url), mockEnv);
+      expect(mockSandbox.validatePortToken).toHaveBeenCalledTimes(1);
+
+      clearTokenValidationCache();
+
+      await proxyToSandbox(new Request(url), mockEnv);
+      expect(mockSandbox.validatePortToken).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/sandbox/tests/request-handler.test.ts
+++ b/packages/sandbox/tests/request-handler.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   clearTokenValidationCache,
   proxyToSandbox,
-  type SandboxEnv
+  type SandboxEnv,
+  TokenValidationCache
 } from '../src/request-handler';
 import type { Sandbox } from '../src/sandbox';
 
@@ -282,6 +283,116 @@ describe('proxyToSandbox - WebSocket Support', () => {
       clearTokenValidationCache();
 
       await proxyToSandbox(new Request(url), mockEnv);
+      expect(mockSandbox.validatePortToken).toHaveBeenCalledTimes(2);
+    });
+
+    it('should re-validate after the TTL has elapsed', async () => {
+      vi.useFakeTimers();
+      try {
+        const cache = new TokenValidationCache({ ttlMs: 10_000 });
+        const url = 'https://8080-sandbox-ttlexpiredtoken12.example.com/';
+
+        await proxyToSandbox(new Request(url), mockEnv, {
+          tokenValidationCache: cache
+        });
+        expect(mockSandbox.validatePortToken).toHaveBeenCalledTimes(1);
+
+        // Inside TTL — still cached.
+        vi.advanceTimersByTime(9_000);
+        await proxyToSandbox(new Request(url), mockEnv, {
+          tokenValidationCache: cache
+        });
+        expect(mockSandbox.validatePortToken).toHaveBeenCalledTimes(1);
+
+        // Past TTL — re-validates.
+        vi.advanceTimersByTime(2_000);
+        await proxyToSandbox(new Request(url), mockEnv, {
+          tokenValidationCache: cache
+        });
+        expect(mockSandbox.validatePortToken).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should evict the oldest entry when the size cap is reached', async () => {
+      const cache = new TokenValidationCache({ maxEntries: 2 });
+
+      // Fill the cache with two distinct triples.
+      await proxyToSandbox(
+        new Request('https://8080-sandbox-tokenaaaaaaaaaaaa.example.com/'),
+        mockEnv,
+        { tokenValidationCache: cache }
+      );
+      await proxyToSandbox(
+        new Request('https://8080-sandbox-tokenbbbbbbbbbbbb.example.com/'),
+        mockEnv,
+        { tokenValidationCache: cache }
+      );
+      // Third distinct triple evicts the first.
+      await proxyToSandbox(
+        new Request('https://8080-sandbox-tokencccccccccccc.example.com/'),
+        mockEnv,
+        { tokenValidationCache: cache }
+      );
+      expect(cache.size).toBe(2);
+      expect(mockSandbox.validatePortToken).toHaveBeenCalledTimes(3);
+
+      // Re-requesting the evicted first triple must re-validate.
+      vi.mocked(mockSandbox.validatePortToken as any).mockClear();
+      await proxyToSandbox(
+        new Request('https://8080-sandbox-tokenaaaaaaaaaaaa.example.com/'),
+        mockEnv,
+        { tokenValidationCache: cache }
+      );
+      expect(mockSandbox.validatePortToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refresh insertion order on cache hit so recent entries survive eviction', async () => {
+      const cache = new TokenValidationCache({ maxEntries: 2 });
+      const a = 'https://8080-sandbox-tokenaaaaaaaaaaaa.example.com/';
+      const b = 'https://8080-sandbox-tokenbbbbbbbbbbbb.example.com/';
+      const c = 'https://8080-sandbox-tokencccccccccccc.example.com/';
+
+      await proxyToSandbox(new Request(a), mockEnv, {
+        tokenValidationCache: cache
+      });
+      await proxyToSandbox(new Request(b), mockEnv, {
+        tokenValidationCache: cache
+      });
+      // Hit A — it should now be newest in insertion order.
+      await proxyToSandbox(new Request(a), mockEnv, {
+        tokenValidationCache: cache
+      });
+      // C enters — B should be evicted, not A.
+      await proxyToSandbox(new Request(c), mockEnv, {
+        tokenValidationCache: cache
+      });
+
+      vi.mocked(mockSandbox.validatePortToken as any).mockClear();
+      // A remains cached — no new validation.
+      await proxyToSandbox(new Request(a), mockEnv, {
+        tokenValidationCache: cache
+      });
+      expect(mockSandbox.validatePortToken).not.toHaveBeenCalled();
+      // B was evicted — must re-validate.
+      await proxyToSandbox(new Request(b), mockEnv, {
+        tokenValidationCache: cache
+      });
+      expect(mockSandbox.validatePortToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('should disable caching entirely when ttlMs is 0', async () => {
+      const cache = new TokenValidationCache({ ttlMs: 0 });
+      const url = 'https://8080-sandbox-disabledtoken123.example.com/';
+
+      await proxyToSandbox(new Request(url), mockEnv, {
+        tokenValidationCache: cache
+      });
+      await proxyToSandbox(new Request(url), mockEnv, {
+        tokenValidationCache: cache
+      });
+
       expect(mockSandbox.validatePortToken).toHaveBeenCalledTimes(2);
     });
   });


### PR DESCRIPTION
## Problem

`proxyToSandbox()` calls `validatePortToken()` over RPC to the Sandbox Durable Object on **every** preview URL request. A single Vite dev page load fans out to 20+ subresource fetches against the same preview URL, producing 20+ RPCs to the DO for the same `{sandboxId, port, token}` triple. This is the dominant source of DO queue pressure for customers serving dev-server traffic through preview URLs — even when tokens are valid and stable, the sheer volume overwhelms the DO.

## Change

Cache successful token validations at the Worker level, keyed by `{sandboxId}:{port}:{token}`. Cached hits short-circuit the RPC entirely.

This PR is a **bridge toward signed (HMAC) tokens** that the Worker can verify locally with zero RPCs. That is the right long-term answer but requires a token-format change and customer migration; the cache unblocks customers today without touching the token format.

### Cache policy

| Property | Default | Rationale |
|---|---|---|
| Scope | Per-isolate `Map` | No shared state across isolates needed — worst case is one re-validation per isolate per triple. |
| TTL | **10 s** (configurable) | Long enough to absorb a page-load burst (which happens in sub-second); short enough that `unexposePort()` takes effect quickly. |
| Size cap | 10,000 entries, LRU-ish eviction (configurable) | Hits refresh insertion order so hot entries survive; oldest evicted first under pressure. |
| Successes only | ✅ | Failures during transient windows (e.g. mid-restart, before ports are re-exposed) **must** retry on the next request, not be pinned as invalid. |
| Invalidation | Implicit (TTL + `unexposePort`) | No cross-isolate bus needed. Worst-case revocation latency = TTL. |

### Public API

```ts
import {
  proxyToSandbox,
  TokenValidationCache,
  clearTokenValidationCache
} from '@cloudflare/sandbox';

// Simple: use the module-level default (10 s TTL, 10k entries).
await proxyToSandbox(request, env);

// Tuned: hold a cache instance and share it across handlers.
const cache = new TokenValidationCache({ ttlMs: 5_000, maxEntries: 1_000 });
await proxyToSandbox(request, env, { tokenValidationCache: cache });

// Disable entirely when you want instant revocation.
const noCache = new TokenValidationCache({ ttlMs: 0 });
await proxyToSandbox(request, env, { tokenValidationCache: noCache });
```

`clearTokenValidationCache()` clears the default cache — useful in tests and for callers that want to force re-validation after an out-of-band token change.

## Why this is safe

- **No cached failures.** A `false` result is never stored, so a revoked or not-yet-exposed port cannot get pinned as invalid, and recovery after re-exposure is instantaneous.
- **Authorization still flows through the DO on first contact.** The cache only accelerates *subsequent* requests within the TTL for an already-authorized triple.
- **Bounded memory.** 10,000-entry cap with LRU eviction; each entry is a short string key + timestamp number (~100 bytes → ~1 MB per isolate max).
- **No change to the security model.** Token binding, port validation, and the hostname → `{port, sandboxId, token}` extraction are all unchanged.
- **Opt-out available.** Operators who need instant revocation can disable caching per call (`ttlMs: 0`).

## Performance impact

For a Vite dev page load against a preview URL:

- **Before:** 20+ RPCs to the Sandbox DO per page load.
- **After:** 1 RPC per `{sandboxId, port, token}` per TTL window (10 s).

Preview traffic is removed as an overload vector for the DO. Under sustained load on the same preview URL, RPCs drop to effectively zero for validation.

## Testing

Nine tests in `tests/request-handler.test.ts` covering the cache invariants:

1. Repeated requests for the same triple call `validatePortToken` exactly once.
2. Different tokens on the same port validate independently.
3. Same token on different ports validates independently.
4. Failed validations are **not** cached — every failing request retries the DO.
5. `clearTokenValidationCache()` forces re-validation.
6. TTL expiry (fake timers) — inside TTL still cached, past TTL re-validates.
7. Size-cap eviction — third entry evicts the first when `maxEntries: 2`.
8. LRU refresh-on-hit — hitting A before inserting C evicts B, not A.
9. `ttlMs: 0` disables caching entirely.

Results:

- `npm run typecheck -w @cloudflare/sandbox` — clean
- `npm test -w @cloudflare/sandbox` — **568/568** passing (559 pre-existing + 9 new)
- Pre-commit hooks pass (biome, format, changeset validation)

## Review responses

Incorporated from the internal review against `REVIEW.md`:

- **"Magic 30 s is a design smell."** Dropped default to 10 s and made it configurable; documented the trade-off explicitly in the `ttlMs` doc.
- **"Revocation is now eventually consistent."** Acknowledged in the PR body and in the changeset, with an explicit opt-out (`ttlMs: 0`).
- **"Why not HMAC?"** Addressed head-on: HMAC is the intended long-term path; this cache is a non-breaking bridge that ships today.
- **"Test the TTL + eviction branches directly."** Added four new tests covering exactly those paths with fake timers and a size-capped instance.
- **"Don't export internal test hooks."** `clearTokenValidationCache` is kept public because it has a real external use case (forcing re-validation after out-of-band token rotation), but it operates only on the module-level default; tuned instances are controlled by the caller.

## Changeset

Bumped to **minor** — the change expands the public API and changes observable revocation semantics beyond a pure bugfix.
