### PR TITLE
Add webhook for nightly performance summary

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -217,14 +217,14 @@ jobs:
         run: npx tsx tests/perf/scripts/ingest-to-d1.ts perf-results/latest.json
 
       - name: Call notifier webhook
-        if: always()
+        if: always() && secrets.PERF_NOTIFIER_WEBHOOK_URL != ''
         env:
           WEBHOOK_URL: ${{ secrets.PERF_NOTIFIER_WEBHOOK_URL }}
           WEBHOOK_SECRET: ${{ secrets.PERF_NOTIFIER_API_SECRET }}
           CF_ACCESS_CLIENT_ID: ${{ secrets.PERF_CF_ACCESS_CLIENT_ID }}
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.PERF_CF_ACCESS_CLIENT_SECRET }}
         run: |
-          curl -X POST $WEBHOOK_URL/api/notify \
+          curl -sf -X POST "$WEBHOOK_URL/api/notify" \
             -H "Authorization: Bearer $WEBHOOK_SECRET" \
             -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
             -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -218,8 +218,15 @@ jobs:
 
       - name: Call notifier webhook
         if: always()
+        env:
+          WEBHOOK_URL: ${{ secrets.PERF_NOTIFIER_WEBHOOK_URL }}
+          WEBHOOK_SECRET: ${{ secrets.PERF_NOTIFIER_API_SECRET }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.PERF_CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.PERF_CF_ACCESS_CLIENT_SECRET }}
         run: |
-          curl -X POST ${{ secrets.PERF_NOTIFIER_WEBHOOK_URL }}/api/notify \
-            -H "Authorization: Bearer ${{ secrets.PERF_NOTIFIER_API_SECRET }}" \
+          curl -X POST $WEBHOOK_URL/api/notify \
+            -H "Authorization: Bearer $WEBHOOK_SECRET" \
+            -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+            -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
             -H "Content-Type: application/json" \
             -d '{"run_id": "perf-${{ github.run_id }}"}'

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -217,8 +217,9 @@ jobs:
         run: npx tsx tests/perf/scripts/ingest-to-d1.ts perf-results/latest.json
 
       - name: Call notifier webhook
+        if: always()
         run: |
-          curl -X POST ${{ secrets.PERF_NOTIFIER_API_SECRET }}/api/notify \
-            -H "Authorization: Bearer ${{ secrets.PERF_NOTIFIER_WEBHOOK_URL }}" \
+          curl -X POST ${{ secrets.PERF_NOTIFIER_WEBHOOK_URL }}/api/notify \
+            -H "Authorization: Bearer ${{ secrets.PERF_NOTIFIER_API_SECRET }}" \
             -H "Content-Type: application/json" \
             -d '{"run_id": "perf-${{ github.run_id }}"}'

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -182,6 +182,7 @@ jobs:
         env:
           TEST_WORKER_URL: ${{ needs.setup.outputs.worker_url }}
           CI: true
+          PERF_RUN_ID: ${{ github.run_id }}
         run: |
           if [ "${{ inputs.scenario }}" = "all" ] || [ -z "${{ inputs.scenario }}" ]; then
             npm run test:perf
@@ -214,3 +215,10 @@ jobs:
           PERF_D1_RETENTION_DAYS: 90
           GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: npx tsx tests/perf/scripts/ingest-to-d1.ts perf-results/latest.json
+
+      - name: Call notifier webhook
+        run: |
+          curl -X POST ${{ secrets.PERF_NOTIFIER_API_SECRET }}/api/notify \
+            -H "Authorization: Bearer ${{ secrets.PERF_NOTIFIER_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d '{"run_id": "perf-${{ github.run_id }}"}'

--- a/tests/perf/helpers/report-generator.ts
+++ b/tests/perf/helpers/report-generator.ts
@@ -185,7 +185,9 @@ export class ReportGenerator {
     return {
       version: getSdkVersion(),
       timestamp: new Date().toISOString(),
-      runId: `perf-${Date.now()}`,
+      runId: process.env.PERF_RUN_ID
+        ? `perf-${process.env.PERF_RUN_ID}`
+        : `perf-${Date.now()}`,
       environment: {
         workerUrl,
         commitSha: process.env.GITHUB_SHA,

--- a/turbo.json
+++ b/turbo.json
@@ -99,7 +99,8 @@
         "GITHUB_SHA",
         "GITHUB_REF_NAME",
         "GITHUB_EVENT_NAME",
-        "CI"
+        "CI",
+        "PERF_RUN_ID"
       ]
     },
     "test:e2e:browser": {


### PR DESCRIPTION
# Summary

To tighten our feedback loop on sandbox-sdk performance, we've added a post-run webhook to the nightly performance workflow. This service analyses benchmark data, identifies statistical drift, and broadcasts a summary to our internal channels to ensure rapid response to performance regressions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
