### PR TITLE
Remove capnweb from integration test matrix

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -48,7 +48,6 @@ jobs:
     outputs:
       http-url: ${{ steps.urls.outputs.http_url }}
       ws-url: ${{ steps.urls.outputs.ws_url }}
-      capnweb-url: ${{ steps.urls.outputs.capnweb_url }}
     steps:
       - name: Check if deploy can be skipped
         if: ${{ inputs.deploy_hash != '' }}
@@ -58,7 +57,7 @@ jobs:
 
           # Check all workers — all must match to skip
           ALL_MATCH=true
-          for TRANSPORT in http websocket capnweb; do
+          for TRANSPORT in http websocket; do
             URL="https://${{ inputs.worker_name_prefix }}-${TRANSPORT}.${{ env.CF_ACCOUNT_SUBDOMAIN }}.workers.dev/health"
             HASH=$(curl -sf --max-time 10 "$URL" 2>/dev/null | jq -r '.deploy_hash // ""' 2>/dev/null || echo "")
             if [[ "$HASH" != "$EXPECTED" ]]; then
@@ -77,7 +76,7 @@ jobs:
 
       # --- Capacity guard (only when deploy is needed) ---
       # Ensures enough container app headroom before deploying. Each PR
-      # creates 18 container apps (3 workers × 6 classes). The account
+      # creates 12 container apps (2 workers × 6 classes). The account
       # has a ~100 app limit. We keep a budget of 84 (leaving 16 headroom)
       # and evict the least-recently-active PR's resources when over budget.
       # Protects: current PR, main workers, and PRs with in-progress CI.
@@ -94,7 +93,7 @@ jobs:
         if: ${{ steps.deploy-check.outputs.skip != 'true' }}
         run: |
           SAFE_BUDGET=84
-          EXPECTED_PR_APPS=18
+          EXPECTED_PR_APPS=12
 
           CONTAINERS=$(wrangler containers list --json 2>/dev/null)
           if [ $? -ne 0 ] || [ -z "$CONTAINERS" ]; then
@@ -170,7 +169,7 @@ jobs:
             # Re-read live state to avoid double-counting with concurrent evictions
             LIVE_CONTAINERS=$(wrangler containers list --json 2>/dev/null || echo "[]")
             EVICTED=0
-            for suffix in "-http" "-websocket" "-capnweb"; do
+            for suffix in "-http" "-websocket"; do
               WORKER="sandbox-e2e-test-worker-pr-${PR_NUM}${suffix}"
               IDS=$(echo "$LIVE_CONTAINERS" | jq -r --arg w "$WORKER" \
                 '.[] | select(.name | startswith($w)) | .id' 2>/dev/null)
@@ -241,7 +240,7 @@ jobs:
       - name: Deploy and configure workers
         if: ${{ steps.deploy-check.outputs.skip != 'true' }}
         run: |
-          for TRANSPORT in http websocket capnweb; do
+          for TRANSPORT in http websocket; do
             WORKER="${{ inputs.worker_name_prefix }}-${TRANSPORT}"
             echo "::group::Deploy ${TRANSPORT} worker"
             cd tests/e2e/test-worker
@@ -283,7 +282,6 @@ jobs:
         run: |
           echo "http_url=https://${{ inputs.worker_name_prefix }}-http.${{ env.CF_ACCOUNT_SUBDOMAIN }}.workers.dev" >> $GITHUB_OUTPUT
           echo "ws_url=https://${{ inputs.worker_name_prefix }}-websocket.${{ env.CF_ACCOUNT_SUBDOMAIN }}.workers.dev" >> $GITHUB_OUTPUT
-          echo "capnweb_url=https://${{ inputs.worker_name_prefix }}-capnweb.${{ env.CF_ACCOUNT_SUBDOMAIN }}.workers.dev" >> $GITHUB_OUTPUT
 
   test-vitest:
     permissions:
@@ -301,9 +299,6 @@ jobs:
           - transport: websocket
             worker_url: ws-url
             sandbox_id: e2e-ws
-          - transport: capnweb
-            worker_url: capnweb-url
-            sandbox_id: e2e-capnweb
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -276,6 +276,30 @@ jobs:
           R2_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           DEPLOY_HASH: ${{ inputs.deploy_hash }}
 
