### PR TITLE
Skip container round-trip in preview URL auth

### DIFF
--- a/.changeset/validate-port-token-skip-container.md
+++ b/.changeset/validate-port-token-skip-container.md
@@ -2,8 +2,10 @@
 '@cloudflare/sandbox': patch
 ---
 
-Speed up preview URL authorization by skipping a container round-trip.
-The Durable Object now answers preview-URL auth checks from its own
-storage instead of asking the container runtime. Pages that fetch many
-assets through a single preview URL see less latency under load and use
-less of the sandbox's per-request capacity.
+Speed up preview URL authorization and close a race in `unexposePort()`.
+Preview URL auth checks no longer make an extra round-trip to the
+container runtime, so pages that fetch many assets through a single
+preview URL do less work per request. `unexposePort()` now revokes
+the preview token before signaling the container, so a preview
+request that races an `unexposePort()` call can no longer reach the
+process running inside the sandbox after the token has been revoked.

--- a/.changeset/validate-port-token-skip-container.md
+++ b/.changeset/validate-port-token-skip-container.md
@@ -9,3 +9,6 @@ preview URL do less work per request. `unexposePort()` now revokes
 the preview token before signaling the container, so a preview
 request that races an `unexposePort()` call can no longer reach the
 process running inside the sandbox after the token has been revoked.
+`getExposedPorts()` also no longer throws when it encounters a port
+left in an inconsistent state by a failed `unexposePort()`; such
+ports are omitted from the result and logged as a warning.

--- a/.changeset/validate-port-token-skip-container.md
+++ b/.changeset/validate-port-token-skip-container.md
@@ -1,0 +1,9 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Speed up preview URL authorization by skipping a container round-trip.
+The Durable Object now answers preview-URL auth checks from its own
+storage instead of asking the container runtime. Pages that fetch many
+assets through a single preview URL see less latency under load and use
+less of the sandbox's per-request capacity.

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1603,10 +1603,11 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
     // Persist cleanup to storage so state is clean on next container start.
     // Port tokens are intentionally preserved so preview URLs survive
-    // container restarts. Tokens are only removed on explicit
+    // container restarts; they are only removed on explicit
     // unexposePort() or full sandbox destroy(). onStart's
-    // restoreExposedPorts() replays storage into the container on the
-    // next start, so auth can trust storage without asking the container.
+    // restoreExposedPorts() replays those tokens into the container on
+    // the next start, which is what lets validatePortToken() answer from
+    // storage alone.
     await this.ctx.storage.delete('defaultSession');
   }
 
@@ -3289,12 +3290,13 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         );
       }
 
