### PR TITLE
Share in-flight default session init

### DIFF
--- a/.changeset/coalesce-default-session-init.md
+++ b/.changeset/coalesce-default-session-init.md
@@ -1,0 +1,11 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Avoid duplicate session-create calls when parallel operations hit a
+fresh sandbox. Parallel callers now share one setup call instead of
+each issuing their own. Sequential operations are unaffected.
+
+If the storage write that records the session id fails after the
+container accepts the create call, setup now retries on the next
+operation instead of being treated as complete.

--- a/.changeset/coalesce-default-session-init.md
+++ b/.changeset/coalesce-default-session-init.md
@@ -6,6 +6,7 @@ Avoid duplicate session-create calls when parallel operations hit a
 fresh sandbox. Parallel callers now share one setup call instead of
 each issuing their own. Sequential operations are unaffected.
 
-Session setup also now retries on the next operation if initialization
-fails partway through, instead of silently treating the session as
-ready.
+Session setup also now retries cleanly on the next operation if it is
+interrupted partway through — including by a container stop during
+first use — instead of leaving the sandbox in a state that looks
+initialized but references a session the container no longer has.

--- a/.changeset/coalesce-default-session-init.md
+++ b/.changeset/coalesce-default-session-init.md
@@ -6,6 +6,6 @@ Avoid duplicate session-create calls when parallel operations hit a
 fresh sandbox. Parallel callers now share one setup call instead of
 each issuing their own. Sequential operations are unaffected.
 
-If the storage write that records the session id fails after the
-container accepts the create call, setup now retries on the next
-operation instead of being treated as complete.
+Session setup also now retries on the next operation if initialization
+fails partway through, instead of silently treating the session as
+ready.

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -419,8 +419,13 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   private sandboxName: string | null = null;
   private normalizeId: boolean = false;
   private defaultSession: string | null = null;
+  // Incremented whenever the container stops. Used to invalidate
+  // in-flight default-session initialization that started against a
+  // now-dead container.
+  private containerGeneration = 0;
   private defaultSessionInit: {
     sessionId: string;
+    generation: number;
     promise: Promise<string>;
   } | null = null;
   envVars: Record<string, string> = {};
@@ -1615,22 +1620,30 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   override async onStop() {
     this.logger.debug('Sandbox stopped');
 
-    // Stop local sync managers before clearing the map to avoid leaking timers
+    // Invalidate default-session state before the first await. Bumping
+    // containerGeneration signals any in-flight initializeDefaultSession
+    // that a new container generation begins next; it observes the
+    // mismatch at its post-createSession check and fails. Clearing the
+    // slot means later callers start a new init against the next
+    // container.
+    this.containerGeneration++;
+    this.defaultSession = null;
+    this.defaultSessionInit = null;
+
+    // Stop local sync managers before clearing the map.
     for (const [, m] of this.activeMounts) {
       if (m.mountType === 'local-sync')
         await m.syncManager.stop().catch(() => {});
     }
 
-    this.defaultSession = null;
     this.activeMounts.clear();
 
     // Persist cleanup to storage so state is clean on next container start.
-    // Port tokens are intentionally preserved so preview URLs survive
-    // container restarts; they are only removed on explicit
-    // unexposePort() or full sandbox destroy(). onStart's
-    // restoreExposedPorts() replays those tokens into the container on
-    // the next start, which is what lets validatePortToken() answer from
-    // storage alone.
+    // Port tokens are preserved so preview URLs survive container restarts;
+    // they are only removed on explicit unexposePort() or full sandbox
+    // destroy(). onStart's restoreExposedPorts() replays those tokens into
+    // the container on the next start, which lets validatePortToken()
+    // answer from storage alone.
     await this.ctx.storage.delete('defaultSession');
   }
 
@@ -2038,30 +2051,36 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       return this.defaultSession;
     }
 
-    // The in-flight slot is keyed by sessionId. A caller whose sessionId
-    // matches the current slot awaits that shared promise. A caller with
-    // a different sessionId (sandboxName changed mid-flight) starts its
-    // own init and takes over the slot.
+    // The in-flight slot is keyed by (sessionId, generation). A caller
+    // whose sessionId matches the current slot AND runs against the same
+    // container generation awaits that shared promise. sandboxName
+    // changing mid-flight yields a sessionId mismatch; a container stop
+    // advances the generation and an older slot becomes non-joinable.
+    const generation = this.containerGeneration;
     const pending = this.defaultSessionInit;
-    if (pending?.sessionId === sessionId) {
+    if (pending?.sessionId === sessionId && pending.generation === generation) {
       return pending.promise;
     }
 
-    const promise = this.initializeDefaultSession(sessionId);
-    const init = { sessionId, promise };
+    const promise = this.initializeDefaultSession(sessionId, generation);
+    const init = { sessionId, generation, promise };
     this.defaultSessionInit = init;
     try {
       return await promise;
     } finally {
       // Identity guard: only clear the slot if it still holds this
-      // attempt. A newer mismatching caller may have taken the slot.
+      // attempt. A newer mismatching caller or an onStop may have
+      // taken the slot.
       if (this.defaultSessionInit === init) {
         this.defaultSessionInit = null;
       }
     }
   }
 