+      - name: Warm container pool
+        if: ${{ steps.deploy-check.outputs.skip != 'true' }}
+        run: |
+          CONTAINERS=$(wrangler containers list --json 2>/dev/null)
+          for TRANSPORT in http websocket; do
+            WORKER="${{ inputs.worker_name_prefix }}-${TRANSPORT}"
+            APP_IDS=$(echo "$CONTAINERS" | jq -r --arg w "$WORKER" \
+              '[.[] | select(.name | startswith($w))] | .[].id')
+            if [ -z "$APP_IDS" ]; then
+              echo "::warning::No container apps found for ${WORKER} — skipping warm pool"
+              continue
+            fi
+            for APP_ID in $APP_IDS; do
+              echo "Setting warm pool for ${WORKER} (app $APP_ID)"
+              curl -sf -X PATCH \
+                "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/containers/applications/${APP_ID}" \
+                -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+                -H "Content-Type: application/json" \
+                -d '{"configuration":{"durable_object_offset_instances": 75}}' || echo "::warning::Failed to set warm pool for app ${APP_ID}"
+            done
+          done
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       # Always set URLs (deterministic, needed by test jobs)
       - name: Set worker URLs
         id: urls

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -279,7 +279,8 @@ jobs:
       - name: Warm container pool
         if: ${{ steps.deploy-check.outputs.skip != 'true' }}
         run: |
