### PR TITLE
Clean up existing Biome lint warnings

### DIFF
--- a/bridge/examples/workspace-chat/frontend/src/styles.css
+++ b/bridge/examples/workspace-chat/frontend/src/styles.css
@@ -1,5 +1,5 @@
-@import "@cloudflare/kumo/styles/tailwind";
-@import "tailwindcss";
+@import '@cloudflare/kumo/styles/tailwind';
+@import 'tailwindcss';
 
 /* Scan Kumo and Streamdown for Tailwind class names */
 @source "../node_modules/@cloudflare/kumo/dist/**/*.{js,jsx,ts,tsx}";
@@ -44,8 +44,8 @@
   margin: 0.5rem 0;
   background: none;
 }
-.sd-theme .rounded-xl:has(pre) > :not(:has(pre)):not(pre) {
-  display: none !important;
+.sd-theme.sd-theme .rounded-xl:has(pre) > :not(:has(pre)):not(pre) {
+  display: none;
 }
 .sd-theme pre {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
@@ -60,10 +60,10 @@
   border: none;
   margin: 0;
 }
-.sd-theme [data-streamdown="code-block-body"] {
-  border: none !important;
-  background: none !important;
-  padding: 0 !important;
+.sd-theme.sd-theme [data-streamdown='code-block-body'] {
+  border: none;
+  background: none;
+  padding: 0;
 }
 .sd-theme ol,
 .sd-theme ul {

--- a/bridge/worker/src/__tests__/warm-pool.test.ts
+++ b/bridge/worker/src/__tests__/warm-pool.test.ts
@@ -1,6 +1,6 @@
 import { env, runDurableObjectAlarm, runInDurableObject } from 'cloudflare:test';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { WarmPool } from '../../../../packages/sandbox/src/bridge/warm-pool';
+import type { WarmPool } from '../../../../packages/sandbox/src/bridge/warm-pool';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/examples/codex-app-server/public/index.html
+++ b/examples/codex-app-server/public/index.html
@@ -1,905 +1,1146 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>codex</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;0,600;1,400&display=swap" rel="stylesheet" />
-  <style>
-    :root {
-      --bg-0: #0a0a0a;
-      --bg-1: #111111;
-      --bg-2: #1a1a1a;
-      --border: #2a2a2a;
-      --text-0: #999999;
-      --text-1: #cccccc;
-      --text-2: #e0e0e0;
-      --accent: #c8ff00;
-      --accent-dim: #6b8a00;
-      --danger: #ff4040;
-      --info: #606060;
-      --user-bg: #141410;
-      --agent-bg: #0f1210;
-      --tool-bg: #0d0d0d;
-      --tool-border: #1f1f1f;
-      --file-add: #4a9a4a;
-      --file-mod: #9a8a3a;
-      --file-del: #9a4a4a;
-    }
-
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-
-    html, body {
-      height: 100%;
-      overflow: hidden;
-      background: var(--bg-0);
-      color: var(--text-1);
-      font-family: 'IBM Plex Mono', monospace;
-      font-size: 13px;
-      line-height: 1.5;
-      -webkit-font-smoothing: antialiased;
-    }
-
-    ::selection { background: var(--accent); color: var(--bg-0); }
-    ::-webkit-scrollbar { width: 6px; }
-    ::-webkit-scrollbar-track { background: transparent; }
-    ::-webkit-scrollbar-thumb { background: #444; }
-    input, textarea, button { font-family: inherit; font-size: inherit; }
-
-    /* --- Layout --- */
-
-    #app { display: flex; flex-direction: column; height: 100vh; }
-    #app.disconnected .main { display: none; }
-    #app:not(.disconnected) .session-gate { display: none; }
-
-    /* --- Session gate --- */
-
-    .session-gate { flex: 1; display: grid; place-items: center; }
-    .session-form { width: 400px; max-width: 90vw; }
-
-    .session-form h1 {
-      font-size: 14px;
-      font-weight: 500;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: var(--accent);
-      margin-bottom: 32px;
-    }
-
-    .session-form .field { margin-bottom: 16px; }
-
-    .session-form label {
-      display: block;
-      font-size: 11px;
-      font-weight: 500;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-      color: var(--text-0);
-      margin-bottom: 6px;
-    }
-
-    .session-form input {
-      width: 100%;
-      padding: 10px 12px;
-      background: var(--bg-1);
-      border: 1px solid var(--border);
-      color: var(--text-2);
-      outline: none;
-    }
-
-    .session-form input:focus { border-color: var(--accent-dim); }
-    .session-form input::placeholder { color: var(--info); }
-    .session-form .hint { font-size: 11px; color: var(--info); margin-top: 4px; }
-
-    .session-form button {
-      margin-top: 24px;
-      width: 100%;
-      padding: 10px;
-      background: var(--accent);
-      color: var(--bg-0);
-      border: none;
-      font-weight: 600;
-      letter-spacing: 0.04em;
-      text-transform: uppercase;
-      cursor: pointer;
-    }
-
-    .session-form button:hover { opacity: 0.85; }
-    .session-form button:disabled { opacity: 0.3; cursor: not-allowed; }
-
-    .session-form .status-line {
-      margin-top: 16px;
-      font-size: 11px;
-      color: var(--text-0);
-      min-height: 1.5em;
-    }
-
-    .session-form .status-line.error { color: var(--danger); }
-
-    /* --- Main view --- */
-
-    .main { display: flex; flex-direction: column; flex: 1; overflow: hidden; }
-
-    .topbar {
-      height: 44px;
-      border-bottom: 1px solid var(--border);
-      display: flex;
-      align-items: center;
-      padding: 0 20px;
-      gap: 12px;
-      flex-shrink: 0;
-    }
-
-    .topbar .session-label {
-      font-size: 11px;
-      font-weight: 500;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-      color: var(--accent);
-      flex: 1;
-    }
-
-    .turn-indicator { display: none; align-items: center; gap: 6px; font-size: 11px; color: var(--accent-dim); }
-    .turn-indicator.active { display: flex; }
-
-    .turn-indicator .spinner {
-      width: 10px; height: 10px;
-      border: 1.5px solid var(--accent-dim);
-      border-top-color: var(--accent);
-      animation: spin 0.8s linear infinite;
-    }
-
-    @keyframes spin { to { transform: rotate(360deg); } }
-
-    .topbar button {
-      font-size: 10px;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-      color: var(--info);
-      cursor: pointer;
-      padding: 4px 8px;
-      border: 1px solid transparent;
-      background: none;
-      user-select: none;
-    }
-
-    .topbar button:hover { color: var(--text-0); }
-    .topbar button.active { color: var(--text-1); border-color: var(--border); }
-    .topbar .end-btn:hover { color: var(--danger); }
-
-    /* --- Messages --- */
-
-    .messages { flex: 1; overflow-y: auto; padding: 20px; }
-
-    .messages .empty-state {
-      height: 100%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      color: var(--info);
-      font-size: 12px;
-      font-style: italic;
-    }
-
-    .msg { margin-bottom: 16px; animation: fadeIn 0.15s ease; }
-
-    @keyframes fadeIn {
-      from { opacity: 0; transform: translateY(4px); }
-      to { opacity: 1; transform: translateY(0); }
-    }
-
-    .msg-header {
-      font-size: 10px;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      margin-bottom: 6px;
-      display: flex;
-      align-items: center;
-      gap: 8px;
-    }
-
-    .msg-header .role { color: var(--text-0); }
-    .msg-header .role.user { color: var(--accent); }
-    .msg-header .ts { color: var(--info); font-weight: 400; }
-
-    .msg-body {
-      padding: 10px 14px;
-      border-left: 2px solid var(--border);
-      white-space: pre-wrap;
-      word-break: break-word;
-      color: var(--text-1);
-      line-height: 1.6;
-    }
-
-    .msg.user .msg-body { border-left-color: var(--accent-dim); background: var(--user-bg); }
-    .msg.agent .msg-body { border-left-color: var(--border); background: var(--agent-bg); }
-
-    .streaming-cursor {
-      display: inline-block;
-      width: 6px; height: 14px;
-      background: var(--accent);
-      margin-left: 2px;
-      vertical-align: text-bottom;
-      animation: blink 0.6s step-end infinite;
-    }
-
-    @keyframes blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
-
-    /* --- Tool call grid --- */
-
-    .tool-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(min(100%, 420px), 1fr));
-      gap: 6px;
-      margin: 8px 0 4px;
-    }
-
-    /* Single tool fills full width */
-    .tool-grid .tool-block:only-child { grid-column: 1 / -1; }
-
-    .tool-block {
-      border: 1px solid var(--tool-border);
-      background: var(--tool-bg);
-      overflow: hidden;
-      min-width: 0;
-    }
-
-    .tool-header {
-      padding: 4px 8px;
-      background: var(--bg-2);
-      font-size: 11px;
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      cursor: pointer;
-      user-select: none;
-    }
-
-    .tool-header:hover { background: #222; }
-
-    .tool-header .tool-type {
-      font-size: 8px;
-      font-weight: 600;
-      letter-spacing: 0.05em;
-      text-transform: uppercase;
-      color: var(--text-0);
-      padding: 0 4px;
-      border: 1px solid var(--border);
-      flex-shrink: 0;
-      line-height: 1.6;
-    }
-
-    .tool-header .tool-label {
-      color: var(--accent);
-      flex: 1;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      font-size: 11px;
-    }
-
-    .tool-header .tool-meta-inline {
-      font-size: 10px;
-      color: var(--info);
-      flex-shrink: 0;
-      white-space: nowrap;
-    }
-
-    .tool-header .tool-status {
-      font-size: 10px;
-      font-weight: 500;
-      flex-shrink: 0;
-    }
-
-    .tool-status.running { color: var(--text-0); }
-    .tool-status.ok { color: var(--accent); }
-    .tool-status.fail { color: var(--danger); }
-    .tool-status.declined { color: var(--danger); }
-
-    .tool-header .tool-chevron {
-      color: var(--info);
-      font-size: 9px;
-      transition: transform 0.15s;
-      flex-shrink: 0;
-    }
-
-    .tool-block.expanded .tool-chevron { transform: rotate(90deg); }
-    .tool-block.expanded .tool-header { border-bottom: 1px solid var(--tool-border); }
-
-    .tool-detail { display: none; }
-    .tool-block.expanded .tool-detail { display: block; }
-
-    .tool-output {
-      padding: 4px 8px;
-      font-size: 11px;
-      color: var(--text-0);
-      max-height: 250px;
-      overflow-y: auto;
-      white-space: pre-wrap;
-      word-break: break-all;
-      line-height: 1.4;
-    }
-
-    .tool-output:empty { display: none; }
-
-    /* File changes */
-
-    .file-changes { padding: 0; }
-    .file-change { border-bottom: 1px solid var(--tool-border); }
-    .file-change:last-child { border-bottom: none; }
-
-    .file-change-header {
-      padding: 4px 8px;
-      font-size: 11px;
-      display: flex;
-      align-items: center;
-      gap: 6px;
-    }
-
-    .file-change-kind {
-      font-size: 8px;
-      font-weight: 600;
-      letter-spacing: 0.04em;
-      text-transform: uppercase;
-      padding: 0 3px;
-    }
-
-    .file-change-kind.create { color: var(--file-add); }
-    .file-change-kind.modify { color: var(--file-mod); }
-    .file-change-kind.delete, .file-change-kind.remove { color: var(--file-del); }
-
-    .file-change-path { color: var(--text-1); font-size: 11px; }
-
-    .file-change-diff {
-      padding: 2px 8px 4px;
-      font-size: 11px;
-      color: var(--text-0);
-      max-height: 200px;
-      overflow-y: auto;
-      white-space: pre-wrap;
-      word-break: break-all;
-      line-height: 1.4;
-    }
-
-    .diff-add { color: var(--file-add); }
-    .diff-del { color: var(--file-del); }
-
-    /* --- Content layout --- */
-
-    .content { display: flex; flex: 1; overflow: hidden; }
-    .chat-col { display: flex; flex-direction: column; flex: 1; min-width: 0; overflow: hidden; }
-
-    /* --- Log side panel --- */
-
-    .log-panel {
-      display: none;
-      width: 380px;
-      flex-shrink: 0;
-      border-left: 1px solid var(--border);
-      background: var(--bg-1);
-      flex-direction: column;
-      overflow: hidden;
-    }
-
-    .log-panel.visible { display: flex; }
-
-    .log-panel-header {
-      padding: 6px 12px;
-      border-bottom: 1px solid var(--border);
-      font-size: 10px;
-      font-weight: 500;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-      color: var(--text-0);
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      flex-shrink: 0;
-    }
-
-    .log-panel-header .log-close {
-      background: none;
-      border: none;
-      color: var(--info);
-      font-size: 16px;
-      cursor: pointer;
-      padding: 0 4px;
-      line-height: 1;
-    }
-
-    .log-panel-header .log-close:hover { color: var(--text-1); }
-
-    .log-entries {
-      flex: 1;
-      overflow-y: auto;
-      padding: 6px 10px;
-      font-size: 10px;
-      color: var(--info);
-    }
-
-    .log-entries .log-entry {
-      white-space: pre-wrap;
-      word-break: break-all;
-      padding: 1px 0;
-      line-height: 1.4;
-    }
-
-    .log-entries .log-entry.out { color: #5a7a9a; }
-    .log-entries .log-entry.in  { color: #7a6a9a; }
-
-    /* --- Input --- */
-
-    .input-area {
-      border-top: 1px solid var(--border);
-      padding: 12px 20px;
-      display: flex;
-      gap: 10px;
-      align-items: flex-end;
-      flex-shrink: 0;
-    }
-
-    .input-area textarea {
-      flex: 1;
-      resize: none;
-      background: var(--bg-1);
-      border: 1px solid var(--border);
-      color: var(--text-2);
-      padding: 10px 12px;
-      outline: none;
-      min-height: 40px;
-      max-height: 120px;
-      line-height: 1.5;
-    }
-
-    .input-area textarea:focus { border-color: var(--accent-dim); }
-    .input-area textarea:disabled { opacity: 0.3; }
-    .input-area textarea::placeholder { color: var(--info); }
-
-    .input-area button {
-      padding: 10px 16px;
-      background: var(--accent);
-      color: var(--bg-0);
-      border: none;
-      font-weight: 600;
-      font-size: 11px;
-      letter-spacing: 0.05em;
-      text-transform: uppercase;
-      cursor: pointer;
-      align-self: stretch;
-    }
-
-    .input-area button:hover { opacity: 0.85; }
-    .input-area button:disabled { opacity: 0.2; cursor: not-allowed; }
-  </style>
-</head>
-<body>
-
-<div id="app" class="disconnected">
-
-  <div class="session-gate">
-    <div class="session-form">
-      <h1>Codex App Server</h1>
-      <div class="field">
-        <label for="sf-session">Session</label>
-        <input id="sf-session" type="text" placeholder="my-project" autocomplete="off" spellcheck="false" />
-        <div class="hint">Names a sandbox instance. Each session gets a fresh container.</div>
-      </div>
-      <div class="field">
-        <label for="sf-repo">Repository (optional)</label>
-        <input id="sf-repo" type="text" placeholder="https://github.com/owner/repo" autocomplete="off" spellcheck="false" />
-        <div class="hint">Cloned into /workspace via sandbox/setup.</div>
-      </div>
-      <button id="sf-connect" disabled>Connect</button>
-      <div id="sf-status" class="status-line"></div>
-    </div>
-  </div>
-
-  <div class="main">
-    <div class="topbar">
-      <span class="session-label" id="topbar-session"></span>
-      <div class="turn-indicator" id="turn-indicator">
-        <div class="spinner"></div>
-        <span>working</span>
-      </div>
-      <button id="btn-log-toggle">Log</button>
-      <button class="end-btn" id="btn-end">End</button>
-    </div>
-
-    <div class="content">
-      <div class="chat-col">
-        <div class="messages" id="messages">
-          <div class="empty-state">Send a message to begin.</div>
-        </div>
-        <div class="input-area">
-          <textarea id="prompt" rows="1" placeholder="Send a message..." disabled></textarea>
-          <button id="btn-send" disabled>Send</button>
-        </div>
-      </div>
-      <div class="log-panel" id="raw-log">
-        <div class="log-panel-header">
-          <span>JSON-RPC Log</span>
-          <button class="log-close" id="btn-log-close">&times;</button>
-        </div>
-        <div class="log-entries" id="log-entries"></div>
-      </div>
-    </div>
-  </div>
-
-</div>
-
-<script>
-// --- State ---
-
-const wsEndpoint = document.documentElement.dataset.wsEndpoint || 'ws://localhost:8787/ws';
-
-let ws = null;
-let nextId = 0;
-let sessionName = '';
-let repoUrl = '';
-
-// Connection: disconnected → connecting → setup → initializing → starting → ready
-let connState = 'disconnected';
-let pendingId = null;
-
-// Single thread
-let threadId = null;
-let turnActive = false;
-let activeAgentMsg = null; // index into messages[]
-const messages = [];       // [{role, text, streaming, items[]}] or [{role, text, ts}]
-const items = {};          // itemId → {id, type, ...metadata}
-
-// --- DOM refs ---
-
-const $ = (s) => document.getElementById(s);
-const app           = $('app');
-const sfSession     = $('sf-session');
-const sfRepo        = $('sf-repo');
-const sfConnect     = $('sf-connect');
-const sfStatus      = $('sf-status');
-const topbarSession = $('topbar-session');
-const turnIndicator = $('turn-indicator');
-const messagesEl    = $('messages');
-const logPanel      = $('raw-log');
-const logEntriesEl  = $('log-entries');
-const btnLogClose   = $('btn-log-close');
-const promptEl      = $('prompt');
-const btnSend       = $('btn-send');
-const btnEnd        = $('btn-end');
-const btnLogToggle  = $('btn-log-toggle');
-
-// --- Helpers ---
-
-function ts() { return new Date().toLocaleTimeString('en-US', { hour12: false }); }
-
-const _escEl = document.createElement('div');
-function esc(s) { _escEl.textContent = s; return _escEl.innerHTML; }
-
-function rpcReq(method, params = {}) { return { method, id: nextId++, params }; }
-
-function send(msg) {
-  if (!ws || ws.readyState !== WebSocket.OPEN) return;
-  const raw = JSON.stringify(msg);
-  ws.send(raw);
-  rawLog('out', raw);
-}
-
-function rawLog(dir, text) {
-  const d = document.createElement('div');
-  d.className = `log-entry ${dir}`;
-  d.textContent = `${dir === 'out' ? '>>>' : '<<<'} ${text}`;
-  logEntriesEl.appendChild(d);
-  while (logEntriesEl.childElementCount > 500) logEntriesEl.removeChild(logEntriesEl.firstChild);
-  logEntriesEl.scrollTop = logEntriesEl.scrollHeight;
-}
-
-function fmtCmd(command) {
-  if (Array.isArray(command)) return command.join(' ');
-  return String(command || '');
-}
-
-// --- Session gate ---
-
-sfSession.value = localStorage.getItem('codex-session') || '';
-sfRepo.value = localStorage.getItem('codex-repo') || '';
-
-function updateConnectBtn() { sfConnect.disabled = !sfSession.value.trim(); }
-sfSession.addEventListener('input', updateConnectBtn);
-updateConnectBtn();
-
-for (const el of [sfSession, sfRepo]) {
-  el.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') { e.preventDefault(); startSession(); }
-  });
-}
-sfConnect.addEventListener('click', startSession);
-
-function startSession() {
-  const name = sfSession.value.trim();
-  if (!name) return;
-  sessionName = name;
-  repoUrl = sfRepo.value.trim();
-  localStorage.setItem('codex-session', name);
-  localStorage.setItem('codex-repo', repoUrl);
-  sfStatus.textContent = '';
-  sfStatus.className = 'status-line';
-  sfConnect.disabled = true;
-  connect();
-}
-
-// --- Connection flow ---
-
-function connect() {
-  if (ws) ws.close();
-  connState = 'connecting';
-  sfStatus.textContent = 'Connecting...';
-  nextId = 0;
-
-  ws = new WebSocket(`${wsEndpoint}/${encodeURIComponent(sessionName)}`);
-
-  ws.addEventListener('open', () => {
-    if (repoUrl) {
-      connState = 'setup';
-      sfStatus.textContent = 'Cloning repository...';
-      const msg = rpcReq('sandbox/setup', { repoUrl });
-      pendingId = msg.id;
-      send(msg);
-    } else {
-      sendInitialize();
-    }
-  });
-
-  ws.addEventListener('message', (e) => {
-    const raw = e.data;
-    rawLog('in', raw);
-    let msg;
-    try { msg = JSON.parse(raw); } catch { return; }
-    routeMessage(msg);
-  });
-
-  ws.addEventListener('close', () => {
-    const wasConnecting = connState !== 'ready';
-    connState = 'disconnected';
-    ws = null;
-    turnActive = false;
-    updateInputState();
-    if (wasConnecting) {
-      sfStatus.textContent = 'Disconnected.';
-      sfStatus.className = 'status-line error';
-      sfConnect.disabled = false;
-    }
-  });
-
-  ws.addEventListener('error', () => {
-    sfStatus.textContent = 'Connection failed.';
-    sfStatus.className = 'status-line error';
-  });
-}
-
-function sendInitialize() {
-  connState = 'initializing';
-  sfStatus.textContent = 'Initializing...';
-  const msg = rpcReq('initialize', {
-    clientInfo: { name: 'sandbox_codex_client', title: 'Sandbox Codex Client', version: '0.2.0' },
-    capabilities: { experimentalApi: true },
-  });
-  pendingId = msg.id;
-  send(msg);
-}
-
-function sendThreadStart() {
-  connState = 'starting';
-  send({ method: 'initialized', params: {} });
-  const msg = rpcReq('thread/start');
-  pendingId = msg.id;
-  send(msg);
-}
-
-function enterReady(codexThreadId) {
-  connState = 'ready';
-  threadId = codexThreadId;
-  app.classList.remove('disconnected');
-  topbarSession.textContent = sessionName;
-  updateInputState();
-  promptEl.focus();
-}
-
-// --- Message routing ---
-
-function routeMessage(msg) {
-  if (msg.id !== undefined && msg.method === undefined) {
-    handleResponse(msg);
-  } else if (msg.method) {
-    handleNotification(msg);
-  }
-}
-
-function handleResponse(msg) {
-  if (msg.error && msg.id === pendingId) {
-    sfStatus.textContent = `Error: ${msg.error.message}`;
-    sfStatus.className = 'status-line error';
-    sfConnect.disabled = false;
-    return;
-  }
-
-  if (msg.id !== pendingId) return;
-  pendingId = null;
-
-  switch (connState) {
-    case 'setup':        sendInitialize(); break;
-    case 'initializing': sendThreadStart(); break;
-    case 'starting':
-      if (msg.result?.thread?.id) enterReady(msg.result.thread.id);
-      break;
-  }
-}
-
-function ensureAgentMsg() {
-  if (activeAgentMsg === null) {
-    activeAgentMsg = messages.length;
-    messages.push({ role: 'agent', text: '', streaming: false, items: [] });
-  }
-  return messages[activeAgentMsg];
-}
-
-function handleNotification(msg) {
-  const p = msg.params || {};
-
-  switch (msg.method) {
-    case 'turn/started':
-      turnActive = true;
-      updateInputState();
-      break;
-
-    case 'turn/completed':
-      turnActive = false;
-      if (activeAgentMsg !== null) {
-        messages[activeAgentMsg].streaming = false;
-        activeAgentMsg = null;
-        renderMessages();
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>codex</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;0,600;1,400&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --bg-0: #0a0a0a;
+        --bg-1: #111111;
+        --bg-2: #1a1a1a;
+        --border: #2a2a2a;
+        --text-0: #999999;
+        --text-1: #cccccc;
+        --text-2: #e0e0e0;
+        --accent: #c8ff00;
+        --accent-dim: #6b8a00;
+        --danger: #ff4040;
+        --info: #606060;
+        --user-bg: #141410;
+        --agent-bg: #0f1210;
+        --tool-bg: #0d0d0d;
+        --tool-border: #1f1f1f;
+        --file-add: #4a9a4a;
+        --file-mod: #9a8a3a;
+        --file-del: #9a4a4a;
       }
-      updateInputState();
-      break;
 
-    case 'item/agentMessage/delta': {
-      const m = ensureAgentMsg();
-      m.streaming = true;
-      const delta = p.delta || '';
-      m.text += delta;
-      updateStreamingText(delta);
-      break;
-    }
-
-    case 'item/started': {
-      const item = p.item || {};
-      if (item.type === 'commandExecution') {
-        items[item.id] = {
-          id: item.id,
-          type: 'command',
-          command: fmtCmd(item.command),
-          cwd: item.cwd || '',
-          output: '',
-          exitCode: null,
-          durationMs: null,
-          status: 'running',
-        };
-      } else if (item.type === 'fileChange') {
-        items[item.id] = {
-          id: item.id,
-          type: 'fileChange',
-          changes: item.changes || [],
-          status: 'running',
-        };
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
       }
-      if (items[item.id]) {
-        ensureAgentMsg().items.push(item.id);
-        renderMessages();
-      }
-      break;
-    }
 
-    case 'item/completed': {
-      const item = p.item || {};
-      if (item.type === 'commandExecution' && items[item.id]) {
-        items[item.id].exitCode = item.exitCode ?? null;
-        items[item.id].durationMs = item.durationMs ?? null;
-        items[item.id].status = item.exitCode === 0 ? 'ok' : 'fail';
-        if (item.aggregatedOutput && !items[item.id].output) {
-          items[item.id].output = item.aggregatedOutput;
+      html,
+      body {
+        height: 100%;
+        overflow: hidden;
+        background: var(--bg-0);
+        color: var(--text-1);
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 13px;
+        line-height: 1.5;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      ::selection {
+        background: var(--accent);
+        color: var(--bg-0);
+      }
+      ::-webkit-scrollbar {
+        width: 6px;
+      }
+      ::-webkit-scrollbar-track {
+        background: transparent;
+      }
+      ::-webkit-scrollbar-thumb {
+        background: #444;
+      }
+      input,
+      textarea,
+      button {
+        font-family: inherit;
+        font-size: inherit;
+      }
+
+      /* --- Layout --- */
+
+      #app {
+        display: flex;
+        flex-direction: column;
+        height: 100vh;
+      }
+
+      /* --- Session gate --- */
+
+      .session-gate {
+        flex: 1;
+        display: grid;
+        place-items: center;
+      }
+      .session-form {
+        width: 400px;
+        max-width: 90vw;
+      }
+
+      .session-form h1 {
+        font-size: 14px;
+        font-weight: 500;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--accent);
+        margin-bottom: 32px;
+      }
+
+      .session-form .field {
+        margin-bottom: 16px;
+      }
+
+      .session-form label {
+        display: block;
+        font-size: 11px;
+        font-weight: 500;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--text-0);
+        margin-bottom: 6px;
+      }
+
+      .session-form input {
+        width: 100%;
+        padding: 10px 12px;
+        background: var(--bg-1);
+        border: 1px solid var(--border);
+        color: var(--text-2);
+        outline: none;
+      }
+
+      .session-form input:focus {
+        border-color: var(--accent-dim);
+      }
+      .session-form input::placeholder {
+        color: var(--info);
+      }
+      .session-form .hint {
+        font-size: 11px;
+        color: var(--info);
+        margin-top: 4px;
+      }
+
+      .session-form button {
+        margin-top: 24px;
+        width: 100%;
+        padding: 10px;
+        background: var(--accent);
+        color: var(--bg-0);
+        border: none;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        cursor: pointer;
+      }
+
+      .session-form button:hover {
+        opacity: 0.85;
+      }
+      .session-form button:disabled {
+        opacity: 0.3;
+        cursor: not-allowed;
+      }
+
+      .session-form .status-line {
+        margin-top: 16px;
+        font-size: 11px;
+        color: var(--text-0);
+        min-height: 1.5em;
+      }
+
+      .session-form .status-line.error {
+        color: var(--danger);
+      }
+
+      /* --- Main view --- */
+
+      .main {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        overflow: hidden;
+      }
+      #app.disconnected .main {
+        display: none;
+      }
+      #app:not(.disconnected) .session-gate {
+        display: none;
+      }
+
+      .topbar {
+        height: 44px;
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        padding: 0 20px;
+        gap: 12px;
+        flex-shrink: 0;
+      }
+
+      .topbar .session-label {
+        font-size: 11px;
+        font-weight: 500;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--accent);
+        flex: 1;
+      }
+
+      .turn-indicator {
+        display: none;
+        align-items: center;
+        gap: 6px;
+        font-size: 11px;
+        color: var(--accent-dim);
+      }
+      .turn-indicator.active {
+        display: flex;
+      }
+
+      .turn-indicator .spinner {
+        width: 10px;
+        height: 10px;
+        border: 1.5px solid var(--accent-dim);
+        border-top-color: var(--accent);
+        animation: spin 0.8s linear infinite;
+      }
+
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
         }
-      } else if (item.type === 'fileChange' && items[item.id]) {
-        items[item.id].changes = item.changes || items[item.id].changes;
-        items[item.id].status = item.status === 'declined' ? 'declined' : 'ok';
       }
-      if (item.type === 'agentMessage' && activeAgentMsg !== null) {
-        messages[activeAgentMsg].streaming = false;
-        activeAgentMsg = null;
+
+      .topbar button {
+        font-size: 10px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--info);
+        cursor: pointer;
+        padding: 4px 8px;
+        border: 1px solid transparent;
+        background: none;
+        user-select: none;
       }
-      renderMessages();
-      break;
-    }
 