-      // Revoke the token from storage before calling the container so
-      // validatePortToken stops honoring it during the container RPC.
-      // Otherwise a preview request arriving between the two awaits
-      // would authorize against storage and reach the backend process
-      // via containerFetch, which does not consult the container's
-      // exposed-port registry.
+      // Storage is the source of truth for preview-URL auth, so clear
+      // the token before the container RPC. A preview request that
+      // arrives during the container call sees no token, fails auth,
+      // and is rejected before containerFetch() can route it to the
+      // process running inside the sandbox. (containerFetch() does not
+      // gate on the container's exposed-port registry; it connects to
+      // the port number directly.)
       const tokens = await this.readPortTokens();
       if (tokens[port.toString()]) {
         delete tokens[port.toString()];

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -3346,24 +3346,34 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     // Read all tokens from storage (protected by input gates)
     const tokens = await this.readPortTokens();
 
-    return response.ports.map((port) => {
+    // A port reported by the container with no corresponding token in
+    // storage is an orphan. It cannot produce a valid preview URL (the
+    // token is what the URL binds to), so it is omitted from the
+    // result. The next container restart reconciles the inconsistency
+    // because restoreExposedPorts() rebuilds the container registry
+    // from storage.
+    return response.ports.flatMap((port) => {
       const entry = tokens[port.port.toString()];
       if (!entry) {
-        throw new Error(
-          `Port ${port.port} is exposed but has no token. This should not happen.`
+        this.logger.warn(
+          'Port exposed on container but no token in storage; omitting from preview URL list',
+          { port: port.port }
         );
+        return [];
       }
 
-      return {
-        url: this.constructPreviewUrl(
-          port.port,
-          this.sandboxName!,
-          hostname,
-          entry.token
-        ),
-        port: port.port,
-        status: port.status
-      };
+      return [
+        {
+          url: this.constructPreviewUrl(
+            port.port,
+            this.sandboxName!,
+            hostname,
+            entry.token
+          ),
+          port: port.port,
+          status: port.status
+        }
+      ];
     });
   }
 

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1601,11 +1601,11 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     this.activeMounts.clear();
 
     // Persist cleanup to storage so state is clean on next container start.
-    // Port tokens are intentionally preserved so preview URLs survive container
-    // restarts. Tokens are only removed on explicit unexposePort() or full
-    // sandbox destroy(). If a port isn't actually exposed on the container
-    // after restart, validatePortToken()'s isPortExposed() check rejects the
-    // request regardless of what's in storage.
+    // Port tokens are intentionally preserved so preview URLs survive
+    // container restarts. Tokens are only removed on explicit
+    // unexposePort() or full sandbox destroy(). onStart's
+    // restoreExposedPorts() replays storage into the container on the
+    // next start, so auth can trust storage without asking the container.
     await this.ctx.storage.delete('defaultSession');
   }
 
@@ -3363,21 +3363,14 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   async validatePortToken(port: number, token: string): Promise<boolean> {
-    // First check if port is exposed
-    const isExposed = await this.isPortExposed(port);
-    if (!isExposed) {
-      return false;
-    }
-
-    // Read stored token from storage (protected by input gates)
+    // Preview-URL auth answers from DO storage alone. onStart's
+    // restoreExposedPorts() replays storage into the container on restart,
+    // and destroy() clears portTokens before super.destroy() runs, so a
+    // storage read gives the right answer for the interleavings this
+    // method can race.
     const tokens = await this.readPortTokens();
     const entry = tokens[port.toString()];
     if (!entry) {
-      this.logger.error(
-        'Port is exposed but has no token - bug detected',
-        undefined,
-        { port }
-      );
       return false;
     }
 

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -56,6 +56,7 @@ import {
   CustomDomainRequiredError,
   ErrorCode,
   InvalidBackupConfigError,
+  PortNotExposedError,
   ProcessExitedBeforeReadyError,
   ProcessReadyTimeoutError,
   SessionAlreadyExistsError
@@ -3287,14 +3288,31 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           `Invalid port number: ${port}. Must be 1024-65535, excluding 3000 (sandbox control plane).`
         );
       }
-      const sessionId = await this.ensureDefaultSession();
-      await this.client.ports.unexposePort(port, sessionId);
 
-      // Clean up token for this port (storage is protected by input gates)
+      // Revoke the token from storage before calling the container so
+      // validatePortToken stops honoring it during the container RPC.
+      // Otherwise a preview request arriving between the two awaits
+      // would authorize against storage and reach the backend process
+      // via containerFetch, which does not consult the container's
+      // exposed-port registry.
       const tokens = await this.readPortTokens();
       if (tokens[port.toString()]) {
         delete tokens[port.toString()];
         await this.ctx.storage.put('portTokens', tokens);
+      }
+
+      const sessionId = await this.ensureDefaultSession();
+      try {
+        await this.client.ports.unexposePort(port, sessionId);
+      } catch (error) {
+        // A container that was asleep when we entered wakes with an
+        // empty exposed-port registry; restoreExposedPorts() has
+        // nothing to replay because we just cleared the token. The
+        // container then reports the port was never exposed, which is
+        // the state we wanted.
+        if (!(error instanceof PortNotExposedError)) {
+          throw error;
+        }
       }
 
       outcome = 'success';

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1246,6 +1246,71 @@ describe('Sandbox - Automatic Session Management', () => {
     });
   });
 