-  private async initializeDefaultSession(sessionId: string): Promise<string> {
+  private async initializeDefaultSession(
+    sessionId: string,
+    generation: number
+  ): Promise<string> {
     try {
       await this.client.utils.createSession({
         id: sessionId,
@@ -2077,6 +2096,16 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       this.logger.debug(
         'Session exists in container but not in DO state, syncing',
         { sessionId }
+      );
+    }
+
+    // Generation check before writing state: if onStop ran while the
+    // container RPC was in flight, this init targets a dead container.
+    // Fail the attempt so the next caller starts fresh against the new
+    // container.
+    if (generation !== this.containerGeneration) {
+      throw new Error(
+        'Default session initialization was invalidated by a container stop'
       );
     }
 

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -419,6 +419,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   private sandboxName: string | null = null;
   private normalizeId: boolean = false;
   private defaultSession: string | null = null;
+  private defaultSessionInit: {
+    sessionId: string;
+    promise: Promise<string>;
+  } | null = null;
   envVars: Record<string, string> = {};
   private logger: ReturnType<typeof createLogger>;
   private keepAliveEnabled: boolean = false;
@@ -2021,12 +2025,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   /**
-   * Ensure default session exists - lazy initialization
-   * This is called automatically by all public methods that need a session
-   *
-   * The session ID is persisted to DO storage. On container restart, if the
-   * container already has this session (from a previous instance), we sync
-   * our state rather than failing on duplicate creation.
+   * Return the default session id, lazily creating the container session
+   * on first use. Called by every public method that needs a session.
+   * Concurrent callers that target the same sessionId share one
+   * in-flight initialization promise.
    */
   private async ensureDefaultSession(): Promise<string> {
     const sessionId = `sandbox-${this.sandboxName || 'default'}`;
@@ -2036,32 +2038,54 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       return this.defaultSession;
     }
 
-    // Create session in container
+    // The in-flight slot is keyed by sessionId. A caller whose sessionId
+    // matches the current slot awaits that shared promise. A caller with
+    // a different sessionId (sandboxName changed mid-flight) starts its
+    // own init and takes over the slot.
+    const pending = this.defaultSessionInit;
+    if (pending?.sessionId === sessionId) {
+      return pending.promise;
+    }
+
+    const promise = this.initializeDefaultSession(sessionId);
+    const init = { sessionId, promise };
+    this.defaultSessionInit = init;
+    try {
+      return await promise;
+    } finally {
+      // Identity guard: only clear the slot if it still holds this
+      // attempt. A newer mismatching caller may have taken the slot.
+      if (this.defaultSessionInit === init) {
+        this.defaultSessionInit = null;
+      }
+    }
+  }
+
+  private async initializeDefaultSession(sessionId: string): Promise<string> {
     try {
       await this.client.utils.createSession({
         id: sessionId,
         env: this.envVars || {},
         cwd: '/workspace'
       });
-
-      this.defaultSession = sessionId;
-      await this.ctx.storage.put('defaultSession', sessionId);
-      this.logger.debug('Default session initialized', { sessionId });
     } catch (error: unknown) {
-      // Session may already exist (e.g., after hot reload or concurrent request)
-      if (error instanceof SessionAlreadyExistsError) {
-        this.logger.debug(
-          'Session exists in container but not in DO state, syncing',
-          { sessionId }
-        );
-        this.defaultSession = sessionId;
-        await this.ctx.storage.put('defaultSession', sessionId);
-      } else {
+      // The container can outlive this DO instance, so an existing session
+      // means the container is already in the state we need.
+      if (!(error instanceof SessionAlreadyExistsError)) {
         throw error;
       }
+      this.logger.debug(
+        'Session exists in container but not in DO state, syncing',
+        { sessionId }
+      );
     }
 
-    return this.defaultSession;
+    // Durable storage is the cross-eviction source of truth for the default
+    // session identity. Update the in-memory cache only after persistence.
+    await this.ctx.storage.put('defaultSession', sessionId);
+    this.defaultSession = sessionId;
+    this.logger.debug('Default session initialized', { sessionId });
+    return sessionId;
   }
 
   // Enhanced exec method - always returns ExecResult with optional streaming

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -332,6 +332,82 @@ describe('Sandbox - Automatic Session Management', () => {
         })
       );
     });
+
+    it('coalesces concurrent callers onto one createSession RPC', async () => {
+      let resolveCreate!: (value: unknown) => void;
+      vi.mocked(sandbox.client.utils.createSession).mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveCreate = resolve;
+        }) as any
+      );
+
+      const first = sandbox.exec('echo one');
+      const second = sandbox.exec('echo two');
+
+      resolveCreate({ success: true, id: 'sandbox-default', message: 'ok' });
+      await Promise.all([first, second]);
+
+      expect(sandbox.client.utils.createSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries createSession after a failed initialization', async () => {
+      vi.mocked(sandbox.client.utils.createSession)
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce({
+          success: true,
+          id: 'sandbox-default',
+          message: 'ok'
+        } as any);
+
+      await expect(sandbox.exec('echo one')).rejects.toThrow('boom');
+      await sandbox.exec('echo two');
+
+      expect(sandbox.client.utils.createSession).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not cache the session id in memory if persistence fails', async () => {
+      vi.mocked(mockCtx.storage.put).mockImplementation(async (key) => {
+        if (key === 'defaultSession') throw new Error('storage down');
+      });
+
+      await expect(sandbox.exec('echo one')).rejects.toThrow('storage down');
+
+      vi.mocked(mockCtx.storage.put).mockResolvedValue(undefined);
+      await sandbox.exec('echo two');
+
+      expect(sandbox.client.utils.createSession).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not share an in-flight init across different session ids', async () => {
+      let resolveFirst!: (value: unknown) => void;
+      let resolveSecond!: (value: unknown) => void;
+      vi.mocked(sandbox.client.utils.createSession)
+        .mockReturnValueOnce(
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          }) as any
+        )
+        .mockReturnValueOnce(
+          new Promise((resolve) => {
+            resolveSecond = resolve;
+          }) as any
+        );
+
+      const first = sandbox.exec('echo one');
+      await sandbox.setSandboxName('renamed');
+      const second = sandbox.exec('echo two');
+      const third = sandbox.exec('echo three');
+
+      resolveFirst({ success: true, id: 'sandbox-default', message: 'ok' });
+      resolveSecond({ success: true, id: 'sandbox-renamed', message: 'ok' });
+      await Promise.all([first, second, third]);
+
+      expect(sandbox.client.utils.createSession).toHaveBeenCalledTimes(2);
+      const calls = vi.mocked(sandbox.client.commands.execute).mock.calls;
+      expect(calls[0][1]).toBe('sandbox-default');
+      expect(calls[1][1]).toBe('sandbox-renamed');
+      expect(calls[2][1]).toBe('sandbox-renamed');
+    });
   });
 
   describe('explicit session creation', () => {

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -408,6 +408,51 @@ describe('Sandbox - Automatic Session Management', () => {
       expect(calls[1][1]).toBe('sandbox-renamed');
       expect(calls[2][1]).toBe('sandbox-renamed');
     });
+
+    it('invalidates an in-flight init when onStop runs mid-flight', async () => {
+      let resolveCreate!: (value: unknown) => void;
+      vi.mocked(sandbox.client.utils.createSession).mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveCreate = resolve;
+        }) as any
+      );
+
+      const inflight = sandbox.exec('echo one');
+      await (sandbox as any).onStop();
+
+      resolveCreate({ success: true, id: 'sandbox-default', message: 'ok' });
+      await expect(inflight).rejects.toThrow();
+
+      const defaultSessionPuts = vi
+        .mocked(mockCtx.storage.put)
+        .mock.calls.filter((call) => call[0] === 'defaultSession');
+      expect(defaultSessionPuts).toHaveLength(0);
+    });
+
+    it('does not join a stale init promise after onStop clears it', async () => {
+      let resolveFirst!: (value: unknown) => void;
+      vi.mocked(sandbox.client.utils.createSession)
+        .mockReturnValueOnce(
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          }) as any
+        )
+        .mockResolvedValueOnce({
+          success: true,
+          id: 'sandbox-default',
+          message: 'ok'
+        } as any);
+
+      const first = sandbox.exec('echo one');
+      await (sandbox as any).onStop();
+      const second = sandbox.exec('echo two');
+
+      resolveFirst({ success: true, id: 'sandbox-default', message: 'ok' });
+      await expect(first).rejects.toThrow();
+      await second;
+
+      expect(sandbox.client.utils.createSession).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('explicit session creation', () => {


### PR DESCRIPTION
Parallel operations on a fresh sandbox each fired their own `createSession` RPC; the first succeeded and the rest got `SessionAlreadyExistsError` handled as a no-op. Sequential callers already short-circuited on the second call, so the duplication was bounded to the narrow window before the first call settled, but there's no reason to let it happen. The first caller now records the in-flight initialization promise, and later callers that arrive before it settles share that promise.

Setup was also writing the session id to the in-memory field before persisting it to DO storage. That ordering means a storage write that fails after the container has accepted the create call would leave the DO thinking setup completed. Swapped to persist-first, cache-second so a failed persistence retries on the next operation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