-    case 'item/commandExecution/outputDelta':
-      if (p.itemId && items[p.itemId] && items[p.itemId].output.length < 100_000) {
-        items[p.itemId].output += (p.output || p.delta || '');
-        updateItemOutput(p.itemId);
+      .topbar button:hover {
+        color: var(--text-0);
       }
-      break;
-  }
-}
+      .topbar button.active {
+        color: var(--text-1);
+        border-color: var(--border);
+      }
+      .topbar .end-btn:hover {
+        color: var(--danger);
+      }
 
-// --- Render ---
+      /* --- Messages --- */
 
-function updateInputState() {
-  const ready = connState === 'ready' && threadId && !turnActive;
-  turnIndicator.className = 'turn-indicator' + (turnActive ? ' active' : '');
-  promptEl.disabled = !ready;
-  btnSend.disabled = !ready;
-}
+      .messages {
+        flex: 1;
+        overflow-y: auto;
+        padding: 20px;
+      }
 
-function renderMessages() {
-  messagesEl.innerHTML = '';
+      .messages .empty-state {
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--info);
+        font-size: 12px;
+        font-style: italic;
+      }
 
-  if (messages.length === 0) {
-    messagesEl.innerHTML = '<div class="empty-state">Send a message to begin.</div>';
-    return;
-  }
+      .msg {
+        margin-bottom: 16px;
+        animation: fadeIn 0.15s ease;
+      }
 
