### PR TITLE
Coalesce concurrent destroy() calls

### DIFF
--- a/.changeset/coalesce-concurrent-destroy.md
+++ b/.changeset/coalesce-concurrent-destroy.md
@@ -1,0 +1,11 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Coalesce concurrent `Sandbox.destroy()` calls onto a single teardown. If a
+previous `destroy()` is still in flight, subsequent calls await the same
+underlying work instead of starting a second teardown, and emit a canonical
+`sandbox.destroy.coalesced` event per coalesced call for observability.
+Once the in-flight teardown settles, later `destroy()` calls run a fresh
+teardown as before. Fixes observed destroy-recreate thrash where external
+health checks can invoke `destroy()` faster than the sandbox can initialize.

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1431,9 +1431,47 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   /**
-   * Cleanup and destroy the sandbox container
+   * In-flight `destroy()` promise. While set, concurrent callers coalesce
+   * onto the same teardown instead of triggering a second one. Cleared when
+   * the underlying work settles, so a later call that genuinely needs to
+   * recreate a destroyed sandbox still runs.
+   */
+  private inflightDestroy: Promise<void> | null = null;
+
+  /**
+   * Cleanup and destroy the sandbox container.
+   *
+   * Concurrent calls coalesce: if a previous `destroy()` is still in flight,
+   * subsequent calls await the same underlying work instead of starting a
+   * second teardown. A canonical `sandbox.destroy.coalesced` event is logged
+   * per coalesced call so repeated destroy traffic is observable.
    */
   override async destroy(): Promise<void> {
+    if (this.inflightDestroy) {
+      logCanonicalEvent(this.logger, {
+        event: 'sandbox.destroy.coalesced',
+        outcome: 'success',
+        durationMs: 0
+      });
+      return this.inflightDestroy;
+    }
+
+    // Assigned synchronously so concurrent callers observe the promise
+    // before any await point inside doDestroy().
+    const work = this.doDestroy();
+    this.inflightDestroy = work;
+    try {
+      await work;
+    } finally {
+      // Clear only if we are still the owner — defensive against a future
+      // refactor that reassigns the field mid-flight.
+      if (this.inflightDestroy === work) {
+        this.inflightDestroy = null;
+      }
+    }
+  }
+
+  private async doDestroy(): Promise<void> {
     const startTime = Date.now();
     let mountsProcessed = 0;
     let mountFailures = 0;

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1471,8 +1471,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     try {
       await work;
     } finally {
-      // Clear only if we are still the owner — defensive against a future
-      // refactor that reassigns the field mid-flight.
+      // Clears only if the field still references this teardown.
       if (this.inflightDestroy === work) {
         this.inflightDestroy = null;
       }

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1435,6 +1435,14 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    * onto the same teardown instead of triggering a second one. Cleared when
    * the underlying work settles, so a later call that genuinely needs to
    * recreate a destroyed sandbox still runs.
+   *
+   * If the underlying teardown hangs (e.g. `super.destroy()` never resolves
+   * because the Containers control plane is unresponsive), every coalesced
+   * caller hangs on the same promise until the Durable Object is evicted.
+   * This is deliberate: a second concurrent teardown would not make a stuck
+   * control plane unstuck, and spawning one would defeat the point of
+   * coalescing. Callers that need bounded waits must apply their own
+   * timeout around `destroy()`.
    */
   private inflightDestroy: Promise<void> | null = null;
 

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -2143,4 +2143,82 @@ describe('Sandbox - Automatic Session Management', () => {
       expect(instance.client.getTransportMode()).toBe('websocket');
     });
   });
+
+  describe('destroy() coalescing', () => {
+    /**
+     * Stub the parent Container.destroy() with a caller-controlled promise so
+     * we can observe how concurrent destroy() calls behave while the first
+     * one is still in flight.
+     */
+    function stubSuperDestroy(): {
+      resolve: () => void;
+      reject: (err: Error) => void;
+      calls: () => number;
+    } {
+      let resolve: () => void = () => {};
+      let reject: (err: Error) => void = () => {};
+      let calls = 0;
+      const parent = Object.getPrototypeOf(Object.getPrototypeOf(sandbox)) as {
+        destroy: () => Promise<void>;
+      };
+      parent.destroy = vi.fn().mockImplementation(
+        () =>
+          new Promise<void>((res, rej) => {
+            calls++;
+            resolve = res;
+            reject = rej;
+          })
+      );
+      return {
+        resolve: () => resolve(),
+        reject: (err) => reject(err),
+        calls: () => calls
+      };
+    }
+
+    it('coalesces concurrent destroy() calls onto a single teardown', async () => {
+      const superDestroy = stubSuperDestroy();
+
+      const first = sandbox.destroy();
+      const second = sandbox.destroy();
+      const third = sandbox.destroy();
+
+      // All three callers are awaiting the same underlying work; the parent
+      // container destroy must only be invoked once.
+      expect(superDestroy.calls()).toBe(1);
+
+      superDestroy.resolve();
+      await expect(Promise.all([first, second, third])).resolves.toEqual([
+        undefined,
+        undefined,
+        undefined
+      ]);
+    });
+
+    it('propagates the same rejection to all coalesced callers', async () => {
+      const superDestroy = stubSuperDestroy();
+      const first = sandbox.destroy();
+      const second = sandbox.destroy();
+
+      superDestroy.reject(new Error('container teardown failed'));
+
+      await expect(first).rejects.toThrow('container teardown failed');
+      await expect(second).rejects.toThrow('container teardown failed');
+    });
+
+    it('runs a fresh teardown for a later destroy() after the previous one settles', async () => {
+      const first = stubSuperDestroy();
+      const firstCall = sandbox.destroy();
+      expect(first.calls()).toBe(1);
+      first.resolve();
+      await firstCall;
+
+      // Re-stub to track the second teardown independently.
+      const second = stubSuperDestroy();
+      const secondCall = sandbox.destroy();
+      expect(second.calls()).toBe(1);
+      second.resolve();
+      await secondCall;
+    });
+  });
 });