-          CONTAINERS=$(wrangler containers list --json 2>/dev/null)
+          CONTAINERS=$(wrangler containers list --json 2>/dev/null || echo "[]")
+
           for TRANSPORT in http websocket; do
             WORKER="${{ inputs.worker_name_prefix }}-${TRANSPORT}"
             APP_IDS=$(echo "$CONTAINERS" | jq -r --arg w "$WORKER" \

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -77,7 +77,7 @@ jobs:
       # --- Capacity guard (only when deploy is needed) ---
       # Ensures enough container app headroom before deploying. Each PR
       # creates 12 container apps (2 workers × 6 classes). The account
-      # has a ~100 app limit. We keep a budget of 84 (leaving 16 headroom)
+      # has a ~600 app limit. We keep a budget of 500 (leaving 100 headroom)
       # and evict the least-recently-active PR's resources when over budget.
       # Protects: current PR, main workers, and PRs with in-progress CI.
       - uses: actions/setup-node@v6
@@ -92,7 +92,7 @@ jobs:
       - name: Ensure container app capacity
         if: ${{ steps.deploy-check.outputs.skip != 'true' }}
         run: |
-          SAFE_BUDGET=84
+          SAFE_BUDGET=500
           EXPECTED_PR_APPS=12
 
           CONTAINERS=$(wrangler containers list --json 2>/dev/null)

--- a/examples/code-interpreter/src/index.ts
+++ b/examples/code-interpreter/src/index.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 export { Sandbox } from '@cloudflare/sandbox';
 
 const API_PATH = '/run';
-const MODEL = '@cf/openai/gpt-oss-120b';
+const MODEL = '@cf/openai/gpt-oss-120b' as const;
 
 async function executePythonCode(env: Env, code: string): Promise<string> {
   const sandboxId = env.Sandbox.idFromName('default');


### PR DESCRIPTION
Looking at failures over the past week, it looks like adding capnweb to the test pool pushed us over the edge. We're provisioning an extra 20 containers per test. Though anecdotally these tests seem to be failing locally too.

I'm going to look into seeing if we can use the bridge worker with the warm pool for these tests.

This also uses the warm pool functionality provided by the containers HTTP API to attempt to provision images for the test run.

I've tested the prewarm API using the following script.

<details><summary>Details</summary>

```
#!/usr/bin/env bash
set -euxo pipefail

usage() {
  cat <<EOF
Usage: $0 -w <worker-prefix> [-n <instances>]

Set the warm pool size for all container apps matching a worker prefix.

Options:
  -w  Worker name prefix (e.g. sandbox-e2e-test-worker-pr-42)
  -n  Number of warm instances (default: 75)

Environment:
  CLOUDFLARE_API_TOKEN   API token with containers permissions
  CLOUDFLARE_ACCOUNT_ID  Cloudflare account ID

Examples:
  $0 -w sandbox-e2e-test-worker-pr-42
  $0 -w sandbox-e2e-test-worker-pr-42 -n 100
EOF
  exit 1
}

WORKER_PREFIX=""
INSTANCES=75

while getopts "w:n:h" opt; do
  case "$opt" in
    w) WORKER_PREFIX="$OPTARG" ;;
    n) INSTANCES="$OPTARG" ;;
    *) usage ;;
  esac
done

if [ -z "$WORKER_PREFIX" ]; then
  echo "Error: -w <worker-prefix> is required" >&2
  usage
fi

: "${CLOUDFLARE_API_TOKEN:?Set CLOUDFLARE_API_TOKEN}"
: "${CLOUDFLARE_ACCOUNT_ID:?Set CLOUDFLARE_ACCOUNT_ID}"

echo "Listing container apps..."
CONTAINERS=$(npx wrangler containers list --json 2>/dev/null)

PATCHED=0
FAILED=0

for TRANSPORT in http websocket; do
  WORKER="${WORKER_PREFIX}-${TRANSPORT}"
  APP_IDS=$(echo "$CONTAINERS" | jq -r --arg w "$WORKER" \
    '[.[] | select(.name | startswith($w))] | .[].id')

  if [ -z "$APP_IDS" ]; then
    echo "Warning: No container apps found for ${WORKER} — skipping"
    continue
  fi

  for APP_ID in $APP_IDS; do
    APP_NAME=$(echo "$CONTAINERS" | jq -r --arg id "$APP_ID" '.[] | select(.id == $id) | .name')
    echo "Setting warm pool to ${INSTANCES} for ${APP_NAME} (${APP_ID})"
    if curl -sf -X PATCH \
      "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/containers/applications/${APP_ID}" \
      -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
      -H "Content-Type: application/json" \
      -d "{\"configuration\":{\"durable_object_offset_instances\": ${INSTANCES}}}"; then
      echo ""
      PATCHED=$((PATCHED + 1))
    else
      echo ""
      echo "  Failed to patch ${APP_NAME}" >&2
      FAILED=$((FAILED + 1))
    fi
  done
done

echo ""
echo "Done: ${PATCHED} patched, ${FAILED} failed"
[ "$FAILED" -eq 0 ]
```

Run with

```
CLOUDFLARE_ACCOUNT_ID=$(npx wrangler whoami --json | jq -r '.accounts | first | .id') CLOUDFLARE_API_TOKEN=$(npx wrangler auth token --json | jq -r .token) ./prewarm.sh -w sandbox-e2e-test-worker-pr-613 -n 11
```

</details> 

## Overall Stats

| Metric | Count |
|--------|-------|
| **Total test-vitest jobs** | 148 |
| **Passed** | **46** (31.7%) |
| **Failed** | **99** (68.3%) |
| **Skipped** | 3 |

## By Transport Protocol

| Transport | Passed | Failed | Pass Rate |
|-----------|--------|--------|-----------|
| **HTTP** (old `test-http` + new matrix) | 23 | 33 | 41% |
| **WebSocket** (old `test-websocket` + new matrix) | 19 | 37 | 34% |
| **Cap'n Web** (new matrix only) | 4 | 29 | 12% |

> **Note:** Job naming changed mid-week from `test-http`/`test-websocket` to a matrix format `test-vitest (http, ...)` / `test-vitest (capnweb, ...)` / `test-vitest (websocket, ...)`. Cap'n Web was added as a new transport in the matrix.

## Per Day Trend

| Date | Runs | Pass | Fail | Rate |
|------|------|------|------|------|
| **Apr 16** | 3 | 6 | 0 | **100%** |
| **Apr 17** | 15 | 26 | 2 | **93%** |
| **Apr 18** | — | — | — | *(no completed runs)* |
| **Apr 19** | — | — | — | *(no runs)* |
| **Apr 20** | 16 | 4 | 38 | **10%** |
| **Apr 21** | 20 | 7 | 50 | **12%** |
| **Apr 22** | 4 | 3 | 9 | **25%** |

Pass rates collapsed from ~93–100% to ~10–12% starting April 20.

## By Branch

| Branch | Runs | Pass | Fail | Rate |
|--------|------|------|------|------|
| `feat/placement-id-api` | 3 | 6 | 0 | **100%** |
| `fix/coalesce-concurrent-destroy` | 3 | 6 | 0 | **100%** |
| `fix/preview-urls-survive-restarts` | 3 | 5 | 0 | **100%** |
| `patch/fix-local-mount-prefix` | 4 | 8 | 0 | **100%** |
| `patch/fix-biome-errors` | 1 | 2 | 0 | **100%** |
| `fix/persist-port-tokens-across-restarts` | 1 | 2 | 0 | **100%** |
| `fix/auto-reexpose-ports-on-recovery` | 1 | 2 | 0 | **100%** |
| `fix/validate-port-token-pure-do-lookup` | 1 | 3 | 0 | **100%** |
| `fix/cache-token-validation` | 3 | 4 | 2 | **67%** |
| `capnweb-rpc` | 13 | 4 | 30 | **12%** |
| `e2e-refactor` | 16 | 4 | 44 | **8%** |
| `add-nightly-push-webhook` | 2 | 0 | 6 | **0%** |
| `debug/backup-mount-perf-tests` | 2 | 0 | 5 | **0%** |
| `patch/support-local-backup-restore` | 4 | 0 | 9 | **0%** |
| `fix/biome-lint-issues` | 1 | 0 | 3 | **0%** |


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
