### PR TITLE
Add timeouts to e2e fetch() requests

### DIFF
--- a/tests/e2e/_smoke.test.ts
+++ b/tests/e2e/_smoke.test.ts
@@ -31,10 +31,13 @@ describe('Integration Infrastructure Smoke Test', () => {
 
   test('should verify worker is running with health check', async () => {
     // Verify worker is running with health check
-    const response = await fetch(`${workerUrl}/health`);
+    const response = await fetch(`${workerUrl}/health`, {
+      signal: AbortSignal.timeout(1000)
+    });
     expect(response.status).toBe(200);
 
-    const data = (await response.json()) as HealthResponse;
-    expect(data.status).toBe('ok');
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({ status: 'ok' })
+    );
   });
 });

--- a/tests/e2e/backup-workflow.test.ts
+++ b/tests/e2e/backup-workflow.test.ts
@@ -41,7 +41,8 @@ async function cleanupDir(
     headers,
     body: JSON.stringify({
       command: `fusermount3 -u ${dir} 2>/dev/null || true; rm -rf ${dir}`
-    })
+    }),
+    signal: AbortSignal.timeout(5000)
   });
 }
 
@@ -81,7 +82,8 @@ describe('Backup Workflow E2E', () => {
     const probeResponse = await fetch(`${workerUrl}/api/backup/create`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ dir: '/nonexistent-probe-dir' })
+      body: JSON.stringify({ dir: '/nonexistent-probe-dir' }),
+      signal: AbortSignal.timeout(10000)
     });
     const probeText = await probeResponse.text();
     if (
@@ -115,7 +117,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `mkdir -p ${TEST_DIR} && echo "${TEST_CONTENT}" > ${TEST_DIR}/${TEST_FILE}`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
       expect(mkdirResponse.ok).toBe(true);
 
@@ -127,7 +130,8 @@ describe('Backup Workflow E2E', () => {
           dir: TEST_DIR,
           name: 'e2e-test-backup',
           ttl: 3600 // 1 hour
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
 
       if (!backupResponse.ok) {
@@ -145,7 +149,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `rm -rf ${TEST_DIR}/*`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
       expect(deleteResponse.ok).toBe(true);
 
@@ -155,7 +160,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `test -f ${TEST_DIR}/${TEST_FILE} && echo "exists" || echo "deleted"`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
       const checkDeletedResult =
         (await checkDeletedResponse.json()) as ExecuteResponse;
@@ -168,7 +174,8 @@ describe('Backup Workflow E2E', () => {
         body: JSON.stringify({
           id: backup.id,
           dir: TEST_DIR
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
       expect(restoreResponse.ok).toBe(true);
 
@@ -181,7 +188,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `cat ${TEST_DIR}/${TEST_FILE}`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
       const verifyResult = (await verifyResponse.json()) as ExecuteResponse;
       expect(verifyResult.exitCode).toBe(0);
@@ -210,7 +218,8 @@ describe('Backup Workflow E2E', () => {
             `echo "keep" > ${TEST_DIR}/keep.txt`,
             `echo "exclude-me" > ${TEST_DIR}/node_modules/a.txt`
           ].join(' && ')
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
       expect(setupResponse.ok).toBe(true);
 
@@ -219,7 +228,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           dir: TEST_DIR
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
       expect(backupResponse.ok).toBe(true);
       const backup = (await backupResponse.json()) as BackupResponse;
@@ -229,13 +239,15 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `rm -rf ${TEST_DIR} && mkdir -p ${TEST_DIR}`
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
 
       const restoreResponse = await fetch(`${workerUrl}/api/backup/restore`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ id: backup.id, dir: TEST_DIR })
+        body: JSON.stringify({ id: backup.id, dir: TEST_DIR }),
+        signal: AbortSignal.timeout(10000)
       });
       expect(restoreResponse.ok).toBe(true);
 
@@ -247,7 +259,8 @@ describe('Backup Workflow E2E', () => {
             `test -f ${TEST_DIR}/keep.txt && echo keep:yes || echo keep:no`,
             `test -e ${TEST_DIR}/node_modules/a.txt && echo excluded:no || echo excluded:yes`
           ].join('; ')
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
       const verifyResult = (await verifyResponse.json()) as ExecuteResponse;
       expect(verifyResult.exitCode).toBe(0);
@@ -274,7 +287,8 @@ describe('Backup Workflow E2E', () => {
             `echo "keep" > ${TEST_DIR}/keep.txt`,
             `echo "bundle" > ${TEST_DIR}/dist/app.js`
           ].join(' && ')
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
       expect(setupResponse.ok).toBe(true);
 
@@ -284,7 +298,8 @@ describe('Backup Workflow E2E', () => {
         body: JSON.stringify({
           dir: TEST_DIR,
           gitignore: false
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
       expect(backupResponse.ok).toBe(true);
       const backup = (await backupResponse.json()) as BackupResponse;
@@ -294,13 +309,15 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `rm -rf ${TEST_DIR} && mkdir -p ${TEST_DIR}`
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
 
       const restoreResponse = await fetch(`${workerUrl}/api/backup/restore`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ id: backup.id, dir: TEST_DIR })
+        body: JSON.stringify({ id: backup.id, dir: TEST_DIR }),
+        signal: AbortSignal.timeout(10000)
       });
       expect(restoreResponse.ok).toBe(true);
 
@@ -312,7 +329,8 @@ describe('Backup Workflow E2E', () => {
             `test -f ${TEST_DIR}/keep.txt && echo keep:yes || echo keep:no`,
             `test -e ${TEST_DIR}/dist/app.js && echo dist:yes || echo dist:no`
           ].join('; ')
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
       const verifyResult = (await verifyResponse.json()) as ExecuteResponse;
       expect(verifyResult.exitCode).toBe(0);
@@ -336,14 +354,16 @@ describe('Backup Workflow E2E', () => {
             `echo "keep" > ${TEST_DIR}/keep.txt`,
             `echo "bundle" > ${TEST_DIR}/dist/app.js`
           ].join(' && ')
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
       expect(setupResponse.ok).toBe(true);
 
       const backupResponse = await fetch(`${workerUrl}/api/backup/create`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ dir: TEST_DIR })
+        body: JSON.stringify({ dir: TEST_DIR }),
+        signal: AbortSignal.timeout(10000)
       });
       expect(backupResponse.ok).toBe(true);
       const backup = (await backupResponse.json()) as BackupResponse;
@@ -353,13 +373,15 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `rm -rf ${TEST_DIR} && mkdir -p ${TEST_DIR}`
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
 
       const restoreResponse = await fetch(`${workerUrl}/api/backup/restore`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ id: backup.id, dir: TEST_DIR })
+        body: JSON.stringify({ id: backup.id, dir: TEST_DIR }),
+        signal: AbortSignal.timeout(10000)
       });
       expect(restoreResponse.ok).toBe(true);
 
@@ -371,7 +393,8 @@ describe('Backup Workflow E2E', () => {
             `test -f ${TEST_DIR}/keep.txt && echo keep:yes || echo keep:no`,
             `test -e ${TEST_DIR}/dist/app.js && echo dist:yes || echo dist:no`
           ].join('; ')
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
       const verifyResult = (await verifyResponse.json()) as ExecuteResponse;
       expect(verifyResult.exitCode).toBe(0);
@@ -400,14 +423,16 @@ describe('Backup Workflow E2E', () => {
             `echo "bundle" > ${TEST_DIR}/dist/app.js`,
             `echo "ignored" > ${TEST_DIR}/server.log`
           ].join(' && ')
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
       expect(setupResponse.ok).toBe(true);
 
       const backupResponse = await fetch(`${workerUrl}/api/backup/create`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ dir: TEST_DIR, gitignore: true })
+        body: JSON.stringify({ dir: TEST_DIR, gitignore: true }),
+        signal: AbortSignal.timeout(10000)
       });
       expect(backupResponse.ok).toBe(true);
       const backup = (await backupResponse.json()) as BackupResponse;
@@ -417,13 +442,15 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `rm -rf ${TEST_DIR} && mkdir -p ${TEST_DIR}`
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
 
       const restoreResponse = await fetch(`${workerUrl}/api/backup/restore`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ id: backup.id, dir: TEST_DIR })
+        body: JSON.stringify({ id: backup.id, dir: TEST_DIR }),
+        signal: AbortSignal.timeout(10000)
       });
       expect(restoreResponse.ok).toBe(true);
 
@@ -436,7 +463,8 @@ describe('Backup Workflow E2E', () => {
             `test -e ${TEST_DIR}/dist/app.js && echo dist:no || echo dist:yes`,
             `test -e ${TEST_DIR}/server.log && echo log:no || echo log:yes`
           ].join('; ')
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
       const verifyResult = (await verifyResponse.json()) as ExecuteResponse;
       expect(verifyResult.exitCode).toBe(0);
@@ -465,7 +493,8 @@ describe('Backup Workflow E2E', () => {
             `echo 'export const VERSION = "1.0.0"' > ${PROJECT_DIR}/src/utils/version.js`,
             `echo '{"port": 3000}' > ${PROJECT_DIR}/config/settings.json`
           ].join(' && ')
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
       expect(setupResponse.ok).toBe(true);
 
@@ -475,7 +504,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `find ${PROJECT_DIR} -type f | sort | xargs md5sum`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
       const checksumBeforeResult =
         (await checksumBeforeResponse.json()) as ExecuteResponse;
@@ -490,7 +520,8 @@ describe('Backup Workflow E2E', () => {
           dir: PROJECT_DIR,
           name: 'nested-tree-backup',
           ttl: 3600
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
 
       if (!backupResponse.ok) {
@@ -507,7 +538,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `rm -rf ${PROJECT_DIR}/*`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
       expect(deleteResponse.ok).toBe(true);
 
@@ -517,7 +549,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `find ${PROJECT_DIR} -type f | wc -l`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
       const verifyDeletedResult =
         (await verifyDeletedResponse.json()) as ExecuteResponse;
@@ -530,7 +563,8 @@ describe('Backup Workflow E2E', () => {
         body: JSON.stringify({
           id: backup.id,
           dir: PROJECT_DIR
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
       expect(restoreResponse.ok).toBe(true);
 
@@ -540,7 +574,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `find ${PROJECT_DIR} -type f | sort | xargs md5sum`
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
       const checksumAfterResult =
         (await checksumAfterResponse.json()) as ExecuteResponse;
@@ -562,14 +597,16 @@ describe('Backup Workflow E2E', () => {
       await fetch(`${workerUrl}/api/execute`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ command: `mkdir -p ${EMPTY_DIR}` })
+        body: JSON.stringify({ command: `mkdir -p ${EMPTY_DIR}` }),
+        signal: AbortSignal.timeout(5000)
       });
 
       // Create backup
       const backupResponse = await fetch(`${workerUrl}/api/backup/create`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ dir: EMPTY_DIR })
+        body: JSON.stringify({ dir: EMPTY_DIR }),
+        signal: AbortSignal.timeout(10000)
       });
 
       expect(backupResponse.ok).toBe(true);
@@ -579,13 +616,15 @@ describe('Backup Workflow E2E', () => {
       await fetch(`${workerUrl}/api/execute`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ command: `rm -rf ${EMPTY_DIR}` })
+        body: JSON.stringify({ command: `rm -rf ${EMPTY_DIR}` }),
+        signal: AbortSignal.timeout(10000)
       });
 
       const restoreResponse = await fetch(`${workerUrl}/api/backup/restore`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ id: backup.id, dir: EMPTY_DIR })
+        body: JSON.stringify({ id: backup.id, dir: EMPTY_DIR }),
+        signal: AbortSignal.timeout(10000)
       });
       expect(restoreResponse.ok).toBe(true);
 
@@ -595,7 +634,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `test -d ${EMPTY_DIR} && echo "exists" || echo "missing"`
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
       const verifyResult = (await verifyResponse.json()) as ExecuteResponse;
       expect(verifyResult.stdout?.trim()).toBe('exists');
@@ -617,7 +657,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `mkdir -p ${TEST_DIR} && echo "test" > ${TEST_DIR}/file.txt`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       // Create backup with very short TTL (1 second)
@@ -627,7 +668,8 @@ describe('Backup Workflow E2E', () => {
         body: JSON.stringify({
           dir: TEST_DIR,
           ttl: 1 // 1 second TTL
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
 
       expect(backupResponse.ok).toBe(true);
@@ -641,7 +683,8 @@ describe('Backup Workflow E2E', () => {
       const restoreResponse = await fetch(`${workerUrl}/api/backup/restore`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ id: backup.id, dir: TEST_DIR })
+        body: JSON.stringify({ id: backup.id, dir: TEST_DIR }),
+        signal: AbortSignal.timeout(10000)
       });
 
       // Should fail with 400 (BACKUP_EXPIRED)
@@ -666,7 +709,8 @@ describe('Backup Workflow E2E', () => {
         body: JSON.stringify({
           id: fakeBackupId,
           dir: '/workspace/test'
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
 
       // Should fail with 404 (BACKUP_NOT_FOUND)
@@ -684,7 +728,8 @@ describe('Backup Workflow E2E', () => {
         body: JSON.stringify({
           id: 'not-a-valid-uuid',
           dir: '/workspace/test'
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
 
       // Should fail with 400 (INVALID_BACKUP_CONFIG or validation error)
@@ -701,7 +746,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           dir: 'relative/path' // Not absolute
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
 
       // Should fail with 400 (validation error)
@@ -716,7 +762,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           dir: '/workspace/../../../etc/passwd'
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
 
       // Should fail with 400 (validation error)
@@ -737,7 +784,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `mkdir -p ${DIR_A} ${DIR_B} && echo "content-a" > ${DIR_A}/file.txt && echo "content-b" > ${DIR_B}/file.txt`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       // Start both backups concurrently
@@ -769,7 +817,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `rm -rf ${DIR_A}/* ${DIR_B}/*`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       // Restore both backups
@@ -795,7 +844,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `cat ${DIR_A}/file.txt && echo "---" && cat ${DIR_B}/file.txt`
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
       const verifyResult = (await verifyResponse.json()) as ExecuteResponse;
       const [contentA, , contentB] = (verifyResult.stdout || '').split('\n');
@@ -825,14 +875,16 @@ describe('Backup Workflow E2E', () => {
             `echo "emoji content" > "${TEST_DIR}/emoji-🎉-file.txt"`,
             `echo "unicode content" > "${TEST_DIR}/日本語ファイル.txt"`
           ].join(' && ')
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       // Create backup
       const backupResponse = await fetch(`${workerUrl}/api/backup/create`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ dir: TEST_DIR })
+        body: JSON.stringify({ dir: TEST_DIR }),
+        signal: AbortSignal.timeout(10000)
       });
 
       if (!backupResponse.ok) {
@@ -846,14 +898,16 @@ describe('Backup Workflow E2E', () => {
       await fetch(`${workerUrl}/api/execute`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ command: `rm -rf "${TEST_DIR}"/*` })
+        body: JSON.stringify({ command: `rm -rf "${TEST_DIR}"/*` }),
+        signal: AbortSignal.timeout(10000)
       });
 
       // Restore
       const restoreResponse = await fetch(`${workerUrl}/api/backup/restore`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ id: backup.id, dir: TEST_DIR })
+        body: JSON.stringify({ id: backup.id, dir: TEST_DIR }),
+        signal: AbortSignal.timeout(10000)
       });
       expect(restoreResponse.ok).toBe(true);
 
@@ -863,7 +917,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `cat "${TEST_DIR}/file with spaces.txt" && cat "${TEST_DIR}/emoji-🎉-file.txt" && cat "${TEST_DIR}/日本語ファイル.txt"`
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
       const verifyResult = (await verifyResponse.json()) as ExecuteResponse;
       expect(verifyResult.exitCode).toBe(0);
@@ -889,14 +944,16 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `mkdir -p ${ORIGINAL_DIR}/subdir && echo "original" > ${ORIGINAL_DIR}/file.txt && echo "nested" > ${ORIGINAL_DIR}/subdir/nested.txt`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       // Create backup of original
       const backupResponse = await fetch(`${workerUrl}/api/backup/create`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ dir: ORIGINAL_DIR })
+        body: JSON.stringify({ dir: ORIGINAL_DIR }),
+        signal: AbortSignal.timeout(10000)
       });
 
       expect(backupResponse.ok).toBe(true);
@@ -906,7 +963,8 @@ describe('Backup Workflow E2E', () => {
       const restoreResponse = await fetch(`${workerUrl}/api/backup/restore`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ id: backup.id, dir: RESTORE_DIR })
+        body: JSON.stringify({ id: backup.id, dir: RESTORE_DIR }),
+        signal: AbortSignal.timeout(10000)
       });
       expect(restoreResponse.ok).toBe(true);
 
@@ -916,7 +974,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `cat ${RESTORE_DIR}/file.txt && cat ${RESTORE_DIR}/subdir/nested.txt`
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
       const verifyResult = (await verifyResponse.json()) as ExecuteResponse;
       expect(verifyResult.exitCode).toBe(0);
@@ -927,7 +986,8 @@ describe('Backup Workflow E2E', () => {
       const originalCheck = await fetch(`${workerUrl}/api/execute`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ command: `cat ${ORIGINAL_DIR}/file.txt` })
+        body: JSON.stringify({ command: `cat ${ORIGINAL_DIR}/file.txt` }),
+        signal: AbortSignal.timeout(5000)
       });
       const originalResult = (await originalCheck.json()) as ExecuteResponse;
       expect(originalResult.stdout?.trim()).toBe('original');
@@ -950,14 +1010,16 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `mkdir -p ${TEST_DIR} && echo "original" > ${TEST_DIR}/file.txt`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       // Create backup
       const backupResponse = await fetch(`${workerUrl}/api/backup/create`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ dir: TEST_DIR })
+        body: JSON.stringify({ dir: TEST_DIR }),
+        signal: AbortSignal.timeout(10000)
       });
       expect(backupResponse.ok).toBe(true);
       const backup = (await backupResponse.json()) as BackupResponse;