### PR DESCRIPTION
## Problem

External callers can invoke `Sandbox.destroy()` faster than the sandbox can tear itself down. A representative pathology observed in production: an upstream health-check loop calling `destroy()` four times in 17 seconds against a sandbox whose teardown hadn't yet completed. Each call independently runs the full teardown sequence — desktop stop, websocket disconnect, mount cleanup, `super.destroy()` — so four concurrent teardowns race on the same container lifecycle, multiply cost, and produce confusing interleaved logs.

## Change

Coalesce concurrent `destroy()` calls onto a single in-flight teardown.

```ts
private inflightDestroy: Promise<void> | null = null;

override async destroy(): Promise<void> {
  if (this.inflightDestroy) {
    logCanonicalEvent(this.logger, {
      event: 'sandbox.destroy.coalesced',
      outcome: 'success',
      durationMs: 0
    });
    return this.inflightDestroy;
  }

  // Assigned synchronously so concurrent callers observe the promise
  // before any await point inside doDestroy().
  const work = this.doDestroy();
  this.inflightDestroy = work;
  try {
    await work;
  } finally {
    if (this.inflightDestroy === work) {
      this.inflightDestroy = null;
    }
  }
}
```

The actual teardown moves into a private `doDestroy()` that preserves the existing behavior exactly — same desktop stop, same mount cleanup, same `super.destroy()`, same canonical `sandbox.destroy` event, same error propagation. `destroy()` becomes a thin coalescing shell around it.

### Why this shape and not a cooldown

An earlier design proposal for this used a time-based cooldown (`if (now - lastDestroyedAt < 15_000) return`). That was rejected because:

- **Magic timeouts are a design smell.** 15 s was tuned to one customer's init time; it would be wrong for everyone else.
- **Silent skip on a destructive API is a trap.** A caller who invokes `destroy()` and gets no error assumes the sandbox is gone. With a cooldown, it isn't.
- **Natural boundary available.** The previous teardown's promise *is* the "done" signal. Use it directly.

The result is semantically honest: every `destroy()` caller gets a promise that resolves exactly when the underlying teardown actually finishes, whether that caller started it or coalesced onto it.

### Observability

Each coalesced call emits a canonical `sandbox.destroy.coalesced` event, so destroy traffic that coalesces shows up in logs and can be correlated with the underlying `sandbox.destroy` event that does the actual work. Operators can distinguish "one destroy" from "ten coalesced destroys" without code changes.

## Why this is safe

- **No silent skips.** Every coalesced caller gets the real teardown's resolution/rejection. No caller sees success while the sandbox is still alive.
- **Rejections propagate identically.** If the underlying teardown rejects, every coalesced caller sees the same error. Verified in test.
- **Re-runnable after settlement.** Once the in-flight promise settles, the field is cleared and a later `destroy()` call runs a fresh teardown — exactly what you want for test harnesses or re-created sandboxes. Verified in test.
- **Synchronous assignment.** The `inflightDestroy` field is set before the first await inside `doDestroy()`, so concurrent callers racing in the same microtask see the promise. This is the same pattern used elsewhere in the codebase for connection-sharing primitives.
- **In-memory scope is correct here.** A DO eviction during teardown invalidates the field, but that's fine — a post-eviction `destroy()` against a fresh DO is a genuinely new operation and should run.

## Testing

Three focused tests in `tests/sandbox.test.ts` under a new `destroy() coalescing` describe:

1. **Coalesces concurrent calls.** Three `destroy()` calls fired while the parent `Container.destroy()` is pending must invoke the parent exactly once and all three must resolve.
2. **Propagates the same rejection to all callers.** When the underlying teardown rejects, every coalesced caller sees the same error.
3. **Runs a fresh teardown after settlement.** A second `destroy()` after the first resolves must invoke the parent again.

The tests use a caller-controlled parent-destroy stub so timing is deterministic — no `setTimeout`, no fake timers, no flakiness.

Results:

- `npm run typecheck -w @cloudflare/sandbox` — clean
- `npm test -w @cloudflare/sandbox` — **562/562** passing (559 pre-existing + 3 new)
- Pre-commit hooks pass (biome, format, changeset validation)

## Release

**Patch** — no public API change, behavior change is narrowly scoped to concurrent `destroy()` semantics. A single caller sees identical behavior to before; a spamming caller sees the same eventual outcome with less work.

## Not included

- **Caller-side throttling.** If a customer's health-check loop is firing `destroy()` four times in 17 seconds, that's arguably a caller bug and this PR only shields the SDK from its effects. Fixing the upstream loop is a separate conversation.
- **Destroy-rate metrics.** The canonical event gives operators what they need to spot this in their logs; proper metrics would be a broader observability project.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