+  describe('validatePortToken', () => {
+    beforeEach(() => {
+      // Mock getExposedPorts so the current implementation's
+      // isPortExposed() round-trip finds port 8080 and produces the
+      // correct booleans. The new tests assert this mock is NOT called
+      // once the round-trip is removed.
+      vi.spyOn(sandbox.client.ports, 'getExposedPorts').mockResolvedValue({
+        success: true,
+        ports: [
+          {
+            port: 8080,
+            exposedAt: new Date().toISOString()
+          }
+        ],
+        count: 1,
+        timestamp: new Date().toISOString()
+      } as any);
+
+      // Default: storage has a token for port 8080. Tests that want a
+      // different state override this.
+      vi.mocked(mockCtx.storage.get).mockImplementation(async (key) =>
+        key === 'portTokens' ? { '8080': { token: 'correcttoken' } } : null
+      );
+    });
+
+    it('returns true for a matching token without calling the container', async () => {
+      const result = await sandbox.validatePortToken(8080, 'correcttoken');
+
+      expect(result).toBe(true);
+      expect(sandbox.client.ports.getExposedPorts).not.toHaveBeenCalled();
+    });
+
+    it('returns false for a mismatched token without calling the container', async () => {
+      const result = await sandbox.validatePortToken(8080, 'wrongtoken');
+
+      expect(result).toBe(false);
+      expect(sandbox.client.ports.getExposedPorts).not.toHaveBeenCalled();
+    });
+
+    it('returns false when no token is stored for the port', async () => {
+      vi.mocked(mockCtx.storage.get).mockImplementation(async (key) =>
+        key === 'portTokens' ? {} : null
+      );
+
+      const result = await sandbox.validatePortToken(8080, 'anytoken');
+
+      expect(result).toBe(false);
+      expect(sandbox.client.ports.getExposedPorts).not.toHaveBeenCalled();
+    });
+
+    it('reads legacy string-valued tokens via readPortTokens normalization', async () => {
+      // readPortTokens normalizes the legacy { port: string } shape to
+      // { port: { token: string } }. validatePortToken must still accept
+      // legacy storage entries after the round-trip removal.
+      vi.mocked(mockCtx.storage.get).mockImplementation(async (key) =>
+        key === 'portTokens' ? { '8080': 'legacytoken' } : null
+      );
+
+      const result = await sandbox.validatePortToken(8080, 'legacytoken');
+
+      expect(result).toBe(true);
+      expect(sandbox.client.ports.getExposedPorts).not.toHaveBeenCalled();
+    });
+  });
+
   describe('sleepAfter configuration', () => {
     it('should call renewActivityTimeout when setSleepAfter is called', async () => {
       // Spy on renewActivityTimeout (inherited from Container)

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1,5 +1,6 @@
 import { Container } from '@cloudflare/containers';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PortNotExposedError } from '../src/errors';
 import { connect, Sandbox } from '../src/sandbox';
 
 // Mock dependencies before imports
@@ -1316,6 +1317,61 @@ describe('Sandbox - Automatic Session Management', () => {
       await sandbox.validatePortToken(8080, 'correcttoken');
 
       expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('unexposePort ordering', () => {
+    beforeEach(() => {
+      vi.mocked(mockCtx.storage.get).mockImplementation(async (key) =>
+        key === 'portTokens' ? { '8080': { token: 'sometoken' } } : null
+      );
+      vi.spyOn(sandbox.client.ports, 'unexposePort').mockResolvedValue(
+        undefined as any
+      );
+    });
+
+    it('revokes the token from storage before the container RPC', async () => {
+      const calls: string[] = [];
+      vi.mocked(mockCtx.storage.put).mockImplementation(async (key) => {
+        if (key === 'portTokens') {
+          calls.push('storage');
+        }
+      });
+      vi.mocked(sandbox.client.ports.unexposePort).mockImplementation(
+        async () => {
+          calls.push('container');
+        }
+      );
+
+      await sandbox.unexposePort(8080);
+
+      expect(calls).toEqual(['storage', 'container']);
+    });
+
+    it('treats PortNotExposedError from the container as success', async () => {
+      vi.mocked(sandbox.client.ports.unexposePort).mockRejectedValue(
+        new PortNotExposedError({
+          error: 'Port not exposed: 8080',
+          code: 'PORT_NOT_EXPOSED',
+          context: { port: 8080 }
+        } as any)
+      );
+
+      await expect(sandbox.unexposePort(8080)).resolves.toBeUndefined();
+      expect(mockCtx.storage.put).toHaveBeenCalledWith(
+        'portTokens',
+        expect.not.objectContaining({ '8080': expect.anything() })
+      );
+    });
+
+    it('rethrows non-PortNotExposedError failures from the container', async () => {
+      vi.mocked(sandbox.client.ports.unexposePort).mockRejectedValue(
+        new Error('network failure')
+      );
+
+      await expect(sandbox.unexposePort(8080)).rejects.toThrow(
+        'network failure'
+      );
     });
   });
 

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1368,6 +1368,43 @@ describe('Sandbox - Automatic Session Management', () => {
     });
   });
 
+  describe('getExposedPorts orphan handling', () => {
+    beforeEach(async () => {
+      await sandbox.setSandboxName('test-sandbox');
+
+      vi.spyOn(sandbox.client.ports, 'getExposedPorts').mockResolvedValue({
+        success: true,
+        ports: [
+          { port: 8080, exposedAt: new Date().toISOString() },
+          { port: 9090, exposedAt: new Date().toISOString() }
+        ],
+        count: 2,
+        timestamp: new Date().toISOString()
+      } as any);
+
+      // Storage has a token for 9090 but not for 8080, so 8080 is an
+      // orphan from getExposedPorts()'s perspective.
+      vi.mocked(mockCtx.storage.get).mockImplementation(async (key) => {
+        if (key === 'portTokens') return { '9090': { token: 'token9090' } };
+        if (key === 'sandboxName') return 'test-sandbox';
+        return null;
+      });
+    });
+
+    it('omits ports with no token from the result', async () => {
+      const warnSpy = vi.spyOn((sandbox as any).logger, 'warn');
+
+      const result = await sandbox.getExposedPorts('example.com');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].port).toBe(9090);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('no token in storage'),
+        expect.objectContaining({ port: 8080 })
+      );
+    });
+  });
+
   describe('sleepAfter configuration', () => {
     it('should call renewActivityTimeout when setSleepAfter is called', async () => {
       // Spy on renewActivityTimeout (inherited from Container)

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1249,24 +1249,15 @@ describe('Sandbox - Automatic Session Management', () => {
 
   describe('validatePortToken', () => {
     beforeEach(() => {
-      // Mock getExposedPorts so the current implementation's
-      // isPortExposed() round-trip finds port 8080 and produces the
-      // correct booleans. The new tests assert this mock is NOT called
-      // once the round-trip is removed.
+      // Spy on getExposedPorts so a regression that reintroduces the
+      // container round-trip is catchable via not.toHaveBeenCalled().
       vi.spyOn(sandbox.client.ports, 'getExposedPorts').mockResolvedValue({
         success: true,
-        ports: [
-          {
-            port: 8080,
-            exposedAt: new Date().toISOString()
-          }
-        ],
-        count: 1,
+        ports: [],
+        count: 0,
         timestamp: new Date().toISOString()
       } as any);
 
-      // Default: storage has a token for port 8080. Tests that want a
-      // different state override this.
       vi.mocked(mockCtx.storage.get).mockImplementation(async (key) =>
         key === 'portTokens' ? { '8080': { token: 'correcttoken' } } : null
       );
@@ -1279,11 +1270,10 @@ describe('Sandbox - Automatic Session Management', () => {
       expect(sandbox.client.ports.getExposedPorts).not.toHaveBeenCalled();
     });
 
-    it('returns false for a mismatched token without calling the container', async () => {
+    it('returns false for a mismatched token', async () => {
       const result = await sandbox.validatePortToken(8080, 'wrongtoken');
 
       expect(result).toBe(false);
-      expect(sandbox.client.ports.getExposedPorts).not.toHaveBeenCalled();
     });
 
     it('returns false when no token is stored for the port', async () => {
@@ -1294,13 +1284,12 @@ describe('Sandbox - Automatic Session Management', () => {
       const result = await sandbox.validatePortToken(8080, 'anytoken');
 
       expect(result).toBe(false);
-      expect(sandbox.client.ports.getExposedPorts).not.toHaveBeenCalled();
     });
 
-    it('reads legacy string-valued tokens via readPortTokens normalization', async () => {
-      // readPortTokens normalizes the legacy { port: string } shape to
-      // { port: { token: string } }. validatePortToken must still accept
-      // legacy storage entries after the round-trip removal.
+    it('accepts legacy string-valued tokens from storage', async () => {
+      // readPortTokens normalizes the { port: string } storage shape
+      // to { port: { token: string } }; legacy entries must still
+      // authenticate.
       vi.mocked(mockCtx.storage.get).mockImplementation(async (key) =>
         key === 'portTokens' ? { '8080': 'legacytoken' } : null
       );
@@ -1308,7 +1297,6 @@ describe('Sandbox - Automatic Session Management', () => {
       const result = await sandbox.validatePortToken(8080, 'legacytoken');
 
       expect(result).toBe(true);
-      expect(sandbox.client.ports.getExposedPorts).not.toHaveBeenCalled();
     });
 
     it('does not call isPortExposed', async () => {
@@ -1340,6 +1328,11 @@ describe('Sandbox - Automatic Session Management', () => {
       vi.mocked(sandbox.client.ports.unexposePort).mockImplementation(
         async () => {
           calls.push('container');
+          return {
+            success: true,
+            port: 8080,
+            timestamp: new Date().toISOString()
+          };
         }
       );
 

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1309,6 +1309,14 @@ describe('Sandbox - Automatic Session Management', () => {
       expect(result).toBe(true);
       expect(sandbox.client.ports.getExposedPorts).not.toHaveBeenCalled();
     });
+
+    it('does not call isPortExposed', async () => {
+      const spy = vi.spyOn(sandbox, 'isPortExposed');
+
+      await sandbox.validatePortToken(8080, 'correcttoken');
+
+      expect(spy).not.toHaveBeenCalled();
+    });
   });
 
   describe('sleepAfter configuration', () => {


### PR DESCRIPTION
`validatePortToken()` used to call `isPortExposed()`, which round-trips to the container to check the port registry, before reading the token from Durable Object storage and comparing. After PR #600, DO storage is the source of truth for exposed ports, so the round-trip was asking the container about state the DO already owned. This removes it.

The same change also flips `unexposePort()` to revoke the stored token before signaling the container. The previous ordering opened a window where a concurrent preview request could authorize against the still-stored token and then forward through `containerFetch()`, which does not consult the container's exposed-port registry — it connects to the port number directly. `unexposePort()` revokes the preview-URL routing but does not terminate the process the user started inside the sandbox, so during that window a revoked URL could still reach the user's running service. `exposePort()` stays container-first, storage-last on purpose — the asymmetry (publish last, revoke first) fails safe in both directions, producing a 404 during the racy window either way.

### Tradeoffs

This reduces the *cost* of each preview-auth RPC but not the *count*. Pages served through a preview URL typically fan out to many subresource fetches, each independently authenticating; each RPC is now a storage read plus a timing-safe compare instead of an HTTP subrequest plus a storage read, but the RPC count is unchanged. Reducing the RPC count (via caching or signed tokens) is an orthogonal change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