@@ -966,13 +1028,15 @@ describe('Backup Workflow E2E', () => {
       await fetch(`${workerUrl}/api/execute`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ command: `rm -rf ${TEST_DIR}/*` })
+        body: JSON.stringify({ command: `rm -rf ${TEST_DIR}/*` }),
+        signal: AbortSignal.timeout(10000)
       });
 
       const restoreResponse = await fetch(`${workerUrl}/api/backup/restore`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ id: backup.id, dir: TEST_DIR })
+        body: JSON.stringify({ id: backup.id, dir: TEST_DIR }),
+        signal: AbortSignal.timeout(10000)
       });
       expect(restoreResponse.ok).toBe(true);
 
@@ -982,7 +1046,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `echo "modified" > ${TEST_DIR}/file.txt && echo "new file" > ${TEST_DIR}/new.txt`
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
 
       // Verify modified content
@@ -991,7 +1056,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `cat ${TEST_DIR}/file.txt && cat ${TEST_DIR}/new.txt`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
       const modifiedResult = (await modifiedCheck.json()) as ExecuteResponse;
       expect(modifiedResult.stdout).toContain('modified');
@@ -1003,7 +1069,8 @@ describe('Backup Workflow E2E', () => {
       const restore2Response = await fetch(`${workerUrl}/api/backup/restore`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ id: backup.id, dir: TEST_DIR })
+        body: JSON.stringify({ id: backup.id, dir: TEST_DIR }),
+        signal: AbortSignal.timeout(10000)
       });
       expect(restore2Response.ok).toBe(true);
 
@@ -1011,7 +1078,8 @@ describe('Backup Workflow E2E', () => {
       const originalCheck = await fetch(`${workerUrl}/api/execute`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ command: `cat ${TEST_DIR}/file.txt` })
+        body: JSON.stringify({ command: `cat ${TEST_DIR}/file.txt` }),
+        signal: AbortSignal.timeout(10000)
       });
       const originalResult = (await originalCheck.json()) as ExecuteResponse;
       expect(originalResult.stdout?.trim()).toBe('original');
@@ -1022,7 +1090,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `test -f ${TEST_DIR}/new.txt && echo "exists" || echo "missing"`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
       const newFileResult = (await newFileCheck.json()) as ExecuteResponse;
       expect(newFileResult.stdout?.trim()).toBe('missing');
@@ -1044,13 +1113,15 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `mkdir -p ${TEST_DIR} && echo "test" > ${TEST_DIR}/file.txt`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       const backupResponse = await fetch(`${workerUrl}/api/backup/create`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ dir: TEST_DIR })
+        body: JSON.stringify({ dir: TEST_DIR }),
+        signal: AbortSignal.timeout(10000)
       });
       expect(backupResponse.ok).toBe(true);
       const backup = (await backupResponse.json()) as BackupResponse;
@@ -1059,7 +1130,8 @@ describe('Backup Workflow E2E', () => {
       await fetch(`${workerUrl}/api/execute`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ command: `rm -rf ${TEST_DIR}` })
+        body: JSON.stringify({ command: `rm -rf ${TEST_DIR}` }),
+        signal: AbortSignal.timeout(10000)
       });
 
       // Try to restore to an invalid path (should fail)
@@ -1068,7 +1140,8 @@ describe('Backup Workflow E2E', () => {
         {
           method: 'POST',
           headers,
-          body: JSON.stringify({ id: backup.id, dir: '/proc/invalid-restore' })
+          body: JSON.stringify({ id: backup.id, dir: '/proc/invalid-restore' }),
+          signal: AbortSignal.timeout(10000)
         }
       );
 
@@ -1081,7 +1154,8 @@ describe('Backup Workflow E2E', () => {
         headers,
         body: JSON.stringify({
           command: `mount | grep -c "overlay.*${backup.id}" 2>/dev/null || true`
-        })
+        }),
+        signal: AbortSignal.timeout(10000)
       });
       const mountResult = (await mountCheck.json()) as ExecuteResponse;
       // Should be 0 (no orphan mounts) - grep -c returns "0" when no matches
@@ -1091,7 +1165,8 @@ describe('Backup Workflow E2E', () => {
       await fetch(`${workerUrl}/api/execute`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ command: `mkdir -p ${TEST_DIR}` })
+        body: JSON.stringify({ command: `mkdir -p ${TEST_DIR}` }),
+        signal: AbortSignal.timeout(5000)
       });
 
       const validRestoreResponse = await fetch(
@@ -1099,7 +1174,8 @@ describe('Backup Workflow E2E', () => {
         {
           method: 'POST',
           headers,
-          body: JSON.stringify({ id: backup.id, dir: TEST_DIR })
+          body: JSON.stringify({ id: backup.id, dir: TEST_DIR }),
+          signal: AbortSignal.timeout(10000)
         }
       );
       expect(validRestoreResponse.ok).toBe(true);
@@ -1108,7 +1184,8 @@ describe('Backup Workflow E2E', () => {
       const verifyResponse = await fetch(`${workerUrl}/api/execute`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ command: `cat ${TEST_DIR}/file.txt` })
+        body: JSON.stringify({ command: `cat ${TEST_DIR}/file.txt` }),
+        signal: AbortSignal.timeout(10000)
       });
       const verifyResult = (await verifyResponse.json()) as ExecuteResponse;
       expect(verifyResult.stdout?.trim()).toBe('test');

--- a/tests/e2e/backup-workflow.test.ts
+++ b/tests/e2e/backup-workflow.test.ts
@@ -689,8 +689,9 @@ describe('Backup Workflow E2E', () => {
 
       // Should fail with 400 (BACKUP_EXPIRED)
       expect(restoreResponse.status).toBe(400);
-      const errorResult = (await restoreResponse.json()) as ErrorResponse;
-      expect(errorResult.code).toBe('BACKUP_EXPIRED');
+      await expect(restoreResponse.json()).resolves.toEqual(
+        expect.objectContaining({ code: 'BACKUP_EXPIRED' })
+      );
 
       // Cleanup (unmounts FUSE overlay if present, then removes directory)
       await cleanupDir(workerUrl, headers, TEST_DIR);
@@ -715,8 +716,9 @@ describe('Backup Workflow E2E', () => {
 
       // Should fail with 404 (BACKUP_NOT_FOUND)
       expect(restoreResponse.status).toBe(404);
-      const errorResult = (await restoreResponse.json()) as ErrorResponse;
-      expect(errorResult.code).toBe('BACKUP_NOT_FOUND');
+      await expect(restoreResponse.json()).resolves.toEqual(
+        expect.objectContaining({ code: 'BACKUP_NOT_FOUND' })
+      );
     }, 30000);
 
     test('should reject invalid backup ID format', async () => {

--- a/tests/e2e/bucket-mounting.test.ts
+++ b/tests/e2e/bucket-mounting.test.ts
@@ -77,7 +77,8 @@ describe('Bucket Mounting E2E', () => {
             key: PRE_EXISTING_FILE,
             content: PRE_EXISTING_CONTENT,
             contentType: 'text/plain'
-          })
+          }),
+          signal: AbortSignal.timeout(5000)
         });
         expect(putResponse.ok).toBe(true);
 
@@ -91,7 +92,8 @@ describe('Bucket Mounting E2E', () => {
             options: {
               endpoint: `https://${process.env.CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com`
             }
-          })
+          }),
+          signal: AbortSignal.timeout(5000)
         });
         expect(mountResponse.ok).toBe(true);
         const mountResult = (await mountResponse.json()) as SuccessResponse;
@@ -105,7 +107,8 @@ describe('Bucket Mounting E2E', () => {
             headers,
             body: JSON.stringify({
               command: `cat ${MOUNT_PATH}/${PRE_EXISTING_FILE}`
-            })
+            }),
+            signal: AbortSignal.timeout(5000)
           }
         );
         const readPreExistingResult =
@@ -119,7 +122,8 @@ describe('Bucket Mounting E2E', () => {
           headers,
           body: JSON.stringify({
             command: `echo "${TEST_CONTENT}" > ${MOUNT_PATH}/${TEST_FILE}`
-          })
+          }),
+          signal: AbortSignal.timeout(5000)
         });
         const writeResult = (await writeResponse.json()) as ExecResult;
         expect(writeResult.exitCode).toBe(0);
@@ -129,7 +133,8 @@ describe('Bucket Mounting E2E', () => {
           `${workerUrl}/api/bucket/get?key=${TEST_FILE}`,
           {
             method: 'GET',
-            headers
+            headers,
+            signal: AbortSignal.timeout(5000)
           }
         );
         expect(getResponse.ok).toBe(true);
@@ -141,7 +146,8 @@ describe('Bucket Mounting E2E', () => {
         const unmountResponse = await fetch(`${workerUrl}/api/bucket/unmount`, {
           method: 'POST',
           headers,
-          body: JSON.stringify({ mountPath: MOUNT_PATH })
+          body: JSON.stringify({ mountPath: MOUNT_PATH }),
+          signal: AbortSignal.timeout(5000)
         });
         expect(unmountResponse.ok).toBe(true);
         const unmountResult =
@@ -154,7 +160,8 @@ describe('Bucket Mounting E2E', () => {
           headers,
           body: JSON.stringify({
             command: `mountpoint -q ${MOUNT_PATH}`
-          })
+          }),
+          signal: AbortSignal.timeout(5000)
         });
         const mountCheckResult = (await mountCheck.json()) as ExecResult;
         expect(mountCheckResult.exitCode).not.toBe(0);
@@ -165,7 +172,8 @@ describe('Bucket Mounting E2E', () => {
           headers,
           body: JSON.stringify({
             command: `test -d ${MOUNT_PATH}`
-          })
+          }),
+          signal: AbortSignal.timeout(5000)
         });
         const dirCheckResult = (await dirCheck.json()) as ExecResult;
         expect(dirCheckResult.exitCode).not.toBe(0);