-  for (let i = 0; i < messages.length; i++) {
-    const m = messages[i];
-    const div = document.createElement('div');
-    div.className = `msg ${m.role}`;
+      @keyframes fadeIn {
+        from {
+          opacity: 0;
+          transform: translateY(4px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
 
-    const header = `<div class="msg-header">
+      .msg-header {
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        margin-bottom: 6px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .msg-header .role {
+        color: var(--text-0);
+      }
+      .msg-header .role.user {
+        color: var(--accent);
+      }
+      .msg-header .ts {
+        color: var(--info);
+        font-weight: 400;
+      }
+
+      .msg-body {
+        padding: 10px 14px;
+        border-left: 2px solid var(--border);
+        white-space: pre-wrap;
+        word-break: break-word;
+        color: var(--text-1);
+        line-height: 1.6;
+      }
+
+      .msg.user .msg-body {
+        border-left-color: var(--accent-dim);
+        background: var(--user-bg);
+      }
+      .msg.agent .msg-body {
+        border-left-color: var(--border);
+        background: var(--agent-bg);
+      }
+
+      .streaming-cursor {
+        display: inline-block;
+        width: 6px;
+        height: 14px;
+        background: var(--accent);
+        margin-left: 2px;
+        vertical-align: text-bottom;
+        animation: blink 0.6s step-end infinite;
+      }
+
+      @keyframes blink {
+        0%,
+        100% {
+          opacity: 1;
+        }
+        50% {
+          opacity: 0;
+        }
+      }
+
+      /* --- Tool call grid --- */
+
+      .tool-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(min(100%, 420px), 1fr));
+        gap: 6px;
+        margin: 8px 0 4px;
+      }
+
+      /* Single tool fills full width */
+      .tool-grid .tool-block:only-child {
+        grid-column: 1 / -1;
+      }
+
+      .tool-block {
+        border: 1px solid var(--tool-border);
+        background: var(--tool-bg);
+        overflow: hidden;
+        min-width: 0;
+      }
+
+      .tool-header {
+        padding: 4px 8px;
+        background: var(--bg-2);
+        font-size: 11px;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        cursor: pointer;
+        user-select: none;
+      }
+
+      .tool-header:hover {
+        background: #222;
+      }
+
+      .tool-header .tool-type {
+        font-size: 8px;
+        font-weight: 600;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        color: var(--text-0);
+        padding: 0 4px;
+        border: 1px solid var(--border);
+        flex-shrink: 0;
+        line-height: 1.6;
+      }
+
+      .tool-header .tool-label {
+        color: var(--accent);
+        flex: 1;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-size: 11px;
+      }
+
+      .tool-header .tool-meta-inline {
+        font-size: 10px;
+        color: var(--info);
+        flex-shrink: 0;
+        white-space: nowrap;
+      }
+
+      .tool-header .tool-status {
+        font-size: 10px;
+        font-weight: 500;
+        flex-shrink: 0;
+      }
+
+      .tool-status.running {
+        color: var(--text-0);
+      }
+      .tool-status.ok {
+        color: var(--accent);
+      }
+      .tool-status.fail {
+        color: var(--danger);
+      }
+      .tool-status.declined {
+        color: var(--danger);
+      }
+
+      .tool-header .tool-chevron {
+        color: var(--info);
+        font-size: 9px;
+        transition: transform 0.15s;
+        flex-shrink: 0;
+      }
+
+      .tool-block.expanded .tool-chevron {
+        transform: rotate(90deg);
+      }
+      .tool-block.expanded .tool-header {
+        border-bottom: 1px solid var(--tool-border);
+      }
+
+      .tool-detail {
+        display: none;
+      }
+      .tool-block.expanded .tool-detail {
+        display: block;
+      }
+
+      .tool-output {
+        padding: 4px 8px;
+        font-size: 11px;
+        color: var(--text-0);
+        max-height: 250px;
+        overflow-y: auto;
+        white-space: pre-wrap;
+        word-break: break-all;
+        line-height: 1.4;
+      }
+
+      .tool-output:empty {
+        display: none;
+      }
+
+      /* File changes */
+
+      .file-changes {
+        padding: 0;
+      }
+      .file-change {
+        border-bottom: 1px solid var(--tool-border);
+      }
+      .file-change:last-child {
+        border-bottom: none;
+      }
+
+      .file-change-header {
+        padding: 4px 8px;
+        font-size: 11px;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .file-change-kind {
+        font-size: 8px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        padding: 0 3px;
+      }
+
+      .file-change-kind.create {
+        color: var(--file-add);
+      }
+      .file-change-kind.modify {
+        color: var(--file-mod);
+      }
+      .file-change-kind.delete,
+      .file-change-kind.remove {
+        color: var(--file-del);
+      }
+
+      .file-change-path {
+        color: var(--text-1);
+        font-size: 11px;
+      }
+
+      .file-change-diff {
+        padding: 2px 8px 4px;
+        font-size: 11px;
+        color: var(--text-0);
+        max-height: 200px;
+        overflow-y: auto;
+        white-space: pre-wrap;
+        word-break: break-all;
+        line-height: 1.4;
+      }
+
+      .diff-add {
+        color: var(--file-add);
+      }
+      .diff-del {
+        color: var(--file-del);
+      }
+
+      /* --- Content layout --- */
+
+      .content {
+        display: flex;
+        flex: 1;
+        overflow: hidden;
+      }
+      .chat-col {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+      }
+
+      /* --- Log side panel --- */
+
+      .log-panel {
+        display: none;
+        width: 380px;
+        flex-shrink: 0;
+        border-left: 1px solid var(--border);
+        background: var(--bg-1);
+        flex-direction: column;
+        overflow: hidden;
+      }
+
+      .log-panel.visible {
+        display: flex;
+      }
+
+      .log-panel-header {
+        padding: 6px 12px;
+        border-bottom: 1px solid var(--border);
+        font-size: 10px;
+        font-weight: 500;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--text-0);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-shrink: 0;
+      }
+
+      .log-panel-header .log-close {
+        background: none;
+        border: none;
+        color: var(--info);
+        font-size: 16px;
+        cursor: pointer;
+        padding: 0 4px;
+        line-height: 1;
+      }
+
+      .log-panel-header .log-close:hover {
+        color: var(--text-1);
+      }
+
+      .log-entries {
+        flex: 1;
+        overflow-y: auto;
+        padding: 6px 10px;
+        font-size: 10px;
+        color: var(--info);
+      }
+
+      .log-entries .log-entry {
+        white-space: pre-wrap;
+        word-break: break-all;
+        padding: 1px 0;
+        line-height: 1.4;
+      }
+
+      .log-entries .log-entry.out {
+        color: #5a7a9a;
+      }
+      .log-entries .log-entry.in {
+        color: #7a6a9a;
+      }
+
+      /* --- Input --- */
+
+      .input-area {
+        border-top: 1px solid var(--border);
+        padding: 12px 20px;
+        display: flex;
+        gap: 10px;
+        align-items: flex-end;
+        flex-shrink: 0;
+      }
+
+      .input-area textarea {
+        flex: 1;
+        resize: none;
+        background: var(--bg-1);
+        border: 1px solid var(--border);
+        color: var(--text-2);
+        padding: 10px 12px;
+        outline: none;
+        min-height: 40px;
+        max-height: 120px;
+        line-height: 1.5;
+      }
+
+      .input-area textarea:focus {
+        border-color: var(--accent-dim);
+      }
+      .input-area textarea:disabled {
+        opacity: 0.3;
+      }
+      .input-area textarea::placeholder {
+        color: var(--info);
+      }
+
+      .input-area button {
+        padding: 10px 16px;
+        background: var(--accent);
+        color: var(--bg-0);
+        border: none;
+        font-weight: 600;
+        font-size: 11px;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        cursor: pointer;
+        align-self: stretch;
+      }
+
+      .input-area button:hover {
+        opacity: 0.85;
+      }
+      .input-area button:disabled {
+        opacity: 0.2;
+        cursor: not-allowed;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app" class="disconnected">
+      <div class="session-gate">
+        <div class="session-form">
+          <h1>Codex App Server</h1>
+          <div class="field">
+            <label for="sf-session">Session</label>
+            <input
+              id="sf-session"
+              type="text"
+              placeholder="my-project"
+              autocomplete="off"
+              spellcheck="false"
+            />
+            <div class="hint">
+              Names a sandbox instance. Each session gets a fresh container.
+            </div>
+          </div>
+          <div class="field">
+            <label for="sf-repo">Repository (optional)</label>
+            <input
+              id="sf-repo"
+              type="text"
+              placeholder="https://github.com/owner/repo"
+              autocomplete="off"
+              spellcheck="false"
+            />
+            <div class="hint">Cloned into /workspace via sandbox/setup.</div>
+          </div>
+          <button id="sf-connect" disabled>Connect</button>
+          <div id="sf-status" class="status-line"></div>
+        </div>
+      </div>
+
+      <div class="main">
+        <div class="topbar">
+          <span class="session-label" id="topbar-session"></span>
+          <div class="turn-indicator" id="turn-indicator">
+            <div class="spinner"></div>
+            <span>working</span>
+          </div>
+          <button id="btn-log-toggle">Log</button>
+          <button class="end-btn" id="btn-end">End</button>
+        </div>
+
+        <div class="content">
+          <div class="chat-col">
+            <div class="messages" id="messages">
+              <div class="empty-state">Send a message to begin.</div>
+            </div>
+            <div class="input-area">
+              <textarea
+                id="prompt"
+                rows="1"
+                placeholder="Send a message..."
+                disabled
+              ></textarea>
+              <button id="btn-send" disabled>Send</button>
+            </div>
+          </div>
+          <div class="log-panel" id="raw-log">
+            <div class="log-panel-header">
+              <span>JSON-RPC Log</span>
+              <button class="log-close" id="btn-log-close">&times;</button>
+            </div>
+            <div class="log-entries" id="log-entries"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      // --- State ---
+
+      const wsEndpoint =
+        document.documentElement.dataset.wsEndpoint || 'ws://localhost:8787/ws';
+
+      let ws = null;
+      let nextId = 0;
+      let sessionName = '';
+      let repoUrl = '';
+
+      // Connection: disconnected → connecting → setup → initializing → starting → ready
+      let connState = 'disconnected';
+      let pendingId = null;
+
+      // Single thread
+      let threadId = null;
+      let turnActive = false;
+      let activeAgentMsg = null; // index into messages[]
+      const messages = []; // [{role, text, streaming, items[]}] or [{role, text, ts}]
+      const items = {}; // itemId → {id, type, ...metadata}
+
+      // --- DOM refs ---
+
+      const $ = (s) => document.getElementById(s);
+      const app = $('app');
+      const sfSession = $('sf-session');
+      const sfRepo = $('sf-repo');
+      const sfConnect = $('sf-connect');
+      const sfStatus = $('sf-status');
+      const topbarSession = $('topbar-session');
+      const turnIndicator = $('turn-indicator');
+      const messagesEl = $('messages');
+      const logPanel = $('raw-log');
+      const logEntriesEl = $('log-entries');
+      const btnLogClose = $('btn-log-close');
+      const promptEl = $('prompt');
+      const btnSend = $('btn-send');
+      const btnEnd = $('btn-end');
+      const btnLogToggle = $('btn-log-toggle');
+
+      // --- Helpers ---
+
+      function ts() {
+        return new Date().toLocaleTimeString('en-US', { hour12: false });
+      }
+
+      const _escEl = document.createElement('div');
+      function esc(s) {
+        _escEl.textContent = s;
+        return _escEl.innerHTML;
+      }
+
+      function rpcReq(method, params = {}) {
+        return { method, id: nextId++, params };
+      }
+
+      function send(msg) {
+        if (!ws || ws.readyState !== WebSocket.OPEN) return;
+        const raw = JSON.stringify(msg);
+        ws.send(raw);
+        rawLog('out', raw);
+      }
+
+      function rawLog(dir, text) {
+        const d = document.createElement('div');
+        d.className = `log-entry ${dir}`;
+        d.textContent = `${dir === 'out' ? '>>>' : '<<<'} ${text}`;
+        logEntriesEl.appendChild(d);
+        while (logEntriesEl.childElementCount > 500)
+          logEntriesEl.removeChild(logEntriesEl.firstChild);
+        logEntriesEl.scrollTop = logEntriesEl.scrollHeight;
+      }
+
+      function fmtCmd(command) {
+        if (Array.isArray(command)) return command.join(' ');
+        return String(command || '');
+      }
+
+      // --- Session gate ---
+
+      sfSession.value = localStorage.getItem('codex-session') || '';
+      sfRepo.value = localStorage.getItem('codex-repo') || '';
+
+      function updateConnectBtn() {
+        sfConnect.disabled = !sfSession.value.trim();
+      }
+      sfSession.addEventListener('input', updateConnectBtn);
+      updateConnectBtn();
+
+      for (const el of [sfSession, sfRepo]) {
+        el.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            startSession();
+          }
+        });
+      }
+      sfConnect.addEventListener('click', startSession);
+
+      function startSession() {
+        const name = sfSession.value.trim();
+        if (!name) return;
+        sessionName = name;
+        repoUrl = sfRepo.value.trim();
+        localStorage.setItem('codex-session', name);
+        localStorage.setItem('codex-repo', repoUrl);
+        sfStatus.textContent = '';
+        sfStatus.className = 'status-line';
+        sfConnect.disabled = true;
+        connect();
+      }
+
+      // --- Connection flow ---
+
+      function connect() {
+        if (ws) ws.close();
+        connState = 'connecting';
+        sfStatus.textContent = 'Connecting...';
+        nextId = 0;
+
+        ws = new WebSocket(`${wsEndpoint}/${encodeURIComponent(sessionName)}`);
+
+        ws.addEventListener('open', () => {
+          if (repoUrl) {
+            connState = 'setup';
+            sfStatus.textContent = 'Cloning repository...';
+            const msg = rpcReq('sandbox/setup', { repoUrl });
+            pendingId = msg.id;
+            send(msg);
+          } else {
+            sendInitialize();
+          }
+        });
+
+        ws.addEventListener('message', (e) => {
+          const raw = e.data;
+          rawLog('in', raw);
+          let msg;
+          try {
+            msg = JSON.parse(raw);
+          } catch {
+            return;
+          }
+          routeMessage(msg);
+        });
+
+        ws.addEventListener('close', () => {
+          const wasConnecting = connState !== 'ready';
+          connState = 'disconnected';
+          ws = null;
+          turnActive = false;
+          updateInputState();
+          if (wasConnecting) {
+            sfStatus.textContent = 'Disconnected.';
+            sfStatus.className = 'status-line error';
+            sfConnect.disabled = false;
+          }
+        });
+
+        ws.addEventListener('error', () => {
+          sfStatus.textContent = 'Connection failed.';
+          sfStatus.className = 'status-line error';
+        });
+      }
+
+      function sendInitialize() {
+        connState = 'initializing';
+        sfStatus.textContent = 'Initializing...';
+        const msg = rpcReq('initialize', {
+          clientInfo: {
+            name: 'sandbox_codex_client',
+            title: 'Sandbox Codex Client',
+            version: '0.2.0'
+          },
+          capabilities: { experimentalApi: true }
+        });
+        pendingId = msg.id;
+        send(msg);
+      }
+
+      function sendThreadStart() {
+        connState = 'starting';
+        send({ method: 'initialized', params: {} });
+        const msg = rpcReq('thread/start');
+        pendingId = msg.id;
+        send(msg);
+      }
+
+      function enterReady(codexThreadId) {
+        connState = 'ready';
+        threadId = codexThreadId;
+        app.classList.remove('disconnected');
+        topbarSession.textContent = sessionName;
+        updateInputState();
+        promptEl.focus();
+      }
+
+      // --- Message routing ---
+
+      function routeMessage(msg) {
+        if (msg.id !== undefined && msg.method === undefined) {
+          handleResponse(msg);
+        } else if (msg.method) {
+          handleNotification(msg);
+        }
+      }
+
+      function handleResponse(msg) {
+        if (msg.error && msg.id === pendingId) {
+          sfStatus.textContent = `Error: ${msg.error.message}`;
+          sfStatus.className = 'status-line error';
+          sfConnect.disabled = false;
+          return;
+        }
+
+        if (msg.id !== pendingId) return;
+        pendingId = null;
+
+        switch (connState) {
+          case 'setup':
+            sendInitialize();
+            break;
+          case 'initializing':
+            sendThreadStart();
+            break;
+          case 'starting':
+            if (msg.result?.thread?.id) enterReady(msg.result.thread.id);
+            break;
+        }
+      }
+
+      function ensureAgentMsg() {
+        if (activeAgentMsg === null) {
+          activeAgentMsg = messages.length;
+          messages.push({
+            role: 'agent',
+            text: '',
+            streaming: false,
+            items: []
+          });
+        }
+        return messages[activeAgentMsg];
+      }
+
+      function handleNotification(msg) {
+        const p = msg.params || {};
+
+        switch (msg.method) {
+          case 'turn/started':
+            turnActive = true;
+            updateInputState();
+            break;
+
+          case 'turn/completed':
+            turnActive = false;
+            if (activeAgentMsg !== null) {
+              messages[activeAgentMsg].streaming = false;
+              activeAgentMsg = null;
+              renderMessages();
+            }
+            updateInputState();
+            break;
+
+          case 'item/agentMessage/delta': {
+            const m = ensureAgentMsg();
+            m.streaming = true;
+            const delta = p.delta || '';
+            m.text += delta;
+            updateStreamingText(delta);
+            break;
+          }
+
+          case 'item/started': {
+            const item = p.item || {};
+            if (item.type === 'commandExecution') {
+              items[item.id] = {
+                id: item.id,
+                type: 'command',
+                command: fmtCmd(item.command),
+                cwd: item.cwd || '',
+                output: '',
+                exitCode: null,
+                durationMs: null,
+                status: 'running'
+              };
+            } else if (item.type === 'fileChange') {
+              items[item.id] = {
+                id: item.id,
+                type: 'fileChange',
+                changes: item.changes || [],
+                status: 'running'
+              };
+            }
+            if (items[item.id]) {
+              ensureAgentMsg().items.push(item.id);
+              renderMessages();
+            }
+            break;
+          }
+
+          case 'item/completed': {
+            const item = p.item || {};
+            if (item.type === 'commandExecution' && items[item.id]) {
+              items[item.id].exitCode = item.exitCode ?? null;
+              items[item.id].durationMs = item.durationMs ?? null;
+              items[item.id].status = item.exitCode === 0 ? 'ok' : 'fail';
+              if (item.aggregatedOutput && !items[item.id].output) {
+                items[item.id].output = item.aggregatedOutput;
+              }
+            } else if (item.type === 'fileChange' && items[item.id]) {
+              items[item.id].changes = item.changes || items[item.id].changes;
+              items[item.id].status =
+                item.status === 'declined' ? 'declined' : 'ok';
+            }
+            if (item.type === 'agentMessage' && activeAgentMsg !== null) {
+              messages[activeAgentMsg].streaming = false;
+              activeAgentMsg = null;
+            }
+            renderMessages();
+            break;
+          }
+
+          case 'item/commandExecution/outputDelta':
+            if (
+              p.itemId &&
+              items[p.itemId] &&
+              items[p.itemId].output.length < 100_000
+            ) {
+              items[p.itemId].output += p.output || p.delta || '';
+              updateItemOutput(p.itemId);
+            }
+            break;
+        }
+      }
+
+      // --- Render ---
+
+      function updateInputState() {
+        const ready = connState === 'ready' && threadId && !turnActive;
+        turnIndicator.className = `turn-indicator${turnActive ? ' active' : ''}`;
+        promptEl.disabled = !ready;
+        btnSend.disabled = !ready;
+      }
+
+      function renderMessages() {
+        messagesEl.innerHTML = '';
+
+        if (messages.length === 0) {
+          messagesEl.innerHTML =
+            '<div class="empty-state">Send a message to begin.</div>';
+          return;
+        }
+
+        for (let i = 0; i < messages.length; i++) {
+          const m = messages[i];
+          const div = document.createElement('div');
+          div.className = `msg ${m.role}`;
+
+          const header = `<div class="msg-header">
       <span class="role ${m.role}">${m.role}</span>
       <span class="ts">${m.ts || ''}</span>
     </div>`;
 
-    let body;
-    if (m.role === 'user') {
-      body = `<div class="msg-body">${esc(m.text)}</div>`;
-    } else {
-      let text = esc(m.text || '');
-      if (m.streaming) text += '<span class="streaming-cursor"></span>';
+          let body;
+          if (m.role === 'user') {
+            body = `<div class="msg-body">${esc(m.text)}</div>`;
+          } else {
+            let text = esc(m.text || '');
+            if (m.streaming) text += '<span class="streaming-cursor"></span>';
 
-      let toolsHtml = '';
-      const itemIds = (m.items || []).filter((id) => items[id]);
-      if (itemIds.length) {
-        toolsHtml = '<div class="tool-grid">';
-        for (const id of itemIds) toolsHtml += renderToolBlock(items[id]);
-        toolsHtml += '</div>';
+            let toolsHtml = '';
+            const itemIds = (m.items || []).filter((id) => items[id]);
+            if (itemIds.length) {
+              toolsHtml = '<div class="tool-grid">';
+              for (const id of itemIds) toolsHtml += renderToolBlock(items[id]);
+              toolsHtml += '</div>';
+            }
+
+            body = `<div class="msg-body" data-msg-idx="${i}"><span class="agent-text">${text}</span>${toolsHtml}</div>`;
+          }
+
+          div.innerHTML = header + body;
+          messagesEl.appendChild(div);
+        }
+
+        messagesEl.scrollTop = messagesEl.scrollHeight;
       }
 
-      body = `<div class="msg-body" data-msg-idx="${i}"><span class="agent-text">${text}</span>${toolsHtml}</div>`;
-    }
+      function renderToolBlock(item) {
+        if (item.type === 'command') return renderCommandBlock(item);
+        if (item.type === 'fileChange') return renderFileChangeBlock(item);
+        return '';
+      }
 
-    div.innerHTML = header + body;
-    messagesEl.appendChild(div);
-  }
+      function renderCommandBlock(item) {
+        const statusClass = item.status;
+        let statusLabel = '...';
+        if (item.status === 'ok') statusLabel = `0`;
+        else if (item.status === 'fail') statusLabel = `${item.exitCode}`;
 
-  messagesEl.scrollTop = messagesEl.scrollHeight;
-}
+        const metaParts = [];
+        if (item.cwd) metaParts.push(item.cwd);
+        if (item.durationMs !== null)
+          metaParts.push(`${(item.durationMs / 1000).toFixed(1)}s`);
+        const metaInline = metaParts.length
+          ? `<span class="tool-meta-inline">${esc(metaParts.join(' '))}</span>`
+          : '';
 
-function renderToolBlock(item) {
-  if (item.type === 'command') return renderCommandBlock(item);
-  if (item.type === 'fileChange') return renderFileChangeBlock(item);
-  return '';
-}
-
-function renderCommandBlock(item) {
-  const statusClass = item.status;
-  let statusLabel = '...';
-  if (item.status === 'ok') statusLabel = `0`;
-  else if (item.status === 'fail') statusLabel = `${item.exitCode}`;
-
-  const metaParts = [];
-  if (item.cwd) metaParts.push(item.cwd);
-  if (item.durationMs !== null) metaParts.push(`${(item.durationMs / 1000).toFixed(1)}s`);
-  const metaInline = metaParts.length ? `<span class="tool-meta-inline">${esc(metaParts.join(' '))}</span>` : '';
-
-  return `<div class="tool-block${item.output ? ' expanded' : ''}" data-item-id="${esc(item.id)}">
+        return `<div class="tool-block${item.output ? ' expanded' : ''}" data-item-id="${esc(item.id)}">
     <div class="tool-header">
       <span class="tool-type">cmd</span>
       <span class="tool-label">$ ${esc(item.command)}</span>
@@ -911,33 +1152,36 @@ function renderCommandBlock(item) {
       <div class="tool-output">${esc(item.output)}</div>
     </div>
   </div>`;
-}
+      }
 
-function renderFileChangeBlock(item) {
-  const statusClass = item.status;
-  const count = item.changes?.length || 0;
-  const statusLabel = item.status === 'running' ? '...'
-    : item.status === 'declined' ? 'declined'
-    : `${count} file${count !== 1 ? 's' : ''}`;
+      function renderFileChangeBlock(item) {
+        const statusClass = item.status;
+        const count = item.changes?.length || 0;
+        const statusLabel =
+          item.status === 'running'
+            ? '...'
+            : item.status === 'declined'
+              ? 'declined'
+              : `${count} file${count !== 1 ? 's' : ''}`;
 
-  let changesHtml = '';
-  if (item.changes?.length) {
-    changesHtml = '<div class="file-changes">';
-    for (const c of item.changes) {
-      const kind = (c.kind || 'modify').toLowerCase();
-      const diffHtml = c.diff ? renderDiff(c.diff) : '';
-      changesHtml += `<div class="file-change">
+        let changesHtml = '';
+        if (item.changes?.length) {
+          changesHtml = '<div class="file-changes">';
+          for (const c of item.changes) {
+            const kind = (c.kind || 'modify').toLowerCase();
+            const diffHtml = c.diff ? renderDiff(c.diff) : '';
+            changesHtml += `<div class="file-change">
         <div class="file-change-header">
           <span class="file-change-kind ${kind}">${kind}</span>
           <span class="file-change-path">${esc(c.path || '')}</span>
         </div>
         ${diffHtml ? `<div class="file-change-diff">${diffHtml}</div>` : ''}
       </div>`;
-    }
-    changesHtml += '</div>';
-  }
+          }
+          changesHtml += '</div>';
+        }
 
-  return `<div class="tool-block" data-item-id="${esc(item.id)}">
+        return `<div class="tool-block" data-item-id="${esc(item.id)}">
     <div class="tool-header">
       <span class="tool-type">file</span>
       <span class="tool-label">file changes</span>
@@ -948,128 +1192,152 @@ function renderFileChangeBlock(item) {
       ${changesHtml}
     </div>
   </div>`;
-}
+      }
 
-function renderDiff(diff) {
-  return diff.split('\n').map((line) => {
-    const escaped = esc(line);
-    if (line.startsWith('+')) return `<span class="diff-add">${escaped}</span>`;
-    if (line.startsWith('-')) return `<span class="diff-del">${escaped}</span>`;
-    return escaped;
-  }).join('\n');
-}
+      function renderDiff(diff) {
+        return diff
+          .split('\n')
+          .map((line) => {
+            const escaped = esc(line);
+            if (line.startsWith('+'))
+              return `<span class="diff-add">${escaped}</span>`;
+            if (line.startsWith('-'))
+              return `<span class="diff-del">${escaped}</span>`;
+            return escaped;
+          })
+          .join('\n');
+      }
 
-function updateStreamingText(delta) {
-  if (activeAgentMsg === null) return;
-  const span = messagesEl.querySelector(`.msg-body[data-msg-idx="${activeAgentMsg}"] .agent-text`);
-  if (!span) { renderMessages(); return; }
+      function updateStreamingText(delta) {
+        if (activeAgentMsg === null) return;
+        const span = messagesEl.querySelector(
+          `.msg-body[data-msg-idx="${activeAgentMsg}"] .agent-text`
+        );
+        if (!span) {
+          renderMessages();
+          return;
+        }
 
-  const cursor = span.querySelector('.streaming-cursor');
-  if (cursor && delta) {
-    cursor.insertAdjacentText('beforebegin', delta);
-  } else {
-    const m = messages[activeAgentMsg];
-    let html = esc(m.text || '');
-    if (m.streaming) html += '<span class="streaming-cursor"></span>';
-    span.innerHTML = html;
-  }
-  autoScroll();
-}
+        const cursor = span.querySelector('.streaming-cursor');
+        if (cursor && delta) {
+          cursor.insertAdjacentText('beforebegin', delta);
+        } else {
+          const m = messages[activeAgentMsg];
+          let html = esc(m.text || '');
+          if (m.streaming) html += '<span class="streaming-cursor"></span>';
+          span.innerHTML = html;
+        }
+        autoScroll();
+      }
 
-function updateItemOutput(itemId) {
-  const block = messagesEl.querySelector(`.tool-block[data-item-id="${CSS.escape(itemId)}"]`);
-  if (!block) { renderMessages(); return; }
+      function updateItemOutput(itemId) {
+        const block = messagesEl.querySelector(
+          `.tool-block[data-item-id="${CSS.escape(itemId)}"]`
+        );
+        if (!block) {
+          renderMessages();
+          return;
+        }
 
-  const item = items[itemId];
-  if (!item?.output) return;
+        const item = items[itemId];
+        if (!item?.output) return;
 
-  // Auto-expand when output arrives
-  block.classList.add('expanded');
+        // Auto-expand when output arrives
+        block.classList.add('expanded');
 
-  let el = block.querySelector('.tool-output');
-  if (!el) {
-    const detail = block.querySelector('.tool-detail');
-    if (!detail) return;
-    el = document.createElement('div');
-    el.className = 'tool-output';
-    detail.appendChild(el);
-  }
-  el.textContent = item.output;
-  autoScroll();
-}
+        let el = block.querySelector('.tool-output');
+        if (!el) {
+          const detail = block.querySelector('.tool-detail');
+          if (!detail) return;
+          el = document.createElement('div');
+          el.className = 'tool-output';
+          detail.appendChild(el);
+        }
+        el.textContent = item.output;
+        autoScroll();
+      }
 
-function autoScroll() {
-  if (messagesEl.scrollHeight - messagesEl.scrollTop - messagesEl.clientHeight < 60) {
-    messagesEl.scrollTop = messagesEl.scrollHeight;
-  }
-}
+      function autoScroll() {
+        if (
+          messagesEl.scrollHeight -
+            messagesEl.scrollTop -
+            messagesEl.clientHeight <
+          60
+        ) {
+          messagesEl.scrollTop = messagesEl.scrollHeight;
+        }
+      }
 
-// --- Input ---
+      // --- Input ---
 
-function sendPrompt() {
-  if (!threadId || turnActive || connState !== 'ready') return;
-  const text = promptEl.value.trim();
-  if (!text) return;
+      function sendPrompt() {
+        if (!threadId || turnActive || connState !== 'ready') return;
+        const text = promptEl.value.trim();
+        if (!text) return;
 
-  messages.push({ role: 'user', text, ts: ts() });
-  activeAgentMsg = null;
+        messages.push({ role: 'user', text, ts: ts() });
+        activeAgentMsg = null;
 
-  send(rpcReq('turn/start', {
-    threadId,
-    input: [{ type: 'text', text }],
-  }));
+        send(
+          rpcReq('turn/start', {
+            threadId,
+            input: [{ type: 'text', text }]
+          })
+        );
 
-  promptEl.value = '';
-  autoResizePrompt();
-  renderMessages();
-}
+        promptEl.value = '';
+        autoResizePrompt();
+        renderMessages();
+      }
 
-function autoResizePrompt() {
-  promptEl.style.height = 'auto';
-  promptEl.style.height = Math.min(promptEl.scrollHeight, 120) + 'px';
-}
+      function autoResizePrompt() {
+        promptEl.style.height = 'auto';
+        promptEl.style.height = `${Math.min(promptEl.scrollHeight, 120)}px`;
+      }
 
-promptEl.addEventListener('input', autoResizePrompt);
-promptEl.addEventListener('keydown', (e) => {
-  if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendPrompt(); }
-});
-btnSend.addEventListener('click', sendPrompt);
+      promptEl.addEventListener('input', autoResizePrompt);
+      promptEl.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          sendPrompt();
+        }
+      });
+      btnSend.addEventListener('click', sendPrompt);
 
