### PR TITLE
Add backup/restore & mount performance tests

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -16,6 +16,8 @@ on:
           - concurrent-creation
           - burst-startup
           - file-io
+          - backup-restore
+          - bucket-mounting
   schedule:
     - cron: '0 0 * * *'
 
@@ -180,8 +182,11 @@ jobs:
 
       - name: Run performance tests
         env:
-          TEST_WORKER_URL: ${{ needs.setup.outputs.worker_url }}
+          PERF_DEPLOYED_WORKER_URL: ${{ needs.setup.outputs.worker_url }}
           CI: true
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           PERF_RUN_ID: ${{ github.run_id }}
         run: |
           if [ "${{ inputs.scenario }}" = "all" ] || [ -z "${{ inputs.scenario }}" ]; then

--- a/tests/e2e/test-worker/index.ts
+++ b/tests/e2e/test-worker/index.ts
@@ -556,22 +556,6 @@ console.log('Terminal server on port ' + port);
 
       // Bucket mount
       if (url.pathname === '/api/bucket/mount' && request.method === 'POST') {
-        // Pass R2 credentials from worker env to sandbox env
-        const sandboxEnvVars: Record<string, string> = {};
-        if (env.CLOUDFLARE_ACCOUNT_ID) {
-          sandboxEnvVars.CLOUDFLARE_ACCOUNT_ID = env.CLOUDFLARE_ACCOUNT_ID;
-        }
-        if (env.AWS_ACCESS_KEY_ID) {
-          sandboxEnvVars.AWS_ACCESS_KEY_ID = env.AWS_ACCESS_KEY_ID;
-        }
-        if (env.AWS_SECRET_ACCESS_KEY) {
-          sandboxEnvVars.AWS_SECRET_ACCESS_KEY = env.AWS_SECRET_ACCESS_KEY;
-        }
-
-        if (Object.keys(sandboxEnvVars).length > 0) {
-          await sandbox.setEnvVars(sandboxEnvVars);
-        }
-
         await sandbox.mountBucket(body.bucket, body.mountPath, body.options);
         const response: SuccessResponse = { success: true };
         return new Response(JSON.stringify(response), {

--- a/tests/e2e/test-worker/wrangler.perf.template.jsonc
+++ b/tests/e2e/test-worker/wrangler.perf.template.jsonc
@@ -6,7 +6,8 @@
   "account_id": "b8afc92c7a87f699592038b756153d22",
 
   "vars": {
-    "SANDBOX_LOG_LEVEL": "debug"
+    "SANDBOX_LOG_LEVEL": "debug",
+    "BACKUP_BUCKET_NAME": "sandbox-e2e-test"
   },
   "observability": {
     "enabled": true
@@ -17,7 +18,9 @@
     {
       "class_name": "Sandbox",
       "image": "{{IMAGE_SANDBOX}}",
-      "name": "{{CONTAINER_NAME}}"
+      "name": "{{CONTAINER_NAME}}",
+      "max_instances": 50,
+      "instance_type": "standard-2"
     }
   ],
 
@@ -29,6 +32,17 @@
       }
     ]
   },