@@ -174,26 +182,30 @@ describe('Bucket Mounting E2E', () => {
         await fetch(`${workerUrl}/api/bucket/delete`, {
           method: 'POST',
           headers,
-          body: JSON.stringify({ key: PRE_EXISTING_FILE })
+          body: JSON.stringify({ key: PRE_EXISTING_FILE }),
+          signal: AbortSignal.timeout(5000)
         });
 
         await fetch(`${workerUrl}/api/bucket/delete`, {
           method: 'POST',
           headers,
-          body: JSON.stringify({ key: TEST_FILE })
+          body: JSON.stringify({ key: TEST_FILE }),
+          signal: AbortSignal.timeout(5000)
         });
       } catch (error) {
         // Cleanup on error
         await fetch(`${workerUrl}/api/bucket/delete`, {
           method: 'POST',
           headers,
-          body: JSON.stringify({ key: PRE_EXISTING_FILE })
+          body: JSON.stringify({ key: PRE_EXISTING_FILE }),
+          signal: AbortSignal.timeout(5000)
         }).catch(() => {});
 
         await fetch(`${workerUrl}/api/bucket/delete`, {
           method: 'POST',
           headers,
-          body: JSON.stringify({ key: TEST_FILE })
+          body: JSON.stringify({ key: TEST_FILE }),
+          signal: AbortSignal.timeout(5000)
         }).catch(() => {});
 
         throw error;

--- a/tests/e2e/bucket-mounting.test.ts
+++ b/tests/e2e/bucket-mounting.test.ts
@@ -96,8 +96,9 @@ describe('Bucket Mounting E2E', () => {
           signal: AbortSignal.timeout(5000)
         });
         expect(mountResponse.ok).toBe(true);
-        const mountResult = (await mountResponse.json()) as SuccessResponse;
-        expect(mountResult.success).toBe(true);
+        await expect(mountResponse.json()).resolves.toEqual(
+          expect.objectContaining({ success: true })
+        );
 
         // 3. Verify pre-existing R2 file appears in mount (R2 → Mount)
         const readPreExistingResponse = await fetch(
@@ -125,8 +126,9 @@ describe('Bucket Mounting E2E', () => {
           }),
           signal: AbortSignal.timeout(5000)
         });
-        const writeResult = (await writeResponse.json()) as ExecResult;
-        expect(writeResult.exitCode).toBe(0);
+        await expect(writeResponse.json()).resolves.toEqual(
+          expect.objectContaining({ exitCode: 0 })
+        );
 
         // 5. Verify new file appears in R2 via binding (Mount → R2)
         const getResponse = await fetch(

--- a/tests/e2e/build-test-workflow.test.ts
+++ b/tests/e2e/build-test-workflow.test.ts
@@ -1,4 +1,3 @@
-import type { ExecResult, ReadFileResult, WriteFileResult } from '@repo/shared';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import {
   cleanupTestSandbox,

--- a/tests/e2e/build-test-workflow.test.ts
+++ b/tests/e2e/build-test-workflow.test.ts
@@ -38,9 +38,12 @@ describe('Build and Test Workflow', () => {
       });
 
       expect(echoResponse.status).toBe(200);
-      const echoData = (await echoResponse.json()) as ExecResult;
-      expect(echoData.exitCode).toBe(0);
-      expect(echoData.stdout).toContain('Hello from sandbox');
+      await expect(echoResponse.json()).resolves.toEqual(
+        expect.objectContaining({
+          exitCode: 0,
+          stdout: expect.stringContaining('Hello from sandbox')
+        })
+      );
 
       // Step 2: Write a file (using absolute path per README pattern)
       const writeResponse = await fetch(`${workerUrl}/api/file/write`, {
@@ -54,8 +57,9 @@ describe('Build and Test Workflow', () => {
       });
 
       expect(writeResponse.status).toBe(200);
-      const writeData = (await writeResponse.json()) as WriteFileResult;
-      expect(writeData.success).toBe(true);
+      await expect(writeResponse.json()).resolves.toEqual(
+        expect.objectContaining({ success: true })
+      );
 
       // Step 3: Read the file back to verify persistence
       const readResponse = await fetch(`${workerUrl}/api/file/read`, {
@@ -68,8 +72,9 @@ describe('Build and Test Workflow', () => {
       });
 
       expect(readResponse.status).toBe(200);
-      const readData = (await readResponse.json()) as ReadFileResult;
-      expect(readData.content).toBe('Integration test content');
+      await expect(readResponse.json()).resolves.toEqual(
+        expect.objectContaining({ content: 'Integration test content' })
+      );
 
       // Step 4: Verify pwd to understand working directory
       const pwdResponse = await fetch(`${workerUrl}/api/execute`, {
@@ -82,8 +87,11 @@ describe('Build and Test Workflow', () => {
       });
 
       expect(pwdResponse.status).toBe(200);
-      const pwdData = (await pwdResponse.json()) as ExecResult;
-      expect(pwdData.stdout).toMatch(/\/workspace/);
+      await expect(pwdResponse.json()).resolves.toEqual(
+        expect.objectContaining({
+          stdout: expect.stringMatching(/\/workspace/)
+        })
+      );
     });
 
     test('should detect shell termination when exit command is used', async () => {
@@ -101,14 +109,12 @@ describe('Build and Test Workflow', () => {
       // Shell exit should surface as 410 SESSION_TERMINATED per the
       // SESSION_TERMINATED contract (see .changeset/session-terminated.md).
       expect(response.status).toBe(410);
-      const data = (await response.json()) as ErrorResponse & {
-        code?: string;
-      };
-
-      expect(data.error).toBeDefined();
-      expect(data.code).toBe('SESSION_TERMINATED');
-      expect(data.error).toMatch(/shell exited/i);
-      expect(data.error).toMatch(/exit code:?\s*1/i);
+      await expect(response.json()).resolves.toEqual(
+        expect.objectContaining({
+          code: 'SESSION_TERMINATED',
+          error: expect.stringMatching(/shell exited/i)
+        })
+      );
     });
 
     afterAll(async () => {

--- a/tests/e2e/build-test-workflow.test.ts
+++ b/tests/e2e/build-test-workflow.test.ts
@@ -33,7 +33,8 @@ describe('Build and Test Workflow', () => {
         headers,
         body: JSON.stringify({
           command: 'echo "Hello from sandbox"'
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(echoResponse.status).toBe(200);
@@ -48,7 +49,8 @@ describe('Build and Test Workflow', () => {
         body: JSON.stringify({
           path: '/test-file.txt',
           content: 'Integration test content'
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(writeResponse.status).toBe(200);
@@ -61,7 +63,8 @@ describe('Build and Test Workflow', () => {
         headers,
         body: JSON.stringify({
           path: '/test-file.txt'
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(readResponse.status).toBe(200);
@@ -74,7 +77,8 @@ describe('Build and Test Workflow', () => {
         headers,
         body: JSON.stringify({
           command: 'pwd'
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(pwdResponse.status).toBe(200);
@@ -90,7 +94,8 @@ describe('Build and Test Workflow', () => {
         headers,
         body: JSON.stringify({
           command: 'exit 1'
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       // Shell exit should surface as 410 SESSION_TERMINATED per the

--- a/tests/e2e/command-timeout.test.ts
+++ b/tests/e2e/command-timeout.test.ts
@@ -65,9 +65,11 @@ describe('Command Timeout', () => {
     const elapsed = Date.now() - startTime;
 
     expect(response.status).toBe(500);
-    const data = (await response.json()) as ErrorResponse;
-    expect(data.error).toBeDefined();
-    expect(data.error).toMatch(/timeout/i);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: expect.stringMatching(/timeout/i)
+      })
+    );
 
     // Command timeout is 1s — elapsed should be well under 15s even with CI latency
     expect(elapsed).toBeLessThan(15000);
@@ -108,9 +110,11 @@ describe('Command Timeout', () => {
     const elapsed = Date.now() - startTime;
 
     expect(execResponse.status).toBe(500);
-    const execData = (await execResponse.json()) as ErrorResponse;
-    expect(execData.error).toBeDefined();
-    expect(execData.error).toMatch(/timeout/i);
+    await expect(execResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: expect.stringMatching(/timeout/i)
+      })
+    );
 
     // Command timeout is 1s — elapsed should be well under 15s even with CI latency
     expect(elapsed).toBeLessThan(15000);
@@ -153,9 +157,11 @@ describe('Command Timeout', () => {
     const elapsed = Date.now() - startTime;
 
     expect(execResponse.status).toBe(500);
-    const execData = (await execResponse.json()) as ErrorResponse;
-    expect(execData.error).toBeDefined();
-    expect(execData.error).toMatch(/timeout/i);
+    await expect(execResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: expect.stringMatching(/timeout/i)
+      })
+    );
 
     // Session-level timeout is 1s — elapsed should be well under 15s even with CI latency
     expect(elapsed).toBeLessThan(15000);
@@ -201,8 +207,11 @@ describe('Command Timeout', () => {
     const elapsed = Date.now() - startTime;
 
     expect(execResponse.status).toBe(500);
-    const execData = (await execResponse.json()) as ErrorResponse;
-    expect(execData.error).toMatch(/timeout/i);
+    await expect(execResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: expect.stringMatching(/timeout/i)
+      })
+    );
 
     // Should have timed out in ~1s, not ~30s
     expect(elapsed).toBeLessThan(10000);
@@ -247,8 +256,11 @@ describe('Command Timeout', () => {
     const elapsed = Date.now() - startTime;
 
     expect(execResponse.status).toBe(500);
-    const execData = (await execResponse.json()) as ErrorResponse;
-    expect(execData.error).toMatch(/timeout/i);
+    await expect(execResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: expect.stringMatching(/timeout/i)
+      })
+    );
 
     // Command timeout is 1s — elapsed should be well under 15s even with CI latency
     expect(elapsed).toBeLessThan(15000);
@@ -282,8 +294,9 @@ describe('Command Timeout', () => {
     );
 
     expect(deleteResponse.status).toBe(200);
-    const deleteData = (await deleteResponse.json()) as SessionDeleteResult;
-    expect(deleteData.success).toBe(true);
+    await expect(deleteResponse.json()).resolves.toEqual(
+      expect.objectContaining({ success: true })
+    );
 
     // Wait briefly for process cleanup after session destruction
     await new Promise((resolve) => setTimeout(resolve, 1000));

--- a/tests/e2e/command-timeout.test.ts
+++ b/tests/e2e/command-timeout.test.ts
@@ -1,8 +1,4 @@
-import type {
-  ExecResult,
-  SessionCreateResult,
-  SessionDeleteResult
-} from '@repo/shared';
+import type { ExecResult, SessionCreateResult } from '@repo/shared';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import {
   cleanupTestSandbox,
@@ -11,7 +7,6 @@ import {
   type TestSandbox
 } from './helpers/global-sandbox';
 import { createTestHeaders } from './helpers/test-fixtures';
-import type { ErrorResponse } from './test-worker/types';
 
 // Diagnostic instrumentation for #482 flake investigation.
 // Remove once root cause is confirmed.

--- a/tests/e2e/comprehensive-workflow.test.ts
+++ b/tests/e2e/comprehensive-workflow.test.ts
@@ -100,8 +100,9 @@ describe('Comprehensive Workflow', () => {
       });
 
       expect(cloneResponse.status).toBe(200);
-      const cloneData = (await cloneResponse.json()) as GitCheckoutResult;
-      expect(cloneData.success).toBe(true);
+      await expect(cloneResponse.json()).resolves.toEqual(
+        expect.objectContaining({ success: true })
+      );
 
       // Verify repo structure using listFiles
       const listResponse = await fetch(`${workerUrl}/api/list-files`, {
@@ -128,8 +129,9 @@ describe('Comprehensive Workflow', () => {
       });
 
       expect(readReadmeResponse.status).toBe(200);
-      const readmeData = (await readReadmeResponse.json()) as ReadFileResult;
-      expect(readmeData.content).toContain('Hello');
+      await expect(readReadmeResponse.json()).resolves.toEqual(
+        expect.objectContaining({ content: expect.stringContaining('Hello') })
+      );
 
       // Create a new directory structure
       const mkdirResponse = await fetch(`${workerUrl}/api/file/mkdir`, {
@@ -209,8 +211,9 @@ export function greet(name) {
       });
 
       expect(readRenamedResponse.status).toBe(200);
-      const renamedData = (await readRenamedResponse.json()) as ReadFileResult;
-      expect(renamedData.content).toContain('greet');
+      await expect(readRenamedResponse.json()).resolves.toEqual(
+        expect.objectContaining({ content: expect.stringContaining('greet') })
+      );
 
       // Phase 3: Run commands with environment
 

--- a/tests/e2e/comprehensive-workflow.test.ts
+++ b/tests/e2e/comprehensive-workflow.test.ts
@@ -58,7 +58,8 @@ describe('Comprehensive Workflow', () => {
           BUILD_ENV: 'test',
           API_KEY: 'test-key-123'
         }
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     if (!setEnvResponse.ok) {
@@ -94,7 +95,8 @@ describe('Comprehensive Workflow', () => {
           repoUrl: 'https://github.com/octocat/Hello-World',
           branch: 'master',
           targetDir: testDir
-        })
+        }),
+        signal: AbortSignal.timeout(30000)
       });
 
       expect(cloneResponse.status).toBe(200);
@@ -105,7 +107,8 @@ describe('Comprehensive Workflow', () => {
       const listResponse = await fetch(`${workerUrl}/api/list-files`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ path: testDir })
+        body: JSON.stringify({ path: testDir }),
+        signal: AbortSignal.timeout(30000)
       });
 
       expect(listResponse.status).toBe(200);
@@ -120,7 +123,8 @@ describe('Comprehensive Workflow', () => {
       const readReadmeResponse = await fetch(`${workerUrl}/api/file/read`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ path: `${testDir}/README` })
+        body: JSON.stringify({ path: `${testDir}/README` }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(readReadmeResponse.status).toBe(200);
@@ -134,7 +138,8 @@ describe('Comprehensive Workflow', () => {
         body: JSON.stringify({
           path: `${testDir}/src/utils`,
           recursive: true
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(mkdirResponse.status).toBe(200);
@@ -156,7 +161,8 @@ describe('Comprehensive Workflow', () => {
         body: JSON.stringify({
           path: `${testDir}/config.json`,
           content: configContent
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(writeConfigResponse.status).toBe(200);
@@ -175,7 +181,8 @@ export function greet(name) {
         body: JSON.stringify({
           path: `${testDir}/src/utils/greet.js`,
           content: sourceCode
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       // Rename the file
@@ -185,7 +192,8 @@ export function greet(name) {
         body: JSON.stringify({
           oldPath: `${testDir}/src/utils/greet.js`,
           newPath: `${testDir}/src/utils/greeter.js`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(renameResponse.status).toBe(200);
@@ -196,7 +204,8 @@ export function greet(name) {
         headers,
         body: JSON.stringify({
           path: `${testDir}/src/utils/greeter.js`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(readRenamedResponse.status).toBe(200);
@@ -212,7 +221,8 @@ export function greet(name) {
         body: JSON.stringify({
           command: `echo "Building $PROJECT_NAME in $BUILD_ENV mode" && ls -la ${testDir}/src`,
           cwd: testDir
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(buildResponse.status).toBe(200);
@@ -227,7 +237,8 @@ export function greet(name) {
         body: JSON.stringify({
           command: 'git status --porcelain',
           cwd: testDir
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(gitStatusResponse.status).toBe(200);
@@ -263,7 +274,8 @@ const interval = setInterval(() => {
         body: JSON.stringify({
           path: `${testDir}/server.js`,
           content: serverScript
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       // Start the background process
@@ -272,7 +284,8 @@ const interval = setInterval(() => {
         headers,
         body: JSON.stringify({
           command: `bun run ${testDir}/server.js`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(startResponse.status).toBe(200);
@@ -290,7 +303,9 @@ const interval = setInterval(() => {
           body: JSON.stringify({
             pattern: 'Done',
             timeout: 10000
-          })
+          }),
+          // Must exceed server-side timeout (10s) to avoid client-side abort
+          signal: AbortSignal.timeout(15000)
         }
       );
       expect(waitResponse.status).toBe(200);
@@ -300,7 +315,8 @@ const interval = setInterval(() => {
         `${workerUrl}/api/process/${processId}/logs`,
         {
           method: 'GET',
-          headers
+          headers,
+          signal: AbortSignal.timeout(5000)
         }
       );
 
@@ -322,7 +338,8 @@ const interval = setInterval(() => {
         body: JSON.stringify({
           path: `${testDir}/backup`,
           recursive: true
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       const moveResponse = await fetch(`${workerUrl}/api/file/move`, {
@@ -331,7 +348,8 @@ const interval = setInterval(() => {
         body: JSON.stringify({
           sourcePath: `${testDir}/config.json`,
           destinationPath: `${testDir}/backup/config.json`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(moveResponse.status).toBe(200);
@@ -342,7 +360,8 @@ const interval = setInterval(() => {
         headers,
         body: JSON.stringify({
           path: `${testDir}/server.js`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(deleteResponse.status).toBe(200);
@@ -354,7 +373,8 @@ const interval = setInterval(() => {
         body: JSON.stringify({
           path: testDir,
           options: { recursive: true }
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(finalListResponse.status).toBe(200);
@@ -424,7 +444,8 @@ const interval = setInterval(() => {
         body: JSON.stringify({
           command:
             'for i in 1 2 3; do echo "[$PROJECT_NAME] Step $i at $(date +%s)"; sleep 0.3; done'
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(streamResponse.status).toBe(200);
@@ -472,7 +493,8 @@ const interval = setInterval(() => {
         body: JSON.stringify({
           command: 'echo "TEMP=$TEMP_VAR, PROJECT=$PROJECT_NAME"',
           env: { TEMP_VAR: 'temporary-value' }
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(cmdEnvResponse.status).toBe(200);
@@ -488,7 +510,8 @@ const interval = setInterval(() => {
         headers,
         body: JSON.stringify({
           command: 'echo "TEMP=$TEMP_VAR"'
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       const verifyEnvData = (await verifyEnvResponse.json()) as ExecResult;
@@ -501,7 +524,8 @@ const interval = setInterval(() => {
         body: JSON.stringify({
           command: 'pwd',
           cwd: '/tmp'
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(cmdCwdResponse.status).toBe(200);
@@ -514,7 +538,8 @@ const interval = setInterval(() => {
         headers,
         body: JSON.stringify({
           command: 'pwd'
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       const verifyCwdData = (await verifyCwdResponse.json()) as ExecResult;
@@ -540,7 +565,8 @@ const interval = setInterval(() => {
         headers,
         body: JSON.stringify({
           command: `echo '${pngBase64}' | base64 -d > /workspace/test-image.png`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       // Read the binary file
@@ -549,7 +575,8 @@ const interval = setInterval(() => {
         headers,
         body: JSON.stringify({
           path: '/workspace/test-image.png'
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(readBinaryResponse.status).toBe(200);
@@ -564,7 +591,8 @@ const interval = setInterval(() => {
       await fetch(`${workerUrl}/api/file/delete`, {
         method: 'DELETE',
         headers,
-        body: JSON.stringify({ path: '/workspace/test-image.png' })
+        body: JSON.stringify({ path: '/workspace/test-image.png' }),
+        signal: AbortSignal.timeout(5000)
       });
     }
   );
@@ -582,21 +610,24 @@ const interval = setInterval(() => {
       const process1Response = await fetch(`${workerUrl}/api/process/start`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ command: 'sleep 30' })
+        body: JSON.stringify({ command: 'sleep 30' }),
+        signal: AbortSignal.timeout(5000)
       });
       const process1 = (await process1Response.json()) as Process;
 
       const process2Response = await fetch(`${workerUrl}/api/process/start`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ command: 'sleep 30' })
+        body: JSON.stringify({ command: 'sleep 30' }),
+        signal: AbortSignal.timeout(5000)
       });
       const process2 = (await process2Response.json()) as Process;
 
       // List processes - startProcess returns after registration, so they're immediately visible
       const listResponse = await fetch(`${workerUrl}/api/process/list`, {
         method: 'GET',
-        headers
+        headers,
+        signal: AbortSignal.timeout(5000)
       });
       expect(listResponse.status).toBe(200);
       const processList = (await listResponse.json()) as Process[];
@@ -610,7 +641,8 @@ const interval = setInterval(() => {
       const killAllResponse = await fetch(`${workerUrl}/api/process/kill-all`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({})
+        body: JSON.stringify({}),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(killAllResponse.status).toBe(200);
@@ -621,7 +653,8 @@ const interval = setInterval(() => {
         await new Promise((resolve) => setTimeout(resolve, 500));
         const listAfterResponse = await fetch(`${workerUrl}/api/process/list`, {
           method: 'GET',
-          headers
+          headers,
+          signal: AbortSignal.timeout(5000)
         });
         const processesAfter = (await listAfterResponse.json()) as Process[];
         running = processesAfter.filter((p) => p.status === 'running');

--- a/tests/e2e/desktop-environment.test.ts
+++ b/tests/e2e/desktop-environment.test.ts
@@ -41,7 +41,7 @@ describe('Desktop Environment', () => {
       await fetch(`${workerUrl}/api/desktop/stop`, {
         method: 'POST',
         headers,
-        signal: AbortSignal.timeout(2000)
+        signal: AbortSignal.timeout(10000)
       });
       await cleanupTestSandbox(sandbox);
     } catch {

--- a/tests/e2e/environment-workflow.test.ts
+++ b/tests/e2e/environment-workflow.test.ts
@@ -43,7 +43,8 @@ describe('Environment Variables', () => {
     const response = await fetch(`${workerUrl}/api/execute`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ command: 'echo $SANDBOX_VERSION' })
+      body: JSON.stringify({ command: 'echo $SANDBOX_VERSION' }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(response.status).toBe(200);
@@ -64,7 +65,8 @@ describe('Environment Variables', () => {
           MY_SESSION_VAR: 'session-value',
           ANOTHER_VAR: 'another-value'
         }
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(setResponse.status).toBe(200);
@@ -75,7 +77,8 @@ describe('Environment Variables', () => {
       headers,
       body: JSON.stringify({
         command: 'echo "$MY_SESSION_VAR:$ANOTHER_VAR"'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(readResponse.status).toBe(200);
@@ -90,7 +93,8 @@ describe('Environment Variables', () => {
       body: JSON.stringify({
         command: 'echo "$CMD_VAR"',
         env: { CMD_VAR: 'command-specific-value' }
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(response.status).toBe(200);
@@ -105,7 +109,8 @@ describe('Environment Variables', () => {
       body: JSON.stringify({
         command: 'echo "$STREAM_VAR"',
         env: { STREAM_VAR: 'stream-env-value' }
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(response.status).toBe(200);
@@ -135,14 +140,16 @@ describe('Environment Variables', () => {
       headers,
       body: JSON.stringify({
         envVars: { OVERRIDE_TEST: 'session-level' }
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     // Verify session value
     const sessionResponse = await fetch(`${workerUrl}/api/execute`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ command: 'echo "$OVERRIDE_TEST"' })
+      body: JSON.stringify({ command: 'echo "$OVERRIDE_TEST"' }),
+      signal: AbortSignal.timeout(5000)
     });
     const sessionData = (await sessionResponse.json()) as ExecResult;
     expect(sessionData.stdout.trim()).toBe('session-level');
@@ -154,7 +161,8 @@ describe('Environment Variables', () => {
       body: JSON.stringify({
         command: 'echo "$OVERRIDE_TEST"',
         env: { OVERRIDE_TEST: 'command-level' }
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
     const overrideData = (await overrideResponse.json()) as ExecResult;
     expect(overrideData.stdout.trim()).toBe('command-level');
@@ -163,7 +171,8 @@ describe('Environment Variables', () => {
     const afterResponse = await fetch(`${workerUrl}/api/execute`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ command: 'echo "$OVERRIDE_TEST"' })
+      body: JSON.stringify({ command: 'echo "$OVERRIDE_TEST"' }),
+      signal: AbortSignal.timeout(5000)
     });
     const afterData = (await afterResponse.json()) as ExecResult;
     expect(afterData.stdout.trim()).toBe('session-level');
@@ -177,7 +186,8 @@ describe('Environment Variables', () => {
     const beforeResponse = await fetch(`${workerUrl}/api/execute`, {
       method: 'POST',
       headers: freshHeaders,
-      body: JSON.stringify({ command: 'echo "$SANDBOX_VERSION"' })
+      body: JSON.stringify({ command: 'echo "$SANDBOX_VERSION"' }),
+      signal: AbortSignal.timeout(5000)
     });
     const beforeData = (await beforeResponse.json()) as ExecResult;
     const dockerValue = beforeData.stdout.trim();
@@ -189,14 +199,16 @@ describe('Environment Variables', () => {
       headers: freshHeaders,
       body: JSON.stringify({
         envVars: { SANDBOX_VERSION: 'overridden-version' }
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     // Verify override
     const afterResponse = await fetch(`${workerUrl}/api/execute`, {
       method: 'POST',
       headers: freshHeaders,
-      body: JSON.stringify({ command: 'echo "$SANDBOX_VERSION"' })
+      body: JSON.stringify({ command: 'echo "$SANDBOX_VERSION"' }),
+      signal: AbortSignal.timeout(5000)
     });
     const afterData = (await afterResponse.json()) as ExecResult;
     expect(afterData.stdout.trim()).toBe('overridden-version');
@@ -209,7 +221,8 @@ describe('Environment Variables', () => {
       headers,
       body: JSON.stringify({
         command: 'cat'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(catResponse.status).toBe(200);
@@ -223,7 +236,8 @@ describe('Environment Variables', () => {
       headers,
       body: JSON.stringify({
         command: 'read -t 1 INPUT_VAR || echo "read returned"'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(readResponse.status).toBe(200);
@@ -237,7 +251,8 @@ describe('Environment Variables', () => {
       headers,
       body: JSON.stringify({
         command: 'grep "test" || true'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(grepResponse.status).toBe(200);
@@ -255,7 +270,8 @@ describe('Environment Variables', () => {
           UNSET_NULL: null,
           UNSET_EMPTY: ''
         }
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(setResponse.status).toBe(200);
@@ -263,7 +279,8 @@ describe('Environment Variables', () => {
     const definedResponse = await fetch(`${workerUrl}/api/execute`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ command: 'echo $UNSET_DEFINED' })
+      body: JSON.stringify({ command: 'echo $UNSET_DEFINED' }),
+      signal: AbortSignal.timeout(5000)
     });
     expect(definedResponse.status).toBe(200);
     const definedData = (await definedResponse.json()) as ExecResult;
@@ -274,7 +291,8 @@ describe('Environment Variables', () => {
       headers,
       body: JSON.stringify({
         command: 'printenv UNSET_NULL || echo "not set"'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
     expect(nullResponse.status).toBe(200);
     const nullData = (await nullResponse.json()) as ExecResult;
@@ -283,7 +301,8 @@ describe('Environment Variables', () => {
     const emptyResponse = await fetch(`${workerUrl}/api/execute`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ command: 'echo "[$UNSET_EMPTY]"' })
+      body: JSON.stringify({ command: 'echo "[$UNSET_EMPTY]"' }),
+      signal: AbortSignal.timeout(5000)
     });
     expect(emptyResponse.status).toBe(200);
     const emptyData = (await emptyResponse.json()) as ExecResult;
@@ -294,14 +313,16 @@ describe('Environment Variables', () => {
     const setResponse = await fetch(`${workerUrl}/api/env/set`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ envVars: { TO_REMOVE: 'initial-value' } })
+      body: JSON.stringify({ envVars: { TO_REMOVE: 'initial-value' } }),
+      signal: AbortSignal.timeout(5000)
     });
     expect(setResponse.status).toBe(200);
 
     const beforeResponse = await fetch(`${workerUrl}/api/execute`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ command: 'echo $TO_REMOVE' })
+      body: JSON.stringify({ command: 'echo $TO_REMOVE' }),
+      signal: AbortSignal.timeout(5000)
     });
     expect(beforeResponse.status).toBe(200);
     const beforeData = (await beforeResponse.json()) as ExecResult;
@@ -310,14 +331,16 @@ describe('Environment Variables', () => {
     const unsetResponse = await fetch(`${workerUrl}/api/env/set`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ envVars: { TO_REMOVE: null } })
+      body: JSON.stringify({ envVars: { TO_REMOVE: null } }),
+      signal: AbortSignal.timeout(5000)
     });
     expect(unsetResponse.status).toBe(200);
 
     const afterResponse = await fetch(`${workerUrl}/api/execute`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ command: 'printenv TO_REMOVE || echo "not set"' })
+      body: JSON.stringify({ command: 'printenv TO_REMOVE || echo "not set"' }),
+      signal: AbortSignal.timeout(5000)
     });
     expect(afterResponse.status).toBe(200);
     const afterData = (await afterResponse.json()) as ExecResult;
@@ -331,7 +354,8 @@ describe('Environment Variables', () => {
       body: JSON.stringify({
         command: 'echo $CMD_VALID',
         env: { CMD_VALID: 'valid-value', CMD_INVALID: null }
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
     expect(validResponse.status).toBe(200);
     const validData = (await validResponse.json()) as ExecResult;
@@ -343,7 +367,8 @@ describe('Environment Variables', () => {
       body: JSON.stringify({
         command: 'printenv CMD_INVALID || echo "not set"',
         env: { CMD_VALID: 'valid-value', CMD_INVALID: null }
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
     expect(invalidResponse.status).toBe(200);
     const invalidData = (await invalidResponse.json()) as ExecResult;

--- a/tests/e2e/environment-workflow.test.ts
+++ b/tests/e2e/environment-workflow.test.ts
@@ -226,9 +226,9 @@ describe('Environment Variables', () => {
     });
 
     expect(catResponse.status).toBe(200);
-    const catData = (await catResponse.json()) as ExecResult;
-    expect(catData.success).toBe(true);
-    expect(catData.stdout).toBe('');
+    await expect(catResponse.json()).resolves.toEqual(
+      expect.objectContaining({ success: true, stdout: '' })
+    );
 
     // Test 2: bash read command should return immediately
     const readResponse = await fetch(`${workerUrl}/api/execute`, {
@@ -256,8 +256,9 @@ describe('Environment Variables', () => {
     });
 
     expect(grepResponse.status).toBe(200);
-    const grepData = (await grepResponse.json()) as ExecResult;
-    expect(grepData.success).toBe(true);
+    await expect(grepResponse.json()).resolves.toEqual(
+      expect.objectContaining({ success: true })
+    );
   }, 90000);
 
   test('should handle null as unset in setEnvVars', async () => {

--- a/tests/e2e/file-operations-workflow.test.ts
+++ b/tests/e2e/file-operations-workflow.test.ts
@@ -75,9 +75,11 @@ describe('File Operations Error Handling', () => {
     });
 
     expect(deleteResponse.status).toBe(500);
-    const deleteData = (await deleteResponse.json()) as ErrorResponse;
-    expect(deleteData.error).toContain('Cannot delete directory');
-    expect(deleteData.error).toContain('deleteFile()');
+    await expect(deleteResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: expect.stringContaining('Cannot delete directory')
+      })
+    );
 
     // Verify directory still exists
     const lsResponse = await fetch(`${workerUrl}/api/execute`, {
@@ -89,9 +91,10 @@ describe('File Operations Error Handling', () => {
       signal: AbortSignal.timeout(5000)
     });
 
-    const lsData = (await lsResponse.json()) as ReadFileResult;
     expect(lsResponse.status).toBe(200);
-    expect(lsData.success).toBe(true);
+    await expect(lsResponse.json()).resolves.toEqual(
+      expect.objectContaining({ success: true })
+    );
   }, 90000);
 
   test('should return error when deleting nonexistent file', async () => {
@@ -105,9 +108,11 @@ describe('File Operations Error Handling', () => {
     });
 
     expect(deleteResponse.status).toBe(404);
-    const errorData = (await deleteResponse.json()) as ErrorResponse;
-    expect(errorData.error).toBeTruthy();
-    expect(errorData.error).toMatch(/not found|does not exist|no such file/i);
+    await expect(deleteResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: expect.stringMatching(/not found|does not exist|no such file/i)
+      })
+    );
   }, 90000);
 
   test('should handle listFiles errors appropriately', async () => {
@@ -122,10 +127,10 @@ describe('File Operations Error Handling', () => {
     });
 
     expect(notFoundResponse.status).toBe(404);
-    const notFoundData = (await notFoundResponse.json()) as ErrorResponse;
-    expect(notFoundData.error).toBeTruthy();
-    expect(notFoundData.error).toMatch(
-      /not found|does not exist|no such file/i
+    await expect(notFoundResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: expect.stringMatching(/not found|does not exist|no such file/i)
+      })
     );
 
     // Test file instead of directory
@@ -262,9 +267,11 @@ describe('File Operations Error Handling', () => {
     });
 
     expect(renameResponse.status).toBe(404);
-    const errorData = (await renameResponse.json()) as ErrorResponse;
-    expect(errorData.error).toBeTruthy();
-    expect(errorData.error).toMatch(/not found|does not exist|no such file/i);
+    await expect(renameResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: expect.stringMatching(/not found|does not exist|no such file/i)
+      })
+    );
   }, 90000);
 
   test('should handle move errors appropriately', async () => {
@@ -283,9 +290,11 @@ describe('File Operations Error Handling', () => {
     });
 
     expect(moveResponse.status).toBe(404);
-    const errorData = (await moveResponse.json()) as ErrorResponse;
-    expect(errorData.error).toBeTruthy();
-    expect(errorData.error).toMatch(/not found|does not exist|no such file/i);
+    await expect(moveResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: expect.stringMatching(/not found|does not exist|no such file/i)
+      })
+    );
   }, 90000);
 
   test('should handle binary file reading', async () => {

--- a/tests/e2e/file-operations-workflow.test.ts
+++ b/tests/e2e/file-operations-workflow.test.ts
@@ -60,7 +60,8 @@ describe('File Operations Error Handling', () => {
       body: JSON.stringify({
         path: dirPath,
         recursive: true
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     // Try to delete directory with deleteFile - should fail
@@ -69,7 +70,8 @@ describe('File Operations Error Handling', () => {
       headers,
       body: JSON.stringify({
         path: dirPath
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(deleteResponse.status).toBe(500);
@@ -83,7 +85,8 @@ describe('File Operations Error Handling', () => {
       headers,
       body: JSON.stringify({
         command: `ls -d ${dirPath}`
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     const lsData = (await lsResponse.json()) as ReadFileResult;
@@ -97,7 +100,8 @@ describe('File Operations Error Handling', () => {
       headers,
       body: JSON.stringify({
         path: `${testDir}/this-file-does-not-exist.txt`
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(deleteResponse.status).toBe(404);
@@ -113,7 +117,8 @@ describe('File Operations Error Handling', () => {
       headers,
       body: JSON.stringify({
         path: `${testDir}/nonexistent-directory`
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(notFoundResponse.status).toBe(404);
@@ -131,7 +136,8 @@ describe('File Operations Error Handling', () => {
       body: JSON.stringify({
         path: filePath,
         content: 'test'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     const fileAsDir = await fetch(`${workerUrl}/api/list-files`, {
@@ -139,13 +145,16 @@ describe('File Operations Error Handling', () => {
       headers,
       body: JSON.stringify({
         path: filePath
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(fileAsDir.status).toBe(500);
-    const fileAsDirData = (await fileAsDir.json()) as ErrorResponse;
-    expect(fileAsDirData.error).toBeTruthy();
-    expect(fileAsDirData.error).toMatch(/not a directory|is not a directory/i);
+    await expect(fileAsDir.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: expect.stringMatching(/not a directory|is not a directory/i)
+      })
+    );
   }, 90000);
 
   // Regression test for #196: hidden files in hidden directories
@@ -156,7 +165,8 @@ describe('File Operations Error Handling', () => {
     await fetch(`${workerUrl}/api/file/mkdir`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ path: `${hiddenDir}/bar`, recursive: true })
+      body: JSON.stringify({ path: `${hiddenDir}/bar`, recursive: true }),
+      signal: AbortSignal.timeout(5000)
     });
 
     // Write visible files in hidden directory
@@ -166,7 +176,8 @@ describe('File Operations Error Handling', () => {
       body: JSON.stringify({
         path: `${hiddenDir}/visible1.txt`,
         content: 'Visible 1'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
     await fetch(`${workerUrl}/api/file/write`, {
       method: 'POST',
@@ -174,7 +185,8 @@ describe('File Operations Error Handling', () => {
       body: JSON.stringify({
         path: `${hiddenDir}/visible2.txt`,
         content: 'Visible 2'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     // Write hidden file in hidden directory
@@ -184,14 +196,16 @@ describe('File Operations Error Handling', () => {
       body: JSON.stringify({
         path: `${hiddenDir}/.hiddenfile.txt`,
         content: 'Hidden'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     // List WITHOUT includeHidden - should NOT show .hiddenfile.txt
     const listResponse = await fetch(`${workerUrl}/api/list-files`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ path: hiddenDir })
+      body: JSON.stringify({ path: hiddenDir }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(listResponse.status).toBe(200);
@@ -215,7 +229,8 @@ describe('File Operations Error Handling', () => {
       body: JSON.stringify({
         path: hiddenDir,
         options: { includeHidden: true }
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(listWithHiddenResponse.status).toBe(200);
@@ -242,7 +257,8 @@ describe('File Operations Error Handling', () => {
       body: JSON.stringify({
         oldPath: sourcePath,
         newPath: destPath
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(renameResponse.status).toBe(404);
@@ -262,7 +278,8 @@ describe('File Operations Error Handling', () => {
       body: JSON.stringify({
         sourcePath: sourcePath,
         destinationPath: `${destDir}/source.txt`
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(moveResponse.status).toBe(404);
@@ -285,7 +302,8 @@ describe('File Operations Error Handling', () => {
         path: pngPath,
         content: pngBase64,
         encoding: 'base64'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(writeResponse.status).toBe(200);
@@ -294,7 +312,8 @@ describe('File Operations Error Handling', () => {
     const readResponse = await fetch(`${workerUrl}/api/file/read`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ path: `${testDir}/test.png` })
+      body: JSON.stringify({ path: `${testDir}/test.png` }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(readResponse.status).toBe(200);

--- a/tests/e2e/file-watch-workflow.test.ts
+++ b/tests/e2e/file-watch-workflow.test.ts
@@ -65,7 +65,7 @@ describe('File Watch Workflow', () => {
     watchId: string | null;
     actionResult: T;
   }> {
-    const { timeoutMs = 5000, stopAfterEvents = 20 } = options;
+    const { timeoutMs = 10000, stopAfterEvents = 20 } = options;
 
     const response = await fetch(`${workerUrl}/api/watch`, {
       method: 'POST',
@@ -155,7 +155,8 @@ describe('File Watch Workflow', () => {
     const response = await fetch(`${workerUrl}/api/file/write`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ path, content })
+      body: JSON.stringify({ path, content }),
+      signal: AbortSignal.timeout(5000)
     });
     await expectOk(response, `createFile(${path})`);
   }
@@ -167,7 +168,8 @@ describe('File Watch Workflow', () => {
     const response = await fetch(`${workerUrl}/api/file/mkdir`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ path, recursive: true })
+      body: JSON.stringify({ path, recursive: true }),
+      signal: AbortSignal.timeout(5000)
     });
     await expectOk(response, `createDir(${path})`);
   }
@@ -179,7 +181,8 @@ describe('File Watch Workflow', () => {
     const response = await fetch(`${workerUrl}/api/file/delete`, {
       method: 'DELETE',
       headers,
-      body: JSON.stringify({ path })
+      body: JSON.stringify({ path }),
+      signal: AbortSignal.timeout(5000)
     });
     await expectOk(response, `deleteFile(${path})`);
   }
@@ -202,7 +205,8 @@ describe('File Watch Workflow', () => {
         include: options.include,
         exclude: options.exclude,
         since: options.since
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     await expectOk(response, `checkChanges(${path})`);
@@ -375,7 +379,8 @@ describe('File Watch Workflow', () => {
     const response = await fetch(`${workerUrl}/api/watch`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ path: testDir })
+      body: JSON.stringify({ path: testDir }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(response.body).toBeTruthy();
@@ -394,7 +399,8 @@ describe('File Watch Workflow', () => {
     const secondResponse = await fetch(`${workerUrl}/api/watch`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ path: testDir })
+      body: JSON.stringify({ path: testDir }),
+      signal: AbortSignal.timeout(5000)
     });
     expect(secondResponse.ok).toBe(true);
     await secondResponse.body?.cancel();
@@ -406,7 +412,8 @@ describe('File Watch Workflow', () => {
       headers,
       body: JSON.stringify({
         path: '/workspace/nonexistent/path/that/does/not/exist'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     // watch() throws when the watcher fails to establish, so the test

--- a/tests/e2e/git-clone-workflow.test.ts
+++ b/tests/e2e/git-clone-workflow.test.ts
@@ -40,7 +40,8 @@ describe('Git Clone Error Handling', () => {
       body: JSON.stringify({
         repoUrl:
           'https://github.com/nonexistent/repository-that-does-not-exist-12345'
-      })
+      }),
+      signal: AbortSignal.timeout(30000)
     });
 
     expect(cloneResponse.status).toBe(500);
@@ -58,7 +59,8 @@ describe('Git Clone Error Handling', () => {
       body: JSON.stringify({
         repoUrl:
           'https://github.com/cloudflare/private-test-repo-that-requires-auth'
-      })
+      }),
+      signal: AbortSignal.timeout(30000)
     });
 
     expect(cloneResponse.status).toBe(500);
@@ -76,7 +78,8 @@ describe('Git Clone Error Handling', () => {
       body: JSON.stringify({
         repoUrl: 'https://github.com/octocat/Spoon-Knife',
         cloneTimeoutMs: 0
-      })
+      }),
+      signal: AbortSignal.timeout(30000)
     });
 
     expect(cloneResponse.status).toBeGreaterThanOrEqual(400);
@@ -128,7 +131,8 @@ describe('Git Shallow Clone', () => {
           repoUrl: 'https://github.com/octocat/Spoon-Knife',
           targetDir: testDir,
           depth: 1
-        })
+        }),
+        signal: AbortSignal.timeout(30000)
       });
 
       expect(cloneResponse.status).toBe(200);
@@ -142,7 +146,8 @@ describe('Git Shallow Clone', () => {
         headers,
         body: JSON.stringify({
           command: `cd ${testDir} && git rev-list --count HEAD`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(countResponse.status).toBe(200);
@@ -158,7 +163,8 @@ describe('Git Shallow Clone', () => {
         headers,
         body: JSON.stringify({
           command: `cd ${testDir} && git rev-parse --is-shallow-repository`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(shallowResponse.status).toBe(200);
@@ -183,7 +189,8 @@ describe('Git Shallow Clone', () => {
           branch: 'main',
           targetDir: testDir,
           depth: 1
-        })
+        }),
+        signal: AbortSignal.timeout(30000)
       });
 
       expect(cloneResponse.status).toBe(200);
@@ -196,7 +203,8 @@ describe('Git Shallow Clone', () => {
         headers,
         body: JSON.stringify({
           command: `cd ${testDir} && git rev-parse --is-shallow-repository`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(shallowResponse.status).toBe(200);
@@ -209,7 +217,8 @@ describe('Git Shallow Clone', () => {
         headers,
         body: JSON.stringify({
           command: `cd ${testDir} && git branch --show-current`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(branchResponse.status).toBe(200);
@@ -222,7 +231,8 @@ describe('Git Shallow Clone', () => {
         headers,
         body: JSON.stringify({
           command: `cd ${testDir} && git rev-list --count HEAD`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(countResponse.status).toBe(200);

--- a/tests/e2e/git-clone-workflow.test.ts
+++ b/tests/e2e/git-clone-workflow.test.ts
@@ -1,4 +1,4 @@
-import type { ExecResult, GitCheckoutResult } from '@repo/shared';
+import type { ExecResult } from '@repo/shared';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import {
   cleanupTestSandbox,
@@ -6,7 +6,6 @@ import {
   createUniqueSession,
   type TestSandbox
 } from './helpers/global-sandbox';
-import type { ErrorResponse } from './test-worker/types';
 
 /**
  * Git Clone Workflow Tests

--- a/tests/e2e/git-clone-workflow.test.ts
+++ b/tests/e2e/git-clone-workflow.test.ts
@@ -45,10 +45,12 @@ describe('Git Clone Error Handling', () => {
     });
 
     expect(cloneResponse.status).toBe(500);
-    const errorData = (await cloneResponse.json()) as ErrorResponse;
-    expect(errorData.error).toBeTruthy();
-    expect(errorData.error).toMatch(
-      /not found|does not exist|repository|fatal/i
+    await expect(cloneResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: expect.stringMatching(
+          /not found|does not exist|repository|fatal/i
+        )
+      })
     );
   }, 90000);
 
@@ -64,10 +66,12 @@ describe('Git Clone Error Handling', () => {
     });
 
     expect(cloneResponse.status).toBe(500);
-    const errorData = (await cloneResponse.json()) as ErrorResponse;
-    expect(errorData.error).toBeTruthy();
-    expect(errorData.error).toMatch(
-      /authentication|permission|access|denied|fatal|not found/i
+    await expect(cloneResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: expect.stringMatching(
+          /authentication|permission|access|denied|fatal|not found/i
+        )
+      })
     );
   }, 90000);
 
@@ -83,11 +87,14 @@ describe('Git Clone Error Handling', () => {
     });
 
     expect(cloneResponse.status).toBeGreaterThanOrEqual(400);
-    const errorData = (await cloneResponse.json()) as ErrorResponse;
     // "Invalid timeout value" comes from the HTTP handler's validation;
     // "Invalid clone timeout" comes from the git service itself.
-    expect(errorData.error).toMatch(
-      /Invalid (timeout value|clone timeout).*0/i
+    await expect(cloneResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: expect.stringMatching(
+          /Invalid (timeout value|clone timeout).*0/i
+        )
+      })
     );
   });
 });
@@ -136,8 +143,9 @@ describe('Git Shallow Clone', () => {
       });
 
       expect(cloneResponse.status).toBe(200);
-      const cloneData = (await cloneResponse.json()) as GitCheckoutResult;
-      expect(cloneData.success).toBe(true);
+      await expect(cloneResponse.json()).resolves.toEqual(
+        expect.objectContaining({ success: true })
+      );
 
       // Verify shallow clone by counting commits
       // A shallow clone with depth: 1 should have exactly 1 commit
@@ -194,8 +202,9 @@ describe('Git Shallow Clone', () => {
       });
 
       expect(cloneResponse.status).toBe(200);
-      const cloneData = (await cloneResponse.json()) as GitCheckoutResult;
-      expect(cloneData.success).toBe(true);
+      await expect(cloneResponse.json()).resolves.toEqual(
+        expect.objectContaining({ success: true })
+      );
 
       // Verify shallow clone
       const shallowResponse = await fetch(`${workerUrl}/api/execute`, {

--- a/tests/e2e/helpers/global-sandbox.ts
+++ b/tests/e2e/helpers/global-sandbox.ts
@@ -6,7 +6,11 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { createSandboxId, createTestHeaders } from './test-fixtures';
+import {
+  createSandboxId,
+  createTestHeaders,
+  fetchWithRetry
+} from './test-fixtures';
 
 export type SandboxType =
   | 'default'
@@ -43,35 +47,55 @@ export interface CreateTestSandboxOptions {
 export async function createTestSandbox(
   options: CreateTestSandboxOptions = {}
 ): Promise<TestSandbox> {
-  const { type = 'default', initCommand = 'echo ready', sleepAfter } = options;
+  const { type = 'default', initCommand = 'true', sleepAfter = '1m' } = options;
   const workerUrl = await getWorkerUrl();
   const sandboxId = createSandboxId();
 
   const makeHeaders = (sessionId?: string): Record<string, string> => {
-    const h: Record<string, string> = {
-      ...createTestHeaders(sandboxId, sessionId)
+    return {
+      ...createTestHeaders(sandboxId, sessionId),
+      // This is required on every request for correct routing.
+      ...(type !== 'default' ? { 'X-Sandbox-Type': type } : {})
     };
-    if (type !== 'default') {
-      h['X-Sandbox-Type'] = type;
-    }
-    if (sleepAfter !== undefined) {
-      h['X-Sandbox-Sleep-After'] = String(sleepAfter);
-    }
-    return h;
   };
 
-  // Initialize the container with a simple command
-  const initResponse = await fetch(`${workerUrl}/api/execute`, {
-    method: 'POST',
-    headers: makeHeaders(),
-    body: JSON.stringify({ command: initCommand })
-  });
+  // Initialize the container — retried because the container may still be booting
+  const initResponse = await fetchWithRetry(
+    () =>
+      fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers: makeHeaders(),
+        body: JSON.stringify({ command: initCommand }),
+        signal: AbortSignal.timeout(30_000)
+      }),
+    { retries: 3, delayMs: 1000 }
+  );
 
   if (!initResponse.ok) {
     const body = await initResponse.text().catch(() => '<unreadable>');
     throw new Error(
       `Failed to initialize ${type} sandbox: ${initResponse.status} - ${body}`
     );
+  }
+
+  if (sleepAfter !== undefined) {
+    const sleepAfterHeaders = makeHeaders();
+    sleepAfterHeaders['X-Sandbox-Sleep-After'] = String(sleepAfter);
+
+    // Configure sleep-after once the container has booted.
+    const sleepAfterResponse = await fetch(`${workerUrl}/api/execute`, {
+      method: 'POST',
+      headers: sleepAfterHeaders,
+      body: JSON.stringify({ command: initCommand }),
+      signal: AbortSignal.timeout(5000)
+    });
+
+    if (!sleepAfterResponse.ok) {
+      const body = await sleepAfterResponse.text().catch(() => '<unreadable>');
+      throw new Error(
+        `Failed to set sleep after: ${sleepAfterResponse.status} - ${body}`
+      );
+    }
   }
 
   return {
@@ -84,9 +108,12 @@ export async function createTestSandbox(
   };
 }
 
+/** Teardown timeout — fail fast so hanging cleanup doesn't block the suite. */
+const CLEANUP_TIMEOUT_MS = 1_000;
+
 /**
  * Clean up a sandbox created by createTestSandbox().
- * Safe to call with null (no-op).
+ * Safe to call with null (no-op). Uses a short timeout so hangs are logged quickly.
  */
 export async function cleanupTestSandbox(
   sandbox: TestSandbox | null
@@ -96,17 +123,26 @@ export async function cleanupTestSandbox(
     const response = await fetch(`${sandbox.workerUrl}/cleanup`, {
       method: 'POST',
       headers: sandbox.headers(),
-      signal: AbortSignal.timeout(1000)
+      signal: AbortSignal.timeout(CLEANUP_TIMEOUT_MS)
     });
     if (!response.ok) {
-      console.warn(
-        `Failed to cleanup sandbox ${sandbox.sandboxId}: ${response.status}`
-      );
+      console.warn({
+        message: 'cleanupTestSandbox: non-OK response',
+        sandboxId: sandbox.sandboxId,
+        status: response.status
+      });
     } else {
-      console.log(`Cleaned up sandbox: ${sandbox.sandboxId}`);
+      console.log({
+        message: 'cleanupTestSandbox: success',
+        sandboxId: sandbox.sandboxId
+      });
     }
   } catch (error) {
-    console.warn(`Error cleaning up sandbox ${sandbox.sandboxId}:`, error);
+    console.warn({
+      message: 'cleanupTestSandbox: request failed (teardown continuing)',
+      sandboxId: sandbox.sandboxId,
+      error
+    });
   }
 }
 

--- a/tests/e2e/helpers/test-fixtures.ts
+++ b/tests/e2e/helpers/test-fixtures.ts
@@ -86,25 +86,57 @@ export function createPythonImageHeaders(
 }
 
 /**
- * Fetch with timeout to prevent hanging tests
+ * Fetch with retries for setup/teardown actions that may be flakey
+ * (e.g. waiting for a container to boot).
  *
- * Usage:
- * ```typescript
- * const res = await fetchOrTimeout(
- *   fetch('http://example.com'),
- *   5000
- * );
- * ```
+ * Each attempt uses `AbortSignal.timeout()` so individual requests
+ * cannot hang indefinitely.
  */
-export async function fetchOrTimeout(
-  fetchPromise: Promise<Response>,
-  timeoutMs: number
+export async function fetchWithRetry(
+  factory: () => Promise<Response>,
+  options: {
+    retries?: number;
+    delayMs?: number;
+  } = {}
 ): Promise<Response> {
-  const timeoutPromise = new Promise<never>((_, reject) =>
-    setTimeout(() => reject(new Error('timeout')), timeoutMs)
-  );
+  const { retries = 3, delayMs = 500 } = options;
+  let lastError: unknown;
 
-  return await Promise.race([fetchPromise, timeoutPromise]);
+  let url: string = '';
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const res = await factory();
+      url = res.url;
+      if (res.ok) return res;
+      if (attempt < retries && res.status >= 500) {
+        console.warn({
+          message: 'fetchWithRetry: transient error',
+          url,
+          status: res.status,
+          attempt
+        });
+        await sleep(delayMs);
+        continue;
+      }
+      return res;
+    } catch (err) {
+      lastError = err;
+      if (attempt < retries) {
+        console.warn({
+          message: 'fetchWithRetry: attempt failed, retrying',
+          url,
+          attempt,
+          error: String(err)
+        });
+        await sleep(delayMs);
+      }
+    }
+  }
+
+  throw (
+    lastError ??
+    new Error(`fetchWithRetry: all ${retries + 1} attempts failed for ${url}`)
+  );
 }
 
 /**
@@ -178,6 +210,14 @@ export function sleep(ms: number): Promise<void> {
  * });
  * ```
  */
+/** Teardown timeout — fail fast so hanging cleanup doesn't block the suite. */
+const CLEANUP_TIMEOUT_MS = 1_000;
+
+/**
+ * Cleanup a sandbox instance by calling its destroy() RPC method.
+ *
+ * Uses a short timeout so teardown doesn't hang the suite.
+ */
 export async function cleanupSandbox(
   workerUrl: string,
   sandboxId: string
@@ -185,21 +225,26 @@ export async function cleanupSandbox(
   try {
     const headers = createTestHeaders(sandboxId);
 
-    // Call the cleanup RPC method via a special endpoint
     const response = await fetch(`${workerUrl}/cleanup`, {
       method: 'POST',
-      headers
+      headers,
+      signal: AbortSignal.timeout(CLEANUP_TIMEOUT_MS)
     });
 
     if (!response.ok) {
-      console.warn(
-        `Failed to cleanup sandbox ${sandboxId}: ${response.status}`
-      );
+      console.warn({
+        message: 'cleanupSandbox: non-OK response',
+        sandboxId,
+        status: response.status
+      });
     } else {
-      console.log(`Cleaned up sandbox: ${sandboxId}`);
+      console.log({ message: 'cleanupSandbox: success', sandboxId });
     }
   } catch (error) {
-    // Don't fail tests if cleanup fails
-    console.warn(`Error cleaning up sandbox ${sandboxId}:`, error);
+    console.warn({
+      message: 'cleanupSandbox: request failed (teardown continuing)',
+      sandboxId,
+      error
+    });
   }
 }

--- a/tests/e2e/keepalive-workflow.test.ts
+++ b/tests/e2e/keepalive-workflow.test.ts
@@ -40,7 +40,8 @@ describe('KeepAlive Feature', () => {
     const response1 = await fetch(`${workerUrl}/api/execute`, {
       method: 'POST',
       headers: keepAliveHeaders,
-      body: JSON.stringify({ command: 'echo "keepAlive command 1"' })
+      body: JSON.stringify({ command: 'echo "keepAlive command 1"' }),
+      signal: AbortSignal.timeout(5000)
     });
     expect(response1.status).toBe(200);
     const data1 = (await response1.json()) as ExecResult;
@@ -50,7 +51,8 @@ describe('KeepAlive Feature', () => {
     const response2 = await fetch(`${workerUrl}/api/execute`, {
       method: 'POST',
       headers: keepAliveHeaders,
-      body: JSON.stringify({ command: 'echo "keepAlive command 2"' })
+      body: JSON.stringify({ command: 'echo "keepAlive command 2"' }),
+      signal: AbortSignal.timeout(5000)
     });
     expect(response2.status).toBe(200);
     const data2 = (await response2.json()) as ExecResult;
@@ -64,7 +66,8 @@ describe('KeepAlive Feature', () => {
     const startResponse = await fetch(`${workerUrl}/api/process/start`, {
       method: 'POST',
       headers: keepAliveHeaders,
-      body: JSON.stringify({ command: 'sleep 10' })
+      body: JSON.stringify({ command: 'sleep 10' }),
+      signal: AbortSignal.timeout(5000)
     });
     expect(startResponse.status).toBe(200);
     const processData = (await startResponse.json()) as Process;
@@ -73,7 +76,11 @@ describe('KeepAlive Feature', () => {
     // Verify process is running
     const statusResponse = await fetch(
       `${workerUrl}/api/process/${processData.id}`,
-      { method: 'GET', headers: keepAliveHeaders }
+      {
+        method: 'GET',
+        headers: keepAliveHeaders,
+        signal: AbortSignal.timeout(5000)
+      }
     );
     expect(statusResponse.status).toBe(200);
     const statusData = (await statusResponse.json()) as Process;
@@ -82,7 +89,8 @@ describe('KeepAlive Feature', () => {
     // Cleanup
     await fetch(`${workerUrl}/api/process/${processData.id}`, {
       method: 'DELETE',
-      headers: keepAliveHeaders
+      headers: keepAliveHeaders,
+      signal: AbortSignal.timeout(5000)
     });
   }, 30000);
 
@@ -97,7 +105,8 @@ describe('KeepAlive Feature', () => {
       body: JSON.stringify({
         path: testPath,
         content: 'keepAlive file content'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
     expect(writeResponse.status).toBe(200);
 
@@ -105,7 +114,8 @@ describe('KeepAlive Feature', () => {
     const readResponse = await fetch(`${workerUrl}/api/file/read`, {
       method: 'POST',
       headers: keepAliveHeaders,
-      body: JSON.stringify({ path: testPath })
+      body: JSON.stringify({ path: testPath }),
+      signal: AbortSignal.timeout(5000)
     });
     expect(readResponse.status).toBe(200);
     const readData = (await readResponse.json()) as ReadFileResult;
@@ -115,7 +125,8 @@ describe('KeepAlive Feature', () => {
     await fetch(`${workerUrl}/api/file/delete`, {
       method: 'DELETE',
       headers: keepAliveHeaders,
-      body: JSON.stringify({ path: testPath })
+      body: JSON.stringify({ path: testPath }),
+      signal: AbortSignal.timeout(5000)
     });
   }, 30000);
 });

--- a/tests/e2e/keepalive-workflow.test.ts
+++ b/tests/e2e/keepalive-workflow.test.ts
@@ -44,8 +44,11 @@ describe('KeepAlive Feature', () => {
       signal: AbortSignal.timeout(5000)
     });
     expect(response1.status).toBe(200);
-    const data1 = (await response1.json()) as ExecResult;
-    expect(data1.stdout).toContain('keepAlive command 1');
+    await expect(response1.json()).resolves.toEqual(
+      expect.objectContaining({
+        stdout: expect.stringContaining('keepAlive command 1')
+      })
+    );
 
     // Second command immediately after
     const response2 = await fetch(`${workerUrl}/api/execute`, {
@@ -55,8 +58,11 @@ describe('KeepAlive Feature', () => {
       signal: AbortSignal.timeout(5000)
     });
     expect(response2.status).toBe(200);
-    const data2 = (await response2.json()) as ExecResult;
-    expect(data2.stdout).toContain('keepAlive command 2');
+    await expect(response2.json()).resolves.toEqual(
+      expect.objectContaining({
+        stdout: expect.stringContaining('keepAlive command 2')
+      })
+    );
   }, 30000);
 
   test('should support background processes with keepAlive', async () => {
@@ -83,8 +89,9 @@ describe('KeepAlive Feature', () => {
       }
     );
     expect(statusResponse.status).toBe(200);
-    const statusData = (await statusResponse.json()) as Process;
-    expect(statusData.status).toBe('running');
+    await expect(statusResponse.json()).resolves.toEqual(
+      expect.objectContaining({ status: 'running' })
+    );
 
     // Cleanup
     await fetch(`${workerUrl}/api/process/${processData.id}`, {
@@ -118,8 +125,9 @@ describe('KeepAlive Feature', () => {
       signal: AbortSignal.timeout(5000)
     });
     expect(readResponse.status).toBe(200);
-    const readData = (await readResponse.json()) as ReadFileResult;
-    expect(readData.content).toBe('keepAlive file content');
+    await expect(readResponse.json()).resolves.toEqual(
+      expect.objectContaining({ content: 'keepAlive file content' })
+    );
 
     // Cleanup
     await fetch(`${workerUrl}/api/file/delete`, {

--- a/tests/e2e/keepalive-workflow.test.ts
+++ b/tests/e2e/keepalive-workflow.test.ts
@@ -1,4 +1,4 @@
-import type { ExecResult, Process, ReadFileResult } from '@repo/shared';
+import type { Process } from '@repo/shared';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import {
   cleanupTestSandbox,

--- a/tests/e2e/musl.test.ts
+++ b/tests/e2e/musl.test.ts
@@ -39,7 +39,8 @@ describe('Musl Image Variant', () => {
     const response = await fetch(`${workerUrl}/api/execute`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ command: 'echo "ok"' })
+      body: JSON.stringify({ command: 'echo "ok"' }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(response.status).toBe(200);
@@ -54,14 +55,16 @@ describe('Musl Image Variant', () => {
     const writeResponse = await fetch(`${workerUrl}/api/file/write`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ path: testPath, content: testContent })
+      body: JSON.stringify({ path: testPath, content: testContent }),
+      signal: AbortSignal.timeout(5000)
     });
     expect(writeResponse.status).toBe(200);
 
     const readResponse = await fetch(`${workerUrl}/api/file/read`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ path: testPath })
+      body: JSON.stringify({ path: testPath }),
+      signal: AbortSignal.timeout(5000)
     });
     expect(readResponse.status).toBe(200);
     const result = (await readResponse.json()) as ReadFileResult;

--- a/tests/e2e/musl.test.ts
+++ b/tests/e2e/musl.test.ts
@@ -10,7 +10,6 @@
  * - File operations work on Alpine filesystem
  */
 
-import type { ExecResult, ReadFileResult } from '@repo/shared';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import {
   cleanupTestSandbox,

--- a/tests/e2e/musl.test.ts
+++ b/tests/e2e/musl.test.ts
@@ -44,8 +44,9 @@ describe('Musl Image Variant', () => {
     });
 
     expect(response.status).toBe(200);
-    const result = (await response.json()) as ExecResult;
-    expect(result.exitCode).toBe(0);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({ exitCode: 0 })
+    );
   });
 
   test('file operations work on Alpine', async () => {
@@ -67,7 +68,8 @@ describe('Musl Image Variant', () => {
       signal: AbortSignal.timeout(5000)
     });
     expect(readResponse.status).toBe(200);
-    const result = (await readResponse.json()) as ReadFileResult;
-    expect(result.content).toBe(testContent);
+    await expect(readResponse.json()).resolves.toEqual(
+      expect.objectContaining({ content: testContent })
+    );
   });
 });

--- a/tests/e2e/opencode-workflow.test.ts
+++ b/tests/e2e/opencode-workflow.test.ts
@@ -34,7 +34,8 @@ describe.sequential('OpenCode Workflow (E2E)', () => {
     const res = await fetch(`${workerUrl}/api/execute`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ command: 'opencode --version' })
+      body: JSON.stringify({ command: 'opencode --version' }),
+      signal: AbortSignal.timeout(5000)
     });
     expect(res.status).toBe(200);
     const result = (await res.json()) as ExecResult;
@@ -54,7 +55,8 @@ describe.sequential('OpenCode Workflow (E2E)', () => {
       while (Date.now() < deadline) {
         res = await fetch(healthUrl, {
           method: 'GET',
-          headers
+          headers,
+          signal: AbortSignal.timeout(5000)
         });
 
         if (res.status === 200) {
@@ -88,7 +90,8 @@ describe.sequential('OpenCode Workflow (E2E)', () => {
         headers,
         body: JSON.stringify({
           command: `opencode serve --port ${testPort} --hostname 0.0.0.0`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       if (startRes.status !== 200) {
@@ -118,7 +121,9 @@ describe.sequential('OpenCode Workflow (E2E)', () => {
                 timeout: 180000,
                 interval: 1000
               }
-            })
+            }),
+            // Must exceed server-side timeout (180s) to avoid client-side abort
+            signal: AbortSignal.timeout(190000)
           }
         );
 
@@ -153,7 +158,8 @@ describe.sequential('OpenCode Workflow (E2E)', () => {
 
         const listRes = await fetch(`${workerUrl}/api/process/list`, {
           method: 'GET',
-          headers
+          headers,
+          signal: AbortSignal.timeout(5000)
         });
         expect(listRes.status).toBe(200);
         const processes = (await listRes.json()) as Array<{
@@ -167,7 +173,8 @@ describe.sequential('OpenCode Workflow (E2E)', () => {
       } finally {
         const killRes = await fetch(`${workerUrl}/api/process/${processId}`, {
           method: 'DELETE',
-          headers
+          headers,
+          signal: AbortSignal.timeout(5000)
         });
 
         // Process might already be gone if it crashed after readiness.

--- a/tests/e2e/opencode-workflow.test.ts
+++ b/tests/e2e/opencode-workflow.test.ts
@@ -6,7 +6,6 @@
  * - Server startup and lifecycle via process API
  */
 
-import type { ExecResult } from '@repo/shared';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import {
   cleanupTestSandbox,

--- a/tests/e2e/opencode-workflow.test.ts
+++ b/tests/e2e/opencode-workflow.test.ts
@@ -38,9 +38,12 @@ describe.sequential('OpenCode Workflow (E2E)', () => {
       signal: AbortSignal.timeout(5000)
     });
     expect(res.status).toBe(200);
-    const result = (await res.json()) as ExecResult;
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout).toMatch(/\d+\.\d+/);
+    await expect(res.json()).resolves.toEqual(
+      expect.objectContaining({
+        exitCode: 0,
+        stdout: expect.stringMatching(/\d+\.\d+/)
+      })
+    );
   });
 
   describe('OpenCode proxy helpers', () => {

--- a/tests/e2e/parallel-context-creation.test.ts
+++ b/tests/e2e/parallel-context-creation.test.ts
@@ -38,7 +38,8 @@ describe('Parallel Context Creation (issue #276)', () => {
     const res = await fetch(`${workerUrl}/api/code/context/create`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ language })
+      body: JSON.stringify({ language }),
+      signal: AbortSignal.timeout(5000)
     });
     const elapsed = Date.now() - start;
     const body = await res.json();
@@ -48,7 +49,8 @@ describe('Parallel Context Creation (issue #276)', () => {
   async function deleteContext(contextId: string): Promise<void> {
     await fetch(`${workerUrl}/api/code/context/${contextId}`, {
       method: 'DELETE',
-      headers
+      headers,
+      signal: AbortSignal.timeout(5000)
     });
   }
 

--- a/tests/e2e/process-lifecycle-workflow.test.ts
+++ b/tests/e2e/process-lifecycle-workflow.test.ts
@@ -121,10 +121,12 @@ describe('Process Lifecycle Error Handling', () => {
     );
 
     expect(killResponse.status).toBe(404);
-    const errorData = (await killResponse.json()) as { error: string };
-    expect(errorData.error).toBeTruthy();
-    expect(errorData.error).toMatch(
-      /not found|does not exist|invalid|unknown/i
+    await expect(killResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: expect.stringMatching(
+          /not found|does not exist|invalid|unknown/i
+        )
+      })
     );
   }, 90000);
 
@@ -157,8 +159,11 @@ describe('Process Lifecycle Error Handling', () => {
     );
 
     expect(logsResponse.status).toBe(200);
-    const logsData = (await logsResponse.json()) as ProcessLogsResult;
-    expect(logsData.stdout).toContain('Hello from process');
+    await expect(logsResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        stdout: expect.stringContaining('Hello from process')
+      })
+    );
   }, 90000);
 
   test('should terminate the full background process tree when killed', async () => {
@@ -260,8 +265,9 @@ wait`;
       { method: 'GET', headers, signal: AbortSignal.timeout(5000) }
     );
     expect(statusResponse.ok).toBe(true);
-    const record = (await statusResponse.json()) as Process;
-    expect(record.status).toBe('killed');
+    await expect(statusResponse.json()).resolves.toEqual(
+      expect.objectContaining({ status: 'killed' })
+    );
   }, 90000);
 
   test('should stream process logs in real-time', async () => {
@@ -364,10 +370,12 @@ console.log("Line 3");
       });
 
       expect(exposeResponse.status).toBeGreaterThanOrEqual(400);
-      const errorData = (await exposeResponse.json()) as { error: string };
-      expect(errorData.error).toBeTruthy();
-      expect(errorData.error).toMatch(
-        /reserved|not allowed|forbidden|invalid port/i
+      await expect(exposeResponse.json()).resolves.toEqual(
+        expect.objectContaining({
+          error: expect.stringMatching(
+            /reserved|not allowed|forbidden|invalid port/i
+          )
+        })
       );
     },
     90000
@@ -386,9 +394,11 @@ console.log("Line 3");
       );
 
       expect(unexposeResponse.status).toBe(404);
-      const errorData = (await unexposeResponse.json()) as { error: string };
-      expect(errorData.error).toBeTruthy();
-      expect(errorData.error).toMatch(/not found|not exposed|does not exist/i);
+      await expect(unexposeResponse.json()).resolves.toEqual(
+        expect.objectContaining({
+          error: expect.stringMatching(/not found|not exposed|does not exist/i)
+        })
+      );
     },
     90000
   );
@@ -641,9 +651,9 @@ while :; do :; done`;
       { method: 'GET', headers, signal: AbortSignal.timeout(5000) }
     );
     expect(statusResponse.ok).toBe(true);
-    const record = (await statusResponse.json()) as Process;
-    expect(record.status).toBe('killed');
-    expect(record.exitCode).toBe(137);
+    await expect(statusResponse.json()).resolves.toEqual(
+      expect.objectContaining({ status: 'killed', exitCode: 137 })
+    );
   }, 90000);
 
   test('should kill background processes when their session is destroyed', async () => {

--- a/tests/e2e/process-lifecycle-workflow.test.ts
+++ b/tests/e2e/process-lifecycle-workflow.test.ts
@@ -47,7 +47,8 @@ describe('Process Lifecycle Error Handling', () => {
       headers,
       body: JSON.stringify({
         command
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(response.status).toBe(200);
@@ -81,7 +82,9 @@ describe('Process Lifecycle Error Handling', () => {
       {
         method: 'POST',
         headers,
-        body: JSON.stringify({ timeout: timeoutMs })
+        body: JSON.stringify({ timeout: timeoutMs }),
+        // Must exceed server-side timeout (timeoutMs) to avoid client-side abort
+        signal: AbortSignal.timeout(timeoutMs + 5000)
       }
     );
 
@@ -94,7 +97,8 @@ describe('Process Lifecycle Error Handling', () => {
       headers,
       body: JSON.stringify({
         command: `if ! kill -0 ${pid} 2>/dev/null; then echo dead; elif [ -r /proc/${pid}/status ] && grep -q '^State:[[:space:]]*Z' /proc/${pid}/status; then echo dead; else echo alive; fi`
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
     expect(response.status).toBe(200);
     const result = (await response.json()) as ExecResult;
@@ -111,7 +115,8 @@ describe('Process Lifecycle Error Handling', () => {
       `${workerUrl}/api/process/fake-process-id-12345`,
       {
         method: 'DELETE',
-        headers
+        headers,
+        signal: AbortSignal.timeout(5000)
       }
     );
 
@@ -129,7 +134,8 @@ describe('Process Lifecycle Error Handling', () => {
       headers,
       body: JSON.stringify({
         command: 'echo "Hello from process"'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(startResponse.status).toBe(200);
@@ -145,7 +151,8 @@ describe('Process Lifecycle Error Handling', () => {
       `${workerUrl}/api/process/${processId}/logs`,
       {
         method: 'GET',
-        headers
+        headers,
+        signal: AbortSignal.timeout(5000)
       }
     );
 
@@ -179,7 +186,8 @@ wait`;
         body: JSON.stringify({
           path: scriptPath,
           content: scriptCode
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       const startResponse = await fetch(`${workerUrl}/api/process/start`, {
@@ -187,7 +195,8 @@ wait`;
         headers,
         body: JSON.stringify({
           command: `bash '${scriptPath}'`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(startResponse.status).toBe(200);
@@ -203,7 +212,8 @@ wait`;
         `${workerUrl}/api/process/${processId}`,
         {
           method: 'DELETE',
-          headers
+          headers,
+          signal: AbortSignal.timeout(5000)
         }
       );
       expect(killResponse.status).toBe(200);
@@ -222,7 +232,8 @@ wait`;
       if (processId) {
         await fetch(`${workerUrl}/api/process/${processId}`, {
           method: 'DELETE',
-          headers
+          headers,
+          signal: AbortSignal.timeout(5000)
         }).catch(() => {});
       }
 
@@ -246,7 +257,7 @@ wait`;
     // Verify the process record reports 'killed' status
     const statusResponse = await fetch(
       `${workerUrl}/api/process/${processId}`,
-      { method: 'GET', headers }
+      { method: 'GET', headers, signal: AbortSignal.timeout(5000) }
     );
     expect(statusResponse.ok).toBe(true);
     const record = (await statusResponse.json()) as Process;
@@ -269,7 +280,8 @@ console.log("Line 3");
       body: JSON.stringify({
         path: '/workspace/script.js',
         content: scriptCode
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     // Start the script
@@ -278,7 +290,8 @@ console.log("Line 3");
       headers,
       body: JSON.stringify({
         command: 'bun run /workspace/script.js'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     const startData = (await startResponse.json()) as Process;
@@ -289,7 +302,8 @@ console.log("Line 3");
       `${workerUrl}/api/process/${processId}/stream`,
       {
         method: 'GET',
-        headers
+        headers,
+        signal: AbortSignal.timeout(5000)
       }
     );
 
@@ -345,7 +359,8 @@ console.log("Line 3");
         body: JSON.stringify({
           port: 22,
           name: 'ssh-server'
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(exposeResponse.status).toBeGreaterThanOrEqual(400);
@@ -365,7 +380,8 @@ console.log("Line 3");
         `${workerUrl}/api/exposed-ports/${PORT_LIFECYCLE_TEST_PORT}`,
         {
           method: 'DELETE',
-          headers: portHeaders
+          headers: portHeaders,
+          signal: AbortSignal.timeout(5000)
         }
       );
 
@@ -421,7 +437,8 @@ console.log("Line 3");
       const startResponse = await fetch(`${workerUrl}/api/process/start`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ command: `bash '${scriptPath}'` })
+        body: JSON.stringify({ command: `bash '${scriptPath}'` }),
+        signal: AbortSignal.timeout(5000)
       });
       expect(startResponse.status).toBe(200);
       const processData = (await startResponse.json()) as Process;
@@ -437,7 +454,7 @@ console.log("Line 3");
 
       const killResponse = await fetch(
         `${workerUrl}/api/process/${processId}`,
-        { method: 'DELETE', headers }
+        { method: 'DELETE', headers, signal: AbortSignal.timeout(5000) }
       );
       expect(killResponse.status).toBe(200);
 
@@ -454,7 +471,8 @@ console.log("Line 3");
       if (processId) {
         await fetch(`${workerUrl}/api/process/${processId}`, {
           method: 'DELETE',
-          headers
+          headers,
+          signal: AbortSignal.timeout(5000)
         }).catch(() => {});
       }
       for (const f of [
@@ -490,13 +508,15 @@ console.log("Line 3");
         await fetch(`${workerUrl}/api/file/write`, {
           method: 'POST',
           headers,
-          body: JSON.stringify({ path: scriptPaths[i], content: scriptCode })
+          body: JSON.stringify({ path: scriptPaths[i], content: scriptCode }),
+          signal: AbortSignal.timeout(5000)
         });
 
         const startResponse = await fetch(`${workerUrl}/api/process/start`, {
           method: 'POST',
           headers,
-          body: JSON.stringify({ command: `bash '${scriptPaths[i]}'` })
+          body: JSON.stringify({ command: `bash '${scriptPaths[i]}'` }),
+          signal: AbortSignal.timeout(5000)
         });
         expect(startResponse.status).toBe(200);
         const processData = (await startResponse.json()) as Process;
@@ -509,7 +529,8 @@ console.log("Line 3");
 
       const killAllResponse = await fetch(`${workerUrl}/api/process/kill-all`, {
         method: 'POST',
-        headers
+        headers,
+        signal: AbortSignal.timeout(5000)
       });
       expect(killAllResponse.status).toBe(200);
 
@@ -524,7 +545,8 @@ console.log("Line 3");
       for (let i = 0; i < 3; i++) {
         await fetch(`${workerUrl}/api/process/${processIds[i]}`, {
           method: 'DELETE',
-          headers
+          headers,
+          signal: AbortSignal.timeout(5000)
         }).catch(() => {});
         await readExecStdout(
           `rm -f '${pidFiles[i]}' '${scriptPaths[i]}'`
@@ -557,13 +579,15 @@ while :; do :; done`;
       await fetch(`${workerUrl}/api/file/write`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ path: scriptPath, content: scriptCode })
+        body: JSON.stringify({ path: scriptPath, content: scriptCode }),
+        signal: AbortSignal.timeout(5000)
       });
 
       const startResponse = await fetch(`${workerUrl}/api/process/start`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ command: `bash '${scriptPath}'` })
+        body: JSON.stringify({ command: `bash '${scriptPath}'` }),
+        signal: AbortSignal.timeout(5000)
       });
       expect(startResponse.status).toBe(200);
       const processData = (await startResponse.json()) as Process;
@@ -574,7 +598,8 @@ while :; do :; done`;
       const killStart = Date.now();
       const killResponse = await fetch(
         `${workerUrl}/api/process/${processId}`,
-        { method: 'DELETE', headers }
+        // SIGTERM grace period is ~5s before SIGKILL escalation
+        { method: 'DELETE', headers, signal: AbortSignal.timeout(15000) }
       );
       expect(killResponse.status).toBe(200);
 
@@ -593,7 +618,8 @@ while :; do :; done`;
       if (processId) {
         await fetch(`${workerUrl}/api/process/${processId}`, {
           method: 'DELETE',
-          headers
+          headers,
+          signal: AbortSignal.timeout(5000)
         }).catch(() => {});
       }
       if (pid) {
@@ -612,7 +638,7 @@ while :; do :; done`;
     // Verify the process record reports 'killed' status with exit code 137
     const statusResponse = await fetch(
       `${workerUrl}/api/process/${processId}`,
-      { method: 'GET', headers }
+      { method: 'GET', headers, signal: AbortSignal.timeout(5000) }
     );
     expect(statusResponse.ok).toBe(true);
     const record = (await statusResponse.json()) as Process;
@@ -635,13 +661,15 @@ while :; do :; done`;
       await fetch(`${workerUrl}/api/file/write`, {
         method: 'POST',
         headers: sessionHeaders,
-        body: JSON.stringify({ path: scriptPath, content: scriptCode })
+        body: JSON.stringify({ path: scriptPath, content: scriptCode }),
+        signal: AbortSignal.timeout(5000)
       });
 
       const startResponse = await fetch(`${workerUrl}/api/process/start`, {
         method: 'POST',
         headers: sessionHeaders,
-        body: JSON.stringify({ command: `bash '${scriptPath}'` })
+        body: JSON.stringify({ command: `bash '${scriptPath}'` }),
+        signal: AbortSignal.timeout(5000)
       });
       expect(startResponse.status).toBe(200);
 
@@ -652,7 +680,8 @@ while :; do :; done`;
       const deleteResponse = await fetch(`${workerUrl}/api/session/delete`, {
         method: 'POST',
         headers: sessionHeaders,
-        body: JSON.stringify({ sessionId })
+        body: JSON.stringify({ sessionId }),
+        signal: AbortSignal.timeout(5000)
       });
       expect(deleteResponse.status).toBe(200);
 
@@ -677,7 +706,8 @@ while :; do :; done`;
       headers,
       body: JSON.stringify({
         command: 'sleep 60'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     const startData = (await startResponse.json()) as Process;
@@ -690,7 +720,8 @@ while :; do :; done`;
       headers,
       body: JSON.stringify({
         command: 'echo "test"'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
     const execDuration = Date.now() - execStart;
 
@@ -700,7 +731,8 @@ while :; do :; done`;
     // Cleanup
     await fetch(`${workerUrl}/api/process/${processId}`, {
       method: 'DELETE',
-      headers
+      headers,
+      signal: AbortSignal.timeout(5000)
     });
   }, 90000);
 });

--- a/tests/e2e/process-lifecycle-workflow.test.ts
+++ b/tests/e2e/process-lifecycle-workflow.test.ts
@@ -1,4 +1,4 @@
-import type { ExecResult, Process, ProcessLogsResult } from '@repo/shared';
+import type { ExecResult, Process } from '@repo/shared';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import {
   cleanupTestSandbox,

--- a/tests/e2e/process-readiness-workflow.test.ts
+++ b/tests/e2e/process-readiness-workflow.test.ts
@@ -1,4 +1,4 @@
-import type { PortExposeResult, Process, WaitForLogResult } from '@repo/shared';
+import type { PortExposeResult, Process } from '@repo/shared';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import {
   cleanupTestSandbox,

--- a/tests/e2e/process-readiness-workflow.test.ts
+++ b/tests/e2e/process-readiness-workflow.test.ts
@@ -88,8 +88,11 @@ await Bun.sleep(60000); // Keep running
     );
 
     expect(waitResponse.status).toBe(200);
-    const waitData = (await waitResponse.json()) as WaitForLogResult;
-    expect(waitData.line).toContain('Server ready on port 8080');
+    await expect(waitResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        line: expect.stringContaining('Server ready on port 8080')
+      })
+    );
 
     // Cleanup
     await fetch(`${workerUrl}/api/process/${processId}`, {
@@ -161,11 +164,13 @@ await Bun.sleep(60000);
       headers,
       body: JSON.stringify({
         command: 'curl -s http://localhost:9090'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
-    const verifyData = (await verifyResponse.json()) as { stdout: string };
-    expect(verifyData.stdout).toBe('OK');
+    await expect(verifyResponse.json()).resolves.toEqual(
+      expect.objectContaining({ stdout: 'OK' })
+    );
 
     // Cleanup
     await fetch(`${workerUrl}/api/process/${processId}`, {
@@ -296,14 +301,18 @@ await Bun.sleep(60000);
         body: JSON.stringify({
           pattern: 'Server ready',
           timeout: 2000
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       }
     );
 
     // Should fail with timeout (408 Request Timeout)
     expect(waitResponse.status).toBe(408);
-    const errorData = (await waitResponse.json()) as { error: string };
-    expect(errorData.error).toMatch(/timeout|did not become ready/i);
+    await expect(waitResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: expect.stringMatching(/timeout|did not become ready/i)
+      })
+    );
 
     // Cleanup
     await fetch(`${workerUrl}/api/process/${processId}`, {
@@ -345,9 +354,12 @@ await Bun.sleep(60000);
 
     // Should fail because process exits before pattern appears
     expect(waitResponse.status).toBe(500);
-    const errorData = (await waitResponse.json()) as { error: string };
-    expect(errorData.error).toMatch(
-      /exited|exit|timeout|did not become ready/i
+    await expect(waitResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        error: expect.stringMatching(
+          /exited|exit|timeout|did not become ready/i
+        )
+      })
     );
   }, 60000);
 
@@ -399,8 +411,11 @@ await Bun.sleep(60000);
     );
 
     expect(waitResponse.status).toBe(200);
-    const waitData = (await waitResponse.json()) as WaitForLogResult;
-    expect(waitData.line).toContain('Ready (stderr)');
+    await expect(waitResponse.json()).resolves.toEqual(
+      expect.objectContaining({
+        line: expect.stringContaining('Ready (stderr)')
+      })
+    );
 
     // Cleanup
     await fetch(`${workerUrl}/api/process/${processId}`, {
@@ -485,13 +500,15 @@ console.log("Server listening on port 9092");
         signal: AbortSignal.timeout(5000)
       });
       expect(apiResponse.status).toBe(200);
-      const apiData = (await apiResponse.json()) as { message: string };
-      expect(apiData.message).toBe('Hello!');
+      await expect(apiResponse.json()).resolves.toEqual(
+        expect.objectContaining({ message: 'Hello!' })
+      );
 
       // Cleanup
       await fetch(`${workerUrl}/api/exposed-ports/9092`, {
         method: 'DELETE',
-        headers: portHeaders
+        headers: portHeaders,
+        signal: AbortSignal.timeout(5000)
       });
       await fetch(`${workerUrl}/api/process/${processId}`, {
         method: 'DELETE',

--- a/tests/e2e/process-readiness-workflow.test.ts
+++ b/tests/e2e/process-readiness-workflow.test.ts
@@ -54,7 +54,8 @@ await Bun.sleep(60000); // Keep running
       body: JSON.stringify({
         path: '/workspace/server.js',
         content: scriptCode
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     // Start the process
@@ -63,7 +64,8 @@ await Bun.sleep(60000); // Keep running
       headers,
       body: JSON.stringify({
         command: 'bun run /workspace/server.js'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(startResponse.status).toBe(200);
@@ -79,7 +81,9 @@ await Bun.sleep(60000); // Keep running
         body: JSON.stringify({
           pattern: 'Server ready on port 8080',
           timeout: 10000
-        })
+        }),
+        // Must exceed server-side timeout (10s) to avoid client-side abort
+        signal: AbortSignal.timeout(15000)
       }
     );
 
@@ -90,7 +94,8 @@ await Bun.sleep(60000); // Keep running
     // Cleanup
     await fetch(`${workerUrl}/api/process/${processId}`, {
       method: 'DELETE',
-      headers
+      headers,
+      signal: AbortSignal.timeout(5000)
     });
   }, 60000);
 
@@ -115,7 +120,8 @@ await Bun.sleep(60000);
       body: JSON.stringify({
         path: '/workspace/portserver.js',
         content: serverCode
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     // Start the process
@@ -124,7 +130,8 @@ await Bun.sleep(60000);
       headers,
       body: JSON.stringify({
         command: 'bun run /workspace/portserver.js'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(startResponse.status).toBe(200);
@@ -140,7 +147,9 @@ await Bun.sleep(60000);
         body: JSON.stringify({
           port: 9090,
           timeout: 15000
-        })
+        }),
+        // Must exceed server-side timeout (15s) to avoid client-side abort
+        signal: AbortSignal.timeout(20000)
       }
     );
 
@@ -161,7 +170,8 @@ await Bun.sleep(60000);
     // Cleanup
     await fetch(`${workerUrl}/api/process/${processId}`, {
       method: 'DELETE',
-      headers
+      headers,
+      signal: AbortSignal.timeout(5000)
     });
   }, 60000);
 
@@ -187,7 +197,8 @@ await Bun.sleep(60000);
       body: JSON.stringify({
         path: '/workspace/app.js',
         content: scriptCode
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     // Start the process
@@ -196,7 +207,8 @@ await Bun.sleep(60000);
       headers,
       body: JSON.stringify({
         command: 'bun run /workspace/app.js'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(startResponse.status).toBe(200);
@@ -212,7 +224,9 @@ await Bun.sleep(60000);
         body: JSON.stringify({
           pattern: 'Database connected',
           timeout: 10000
-        })
+        }),
+        // Must exceed server-side timeout (10s) to avoid client-side abort
+        signal: AbortSignal.timeout(15000)
       }
     );
     expect(waitLogResponse.status).toBe(200);
@@ -226,7 +240,9 @@ await Bun.sleep(60000);
         body: JSON.stringify({
           port: 9091,
           timeout: 10000
-        })
+        }),
+        // Must exceed server-side timeout (10s) to avoid client-side abort
+        signal: AbortSignal.timeout(15000)
       }
     );
     expect(waitPortResponse.status).toBe(200);
@@ -234,7 +250,8 @@ await Bun.sleep(60000);
     // Cleanup
     await fetch(`${workerUrl}/api/process/${processId}`, {
       method: 'DELETE',
-      headers
+      headers,
+      signal: AbortSignal.timeout(5000)
     });
   }, 60000);
 
@@ -252,7 +269,8 @@ await Bun.sleep(60000);
       body: JSON.stringify({
         path: '/workspace/slow.js',
         content: scriptCode
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     // Start the process
@@ -261,7 +279,8 @@ await Bun.sleep(60000);
       headers,
       body: JSON.stringify({
         command: 'bun run /workspace/slow.js'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(startResponse.status).toBe(200);
@@ -289,7 +308,8 @@ await Bun.sleep(60000);
     // Cleanup
     await fetch(`${workerUrl}/api/process/${processId}`, {
       method: 'DELETE',
-      headers
+      headers,
+      signal: AbortSignal.timeout(5000)
     });
   }, 60000);
 
@@ -300,7 +320,8 @@ await Bun.sleep(60000);
       headers,
       body: JSON.stringify({
         command: 'echo "quick exit"'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(startResponse.status).toBe(200);
@@ -316,7 +337,9 @@ await Bun.sleep(60000);
         body: JSON.stringify({
           pattern: 'Server ready',
           timeout: 10000
-        })
+        }),
+        // Must exceed server-side timeout (10s) to avoid client-side abort
+        signal: AbortSignal.timeout(15000)
       }
     );
 
@@ -342,7 +365,8 @@ await Bun.sleep(60000);
       body: JSON.stringify({
         path: '/workspace/stderr.js',
         content: scriptCode
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     // Start the process
@@ -351,7 +375,8 @@ await Bun.sleep(60000);
       headers,
       body: JSON.stringify({
         command: 'bun run /workspace/stderr.js'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(startResponse.status).toBe(200);
@@ -367,7 +392,9 @@ await Bun.sleep(60000);
         body: JSON.stringify({
           pattern: 'Ready (stderr)',
           timeout: 30000
-        })
+        }),
+        // Must exceed server-side timeout (30s) to avoid client-side abort
+        signal: AbortSignal.timeout(35000)
       }
     );
 
@@ -378,7 +405,8 @@ await Bun.sleep(60000);
     // Cleanup
     await fetch(`${workerUrl}/api/process/${processId}`, {
       method: 'DELETE',
-      headers
+      headers,
+      signal: AbortSignal.timeout(5000)
     });
   }, 60000);
 
@@ -404,7 +432,8 @@ console.log("Server listening on port 9092");
         body: JSON.stringify({
           path: '/workspace/http-server.js',
           content: serverCode
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       // Start the process
@@ -413,7 +442,8 @@ console.log("Server listening on port 9092");
         headers,
         body: JSON.stringify({
           command: 'bun run /workspace/http-server.js'
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(startResponse.status).toBe(200);
@@ -429,7 +459,9 @@ console.log("Server listening on port 9092");
           body: JSON.stringify({
             port: 9092,
             timeout: 30000
-          })
+          }),
+          // Must exceed server-side timeout (30s) to avoid client-side abort
+          signal: AbortSignal.timeout(35000)
         }
       );
       expect(waitPortResponse.status).toBe(200);
@@ -440,7 +472,8 @@ console.log("Server listening on port 9092");
         headers: portHeaders,
         body: JSON.stringify({
           port: 9092
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(exposeResponse.status).toBe(200);
@@ -448,7 +481,9 @@ console.log("Server listening on port 9092");
       expect(exposeData.url).toBeTruthy();
 
       // Make a request to the exposed URL
-      const apiResponse = await fetch(exposeData.url);
+      const apiResponse = await fetch(exposeData.url, {
+        signal: AbortSignal.timeout(5000)
+      });
       expect(apiResponse.status).toBe(200);
       const apiData = (await apiResponse.json()) as { message: string };
       expect(apiData.message).toBe('Hello!');
@@ -460,7 +495,8 @@ console.log("Server listening on port 9092");
       });
       await fetch(`${workerUrl}/api/process/${processId}`, {
         method: 'DELETE',
-        headers
+        headers,
+        signal: AbortSignal.timeout(5000)
       });
     },
     90000
@@ -484,43 +520,52 @@ Bun.serve({
         body: JSON.stringify({
           path: '/workspace/token-server.js',
           content: serverCode
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       const startResponse = await fetch(`${workerUrl}/api/process/start`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ command: 'bun run /workspace/token-server.js' })
+        body: JSON.stringify({ command: 'bun run /workspace/token-server.js' }),
+        signal: AbortSignal.timeout(5000)
       });
       const { id: processId } = (await startResponse.json()) as Process;
 
       await fetch(`${workerUrl}/api/process/${processId}/waitForPort`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ port: 9093, timeout: 30000 })
+        body: JSON.stringify({ port: 9093, timeout: 30000 }),
+        // Must exceed server-side timeout (30s) to avoid client-side abort
+        signal: AbortSignal.timeout(35000)
       });
 
       const exposeResponse = await fetch(`${workerUrl}/api/port/expose`, {
         method: 'POST',
         headers: portHeaders,
-        body: JSON.stringify({ port: 9093, token: 'my_stable_token' })
+        body: JSON.stringify({ port: 9093, token: 'my_stable_token' }),
+        signal: AbortSignal.timeout(5000)
       });
 
       expect(exposeResponse.status).toBe(200);
       const { url } = (await exposeResponse.json()) as PortExposeResult;
       expect(url).toContain('my_stable_token');
 
-      const apiResponse = await fetch(url);
+      const apiResponse = await fetch(url, {
+        signal: AbortSignal.timeout(5000)
+      });
       expect(apiResponse.status).toBe(200);
       expect(await apiResponse.text()).toBe('token-test-ok');
 
       await fetch(`${workerUrl}/api/exposed-ports/9093`, {
         method: 'DELETE',
-        headers: portHeaders
+        headers: portHeaders,
+        signal: AbortSignal.timeout(5000)
       });
       await fetch(`${workerUrl}/api/process/${processId}`, {
         method: 'DELETE',
-        headers
+        headers,
+        signal: AbortSignal.timeout(5000)
       });
     },
     90000

--- a/tests/e2e/pty.test.ts
+++ b/tests/e2e/pty.test.ts
@@ -193,7 +193,9 @@ describe('PTY', () => {
 
   describe('Error Handling', () => {
     test('returns 426 for non-WebSocket request', async () => {
-      const response = await fetch(`${workerUrl}/terminal`);
+      const response = await fetch(`${workerUrl}/terminal`, {
+        signal: AbortSignal.timeout(5000)
+      });
       expect(response.status).toBe(426);
     }, 10000);
   });

--- a/tests/e2e/redirect-proxy-workflow.test.ts
+++ b/tests/e2e/redirect-proxy-workflow.test.ts
@@ -69,7 +69,8 @@ await Bun.sleep(60000);
         body: JSON.stringify({
           path: '/workspace/redirect-server.ts',
           content: serverCode
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       // Start the server process
@@ -78,7 +79,8 @@ await Bun.sleep(60000);
         headers,
         body: JSON.stringify({
           command: `bun run /workspace/redirect-server.ts`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
       expect(startResponse.status).toBe(200);
       const { id: processId } = (await startResponse.json()) as Process;
@@ -92,7 +94,9 @@ await Bun.sleep(60000);
             port: REDIRECT_TEST_PORT,
             timeout: 15000,
             mode: 'tcp'
-          })
+          }),
+          // Must exceed server-side timeout (15s) to avoid client-side abort
+          signal: AbortSignal.timeout(20000)
         }
       );
       expect(waitPortResponse.status).toBe(200);
@@ -104,14 +108,18 @@ await Bun.sleep(60000);
         body: JSON.stringify({
           port: REDIRECT_TEST_PORT,
           name: 'redirect-test'
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
       expect(exposeResponse.status).toBe(200);
       const { url: exposedUrl } =
         (await exposeResponse.json()) as PortExposeResult;
 
       // Fetch the exposed URL
-      const proxyResponse = await fetch(exposedUrl, { redirect: 'manual' });
+      const proxyResponse = await fetch(exposedUrl, {
+        redirect: 'manual',
+        signal: AbortSignal.timeout(5000)
+      });
 
       // The proxy should return the 307
       expect(proxyResponse.status).toBe(307);
@@ -125,11 +133,13 @@ await Bun.sleep(60000);
       // Cleanup
       await fetch(`${workerUrl}/api/exposed-ports/${REDIRECT_TEST_PORT}`, {
         method: 'DELETE',
-        headers: portHeaders
+        headers: portHeaders,
+        signal: AbortSignal.timeout(5000)
       });
       await fetch(`${workerUrl}/api/process/${processId}`, {
         method: 'DELETE',
-        headers
+        headers,
+        signal: AbortSignal.timeout(5000)
       });
     },
     90000

--- a/tests/e2e/session-state-isolation-workflow.test.ts
+++ b/tests/e2e/session-state-isolation-workflow.test.ts
@@ -1,10 +1,8 @@
 import type {
   ExecResult,
   Process,
-  ReadFileResult,
   SessionCreateResult,
-  SessionDeleteResult,
-  WaitForExitResult
+  SessionDeleteResult
 } from '@repo/shared';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import {

--- a/tests/e2e/session-state-isolation-workflow.test.ts
+++ b/tests/e2e/session-state-isolation-workflow.test.ts
@@ -48,7 +48,8 @@ describe('Session State Isolation Workflow', () => {
       headers: baseHeaders,
       body: JSON.stringify({
         command: 'echo "Session isolation sandbox ready"'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
   }, 120000);
 
@@ -68,7 +69,8 @@ describe('Session State Isolation Workflow', () => {
           API_KEY: 'prod-key-123',
           DB_HOST: 'prod.example.com'
         }
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(session1Response.status).toBe(200);
@@ -87,7 +89,8 @@ describe('Session State Isolation Workflow', () => {
           API_KEY: 'test-key-456',
           DB_HOST: 'test.example.com'
         }
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(session2Response.status).toBe(200);
@@ -101,7 +104,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session1Id),
       body: JSON.stringify({
         command: 'echo "$NODE_ENV|$API_KEY|$DB_HOST"'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(exec1Response.status).toBe(200);
@@ -117,7 +121,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session2Id),
       body: JSON.stringify({
         command: 'echo "$NODE_ENV|$API_KEY|$DB_HOST"'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(exec2Response.status).toBe(200);
@@ -131,7 +136,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session1Id),
       body: JSON.stringify({
         envVars: { NEW_VAR: 'session1-only' }
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(setEnv1Response.status).toBe(200);
@@ -142,7 +148,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session1Id),
       body: JSON.stringify({
         command: 'echo $NEW_VAR'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     const check1Data = (await check1Response.json()) as ExecResult;
@@ -154,7 +161,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session2Id),
       body: JSON.stringify({
         command: 'echo "VALUE:$NEW_VAR:END"'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     const check2Data = (await check2Response.json()) as ExecResult;
@@ -169,7 +177,8 @@ describe('Session State Isolation Workflow', () => {
       body: JSON.stringify({
         path: '/workspace/app',
         recursive: true
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     await fetch(`${workerUrl}/api/file/mkdir`, {
@@ -178,7 +187,8 @@ describe('Session State Isolation Workflow', () => {
       body: JSON.stringify({
         path: '/workspace/test',
         recursive: true
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     await fetch(`${workerUrl}/api/file/mkdir`, {
@@ -187,7 +197,8 @@ describe('Session State Isolation Workflow', () => {
       body: JSON.stringify({
         path: '/workspace/app/src',
         recursive: true
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     await fetch(`${workerUrl}/api/file/mkdir`, {
@@ -196,7 +207,8 @@ describe('Session State Isolation Workflow', () => {
       body: JSON.stringify({
         path: '/workspace/test/unit',
         recursive: true
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     // Create session1 with cwd: /workspace/app
@@ -205,7 +217,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId!),
       body: JSON.stringify({
         cwd: '/workspace/app'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     const session1Data = (await session1Response.json()) as SessionCreateResult;
@@ -217,7 +230,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId!),
       body: JSON.stringify({
         cwd: '/workspace/test'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     const session2Data = (await session2Response.json()) as SessionCreateResult;
@@ -229,7 +243,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session1Id),
       body: JSON.stringify({
         command: 'pwd'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     const pwd1Data = (await pwd1Response.json()) as ExecResult;
@@ -241,7 +256,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session2Id),
       body: JSON.stringify({
         command: 'pwd'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     const pwd2Data = (await pwd2Response.json()) as ExecResult;
@@ -253,7 +269,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session1Id),
       body: JSON.stringify({
         command: 'cd src'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     // Change directory in session2
@@ -262,7 +279,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session2Id),
       body: JSON.stringify({
         command: 'cd unit'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     // Verify session1 is in /workspace/app/src
@@ -271,7 +289,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session1Id),
       body: JSON.stringify({
         command: 'pwd'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     const newPwd1Data = (await newPwd1Response.json()) as ExecResult;
@@ -283,7 +302,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session2Id),
       body: JSON.stringify({
         command: 'pwd'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     const newPwd2Data = (await newPwd2Response.json()) as ExecResult;
@@ -295,7 +315,8 @@ describe('Session State Isolation Workflow', () => {
     const session1Response = await fetch(`${workerUrl}/api/session/create`, {
       method: 'POST',
       headers: createTestHeaders(sandboxId!),
-      body: JSON.stringify({})
+      body: JSON.stringify({}),
+      signal: AbortSignal.timeout(5000)
     });
 
     const session1Data = (await session1Response.json()) as SessionCreateResult;
@@ -304,7 +325,8 @@ describe('Session State Isolation Workflow', () => {
     const session2Response = await fetch(`${workerUrl}/api/session/create`, {
       method: 'POST',
       headers: createTestHeaders(sandboxId!),
-      body: JSON.stringify({})
+      body: JSON.stringify({}),
+      signal: AbortSignal.timeout(5000)
     });
 
     const session2Data = (await session2Response.json()) as SessionCreateResult;
@@ -316,7 +338,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session1Id),
       body: JSON.stringify({
         command: 'greet() { echo "Hello from Production"; }'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(defineFunc1Response.status).toBe(200);
@@ -327,7 +350,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session1Id),
       body: JSON.stringify({
         command: 'greet'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     const call1Data = (await call1Response.json()) as ExecResult;
@@ -340,7 +364,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session2Id),
       body: JSON.stringify({
         command: 'greet'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     const call2Data = (await call2Response.json()) as ExecResult;
@@ -353,7 +378,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session2Id),
       body: JSON.stringify({
         command: 'greet() { echo "Hello from Test"; }'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     // Call greet() in session2 - should use session2's definition
@@ -362,7 +388,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session2Id),
       body: JSON.stringify({
         command: 'greet'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     const call3Data = (await call3Response.json()) as ExecResult;
@@ -375,7 +402,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session1Id),
       body: JSON.stringify({
         command: 'greet'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     const call4Data = (await call4Response.json()) as ExecResult;
@@ -387,7 +415,8 @@ describe('Session State Isolation Workflow', () => {
     const session1Response = await fetch(`${workerUrl}/api/session/create`, {
       method: 'POST',
       headers: createTestHeaders(sandboxId!),
-      body: JSON.stringify({})
+      body: JSON.stringify({}),
+      signal: AbortSignal.timeout(5000)
     });
 
     const session1Data = (await session1Response.json()) as SessionCreateResult;
@@ -396,7 +425,8 @@ describe('Session State Isolation Workflow', () => {
     const session2Response = await fetch(`${workerUrl}/api/session/create`, {
       method: 'POST',
       headers: createTestHeaders(sandboxId!),
-      body: JSON.stringify({})
+      body: JSON.stringify({}),
+      signal: AbortSignal.timeout(5000)
     });
 
     const session2Data = (await session2Response.json()) as SessionCreateResult;
@@ -408,7 +438,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session1Id),
       body: JSON.stringify({
         command: 'sleep 120'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(startResponse.status).toBe(200);
@@ -419,7 +450,8 @@ describe('Session State Isolation Workflow', () => {
     // so process is immediately visible (shared process table)
     const listResponse = await fetch(`${workerUrl}/api/process/list`, {
       method: 'GET',
-      headers: createTestHeaders(sandboxId, session2Id)
+      headers: createTestHeaders(sandboxId, session2Id),
+      signal: AbortSignal.timeout(5000)
     });
     expect(listResponse.status).toBe(200);
     const processes = (await listResponse.json()) as Process[];
@@ -434,7 +466,8 @@ describe('Session State Isolation Workflow', () => {
     // Kill the process from session2 - should work (shared process table)
     const killResponse = await fetch(`${workerUrl}/api/process/${processId}`, {
       method: 'DELETE',
-      headers: createTestHeaders(sandboxId, session2Id)
+      headers: createTestHeaders(sandboxId, session2Id),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(killResponse.status).toBe(200);
@@ -445,7 +478,9 @@ describe('Session State Isolation Workflow', () => {
       {
         method: 'POST',
         headers: createTestHeaders(sandboxId, session1Id),
-        body: JSON.stringify({ timeout: 5000 })
+        body: JSON.stringify({ timeout: 5000 }),
+        // Must exceed server-side timeout (5s) to avoid client-side abort
+        signal: AbortSignal.timeout(10000)
       }
     );
     expect(waitExitResponse.status).toBe(200);
@@ -458,7 +493,8 @@ describe('Session State Isolation Workflow', () => {
     const session1Response = await fetch(`${workerUrl}/api/session/create`, {
       method: 'POST',
       headers: createTestHeaders(sandboxId!),
-      body: JSON.stringify({})
+      body: JSON.stringify({}),
+      signal: AbortSignal.timeout(5000)
     });
 
     const session1Data = (await session1Response.json()) as SessionCreateResult;
@@ -467,7 +503,8 @@ describe('Session State Isolation Workflow', () => {
     const session2Response = await fetch(`${workerUrl}/api/session/create`, {
       method: 'POST',
       headers: createTestHeaders(sandboxId!),
-      body: JSON.stringify({})
+      body: JSON.stringify({}),
+      signal: AbortSignal.timeout(5000)
     });
 
     const session2Data = (await session2Response.json()) as SessionCreateResult;
@@ -480,7 +517,8 @@ describe('Session State Isolation Workflow', () => {
       body: JSON.stringify({
         path: '/workspace/shared.txt',
         content: 'Written by session1'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(writeResponse.status).toBe(200);
@@ -491,7 +529,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session2Id),
       body: JSON.stringify({
         path: '/workspace/shared.txt'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(readResponse.status).toBe(200);
@@ -505,7 +544,8 @@ describe('Session State Isolation Workflow', () => {
       body: JSON.stringify({
         path: '/workspace/shared.txt',
         content: 'Modified by session2'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(modifyResponse.status).toBe(200);
@@ -516,7 +556,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session1Id),
       body: JSON.stringify({
         path: '/workspace/shared.txt'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     const verifyData = (await verifyResponse.json()) as ReadFileResult;
@@ -528,7 +569,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session1Id),
       body: JSON.stringify({
         path: '/workspace/shared.txt'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
   }, 90000);
 
@@ -539,7 +581,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId!),
       body: JSON.stringify({
         env: { SESSION_NAME: 'session1' }
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     const session1Data = (await session1Response.json()) as SessionCreateResult;
@@ -550,7 +593,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId!),
       body: JSON.stringify({
         env: { SESSION_NAME: 'session2' }
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     const session2Data = (await session2Response.json()) as SessionCreateResult;
@@ -562,7 +606,9 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session1Id),
       body: JSON.stringify({
         command: 'sleep 2 && echo "Completed in $SESSION_NAME"'
-      })
+      }),
+      // Must exceed the 2s sleep in the command
+      signal: AbortSignal.timeout(10000)
     });
 
     const exec2Promise = fetch(`${workerUrl}/api/execute`, {
@@ -570,7 +616,9 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, session2Id),
       body: JSON.stringify({
         command: 'sleep 2 && echo "Completed in $SESSION_NAME"'
-      })
+      }),
+      // Must exceed the 2s sleep in the command
+      signal: AbortSignal.timeout(10000)
     });
 
     // Wait for both to complete
@@ -635,7 +683,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId!),
       body: JSON.stringify({
         env: { SESSION_VAR: 'test-value' }
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(sessionResponse.status).toBe(200);
@@ -648,7 +697,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, sessionId),
       body: JSON.stringify({
         command: 'echo $SESSION_VAR'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(execBeforeResponse.status).toBe(200);
@@ -661,7 +711,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId!),
       body: JSON.stringify({
         sessionId: sessionId
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(deleteResponse.status).toBe(200);
@@ -678,7 +729,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId, sessionId), // Use same session ID
       body: JSON.stringify({
         command: 'echo $SESSION_VAR'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(useDeletedSessionResponse.status).toBe(200);
@@ -694,7 +746,8 @@ describe('Session State Isolation Workflow', () => {
       headers: createTestHeaders(sandboxId!), // Use default session
       body: JSON.stringify({
         command: 'echo "sandbox-alive"'
-      })
+      }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(sandboxStillAliveResponse.status).toBe(200);

--- a/tests/e2e/session-state-isolation-workflow.test.ts
+++ b/tests/e2e/session-state-isolation-workflow.test.ts
@@ -484,8 +484,9 @@ describe('Session State Isolation Workflow', () => {
       }
     );
     expect(waitExitResponse.status).toBe(200);
-    const exitResult = (await waitExitResponse.json()) as WaitForExitResult;
-    expect(exitResult.exitCode).toBeDefined();
+    await expect(waitExitResponse.json()).resolves.toEqual(
+      expect.objectContaining({ exitCode: expect.anything() })
+    );
   }, 90000);
 
   test('should share file system between sessions (by design)', async () => {
@@ -534,8 +535,9 @@ describe('Session State Isolation Workflow', () => {
     });
 
     expect(readResponse.status).toBe(200);
-    const readData = (await readResponse.json()) as ReadFileResult;
-    expect(readData.content).toBe('Written by session1');
+    await expect(readResponse.json()).resolves.toEqual(
+      expect.objectContaining({ content: 'Written by session1' })
+    );
 
     // Modify the file from session2
     const modifyResponse = await fetch(`${workerUrl}/api/file/write`, {
@@ -560,8 +562,9 @@ describe('Session State Isolation Workflow', () => {
       signal: AbortSignal.timeout(5000)
     });
 
-    const verifyData = (await verifyResponse.json()) as ReadFileResult;
-    expect(verifyData.content).toBe('Modified by session2');
+    await expect(verifyResponse.json()).resolves.toEqual(
+      expect.objectContaining({ content: 'Modified by session2' })
+    );
 
     // Cleanup
     await fetch(`${workerUrl}/api/file/delete`, {

--- a/tests/e2e/standalone-binary-workflow.test.ts
+++ b/tests/e2e/standalone-binary-workflow.test.ts
@@ -42,7 +42,8 @@ describe('Standalone Binary Workflow', () => {
     const response = await fetch(`${workerUrl}/api/execute`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ command: 'echo "ok"' })
+      body: JSON.stringify({ command: 'echo "ok"' }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(response.status).toBe(200);
@@ -55,7 +56,8 @@ describe('Standalone Binary Workflow', () => {
     const response = await fetch(`${workerUrl}/api/file/read`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ path: '/tmp/startup-marker.txt' })
+      body: JSON.stringify({ path: '/tmp/startup-marker.txt' }),
+      signal: AbortSignal.timeout(5000)
     });
 
     expect(response.status).toBe(200);

--- a/tests/e2e/standalone-binary-workflow.test.ts
+++ b/tests/e2e/standalone-binary-workflow.test.ts
@@ -47,8 +47,9 @@ describe('Standalone Binary Workflow', () => {
     });
 
     expect(response.status).toBe(200);
-    const result = (await response.json()) as ExecResult;
-    expect(result.exitCode).toBe(0);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({ exitCode: 0 })
+    );
   });
 
   test('CMD passthrough executes startup script', async () => {
@@ -61,7 +62,10 @@ describe('Standalone Binary Workflow', () => {
     });
 
     expect(response.status).toBe(200);
-    const result = (await response.json()) as ReadFileResult;
-    expect(result.content).toMatch(/^startup-\d+$/);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        content: expect.stringMatching(/^startup-\d+$/)
+      })
+    );
   });
 });

--- a/tests/e2e/standalone-binary-workflow.test.ts
+++ b/tests/e2e/standalone-binary-workflow.test.ts
@@ -10,7 +10,6 @@
  * - Server continues running after CMD exits
  */
 
-import type { ExecResult, ReadFileResult } from '@repo/shared';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import {
   cleanupTestSandbox,

--- a/tests/e2e/test-worker/index.ts
+++ b/tests/e2e/test-worker/index.ts
@@ -208,9 +208,11 @@ export default {
     // Suffix sandbox ID with transport so each transport gets its own DO instance
     const sandboxId = `${baseSandboxId}-${transport}`;
 
-    // Check if keepAlive is requested
+    // Only pass keepAlive / sleepAfter when the caller explicitly set them.
+    // Passing keepAlive: false on every request triggers setKeepAlive(false)
+    // which calls renewActivityTimeout(), resetting the sleepAfter countdown
+    // whenever the Worker isolate recycles and the configuration cache is cold.
     const keepAliveHeader = request.headers.get('X-Sandbox-KeepAlive');
-    const keepAlive = keepAliveHeader === 'true';
     const sleepAfter = request.headers.get('X-Sandbox-Sleep-After');
 
     // Select sandbox type based on X-Sandbox-Type header
@@ -231,7 +233,9 @@ export default {
     }
 
     const sandbox = getSandbox(sandboxNamespace, sandboxId, {
-      keepAlive,
+      ...(keepAliveHeader !== null && {
+        keepAlive: keepAliveHeader === 'true'
+      }),
       transport,
       ...(sleepAfter !== null && { sleepAfter })
     });

--- a/tests/e2e/websocket-connect.test.ts
+++ b/tests/e2e/websocket-connect.test.ts
@@ -24,7 +24,9 @@ describe('WebSocket Connections', () => {
     // Initialize sandbox (container echo server is built-in)
     const initRes = await fetch(`${workerUrl}/api/init`, {
       method: 'POST',
-      headers: { 'X-Sandbox-Id': sandboxId }
+      headers: { 'X-Sandbox-Id': sandboxId },
+      // Wait for port uses 30s timeout per port.
+      signal: AbortSignal.timeout(60000)
     });
     expect(initRes.status).toBe(200);
   }, 120000);

--- a/tests/e2e/websocket-workflow.test.ts
+++ b/tests/e2e/websocket-workflow.test.ts
@@ -55,7 +55,8 @@ describe('WebSocket Port Exposure', () => {
         body: JSON.stringify({
           path: '/workspace/ws-server.ts',
           content: serverCode
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
 
       // Start server on dedicated port
@@ -65,7 +66,8 @@ describe('WebSocket Port Exposure', () => {
         headers,
         body: JSON.stringify({
           command: `bun run /workspace/ws-server.ts ${port}`
-        })
+        }),
+        signal: AbortSignal.timeout(5000)
       });
       expect(startResponse.status).toBe(200);
       const processData = (await startResponse.json()) as Process;
@@ -80,7 +82,9 @@ describe('WebSocket Port Exposure', () => {
             port,
             mode: 'tcp',
             timeout: 10000
-          })
+          }),
+          // Must exceed server-side timeout (10s) to avoid client-side abort
+          signal: AbortSignal.timeout(15000)
         }
       );
       expect(waitPortResponse.status).toBe(200);
@@ -89,7 +93,8 @@ describe('WebSocket Port Exposure', () => {
       const exposeResponse = await fetch(`${workerUrl}/api/port/expose`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ port, name: 'ws-test' })
+        body: JSON.stringify({ port, name: 'ws-test' }),
+        signal: AbortSignal.timeout(5000)
       });
       expect(exposeResponse.status).toBe(200);
       const exposeData = (await exposeResponse.json()) as PortExposeResult;
@@ -117,11 +122,13 @@ describe('WebSocket Port Exposure', () => {
       ws.close();
       await fetch(`${workerUrl}/api/process/${processData.id}`, {
         method: 'DELETE',
-        headers
+        headers,
+        signal: AbortSignal.timeout(5000)
       });
       await fetch(`${workerUrl}/api/exposed-ports/${port}`, {
         method: 'DELETE',
-        headers
+        headers,
+        signal: AbortSignal.timeout(5000)
       });
     },
     30000


### PR DESCRIPTION
This makes it easier to see which part of the test was slow vs. the entire test failing due to timeout.

Also updated the response body assertions to use `expect(body).resolves.toEqual(...)`, this then makes it easier to see what the response body actually looked like on failure.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