-// --- Actions ---
+      // --- Actions ---
 
-btnEnd.addEventListener('click', disconnect);
+      btnEnd.addEventListener('click', disconnect);
 
-function disconnect() {
-  if (ws) ws.close();
-  connState = 'disconnected';
-  ws = null;
-  threadId = null;
-  turnActive = false;
-  activeAgentMsg = null;
-  messages.length = 0;
-  for (const k of Object.keys(items)) delete items[k];
-  app.classList.add('disconnected');
-  sfConnect.disabled = false;
-  sfStatus.textContent = '';
-  sfStatus.className = 'status-line';
-}
+      function disconnect() {
+        if (ws) ws.close();
+        connState = 'disconnected';
+        ws = null;
+        threadId = null;
+        turnActive = false;
+        activeAgentMsg = null;
+        messages.length = 0;
+        for (const k of Object.keys(items)) delete items[k];
+        app.classList.add('disconnected');
+        sfConnect.disabled = false;
+        sfStatus.textContent = '';
+        sfStatus.className = 'status-line';
+      }
 
-function toggleLog() {
-  logPanel.classList.toggle('visible');
-  btnLogToggle.classList.toggle('active');
-}
+      function toggleLog() {
+        logPanel.classList.toggle('visible');
+        btnLogToggle.classList.toggle('active');
+      }
 