+
+  "r2_buckets": [
+    {
+      "binding": "TEST_BUCKET",
+      "bucket_name": "sandbox-e2e-test"
+    },
+    {
+      "binding": "BACKUP_BUCKET",
+      "bucket_name": "sandbox-e2e-test"
+    }
+  ],
 
   "migrations": [
     {

--- a/tests/perf/helpers/constants.ts
+++ b/tests/perf/helpers/constants.ts
@@ -8,7 +8,9 @@ export const SCENARIOS = {
   SUSTAINED: 'sustained-throughput',
   BURST: 'bursty-traffic',
   BURST_STARTUP: 'burst-startup',
-  FILE_IO: 'file-io'
+  FILE_IO: 'file-io',
+  BACKUP_RESTORE: 'backup-restore',
+  BUCKET_MOUNTING: 'bucket-mounting'
 } as const;
 
 export const METRICS = {
@@ -41,7 +43,18 @@ export const METRICS = {
   FILE_READ_LATENCY: 'file-read-latency',
   FILE_ROUNDTRIP_LATENCY: 'file-roundtrip-latency',
   FILE_CONCURRENT_WRITE: 'file-concurrent-write',
-  FILE_CONCURRENT_READ: 'file-concurrent-read'
+  FILE_CONCURRENT_READ: 'file-concurrent-read',
+  // Backup / restore — used as prefixes, appended with '-<size>' (e.g. 'backup-create-latency-small')
+  BACKUP_CREATE_LATENCY: 'backup-create-latency',
+  BACKUP_RESTORE_LATENCY: 'backup-restore-latency',
+  BACKUP_READ_AFTER_RESTORE: 'backup-read-after-restore',
+  BACKUP_WRITE_AFTER_RESTORE: 'backup-write-after-restore',
+  // Bucket mounting
+  BUCKET_MOUNT_LATENCY: 'bucket-mount-latency',
+  BUCKET_UNMOUNT_LATENCY: 'bucket-unmount-latency',
+  BUCKET_WRITE_LATENCY: 'bucket-write-latency',
+  BUCKET_READ_LATENCY: 'bucket-read-latency',
+  BUCKET_ROUNDTRIP_LATENCY: 'bucket-roundtrip-latency'
 } as const;
 
 /** Minimum success rate to pass a scenario (percentage) */

--- a/tests/perf/helpers/perf-sandbox-manager.ts
+++ b/tests/perf/helpers/perf-sandbox-manager.ts
@@ -35,6 +35,31 @@ export interface FileResult {
   error?: string;
 }
 
+export interface BackupResult {
+  success: boolean;
+  duration: number;
+  id?: string;
+  error?: string;
+}
+
+export interface RestoreResult {
+  success: boolean;
+  duration: number;
+  error?: string;
+}
+
+export interface MountResult {
+  success: boolean;
+  duration: number;
+  error?: string;
+}
+
+export interface UnmountResult {
+  success: boolean;
+  duration: number;
+  error?: string;
+}
+
 export class PerfSandboxManager {
   private workerUrl: string;
   private sandboxType: string;
@@ -190,6 +215,198 @@ export class PerfSandboxManager {
         error: error instanceof Error ? error.message : String(error)
       };
     }
+  }
+
+  /**
+   * Create a backup of a directory in a sandbox
+   */
+  async createBackup(
+    sandbox: SandboxInstance,
+    dir: string,
+    options?: { name?: string; ttl?: number }
+  ): Promise<BackupResult> {
+    const start = performance.now();
+    try {
+      const response = await fetch(`${this.workerUrl}/api/backup/create`, {
+        method: 'POST',
+        headers: sandbox.headers,
+        body: JSON.stringify({ dir, ...options })
+      });
+      const duration = performance.now() - start;
+      if (!response.ok) {
+        return { success: false, duration, error: `HTTP ${response.status}` };
+      }
+      const result = (await response.json()) as { id: string };
+      return { success: true, duration, id: result.id };
+    } catch (error) {
+      return {
+        success: false,
+        duration: performance.now() - start,
+        error: error instanceof Error ? error.message : String(error)
+      };
+    }
+  }
+
+  /**
+   * Restore a backup to a directory in a sandbox
+   */
+  async restoreBackup(
+    sandbox: SandboxInstance,
+    id: string,
+    dir: string
+  ): Promise<RestoreResult> {
+    const start = performance.now();
+    try {
+      const response = await fetch(`${this.workerUrl}/api/backup/restore`, {
+        method: 'POST',
+        headers: sandbox.headers,
+        body: JSON.stringify({ id, dir })
+      });
+      const duration = performance.now() - start;
+      if (!response.ok) {
+        return { success: false, duration, error: `HTTP ${response.status}` };
+      }
+      return { success: true, duration };
+    } catch (error) {
+      return {
+        success: false,
+        duration: performance.now() - start,
+        error: error instanceof Error ? error.message : String(error)
+      };
+    }
+  }
+
+  /**
+   * Mount an R2 bucket into a sandbox
+   */
+  async mountBucket(
+    sandbox: SandboxInstance,
+    bucket: string,
+    mountPath: string,
+    options?: {
+      endpoint?: string;
+      credentials?: { accessKeyId: string; secretAccessKey: string };
+    }
+  ): Promise<MountResult> {
+    const start = performance.now();
+    try {
+      const response = await fetch(`${this.workerUrl}/api/bucket/mount`, {
+        method: 'POST',
+        headers: sandbox.headers,
+        body: JSON.stringify({ bucket, mountPath, options })
+      });
+      const duration = performance.now() - start;
+      if (!response.ok) {
+        return { success: false, duration, error: `HTTP ${response.status}` };
+      }
+      return { success: true, duration };
+    } catch (error) {
+      return {
+        success: false,
+        duration: performance.now() - start,
+        error: error instanceof Error ? error.message : String(error)
+      };
+    }
+  }
+
+  /**
+   * Unmount a bucket from a sandbox
+   */
+  async unmountBucket(
+    sandbox: SandboxInstance,
+    mountPath: string
+  ): Promise<UnmountResult> {
+    const start = performance.now();
+    try {
+      const response = await fetch(`${this.workerUrl}/api/bucket/unmount`, {
+        method: 'POST',
+        headers: sandbox.headers,
+        body: JSON.stringify({ mountPath })
+      });
+      const duration = performance.now() - start;
+      if (!response.ok) {
+        return { success: false, duration, error: `HTTP ${response.status}` };
+      }
+      return { success: true, duration };
+    } catch (error) {
+      return {
+        success: false,
+        duration: performance.now() - start,
+        error: error instanceof Error ? error.message : String(error)
+      };
+    }
+  }
+
+  /**
+   * Put an object into the R2 test bucket via the worker
+   */
+  async putBucketObject(
+    sandbox: SandboxInstance,
+    key: string,
+    content: string
+  ): Promise<{ success: boolean }> {
+    try {
+      const response = await fetch(`${this.workerUrl}/api/bucket/put`, {
+        method: 'POST',
+        headers: sandbox.headers,
+        body: JSON.stringify({ key, content, contentType: 'text/plain' })
+      });
+      return { success: response.ok };
+    } catch {
+      return { success: false };
+    }
+  }
+
+  /**
+   * Get an object from the R2 test bucket via the worker
+   */
+  async getBucketObject(
+    sandbox: SandboxInstance,
+    key: string
+  ): Promise<{ success: boolean; content?: string }> {
+    try {
+      const response = await fetch(
+        `${this.workerUrl}/api/bucket/get?key=${encodeURIComponent(key)}`,
+        { method: 'GET', headers: sandbox.headers }
+      );
+      if (!response.ok) return { success: false };
+      const result = (await response.json()) as { content?: string };
+      return { success: true, content: result.content };
+    } catch {
+      return { success: false };
+    }
+  }
+
+  /**
+   * Delete an object from the R2 test bucket via the worker
+   */
+  async deleteBucketObject(
+    sandbox: SandboxInstance,
+    key: string
+  ): Promise<void> {
+    try {
+      await fetch(`${this.workerUrl}/api/bucket/delete`, {
+        method: 'POST',
+        headers: sandbox.headers,
+        body: JSON.stringify({ key })
+      });
+    } catch {
+      // Best-effort cleanup
+    }
+  }
+
+  /**
+   * Set environment variables on a sandbox
+   */
+  async setEnvVars(
+    sandbox: SandboxInstance,
+    envVars: Record<string, string>
+  ): Promise<void> {
+    await fetch(`${this.workerUrl}/api/env/set`, {
+      method: 'POST',
+      headers: sandbox.headers,
+      body: JSON.stringify({ envVars })
+    });
   }
 
   /**

--- a/tests/perf/scenarios/backup-restore.test.ts
+++ b/tests/perf/scenarios/backup-restore.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Backup & Restore Performance Test
+ *
+ * Measures backup creation and restore latencies across multiple directory sizes:
+ * - Small (10 files, ~10 KB total)
+ * - Medium (50 files, ~500 KB total)
+ * - Large (100 files, ~5 MB total)
+ *
+ * Also measures post-restore read/write latency to verify the restored
+ * filesystem is fully functional.
+ *
+ * Requires BACKUP_BUCKET R2 binding on the deployed test worker.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { METRICS, PASS_THRESHOLD, SCENARIOS } from '../helpers/constants';
+import {
+  PerfSandboxManager,
+  type SandboxInstance
+} from '../helpers/perf-sandbox-manager';
+import {
+  createPerfTestContext,
+  registerPerfScenario
+} from '../helpers/perf-test-fixture';
+
+describe('Backup & Restore', () => {
+  const ctx = createPerfTestContext(SCENARIOS.BACKUP_RESTORE);
+  let sandbox: SandboxInstance;
+  let manager: PerfSandboxManager;
+  let shouldRun = false;
+
+  const ITERATIONS = 5;
+
+  const DIR_SIZES: Array<{
+    label: string;
+    fileCount: number;
+    fileSizeBytes: number;
+  }> = [
+    { label: 'small', fileCount: 10, fileSizeBytes: 1_024 },
+    { label: 'medium', fileCount: 50, fileSizeBytes: 10_240 },
+    { label: 'large', fileCount: 100, fileSizeBytes: 51_200 }
+  ];
+
+  beforeAll(async () => {
+    const deployedUrl = process.env.PERF_DEPLOYED_WORKER_URL;
+    if (!deployedUrl) {
+      console.warn(
+        'PERF_DEPLOYED_WORKER_URL not set — backup perf tests will be skipped'
+      );
+      return;
+    }
+
+    manager = new PerfSandboxManager({ workerUrl: deployedUrl });
+    sandbox = await manager.createSandbox({ initialize: true });
+
+    // Probe for BACKUP_BUCKET availability
+    const probe = await manager.createBackup(sandbox, '/nonexistent-probe-dir');
+    // If the error mentions BACKUP_BUCKET or "not configured", the binding is missing
+    if (
+      probe.error?.includes('BACKUP_BUCKET') ||
+      probe.error?.includes('not configured')
+    ) {
+      console.warn(
+        'BACKUP_BUCKET R2 binding not configured — backup perf tests will be skipped'
+      );
+    } else {
+      shouldRun = true;
+    }
+  }, 120000);
+
+  afterAll(async () => {
+    if (manager) await manager.destroyAll();
+    registerPerfScenario(ctx);
+  });
+
+  test('should measure backup creation latency by directory size', async () => {
+    if (!shouldRun) {
+      console.log('  Skipped — deployed worker / BACKUP_BUCKET not available');
+      return;
+    }
+
+    for (const { label, fileCount, fileSizeBytes } of DIR_SIZES) {
+      console.log(
+        `\n  Backup create ${label} (${fileCount} files × ${(fileSizeBytes / 1024).toFixed(0)} KB, ${ITERATIONS} iterations):`
+      );
+
+      for (let i = 0; i < ITERATIONS; i++) {
+        const dir = `/tmp/perf-backup-${label}-${i}`;
+
+        // Populate directory
+        const chunk = 'abcdefghijklmnopqrstuvwxyz0123456789\n';
+        const fileContent = chunk
+          .repeat(Math.ceil(fileSizeBytes / chunk.length))
+          .slice(0, fileSizeBytes);
+        const cmds = [`mkdir -p ${dir}`];
+        for (let f = 0; f < fileCount; f++) {
+          cmds.push(
+            `printf '%s' '${fileContent.replace(/'/g, "'\\''")}' > ${dir}/file-${f}.txt`
+          );
+        }
+        await manager.executeCommand(sandbox, cmds.join(' && '), {
+          timeout: 60000
+        });
+
+        const result = await manager.createBackup(sandbox, dir, {
+          name: `perf-${label}-${i}`,
+          ttl: 3600
+        });
+
+        ctx.collector.record(
+          `${METRICS.BACKUP_CREATE_LATENCY}-${label}`,
+          result.duration,
+          'ms',
+          { success: result.success, iteration: i }
+        );
+
+        // Cleanup directory
+        await manager.executeCommand(
+          sandbox,
+          `fusermount3 -u ${dir} 2>/dev/null || true; rm -rf ${dir}`
+        );
+      }
+
+      const stats = ctx.collector.getStats(
+        `${METRICS.BACKUP_CREATE_LATENCY}-${label}`
+      );
+      if (stats) {
+        console.log(
+          `    p50=${stats.p50.toFixed(0)}ms  p95=${stats.p95.toFixed(0)}ms`
+        );
+      }
+    }
+
+    const smallRate = ctx.collector.getSuccessRate(
+      `${METRICS.BACKUP_CREATE_LATENCY}-small`
+    );
+    expect(smallRate.rate).toBeGreaterThanOrEqual(PASS_THRESHOLD);
+  }, 600000);
+
+  test('should measure backup restore latency by directory size', async () => {
+    if (!shouldRun) {
+      console.log('  Skipped — deployed worker / BACKUP_BUCKET not available');
+      return;
+    }
+
+    for (const { label, fileCount, fileSizeBytes } of DIR_SIZES) {
+      console.log(
+        `\n  Backup restore ${label} (${fileCount} files × ${(fileSizeBytes / 1024).toFixed(0)} KB, ${ITERATIONS} iterations):`
+      );
+
+      for (let i = 0; i < ITERATIONS; i++) {
+        const dir = `/tmp/perf-restore-${label}-${i}`;
+
+        // Create source directory and backup it
+        const chunk = 'abcdefghijklmnopqrstuvwxyz0123456789\n';
+        const fileContent = chunk
+          .repeat(Math.ceil(fileSizeBytes / chunk.length))
+          .slice(0, fileSizeBytes);
+        const cmds = [`mkdir -p ${dir}`];
+        for (let f = 0; f < fileCount; f++) {
+          cmds.push(
+            `printf '%s' '${fileContent.replace(/'/g, "'\\''")}' > ${dir}/file-${f}.txt`
+          );
+        }
+        await manager.executeCommand(sandbox, cmds.join(' && '), {
+          timeout: 60000
+        });
+
+        const backup = await manager.createBackup(sandbox, dir, {
+          name: `perf-restore-${label}-${i}`,
+          ttl: 3600
+        });
+
+        if (!backup.success || !backup.id) {
+          ctx.collector.record(
+            `${METRICS.BACKUP_RESTORE_LATENCY}-${label}`,
+            0,
+            'ms',
+            { success: false, iteration: i, error: 'backup creation failed' }
+          );
+          await manager.executeCommand(
+            sandbox,
+            `fusermount3 -u ${dir} 2>/dev/null || true; rm -rf ${dir}`
+          );
+          continue;
+        }
+
+        // Wipe the directory
+        await manager.executeCommand(
+          sandbox,
+          `fusermount3 -u ${dir} 2>/dev/null || true; rm -rf ${dir} && mkdir -p ${dir}`
+        );
+
+        // Measure restore
+        const result = await manager.restoreBackup(sandbox, backup.id, dir);
+
+        ctx.collector.record(
+          `${METRICS.BACKUP_RESTORE_LATENCY}-${label}`,
+          result.duration,
+          'ms',
+          { success: result.success, iteration: i }
+        );
+
+        // Cleanup
+        await manager.executeCommand(
+          sandbox,
+          `fusermount3 -u ${dir} 2>/dev/null || true; rm -rf ${dir}`
+        );
+      }
+
+      const stats = ctx.collector.getStats(
+        `${METRICS.BACKUP_RESTORE_LATENCY}-${label}`
+      );
+      if (stats) {
+        console.log(
+          `    p50=${stats.p50.toFixed(0)}ms  p95=${stats.p95.toFixed(0)}ms`
+        );
+      }
+    }
+
+    const smallRate = ctx.collector.getSuccessRate(
+      `${METRICS.BACKUP_RESTORE_LATENCY}-small`
+    );
+    expect(smallRate.rate).toBeGreaterThanOrEqual(PASS_THRESHOLD);
+  }, 600000);
+
+  test('should measure post-restore read and write latency', async () => {
+    if (!shouldRun) {
+      console.log('  Skipped — deployed worker / BACKUP_BUCKET not available');
+      return;
+    }
+
+    console.log(`\n  Post-restore I/O (${ITERATIONS} iterations):`);
+
+    for (let i = 0; i < ITERATIONS; i++) {
+      const dir = `/tmp/perf-post-restore-${i}`;
+      const content = `perf-test-content-${i}`;
+
+      // Create, backup, wipe, restore
+      await manager.executeCommand(
+        sandbox,
+        `mkdir -p ${dir} && echo "${content}" > ${dir}/test.txt`
+      );
+
+      const backup = await manager.createBackup(sandbox, dir, {
+        name: `perf-post-${i}`,
+        ttl: 3600
+      });
+
+      if (!backup.success || !backup.id) {
+        await manager.executeCommand(
+          sandbox,
+          `fusermount3 -u ${dir} 2>/dev/null || true; rm -rf ${dir}`
+        );
+        continue;
+      }
+
+      await manager.executeCommand(
+        sandbox,
+        `fusermount3 -u ${dir} 2>/dev/null || true; rm -rf ${dir} && mkdir -p ${dir}`
+      );
+      await manager.restoreBackup(sandbox, backup.id, dir);
+
+      // Measure read after restore
+      const readResult = await manager.executeCommand(
+        sandbox,
+        `cat ${dir}/test.txt`
+      );
+      ctx.collector.record(
+        METRICS.BACKUP_READ_AFTER_RESTORE,
+        readResult.duration,
+        'ms',
+        {
+          success: readResult.success && readResult.stdout.trim() === content,
+          iteration: i
+        }
+      );
+
+      // Measure write after restore
+      const writeResult = await manager.executeCommand(
+        sandbox,
+        `echo "new-content-${i}" > ${dir}/new-file.txt`
+      );
+      ctx.collector.record(
+        METRICS.BACKUP_WRITE_AFTER_RESTORE,
+        writeResult.duration,
+        'ms',
+        { success: writeResult.success, iteration: i }
+      );
+
+      // Cleanup
+      await manager.executeCommand(
+        sandbox,
+        `fusermount3 -u ${dir} 2>/dev/null || true; rm -rf ${dir}`
+      );
+    }
+
+    const readStats = ctx.collector.getStats(METRICS.BACKUP_READ_AFTER_RESTORE);
+    const writeStats = ctx.collector.getStats(
+      METRICS.BACKUP_WRITE_AFTER_RESTORE
+    );
+    if (readStats) {
+      console.log(
+        `    Read  p50=${readStats.p50.toFixed(0)}ms  p95=${readStats.p95.toFixed(0)}ms`
+      );
+    }
+    if (writeStats) {
+      console.log(
+        `    Write p50=${writeStats.p50.toFixed(0)}ms  p95=${writeStats.p95.toFixed(0)}ms`
+      );
+    }
+
+    const readRate = ctx.collector.getSuccessRate(
+      METRICS.BACKUP_READ_AFTER_RESTORE
+    );
+    expect(readRate.rate).toBeGreaterThanOrEqual(PASS_THRESHOLD);
+  }, 600000);
+});

--- a/tests/perf/scenarios/backup-restore.test.ts
+++ b/tests/perf/scenarios/backup-restore.test.ts
@@ -2,9 +2,12 @@
  * Backup & Restore Performance Test
  *
  * Measures backup creation and restore latencies across multiple directory sizes:
- * - 10kb (10 files, ~10 KB total)
- * - 500kb (50 files, ~500 KB total)
- * - 5mb (100 files, ~5 MB total)
+ * - 100mb
+ * - 500mb
+ * - 1gb
+ *
+ * Data is generated from /dev/urandom so it is effectively incompressible —
+ * this prevents squashfs compression from masking real I/O / transfer costs.
  *
  * Also measures post-restore read/write latency to verify the restored
  * filesystem is fully functional.
@@ -29,17 +32,36 @@ describe('Backup & Restore', () => {
   let manager: PerfSandboxManager;
   let shouldRun = false;
 
-  const ITERATIONS = 5;
+  const ITERATIONS = 3;
 
   const DIR_SIZES: Array<{
     label: string;
     fileCount: number;
-    fileSizeBytes: number;
+    fileSizeMB: number;
   }> = [
-    { label: '10kb', fileCount: 10, fileSizeBytes: 1_024 },
-    { label: '500kb', fileCount: 50, fileSizeBytes: 10_240 },
-    { label: '5mb', fileCount: 100, fileSizeBytes: 51_200 }
+    { label: '100mb', fileCount: 4, fileSizeMB: 25 },
+    { label: '500mb', fileCount: 5, fileSizeMB: 100 },
+    { label: '1gb', fileCount: 8, fileSizeMB: 128 }
   ];
+
+  /**
+   * Build a shell command that populates `dir` with `fileCount` files of
+   * `fileSizeMB` each, sourced from /dev/urandom so the data is
+   * pseudorandom (and therefore near-incompressible by squashfs).
+   */
+  function populateDirCmd(
+    dir: string,
+    fileCount: number,
+    fileSizeMB: number
+  ): string {
+    const cmds = [`mkdir -p ${dir}`];
+    for (let f = 0; f < fileCount; f++) {
+      cmds.push(
+        `dd if=/dev/urandom of=${dir}/file-${f}.bin bs=1M count=${fileSizeMB} status=none`
+      );
+    }
+    return cmds.join(' && ');
+  }
 
   beforeAll(async () => {
     const deployedUrl = process.env.PERF_DEPLOYED_WORKER_URL;
@@ -79,28 +101,19 @@ describe('Backup & Restore', () => {
       return;
     }
 
-    for (const { label, fileCount, fileSizeBytes } of DIR_SIZES) {
+    for (const { label, fileCount, fileSizeMB } of DIR_SIZES) {
       console.log(
-        `\n  Backup create ${label} (${fileCount} files × ${(fileSizeBytes / 1024).toFixed(0)} KB, ${ITERATIONS} iterations):`
+        `\n  Backup create ${label} (${fileCount} files × ${fileSizeMB} MB urandom, ${ITERATIONS} iterations):`
       );
 
       for (let i = 0; i < ITERATIONS; i++) {
         const dir = `/tmp/perf-backup-${label}-${i}`;
 
-        // Populate directory
-        const chunk = 'abcdefghijklmnopqrstuvwxyz0123456789\n';
-        const fileContent = chunk
-          .repeat(Math.ceil(fileSizeBytes / chunk.length))
-          .slice(0, fileSizeBytes);
-        const cmds = [`mkdir -p ${dir}`];
-        for (let f = 0; f < fileCount; f++) {
-          cmds.push(
-            `printf '%s' '${fileContent.replace(/'/g, "'\\''")}' > ${dir}/file-${f}.txt`
-          );
-        }
-        await manager.executeCommand(sandbox, cmds.join(' && '), {
-          timeout: 60000
-        });
+        await manager.executeCommand(
+          sandbox,
+          populateDirCmd(dir, fileCount, fileSizeMB),
+          { timeout: 600000 }
+        );
 
         const result = await manager.createBackup(sandbox, dir, {
           name: `perf-${label}-${i}`,
@@ -132,10 +145,10 @@ describe('Backup & Restore', () => {
     }
 
     const smallRate = ctx.collector.getSuccessRate(
-      `${METRICS.BACKUP_CREATE_LATENCY}-10kb`
+      `${METRICS.BACKUP_CREATE_LATENCY}-100mb`
     );
     expect(smallRate.rate).toBeGreaterThanOrEqual(PASS_THRESHOLD);
-  }, 600000);
+  }, 3_600_000);
 
   test('should measure backup restore latency by directory size', async () => {
     if (!shouldRun) {
@@ -143,28 +156,19 @@ describe('Backup & Restore', () => {
       return;
     }
 
-    for (const { label, fileCount, fileSizeBytes } of DIR_SIZES) {
+    for (const { label, fileCount, fileSizeMB } of DIR_SIZES) {
       console.log(
-        `\n  Backup restore ${label} (${fileCount} files × ${(fileSizeBytes / 1024).toFixed(0)} KB, ${ITERATIONS} iterations):`
+        `\n  Backup restore ${label} (${fileCount} files × ${fileSizeMB} MB urandom, ${ITERATIONS} iterations):`
       );
 
       for (let i = 0; i < ITERATIONS; i++) {
         const dir = `/tmp/perf-restore-${label}-${i}`;
 
-        // Create source directory and backup it
-        const chunk = 'abcdefghijklmnopqrstuvwxyz0123456789\n';
-        const fileContent = chunk
-          .repeat(Math.ceil(fileSizeBytes / chunk.length))
-          .slice(0, fileSizeBytes);
-        const cmds = [`mkdir -p ${dir}`];
-        for (let f = 0; f < fileCount; f++) {
-          cmds.push(
-            `printf '%s' '${fileContent.replace(/'/g, "'\\''")}' > ${dir}/file-${f}.txt`
-          );
-        }
-        await manager.executeCommand(sandbox, cmds.join(' && '), {
-          timeout: 60000
-        });
+        await manager.executeCommand(
+          sandbox,
+          populateDirCmd(dir, fileCount, fileSizeMB),
+          { timeout: 600000 }
+        );
 
         const backup = await manager.createBackup(sandbox, dir, {
           name: `perf-restore-${label}-${i}`,
@@ -219,10 +223,10 @@ describe('Backup & Restore', () => {
     }
 
     const smallRate = ctx.collector.getSuccessRate(
-      `${METRICS.BACKUP_RESTORE_LATENCY}-10kb`
+      `${METRICS.BACKUP_RESTORE_LATENCY}-100mb`
     );
     expect(smallRate.rate).toBeGreaterThanOrEqual(PASS_THRESHOLD);
-  }, 600000);
+  }, 3_600_000);
 
   test('should measure post-restore read and write latency', async () => {
     if (!shouldRun) {

--- a/tests/perf/scenarios/backup-restore.test.ts
+++ b/tests/perf/scenarios/backup-restore.test.ts
@@ -2,9 +2,9 @@
  * Backup & Restore Performance Test
  *
  * Measures backup creation and restore latencies across multiple directory sizes:
- * - Small (10 files, ~10 KB total)
- * - Medium (50 files, ~500 KB total)
- * - Large (100 files, ~5 MB total)
+ * - 10kb (10 files, ~10 KB total)
+ * - 500kb (50 files, ~500 KB total)
+ * - 5mb (100 files, ~5 MB total)
  *
  * Also measures post-restore read/write latency to verify the restored
  * filesystem is fully functional.
@@ -36,9 +36,9 @@ describe('Backup & Restore', () => {
     fileCount: number;
     fileSizeBytes: number;
   }> = [
-    { label: 'small', fileCount: 10, fileSizeBytes: 1_024 },
-    { label: 'medium', fileCount: 50, fileSizeBytes: 10_240 },
-    { label: 'large', fileCount: 100, fileSizeBytes: 51_200 }
+    { label: '10kb', fileCount: 10, fileSizeBytes: 1_024 },
+    { label: '500kb', fileCount: 50, fileSizeBytes: 10_240 },
+    { label: '5mb', fileCount: 100, fileSizeBytes: 51_200 }
   ];
 
   beforeAll(async () => {
@@ -132,7 +132,7 @@ describe('Backup & Restore', () => {
     }
 
     const smallRate = ctx.collector.getSuccessRate(
-      `${METRICS.BACKUP_CREATE_LATENCY}-small`
+      `${METRICS.BACKUP_CREATE_LATENCY}-10kb`
     );
     expect(smallRate.rate).toBeGreaterThanOrEqual(PASS_THRESHOLD);
   }, 600000);
@@ -219,7 +219,7 @@ describe('Backup & Restore', () => {
     }
 
     const smallRate = ctx.collector.getSuccessRate(
-      `${METRICS.BACKUP_RESTORE_LATENCY}-small`
+      `${METRICS.BACKUP_RESTORE_LATENCY}-10kb`
     );
     expect(smallRate.rate).toBeGreaterThanOrEqual(PASS_THRESHOLD);
   }, 600000);

--- a/tests/perf/scenarios/bucket-mounting.test.ts
+++ b/tests/perf/scenarios/bucket-mounting.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Bucket Mounting Performance Test
+ *
+ * Measures S3-compatible bucket mount/unmount latencies and I/O through
+ * the mounted filesystem:
+ * - Mount latency (s3fs FUSE mount)
+ * - Write latency through mount (file appears in R2)
+ * - Read latency through mount (file from R2 visible on disk)
+ * - Write → read roundtrip through mount
+ * - Unmount latency
+ *
+ * Requires:
+ *   CLOUDFLARE_ACCOUNT_ID, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+ *   TEST_BUCKET R2 binding on the deployed test worker
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { METRICS, PASS_THRESHOLD, SCENARIOS } from '../helpers/constants';
+import {
+  PerfSandboxManager,
+  type SandboxInstance
+} from '../helpers/perf-sandbox-manager';
+import {
+  createPerfTestContext,
+  registerPerfScenario
+} from '../helpers/perf-test-fixture';
+
+describe('Bucket Mounting', () => {
+  const ctx = createPerfTestContext(SCENARIOS.BUCKET_MOUNTING);
+  let sandbox: SandboxInstance;
+  let manager: PerfSandboxManager;
+  let shouldRun = false;
+
+  const BUCKET_NAME = 'sandbox-e2e-test';
+  const MOUNT_ITERATIONS = 5;
+  const IO_ITERATIONS = 10;
+
+  function mountOptions() {
+    return {
+      endpoint: `https://${process.env.CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+      credentials: {
+        accessKeyId: process.env.AWS_ACCESS_KEY_ID || '',
+        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || ''
+      }
+    };
+  }
+
+  beforeAll(async () => {
+    const deployedUrl = process.env.PERF_DEPLOYED_WORKER_URL;
+    if (!deployedUrl) {
+      console.warn(
+        'PERF_DEPLOYED_WORKER_URL not set — bucket mounting perf tests will be skipped'
+      );
+      return;
+    }
+
+    const required = [
+      'CLOUDFLARE_ACCOUNT_ID',
+      'AWS_ACCESS_KEY_ID',
+      'AWS_SECRET_ACCESS_KEY'
+    ];
+    const missing = required.filter((v) => !process.env[v]);
+    if (missing.length > 0) {
+      console.warn(
+        `Missing env vars for bucket mounting: ${missing.join(', ')} — tests will be skipped`
+      );
+      return;
+    }
+
+    manager = new PerfSandboxManager({ workerUrl: deployedUrl });
+    sandbox = await manager.createSandbox({ initialize: true });
+    shouldRun = true;
+  }, 120000);
+
+  afterAll(async () => {
+    if (manager) await manager.destroyAll();
+    registerPerfScenario(ctx);
+  });
+
+  test('should measure mount and unmount latency', async () => {
+    if (!shouldRun) {
+      console.log('  Skipped — deployed worker / credentials not available');
+      return;
+    }
+
+    console.log(`\n  Mount/unmount latency (${MOUNT_ITERATIONS} iterations):`);
+
+    for (let i = 0; i < MOUNT_ITERATIONS; i++) {
+      const mountPath = `/mnt/perf-mount-${i}`;
+
+      // Measure mount
+      const mountResult = await manager.mountBucket(
+        sandbox,
+        BUCKET_NAME,
+        mountPath,
+        mountOptions()
+      );
+      ctx.collector.record(
+        METRICS.BUCKET_MOUNT_LATENCY,
+        mountResult.duration,
+        'ms',
+        {
+          success: mountResult.success,
+          iteration: i
+        }
+      );
+
+      if (!mountResult.success) {
+        console.warn(`    Mount ${i} failed: ${mountResult.error}`);
+        continue;
+      }
+
+      // Measure unmount
+      const unmountResult = await manager.unmountBucket(sandbox, mountPath);
+      ctx.collector.record(
+        METRICS.BUCKET_UNMOUNT_LATENCY,
+        unmountResult.duration,
+        'ms',
+        { success: unmountResult.success, iteration: i }
+      );
+    }
+
+    const mountStats = ctx.collector.getStats(METRICS.BUCKET_MOUNT_LATENCY);
+    const unmountStats = ctx.collector.getStats(METRICS.BUCKET_UNMOUNT_LATENCY);
+    if (mountStats) {
+      console.log(
+        `    Mount   p50=${mountStats.p50.toFixed(0)}ms  p95=${mountStats.p95.toFixed(0)}ms`
+      );
+    }
+    if (unmountStats) {
+      console.log(
+        `    Unmount p50=${unmountStats.p50.toFixed(0)}ms  p95=${unmountStats.p95.toFixed(0)}ms`
+      );
+    }
+
+    const mountRate = ctx.collector.getSuccessRate(
+      METRICS.BUCKET_MOUNT_LATENCY
+    );
+    expect(mountRate.rate).toBeGreaterThanOrEqual(PASS_THRESHOLD);
+  }, 600000);
+
+  test('should measure write latency through mounted bucket', async () => {
+    if (!shouldRun) {
+      console.log('  Skipped — deployed worker / credentials not available');
+      return;
+    }
+
+    console.log(`\n  Write through mount (${IO_ITERATIONS} iterations):`);
+
+    const mountPath = '/mnt/perf-write-test';
+    const testKeys: string[] = [];
+
+    // Mount once for all write iterations
+    const mountResult = await manager.mountBucket(
+      sandbox,
+      BUCKET_NAME,
+      mountPath,
+      mountOptions()
+    );
+    if (!mountResult.success) {
+      console.warn(`  Mount failed: ${mountResult.error} — skipping`);
+      return;
+    }
+
+    try {
+      for (let i = 0; i < IO_ITERATIONS; i++) {
+        const key = `perf-write-${Date.now()}-${i}.txt`;
+        const content = `perf write test iteration ${i} - ${Date.now()}`;
+        testKeys.push(key);
+
+        const start = performance.now();
+        const writeResult = await manager.executeCommand(
+          sandbox,
+          `echo "${content}" > ${mountPath}/${key}`
+        );
+        const duration = performance.now() - start;
+
+        ctx.collector.record(METRICS.BUCKET_WRITE_LATENCY, duration, 'ms', {
+          success: writeResult.success,
+          iteration: i
+        });
+      }
+
+      const stats = ctx.collector.getStats(METRICS.BUCKET_WRITE_LATENCY);
+      if (stats) {
+        console.log(
+          `    p50=${stats.p50.toFixed(0)}ms  p95=${stats.p95.toFixed(0)}ms`
+        );
+      }
+
+      const writeRate = ctx.collector.getSuccessRate(
+        METRICS.BUCKET_WRITE_LATENCY
+      );
+      expect(writeRate.rate).toBeGreaterThanOrEqual(PASS_THRESHOLD);
+    } finally {
+      // Unmount and cleanup test files from R2
+      await manager.unmountBucket(sandbox, mountPath);
+      for (const key of testKeys) {
+        await manager.deleteBucketObject(sandbox, key);
+      }
+    }
+  }, 600000);
+
+  test('should measure read latency through mounted bucket', async () => {
+    if (!shouldRun) {
+      console.log('  Skipped — deployed worker / credentials not available');
+      return;
+    }
+
+    console.log(`\n  Read through mount (${IO_ITERATIONS} iterations):`);
+
+    const mountPath = '/mnt/perf-read-test';
+    const testKeys: string[] = [];
+
+    // Seed R2 with test files before mounting
+    for (let i = 0; i < IO_ITERATIONS; i++) {
+      const key = `perf-read-${Date.now()}-${i}.txt`;
+      const content = `perf read test iteration ${i}`;
+      testKeys.push(key);
+      await manager.putBucketObject(sandbox, key, content);
+    }
+
+    // Mount
+    const mountResult = await manager.mountBucket(
+      sandbox,
+      BUCKET_NAME,
+      mountPath,
+      mountOptions()
+    );
+    if (!mountResult.success) {
+      console.warn(`  Mount failed: ${mountResult.error} — skipping`);
+      for (const key of testKeys) {
+        await manager.deleteBucketObject(sandbox, key);
+      }
+      return;
+    }
+
+    try {
+      for (let i = 0; i < IO_ITERATIONS; i++) {
+        const start = performance.now();
+        const readResult = await manager.executeCommand(
+          sandbox,
+          `cat ${mountPath}/${testKeys[i]}`
+        );
+        const duration = performance.now() - start;
+
+        ctx.collector.record(METRICS.BUCKET_READ_LATENCY, duration, 'ms', {
+          success: readResult.success && readResult.exitCode === 0,
+          iteration: i
+        });
+      }
+
+      const stats = ctx.collector.getStats(METRICS.BUCKET_READ_LATENCY);
+      if (stats) {
+        console.log(
+          `    p50=${stats.p50.toFixed(0)}ms  p95=${stats.p95.toFixed(0)}ms`
+        );
+      }
+
+      const readRate = ctx.collector.getSuccessRate(
+        METRICS.BUCKET_READ_LATENCY
+      );
+      expect(readRate.rate).toBeGreaterThanOrEqual(PASS_THRESHOLD);
+    } finally {
+      await manager.unmountBucket(sandbox, mountPath);
+      for (const key of testKeys) {
+        await manager.deleteBucketObject(sandbox, key);
+      }
+    }
+  }, 600000);
+
+  test('should measure write→read roundtrip latency through mount', async () => {
+    if (!shouldRun) {
+      console.log('  Skipped — deployed worker / credentials not available');
+      return;
+    }
+
+    console.log(
+      `\n  Roundtrip (write+read) through mount (${IO_ITERATIONS} iterations):`
+    );
+
+    const mountPath = '/mnt/perf-roundtrip-test';
+    const testKeys: string[] = [];
+
+    const mountResult = await manager.mountBucket(
+      sandbox,
+      BUCKET_NAME,
+      mountPath,
+      mountOptions()
+    );
+    if (!mountResult.success) {
+      console.warn(`  Mount failed: ${mountResult.error} — skipping`);
+      return;
+    }
+
+    try {
+      for (let i = 0; i < IO_ITERATIONS; i++) {
+        const key = `perf-rt-${Date.now()}-${i}.txt`;
+        const content = `roundtrip-${i}-${Date.now()}`;
+        testKeys.push(key);
+
+        const start = performance.now();
+
+        // Write
+        const writeResult = await manager.executeCommand(
+          sandbox,
+          `echo "${content}" > ${mountPath}/${key}`
+        );
+
+        let roundtripSuccess = false;
+        if (writeResult.success) {
+          // Read back
+          const readResult = await manager.executeCommand(
+            sandbox,
+            `cat ${mountPath}/${key}`
+          );
+          roundtripSuccess =
+            readResult.success && readResult.stdout.trim() === content;
+        }
+
+        const duration = performance.now() - start;
+
+        ctx.collector.record(METRICS.BUCKET_ROUNDTRIP_LATENCY, duration, 'ms', {
+          success: roundtripSuccess,
+          iteration: i
+        });
+      }
+
+      const stats = ctx.collector.getStats(METRICS.BUCKET_ROUNDTRIP_LATENCY);
+      if (stats) {
+        console.log(
+          `    p50=${stats.p50.toFixed(0)}ms  p95=${stats.p95.toFixed(0)}ms`
+        );
+      }
+
+      const rtRate = ctx.collector.getSuccessRate(
+        METRICS.BUCKET_ROUNDTRIP_LATENCY
+      );
+      expect(rtRate.rate).toBeGreaterThanOrEqual(PASS_THRESHOLD);
+    } finally {
+      await manager.unmountBucket(sandbox, mountPath);
+      for (const key of testKeys) {
+        await manager.deleteBucketObject(sandbox, key);
+      }
+    }
+  }, 600000);
+});

--- a/turbo.json
+++ b/turbo.json
@@ -94,14 +94,13 @@
         "vitest.perf.config.ts",
         "packages/sandbox/Dockerfile"
       ],
-      "env": [
-        "TEST_WORKER_URL",
-        "GITHUB_SHA",
-        "GITHUB_REF_NAME",
-        "GITHUB_EVENT_NAME",
-        "CI",
-        "PERF_RUN_ID"
-      ]
+      "passThroughEnv": [
+        "PERF_DEPLOYED_WORKER_URL",
+        "CLOUDFLARE_ACCOUNT_ID",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY"
+      ],
+      "env": ["GITHUB_SHA", "GITHUB_REF_NAME", "GITHUB_EVENT_NAME", "CI", "PERF_RUN_ID"]
     },
     "test:e2e:browser": {
       "dependsOn": ["^build", "docker:local"],


### PR DESCRIPTION
# Summary

Adds two new performance scenarios — **bucket mounting** and **backup & restore** — to the perf suite.

Both require FUSE access and R2 credentials that are only available on the deployed test worker, so they create their own `PerfSandboxManager` pointed at `PERF_DEPLOYED_WORKER_URL` and skip gracefully when it isn't set. This keeps them isolated from the rest of the suite, which continues to use the local wrangler dev server started by `global-setup.ts`.

To prevent existing scenarios from regressing back to running against the deployed worker, `TEST_WORKER_URL` is replaced with `PERF_DEPLOYED_WORKER_URL` throughout — existing scenarios never see the deployed URL and fall back to local dev as before.

# Changes

- **`tests/perf/scenarios/bucket-mounting.test.ts`** — measures s3fs mount/unmount latency and write, read, and write→read roundtrip I/O through a FUSE-mounted R2 bucket.
- **`tests/perf/scenarios/backup-restore.test.ts`** — measures backup creation (`mksquashfs` → R2) and restore latency across small, medium, and large directory sizes; includes post-restore read and write verification.
- **`tests/perf/helpers/perf-sandbox-manager.ts`** — adds `mountBucket`, `unmountBucket`, `createBackup`, `restoreBackup`, and bucket object CRUD helpers used by the new scenarios.
- **`tests/perf/helpers/constants.ts`** — adds `BACKUP_RESTORE` / `BUCKET_MOUNTING` scenario constants and associated metric keys.
- **`tests/e2e/test-worker/wrangler.perf.template.jsonc`** — adds `BACKUP_BUCKET` R2 binding required by the backup scenario.
- **`.github/workflows/performance.yml`** — registers both new scenarios in the dispatch list; swaps `TEST_WORKER_URL` → `PERF_DEPLOYED_WORKER_URL` and exposes `CLOUDFLARE_ACCOUNT_ID`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` to the test process (used by `mountOptions()` to pass credentials via request body).
- **`turbo.json`** — mirrors the `TEST_WORKER_URL` → `PERF_DEPLOYED_WORKER_URL` swap; adds `CLOUDFLARE_ACCOUNT_ID`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