-btnLogToggle.addEventListener('click', toggleLog);
-btnLogClose.addEventListener('click', toggleLog);
+      btnLogToggle.addEventListener('click', toggleLog);
+      btnLogClose.addEventListener('click', toggleLog);
 
-// Event delegation for tool header expand/collapse
-messagesEl.addEventListener('click', (e) => {
-  const header = e.target.closest('.tool-header');
-  if (header) header.closest('.tool-block').classList.toggle('expanded');
-});
+      // Event delegation for tool header expand/collapse
+      messagesEl.addEventListener('click', (e) => {
+        const header = e.target.closest('.tool-header');
+        if (header) header.closest('.tool-block').classList.toggle('expanded');
+      });
 
-sfSession.focus();
-</script>
-
-</body>
+      sfSession.focus();
+    </script>
+  </body>
 </html>

--- a/examples/codex-app-server/public/index.html
+++ b/examples/codex-app-server/public/index.html
@@ -751,7 +751,9 @@
       let turnActive = false;
       let activeAgentMsg = null; // index into messages[]
       const messages = []; // [{role, text, streaming, items[]}] or [{role, text, ts}]
-      const items = {}; // itemId → {id, type, ...metadata}
+      // Null-prototype map; keys come straight from server payloads
+      // (`item.id`) and are looked up without traversing Object.prototype.
+      const items = Object.create(null); // itemId → {id, type, ...metadata}
 
       // --- DOM refs ---
 

--- a/packages/sandbox/src/bridge/helpers.ts
+++ b/packages/sandbox/src/bridge/helpers.ts
@@ -83,7 +83,7 @@ export function shellQuote(arg: string): string {
     .replace(/\n/g, '\\n')
     .replace(/\r/g, '\\r')
     .replace(/\t/g, '\\t');
-  return "$'" + escaped + "'";
+  return `$'${escaped}'`;
 }
 
 // ---------------------------------------------------------------------------
@@ -109,7 +109,7 @@ export function resolveWorkspacePath(userPath: string): string | null {
       parts.push(seg);
     }
   }
-  const resolved = '/' + parts.join('/');
+  const resolved = `/${parts.join('/')}`;
 
   // Must be exactly /workspace or start with /workspace/
   if (resolved === '/workspace' || resolved.startsWith('/workspace/')) {

--- a/packages/sandbox/src/bridge/index.ts
+++ b/packages/sandbox/src/bridge/index.ts
@@ -127,7 +127,7 @@ export function bridge(
       // 1. Try bridge API routes
       const url = new URL(request.url);
       if (
-        url.pathname.startsWith(apiPrefix + '/') ||
+        url.pathname.startsWith(`${apiPrefix}/`) ||
         url.pathname === apiPrefix ||
         url.pathname === healthPath
       ) {

--- a/packages/sandbox/src/bridge/routes.ts
+++ b/packages/sandbox/src/bridge/routes.ts
@@ -341,7 +341,7 @@ export function createBridgeApp(
     }
 
     // Prepend / to make it absolute before validation
-    const resolvedPath = resolveWorkspacePath('/' + relativePath);
+    const resolvedPath = resolveWorkspacePath(`/${relativePath}`);
     if (!resolvedPath) {
       return errorJson(
         'path must resolve to a location within /workspace',
@@ -399,7 +399,7 @@ export function createBridgeApp(
     }
 
     // Prepend / to make it absolute before validation
-    const resolvedPath = resolveWorkspacePath('/' + relativePath);
+    const resolvedPath = resolveWorkspacePath(`/${relativePath}`);
     if (!resolvedPath) {
       return errorJson(
         'path must resolve to a location within /workspace',
@@ -545,7 +545,7 @@ export function createBridgeApp(
 
     const tmpPath = `/tmp/sandbox-persist-${Date.now()}.tar`;
     const excludeArgs = excludes
-      .map((rel) => `--exclude ${shellQuote('./' + rel.replace(/^\.\//, ''))}`)
+      .map((rel) => `--exclude ${shellQuote(`./${rel.replace(/^\.\//, '')}`)}`)
       .join(' ');
     const tarCmd = excludeArgs
       ? `tar cf ${shellQuote(tmpPath)} ${excludeArgs} -C ${shellQuote(root)} .`

--- a/packages/sandbox/src/clients/backup-client.ts
+++ b/packages/sandbox/src/clients/backup-client.ts
@@ -27,24 +27,20 @@ export class BackupClient extends BaseHttpClient {
     gitignore = false,
     excludes: string[] = []
   ): Promise<CreateBackupResponse> {
-    try {
-      const data: CreateBackupRequest = {
-        dir,
-        archivePath,
-        gitignore,
-        excludes,
-        sessionId
-      };
+    const data: CreateBackupRequest = {
+      dir,
+      archivePath,
+      gitignore,
+      excludes,
+      sessionId
+    };
 
-      const response = await this.post<CreateBackupResponse>(
-        '/api/backup/create',
-        data
-      );
+    const response = await this.post<CreateBackupResponse>(
+      '/api/backup/create',
+      data
+    );
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 
   /**
@@ -58,21 +54,17 @@ export class BackupClient extends BaseHttpClient {
     archivePath: string,
     sessionId: string
   ): Promise<RestoreBackupResponse> {
-    try {
-      const data: RestoreBackupRequest = {
-        dir,
-        archivePath,
-        sessionId
-      };
+    const data: RestoreBackupRequest = {
+      dir,
+      archivePath,
+      sessionId
+    };
 
-      const response = await this.post<RestoreBackupResponse>(
-        '/api/backup/restore',
-        data
-      );
+    const response = await this.post<RestoreBackupResponse>(
+      '/api/backup/restore',
+      data
+    );
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 }

--- a/packages/sandbox/src/clients/desktop-client.ts
+++ b/packages/sandbox/src/clients/desktop-client.ts
@@ -188,14 +188,10 @@ export class DesktopClient extends BaseHttpClient {
    * Get desktop lifecycle and process health status.
    */
   async status(): Promise<DesktopStatusResponse> {
-    try {
-      const response = await this.get<DesktopStatusResponse>(
-        '/api/desktop/status'
-      );
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    const response = await this.get<DesktopStatusResponse>(
+      '/api/desktop/status'
+    );
+    return response;
   }
 
   /**
@@ -213,41 +209,37 @@ export class DesktopClient extends BaseHttpClient {
   async screenshot(
     options?: ScreenshotOptions
   ): Promise<ScreenshotResponse | ScreenshotBytesResponse> {
-    try {
-      const wantsBytes = options?.format === 'bytes';
-      const data = {
-        format: 'base64',
-        ...(options?.imageFormat !== undefined && {
-          imageFormat: options.imageFormat
-        }),
-        ...(options?.quality !== undefined && { quality: options.quality }),
-        ...(options?.showCursor !== undefined && {
-          showCursor: options.showCursor
-        })
-      };
+    const wantsBytes = options?.format === 'bytes';
+    const data = {
+      format: 'base64',
+      ...(options?.imageFormat !== undefined && {
+        imageFormat: options.imageFormat
+      }),
+      ...(options?.quality !== undefined && { quality: options.quality }),
+      ...(options?.showCursor !== undefined && {
+        showCursor: options.showCursor
+      })
+    };
 
-      const response = await this.post<ScreenshotResponse>(
-        '/api/desktop/screenshot',
-        data
-      );
+    const response = await this.post<ScreenshotResponse>(
+      '/api/desktop/screenshot',
+      data
+    );
 
-      if (wantsBytes) {
-        const binaryString = atob(response.data);
-        const bytes = new Uint8Array(binaryString.length);
-        for (let i = 0; i < binaryString.length; i++) {
-          bytes[i] = binaryString.charCodeAt(i);
-        }
-
-        return {
-          ...response,
-          data: bytes
-        } as ScreenshotBytesResponse;
+    if (wantsBytes) {
+      const binaryString = atob(response.data);
+      const bytes = new Uint8Array(binaryString.length);
+      for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
       }
 
-      return response;
-    } catch (error) {
-      throw error;
+      return {
+        ...response,
+        data: bytes
+      } as ScreenshotBytesResponse;
     }
+
+    return response;
   }
 
   /**
@@ -268,58 +260,50 @@ export class DesktopClient extends BaseHttpClient {
     region: ScreenshotRegion,
     options?: ScreenshotOptions
   ): Promise<ScreenshotResponse | ScreenshotBytesResponse> {
-    try {
-      const wantsBytes = options?.format === 'bytes';
-      const data = {
-        region,
-        format: 'base64',
-        ...(options?.imageFormat !== undefined && {
-          imageFormat: options.imageFormat
-        }),
-        ...(options?.quality !== undefined && { quality: options.quality }),
-        ...(options?.showCursor !== undefined && {
-          showCursor: options.showCursor
-        })
-      };
+    const wantsBytes = options?.format === 'bytes';
+    const data = {
+      region,
+      format: 'base64',
+      ...(options?.imageFormat !== undefined && {
+        imageFormat: options.imageFormat
+      }),
+      ...(options?.quality !== undefined && { quality: options.quality }),
+      ...(options?.showCursor !== undefined && {
+        showCursor: options.showCursor
+      })
+    };
 
-      const response = await this.post<ScreenshotResponse>(
-        '/api/desktop/screenshot/region',
-        data
-      );
+    const response = await this.post<ScreenshotResponse>(
+      '/api/desktop/screenshot/region',
+      data
+    );
 
-      if (wantsBytes) {
-        const binaryString = atob(response.data);
-        const bytes = new Uint8Array(binaryString.length);
-        for (let i = 0; i < binaryString.length; i++) {
-          bytes[i] = binaryString.charCodeAt(i);
-        }
-
-        return {
-          ...response,
-          data: bytes
-        } as ScreenshotBytesResponse;
+    if (wantsBytes) {
+      const binaryString = atob(response.data);
+      const bytes = new Uint8Array(binaryString.length);
+      for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
       }
 
-      return response;
-    } catch (error) {
-      throw error;
+      return {
+        ...response,
+        data: bytes
+      } as ScreenshotBytesResponse;
     }
+
+    return response;
   }
 
   /**
    * Single-click at the given coordinates.
    */
   async click(x: number, y: number, options?: ClickOptions): Promise<void> {
-    try {
-      await this.post<BaseApiResponse>('/api/desktop/mouse/click', {
-        x,
-        y,
-        button: options?.button ?? 'left',
-        clickCount: 1
-      });
-    } catch (error) {
-      throw error;
-    }
+    await this.post<BaseApiResponse>('/api/desktop/mouse/click', {
+      x,
+      y,
+      button: options?.button ?? 'left',
+      clickCount: 1
+    });
   }
 
   /**
@@ -330,16 +314,12 @@ export class DesktopClient extends BaseHttpClient {
     y: number,
     options?: ClickOptions
   ): Promise<void> {
-    try {
-      await this.post<BaseApiResponse>('/api/desktop/mouse/click', {
-        x,
-        y,
-        button: options?.button ?? 'left',
-        clickCount: 2
-      });
-    } catch (error) {
-      throw error;
-    }
+    await this.post<BaseApiResponse>('/api/desktop/mouse/click', {
+      x,
+      y,
+      button: options?.button ?? 'left',
+      clickCount: 2
+    });
   }
 
   /**
@@ -350,48 +330,36 @@ export class DesktopClient extends BaseHttpClient {
     y: number,
     options?: ClickOptions
   ): Promise<void> {
-    try {
-      await this.post<BaseApiResponse>('/api/desktop/mouse/click', {
-        x,
-        y,
-        button: options?.button ?? 'left',
-        clickCount: 3
-      });
-    } catch (error) {
-      throw error;
-    }
+    await this.post<BaseApiResponse>('/api/desktop/mouse/click', {
+      x,
+      y,
+      button: options?.button ?? 'left',
+      clickCount: 3
+    });
   }
 
   /**
    * Right-click at the given coordinates.
    */
   async rightClick(x: number, y: number): Promise<void> {
-    try {
-      await this.post<BaseApiResponse>('/api/desktop/mouse/click', {
-        x,
-        y,
-        button: 'right',
-        clickCount: 1
-      });
-    } catch (error) {
-      throw error;
-    }
+    await this.post<BaseApiResponse>('/api/desktop/mouse/click', {
+      x,
+      y,
+      button: 'right',
+      clickCount: 1
+    });
   }
 
   /**
    * Middle-click at the given coordinates.
    */
   async middleClick(x: number, y: number): Promise<void> {
-    try {
-      await this.post<BaseApiResponse>('/api/desktop/mouse/click', {
-        x,
-        y,
-        button: 'middle',
-        clickCount: 1
-      });
-    } catch (error) {
-      throw error;
-    }
+    await this.post<BaseApiResponse>('/api/desktop/mouse/click', {
+      x,
+      y,
+      button: 'middle',
+      clickCount: 1
+    });
   }
 
   /**
@@ -402,41 +370,29 @@ export class DesktopClient extends BaseHttpClient {
     y?: number,
     options?: ClickOptions
   ): Promise<void> {
-    try {
-      await this.post<BaseApiResponse>('/api/desktop/mouse/down', {
-        ...(x !== undefined && { x }),
-        ...(y !== undefined && { y }),
-        button: options?.button ?? 'left'
-      });
-    } catch (error) {
-      throw error;
-    }
+    await this.post<BaseApiResponse>('/api/desktop/mouse/down', {
+      ...(x !== undefined && { x }),
+      ...(y !== undefined && { y }),
+      button: options?.button ?? 'left'
+    });
   }
 
   /**
    * Release a held mouse button.
    */
   async mouseUp(x?: number, y?: number, options?: ClickOptions): Promise<void> {
-    try {
-      await this.post<BaseApiResponse>('/api/desktop/mouse/up', {
-        ...(x !== undefined && { x }),
-        ...(y !== undefined && { y }),
-        button: options?.button ?? 'left'
-      });
-    } catch (error) {
-      throw error;
-    }
+    await this.post<BaseApiResponse>('/api/desktop/mouse/up', {
+      ...(x !== undefined && { x }),
+      ...(y !== undefined && { y }),
+      button: options?.button ?? 'left'
+    });
   }
 
   /**
    * Move the mouse cursor to coordinates.
    */
   async moveMouse(x: number, y: number): Promise<void> {
-    try {
-      await this.post<BaseApiResponse>('/api/desktop/mouse/move', { x, y });
-    } catch (error) {
-      throw error;
-    }
+    await this.post<BaseApiResponse>('/api/desktop/mouse/move', { x, y });
   }
 
   /**
@@ -449,17 +405,13 @@ export class DesktopClient extends BaseHttpClient {
     endY: number,
     options?: ClickOptions
   ): Promise<void> {
-    try {
-      await this.post<BaseApiResponse>('/api/desktop/mouse/drag', {
-        startX,
-        startY,
-        endX,
-        endY,
-        button: options?.button ?? 'left'
-      });
-    } catch (error) {
-      throw error;
-    }
+    await this.post<BaseApiResponse>('/api/desktop/mouse/drag', {
+      startX,
+      startY,
+      endX,
+      endY,
+      button: options?.button ?? 'left'
+    });
   }
 
   /**
@@ -471,91 +423,63 @@ export class DesktopClient extends BaseHttpClient {
     direction: ScrollDirection,
     amount = 3
   ): Promise<void> {
-    try {
-      await this.post<BaseApiResponse>('/api/desktop/mouse/scroll', {
-        x,
-        y,
-        direction,
-        amount
-      });
-    } catch (error) {
-      throw error;
-    }
+    await this.post<BaseApiResponse>('/api/desktop/mouse/scroll', {
+      x,
+      y,
+      direction,
+      amount
+    });
   }
 
   /**
    * Get the current cursor coordinates.
    */
   async getCursorPosition(): Promise<CursorPositionResponse> {
-    try {
-      const response = await this.get<CursorPositionResponse>(
-        '/api/desktop/mouse/position'
-      );
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    const response = await this.get<CursorPositionResponse>(
+      '/api/desktop/mouse/position'
+    );
+    return response;
   }
 
   /**
    * Type text into the focused element.
    */
   async type(text: string, options?: TypeOptions): Promise<void> {
-    try {
-      await this.post<BaseApiResponse>('/api/desktop/keyboard/type', {
-        text,
-        ...(options?.delayMs !== undefined && { delayMs: options.delayMs })
-      });
-    } catch (error) {
-      throw error;
-    }
+    await this.post<BaseApiResponse>('/api/desktop/keyboard/type', {
+      text,
+      ...(options?.delayMs !== undefined && { delayMs: options.delayMs })
+    });
   }
 
   /**
    * Press and release a key or key combination.
    */
   async press(key: KeyInput): Promise<void> {
-    try {
-      await this.post<BaseApiResponse>('/api/desktop/keyboard/press', { key });
-    } catch (error) {
-      throw error;
-    }
+    await this.post<BaseApiResponse>('/api/desktop/keyboard/press', { key });
   }
 
   /**
    * Press and hold a key.
    */
   async keyDown(key: KeyInput): Promise<void> {
-    try {
-      await this.post<BaseApiResponse>('/api/desktop/keyboard/down', { key });
-    } catch (error) {
-      throw error;
-    }
+    await this.post<BaseApiResponse>('/api/desktop/keyboard/down', { key });
   }
 
   /**
    * Release a held key.
    */
   async keyUp(key: KeyInput): Promise<void> {
-    try {
-      await this.post<BaseApiResponse>('/api/desktop/keyboard/up', { key });
-    } catch (error) {
-      throw error;
-    }
+    await this.post<BaseApiResponse>('/api/desktop/keyboard/up', { key });
   }
 
   /**
    * Get the active desktop screen size.
    */
   async getScreenSize(): Promise<ScreenSizeResponse> {
-    try {
-      const response = await this.get<ScreenSizeResponse>(
-        '/api/desktop/screen/size'
-      );
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    const response = await this.get<ScreenSizeResponse>(
+      '/api/desktop/screen/size'
+    );
+    return response;
   }
 
   /**
@@ -566,14 +490,10 @@ export class DesktopClient extends BaseHttpClient {
   ): Promise<
     BaseApiResponse & { running: boolean; pid?: number; uptime?: number }
   > {
-    try {
-      const response = await this.get<
-        BaseApiResponse & { running: boolean; pid?: number; uptime?: number }
-      >(`/api/desktop/process/${encodeURIComponent(name)}/status`);
+    const response = await this.get<
+      BaseApiResponse & { running: boolean; pid?: number; uptime?: number }
+    >(`/api/desktop/process/${encodeURIComponent(name)}/status`);
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 }

--- a/packages/sandbox/src/clients/file-client.ts
+++ b/packages/sandbox/src/clients/file-client.ts
@@ -60,19 +60,15 @@ export class FileClient extends BaseHttpClient {
     sessionId: string,
     options?: { recursive?: boolean }
   ): Promise<MkdirResult> {
-    try {
-      const data = {
-        path,
-        sessionId,
-        recursive: options?.recursive ?? false
-      };
+    const data = {
+      path,
+      sessionId,
+      recursive: options?.recursive ?? false
+    };
 
-      const response = await this.post<MkdirResult>('/api/mkdir', data);
+    const response = await this.post<MkdirResult>('/api/mkdir', data);
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 
   /**
@@ -88,20 +84,16 @@ export class FileClient extends BaseHttpClient {
     sessionId: string,
     options?: { encoding?: string }
   ): Promise<WriteFileResult> {
-    try {
-      const data = {
-        path,
-        content,
-        sessionId,
-        encoding: options?.encoding
-      };
+    const data = {
+      path,
+      content,
+      sessionId,
+      encoding: options?.encoding
+    };
 
-      const response = await this.post<WriteFileResult>('/api/write', data);
+    const response = await this.post<WriteFileResult>('/api/write', data);
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 
   /**
@@ -115,19 +107,15 @@ export class FileClient extends BaseHttpClient {
     sessionId: string,
     options?: { encoding?: string }
   ): Promise<ReadFileResult> {
-    try {
-      const data = {
-        path,
-        sessionId,
-        encoding: options?.encoding
-      };
+    const data = {
+      path,
+      sessionId,
+      encoding: options?.encoding
+    };
 
-      const response = await this.post<ReadFileResult>('/api/read', data);
+    const response = await this.post<ReadFileResult>('/api/read', data);
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 
   /**
@@ -140,18 +128,14 @@ export class FileClient extends BaseHttpClient {
     path: string,
     sessionId: string
   ): Promise<ReadableStream<Uint8Array>> {
-    try {
-      const data = {
-        path,
-        sessionId
-      };
+    const data = {
+      path,
+      sessionId
+    };
 
-      // Use doStreamFetch which handles both WebSocket and HTTP streaming
-      const stream = await this.doStreamFetch('/api/read/stream', data);
-      return stream;
-    } catch (error) {
-      throw error;
-    }
+    // Use doStreamFetch which handles both WebSocket and HTTP streaming
+    const stream = await this.doStreamFetch('/api/read/stream', data);
+    return stream;
   }
 
   /**
@@ -160,15 +144,11 @@ export class FileClient extends BaseHttpClient {
    * @param sessionId - The session ID for this operation
    */
   async deleteFile(path: string, sessionId: string): Promise<DeleteFileResult> {
-    try {
-      const data = { path, sessionId };
+    const data = { path, sessionId };
 
-      const response = await this.post<DeleteFileResult>('/api/delete', data);
+    const response = await this.post<DeleteFileResult>('/api/delete', data);
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 
   /**
@@ -182,15 +162,11 @@ export class FileClient extends BaseHttpClient {
     newPath: string,
     sessionId: string
   ): Promise<RenameFileResult> {
-    try {
-      const data = { oldPath: path, newPath, sessionId };
+    const data = { oldPath: path, newPath, sessionId };
 
-      const response = await this.post<RenameFileResult>('/api/rename', data);
+    const response = await this.post<RenameFileResult>('/api/rename', data);
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 
   /**
@@ -204,15 +180,11 @@ export class FileClient extends BaseHttpClient {
     newPath: string,
     sessionId: string
   ): Promise<MoveFileResult> {
-    try {
-      const data = { sourcePath: path, destinationPath: newPath, sessionId };
+    const data = { sourcePath: path, destinationPath: newPath, sessionId };
 
-      const response = await this.post<MoveFileResult>('/api/move', data);
+    const response = await this.post<MoveFileResult>('/api/move', data);
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 
   /**
@@ -226,22 +198,15 @@ export class FileClient extends BaseHttpClient {
     sessionId: string,
     options?: ListFilesOptions
   ): Promise<ListFilesResult> {
-    try {
-      const data = {
-        path,
-        sessionId,
-        options: options || {}
-      };
+    const data = {
+      path,
+      sessionId,
+      options: options || {}
+    };
 
-      const response = await this.post<ListFilesResult>(
-        '/api/list-files',
-        data
-      );
+    const response = await this.post<ListFilesResult>('/api/list-files', data);
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 
   /**
@@ -250,17 +215,13 @@ export class FileClient extends BaseHttpClient {
    * @param sessionId - The session ID for this operation
    */
   async exists(path: string, sessionId: string): Promise<FileExistsResult> {
-    try {
-      const data = {
-        path,
-        sessionId
-      };
+    const data = {
+      path,
+      sessionId
+    };
 
-      const response = await this.post<FileExistsResult>('/api/exists', data);
+    const response = await this.post<FileExistsResult>('/api/exists', data);
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 }

--- a/packages/sandbox/src/clients/git-client.ts
+++ b/packages/sandbox/src/clients/git-client.ts
@@ -53,56 +53,52 @@ export class GitClient extends BaseHttpClient {
       timeoutMs?: number;
     }
   ): Promise<GitCheckoutResult> {
-    try {
-      const timeoutMs = options?.timeoutMs ?? DEFAULT_GIT_CLONE_TIMEOUT_MS;
+    const timeoutMs = options?.timeoutMs ?? DEFAULT_GIT_CLONE_TIMEOUT_MS;
 
-      // Determine target directory - use provided path or generate from repo name
-      let targetDir = options?.targetDir;
-      if (!targetDir) {
-        targetDir = `/workspace/${extractRepoName(repoUrl)}`;
-      }
+    // Determine target directory - use provided path or generate from repo name
+    let targetDir = options?.targetDir;
+    if (!targetDir) {
+      targetDir = `/workspace/${extractRepoName(repoUrl)}`;
+    }
 
-      const data: GitCheckoutRequest = {
-        repoUrl,
-        sessionId,
-        targetDir
-      };
+    const data: GitCheckoutRequest = {
+      repoUrl,
+      sessionId,
+      targetDir
+    };
 
-      // Only include branch if explicitly specified
-      // This allows Git to use the repository's default branch
-      if (options?.branch) {
-        data.branch = options.branch;
-      }
+    // Only include branch if explicitly specified
+    // This allows Git to use the repository's default branch
+    if (options?.branch) {
+      data.branch = options.branch;
+    }
 
-      if (options?.depth !== undefined) {
-        if (!Number.isInteger(options.depth) || options.depth <= 0) {
-          throw new Error(
-            `Invalid depth value: ${options.depth}. Must be a positive integer (e.g., 1, 5, 10).`
-          );
-        }
-        data.depth = options.depth;
-      }
-
-      if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+    if (options?.depth !== undefined) {
+      if (!Number.isInteger(options.depth) || options.depth <= 0) {
         throw new Error(
-          `Invalid timeout value: ${timeoutMs}. Must be a positive integer number of milliseconds.`
+          `Invalid depth value: ${options.depth}. Must be a positive integer (e.g., 1, 5, 10).`
         );
       }
-
-      data.timeoutMs = timeoutMs;
-
-      const response = await this.post<GitCheckoutResult>(
-        '/api/git/checkout',
-        data,
-        undefined,
-        {
-          requestTimeoutMs: timeoutMs + GitClient.REQUEST_TIMEOUT_BUFFER_MS
-        }
-      );
-
-      return response;
-    } catch (error) {
-      throw error;
+      data.depth = options.depth;
     }
+
+    if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+      throw new Error(
+        `Invalid timeout value: ${timeoutMs}. Must be a positive integer number of milliseconds.`
+      );
+    }
+
+    data.timeoutMs = timeoutMs;
+
+    const response = await this.post<GitCheckoutResult>(
+      '/api/git/checkout',
+      data,
+      undefined,
+      {
+        requestTimeoutMs: timeoutMs + GitClient.REQUEST_TIMEOUT_BUFFER_MS
+      }
+    );
+
+    return response;
   }
 }

--- a/packages/sandbox/src/clients/port-client.ts
+++ b/packages/sandbox/src/clients/port-client.ts
@@ -37,18 +37,14 @@ export class PortClient extends BaseHttpClient {
     sessionId: string,
     name?: string
   ): Promise<PortExposeResult> {
-    try {
-      const data = { port, sessionId, name };
+    const data = { port, sessionId, name };
 
-      const response = await this.post<PortExposeResult>(
-        '/api/expose-port',
-        data
-      );
+    const response = await this.post<PortExposeResult>(
+      '/api/expose-port',
+      data
+    );
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 
   /**
@@ -60,16 +56,12 @@ export class PortClient extends BaseHttpClient {
     port: number,
     sessionId: string
   ): Promise<PortCloseResult> {
-    try {
-      const url = `/api/exposed-ports/${port}?session=${encodeURIComponent(
-        sessionId
-      )}`;
-      const response = await this.delete<PortCloseResult>(url);
+    const url = `/api/exposed-ports/${port}?session=${encodeURIComponent(
+      sessionId
+    )}`;
+    const response = await this.delete<PortCloseResult>(url);
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 
   /**
@@ -77,14 +69,10 @@ export class PortClient extends BaseHttpClient {
    * @param sessionId - The session ID for this operation
    */
   async getExposedPorts(sessionId: string): Promise<PortListResult> {
-    try {
-      const url = `/api/exposed-ports?session=${encodeURIComponent(sessionId)}`;
-      const response = await this.get<PortListResult>(url);
+    const url = `/api/exposed-ports?session=${encodeURIComponent(sessionId)}`;
+    const response = await this.get<PortListResult>(url);
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 
   /**
@@ -95,11 +83,7 @@ export class PortClient extends BaseHttpClient {
   async watchPort(
     request: PortWatchRequest
   ): Promise<ReadableStream<Uint8Array>> {
-    try {
-      const stream = await this.doStreamFetch('/api/port-watch', request);
-      return stream;
-    } catch (error) {
-      throw error;
-    }
+    const stream = await this.doStreamFetch('/api/port-watch', request);
+    return stream;
   }
 }

--- a/packages/sandbox/src/clients/process-client.ts
+++ b/packages/sandbox/src/clients/process-client.ts
@@ -44,48 +44,40 @@ export class ProcessClient extends BaseHttpClient {
       origin?: 'user' | 'internal';
     }
   ): Promise<ProcessStartResult> {
-    try {
-      const data: StartProcessRequest = {
-        command,
-        sessionId,
-        ...(options?.origin !== undefined && { origin: options.origin }),
-        ...(options?.processId !== undefined && {
-          processId: options.processId
-        }),
-        ...(options?.timeoutMs !== undefined && {
-          timeoutMs: options.timeoutMs
-        }),
-        ...(options?.env !== undefined && { env: options.env }),
-        ...(options?.cwd !== undefined && { cwd: options.cwd }),
-        ...(options?.encoding !== undefined && { encoding: options.encoding }),
-        ...(options?.autoCleanup !== undefined && {
-          autoCleanup: options.autoCleanup
-        })
-      };
+    const data: StartProcessRequest = {
+      command,
+      sessionId,
+      ...(options?.origin !== undefined && { origin: options.origin }),
+      ...(options?.processId !== undefined && {
+        processId: options.processId
+      }),
+      ...(options?.timeoutMs !== undefined && {
+        timeoutMs: options.timeoutMs
+      }),
+      ...(options?.env !== undefined && { env: options.env }),
+      ...(options?.cwd !== undefined && { cwd: options.cwd }),
+      ...(options?.encoding !== undefined && { encoding: options.encoding }),
+      ...(options?.autoCleanup !== undefined && {
+        autoCleanup: options.autoCleanup
+      })
+    };
 
-      const response = await this.post<ProcessStartResult>(
-        '/api/process/start',
-        data
-      );
+    const response = await this.post<ProcessStartResult>(
+      '/api/process/start',
+      data
+    );
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 
   /**
    * List all processes (sandbox-scoped, not session-scoped)
    */
   async listProcesses(): Promise<ProcessListResult> {
-    try {
-      const url = `/api/process/list`;
-      const response = await this.get<ProcessListResult>(url);
+    const url = `/api/process/list`;
+    const response = await this.get<ProcessListResult>(url);
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 
   /**
@@ -93,14 +85,10 @@ export class ProcessClient extends BaseHttpClient {
    * @param processId - ID of the process to retrieve
    */
   async getProcess(processId: string): Promise<ProcessInfoResult> {
-    try {
-      const url = `/api/process/${processId}`;
-      const response = await this.get<ProcessInfoResult>(url);
+    const url = `/api/process/${processId}`;
+    const response = await this.get<ProcessInfoResult>(url);
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 
   /**
@@ -108,28 +96,20 @@ export class ProcessClient extends BaseHttpClient {
    * @param processId - ID of the process to kill
    */
   async killProcess(processId: string): Promise<ProcessKillResult> {
-    try {
-      const url = `/api/process/${processId}`;
-      const response = await this.delete<ProcessKillResult>(url);
+    const url = `/api/process/${processId}`;
+    const response = await this.delete<ProcessKillResult>(url);
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 
   /**
    * Kill all running processes (sandbox-scoped, not session-scoped)
    */
   async killAllProcesses(): Promise<ProcessCleanupResult> {
-    try {
-      const url = `/api/process/kill-all`;
-      const response = await this.delete<ProcessCleanupResult>(url);
+    const url = `/api/process/kill-all`;
+    const response = await this.delete<ProcessCleanupResult>(url);
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 
   /**
@@ -137,14 +117,10 @@ export class ProcessClient extends BaseHttpClient {
    * @param processId - ID of the process to get logs from
    */
   async getProcessLogs(processId: string): Promise<ProcessLogsResult> {
-    try {
-      const url = `/api/process/${processId}/logs`;
-      const response = await this.get<ProcessLogsResult>(url);
+    const url = `/api/process/${processId}/logs`;
+    const response = await this.get<ProcessLogsResult>(url);
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 
   /**
@@ -154,14 +130,10 @@ export class ProcessClient extends BaseHttpClient {
   async streamProcessLogs(
     processId: string
   ): Promise<ReadableStream<Uint8Array>> {
-    try {
-      const url = `/api/process/${processId}/stream`;
-      // Use doStreamFetch with GET method (process log streaming is GET)
-      const stream = await this.doStreamFetch(url, undefined, 'GET');
+    const url = `/api/process/${processId}/stream`;
+    // Use doStreamFetch with GET method (process log streaming is GET)
+    const stream = await this.doStreamFetch(url, undefined, 'GET');
 
-      return stream;
-    } catch (error) {
-      throw error;
-    }
+    return stream;
   }
 }

--- a/packages/sandbox/src/clients/utility-client.ts
+++ b/packages/sandbox/src/clients/utility-client.ts
@@ -64,26 +64,18 @@ export class UtilityClient extends BaseHttpClient {
    * Ping the sandbox to check if it's responsive
    */
   async ping(): Promise<string> {
-    try {
-      const response = await this.get<PingResponse>('/api/ping');
+    const response = await this.get<PingResponse>('/api/ping');
 
-      return response.message;
-    } catch (error) {
-      throw error;
-    }
+    return response.message;
   }
 
   /**
    * Get list of available commands in the sandbox environment
    */
   async getCommands(): Promise<string[]> {
-    try {
-      const response = await this.get<CommandsResponse>('/api/commands');
+    const response = await this.get<CommandsResponse>('/api/commands');
 
-      return response.availableCommands;
-    } catch (error) {
-      throw error;
-    }
+    return response.availableCommands;
   }
 
   /**
@@ -93,16 +85,12 @@ export class UtilityClient extends BaseHttpClient {
   async createSession(
     options: CreateSessionRequest
   ): Promise<CreateSessionResponse> {
-    try {
-      const response = await this.post<CreateSessionResponse>(
-        '/api/session/create',
-        options
-      );
+    const response = await this.post<CreateSessionResponse>(
+      '/api/session/create',
+      options
+    );
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 
   /**
@@ -110,16 +98,12 @@ export class UtilityClient extends BaseHttpClient {
    * @param sessionId - Session ID to delete
    */
   async deleteSession(sessionId: string): Promise<DeleteSessionResponse> {
-    try {
-      const response = await this.post<DeleteSessionResponse>(
-        '/api/session/delete',
-        { sessionId }
-      );
+    const response = await this.post<DeleteSessionResponse>(
+      '/api/session/delete',
+      { sessionId }
+    );
 
-      return response;
-    } catch (error) {
-      throw error;
-    }
+    return response;
   }
 
   /**

--- a/packages/sandbox/src/clients/watch-client.ts
+++ b/packages/sandbox/src/clients/watch-client.ts
@@ -35,14 +35,10 @@ export class WatchClient extends BaseHttpClient {
    * @param request - Watch request with path and options
    */
   async watch(request: WatchRequest): Promise<ReadableStream<Uint8Array>> {
-    try {
-      const stream = await this.doStreamFetch('/api/watch', request);
-      const readyStream = await this.waitForReadiness(stream);
+    const stream = await this.doStreamFetch('/api/watch', request);
+    const readyStream = await this.waitForReadiness(stream);
 
-      return readyStream;
-    } catch (error) {
-      throw error;
-    }
+    return readyStream;
   }
 
   /**

--- a/packages/shared/tests/logger/canonical.test.ts
+++ b/packages/shared/tests/logger/canonical.test.ts
@@ -100,7 +100,7 @@ describe('buildMessage', () => {
   });
 
   it('truncates long commands', () => {
-    const longCmd = 'echo ' + 'a'.repeat(200);
+    const longCmd = `echo ${'a'.repeat(200)}`;
     const msg = buildMessage({
       event: 'sandbox.exec',
       outcome: 'success',
@@ -202,7 +202,7 @@ describe('logCanonicalEvent', () => {
 
   it('sets commandTruncated when command is long', () => {
     const logger = createMockLogger();
-    const longCmd = 'echo ' + 'x'.repeat(200);
+    const longCmd = `echo ${'x'.repeat(200)}`;
     logCanonicalEvent(logger, {
       event: 'sandbox.exec',
       outcome: 'success',


### PR DESCRIPTION
`npm run check` emitted 65 non-blocking Biome diagnostics. Future violations get lost in that noise.

The bulk are useless try/catch wrappers in the SDK HTTP clients and string-concat-to-template-literal swaps. The workspace-chat `!important` declarations, which were there to beat third-party streamdown styles, are replaced by doubling the `.sd-theme` selector to raise specificity without changing what it matches.

Most of the diff in `examples/codex-app-server/public/index.html` is Biome reformatting the embedded `<style>` block (4-space to 2-space, lowercase `<!doctype>`); the only logical change there is reordering two rules so higher-specificity selectors follow lower-specificity ones.

No behavior change. Unit tests still pass (559 SDK, 114 shared, 618 container).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
