### PR TITLE
Make transport configurable per instance

### DIFF
--- a/.changeset/get-sandbox-with-transport.md
+++ b/.changeset/get-sandbox-with-transport.md
@@ -1,0 +1,16 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Adds a new `transport: 'http' | 'websocket'` field to the `getSandbox()` options. This can be
+used to dynamically select transport on a per-sandbox basis.
+
+> [!NOTE]
+> Changing transport on an already existing sandbox may result in dropped connections, it is
+> recommended to keep the same transport for the lifetime of the sandbox instance.
+
+```ts
+const sandbox = getSandbox(env.Sandbox, 'my-sandbox', {
+  transport: 'websocket'
+});
+```

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -106,6 +106,7 @@ type SandboxConfiguration = {
   sleepAfter?: string | number;
   keepAlive?: boolean;
   containerTimeouts?: NonNullable<SandboxOptions['containerTimeouts']>;
+  transport?: 'http' | 'websocket';
 };
 
 type CachedSandboxConfiguration = {
@@ -114,6 +115,7 @@ type CachedSandboxConfiguration = {
   sleepAfter?: string | number;
   keepAlive?: boolean;
   containerTimeouts?: NonNullable<SandboxOptions['containerTimeouts']>;
+  transport?: 'http' | 'websocket';
 };
 
 type ConfigurableSandboxStub = {
@@ -124,6 +126,7 @@ type ConfigurableSandboxStub = {
   setContainerTimeouts?: (
     timeouts: NonNullable<SandboxOptions['containerTimeouts']>
   ) => Promise<void>;
+  setTransport?: (transport: 'http' | 'websocket') => Promise<void>;
 };
 
 const sandboxConfigurationCache = new WeakMap<
@@ -200,6 +203,13 @@ function buildSandboxConfiguration(
     configuration.containerTimeouts = options.containerTimeouts;
   }
 
+  if (
+    options?.transport !== undefined &&
+    cached?.transport !== options.transport
+  ) {
+    configuration.transport = options.transport;
+  }
+
   return configuration;
 }
 
@@ -208,7 +218,8 @@ function hasSandboxConfiguration(configuration: SandboxConfiguration): boolean {
     configuration.sandboxName !== undefined ||
     configuration.sleepAfter !== undefined ||
     configuration.keepAlive !== undefined ||
-    configuration.containerTimeouts !== undefined
+    configuration.containerTimeouts !== undefined ||
+    configuration.transport !== undefined
   );
 }
 
@@ -230,6 +241,9 @@ function mergeSandboxConfiguration(
     }),
     ...(configuration.containerTimeouts !== undefined && {
       containerTimeouts: configuration.containerTimeouts
+    }),
+    ...(configuration.transport !== undefined && {
+      transport: configuration.transport
     })
   };
 }
@@ -269,6 +283,12 @@ function applySandboxConfiguration(
     operations.push(
       stub.setContainerTimeouts?.(configuration.containerTimeouts) ??
         Promise.resolve()
+    );
+  }
+
+  if (configuration.transport !== undefined) {
+    operations.push(
+      stub.setTransport?.(configuration.transport) ?? Promise.resolve()
     );
   }
 
@@ -433,6 +453,14 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   private keepAliveEnabled: boolean = false;
   private activeMounts: Map<string, MountInfo> = new Map();
   private transport: 'http' | 'websocket' = 'http';
+
+  /**
+   * True once transport has been written to storage at least once (either
+   * via setTransport or restored on cold start). Gates the idempotency
+   * check so a first explicit call persists even when the requested value
+   * already equals the env-derived in-memory default.
+   */
+  private hasStoredTransport = false;
 
   // R2 bucket binding for backup storage (optional — only set if user configures BACKUP_BUCKET)
   private backupBucket: R2Bucket | null = null;
@@ -669,6 +697,21 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         this.renewActivityTimeout();
       }
 
+      // Restore transport setting from storage (overrides env var default)
+      const storedTransport = await this.ctx.storage.get<'http' | 'websocket'>(
+        'transport'
+      );
+      if (storedTransport && storedTransport !== this.transport) {
+        this.transport = storedTransport;
+        const previousClient = this.client;
+        this.client = this.createSandboxClient();
+        this.codeInterpreter = new CodeInterpreter(this);
+        previousClient.disconnect();
+      }
+      if (storedTransport) {
+        this.hasStoredTransport = true;
+      }
+
       if (this.interceptHttps) {
         this.envVars = { ...this.envVars, SANDBOX_INTERCEPT_HTTPS: '1' };
       }
@@ -714,6 +757,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
     if (configuration.containerTimeouts !== undefined) {
       await this.setContainerTimeouts(configuration.containerTimeouts);
+    }
+
+    if (configuration.transport !== undefined) {
+      await this.setTransport(configuration.transport);
     }
   }
 
@@ -847,6 +894,34 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     this.client.setRetryTimeoutMs(this.computeRetryTimeoutMs());
 
     this.logger.debug('Container timeouts updated', this.containerTimeouts);
+  }
+
+  /**
+   * RPC method to set the transport protocol. Idempotent once the value
+   * has been persisted: re-applying the same transport is a no-op.
+   * Storage is written before the in-memory state and client are updated.
+   */
+  async setTransport(transport: 'http' | 'websocket'): Promise<void> {
+    if (transport !== 'http' && transport !== 'websocket') {
+      this.logger.warn(
+        `Invalid transport value: "${transport}". Must be "http" or "websocket". Ignoring.`
+      );
+      return;
+    }
+
+    if (this.hasStoredTransport && this.transport === transport) {
+      return;
+    }
+
+    await this.ctx.storage.put('transport', transport);
+
+    const previousClient = this.client;
+    this.transport = transport;
+    this.hasStoredTransport = true;
+    this.client = this.createSandboxClient();
+    this.codeInterpreter = new CodeInterpreter(this);
+    previousClient.disconnect();
+    this.logger.debug('Transport updated', { transport });
   }
 
   /**

--- a/packages/sandbox/tests/get-sandbox.test.ts
+++ b/packages/sandbox/tests/get-sandbox.test.ts
@@ -214,6 +214,92 @@ describe('getSandbox', () => {
     });
   });
 
+  it('should apply transport option when set to websocket', () => {
+    const mockNamespace = {} as any;
+    getSandbox(mockNamespace, 'test-sandbox', {
+      transport: 'websocket'
+    });
+
+    expect(mockStub.configure).toHaveBeenCalledWith({
+      sandboxName: {
+        name: 'test-sandbox',
+        normalizeId: undefined
+      },
+      transport: 'websocket'
+    });
+  });
+
+  it('should apply transport option when set to http', () => {
+    const mockNamespace = {} as any;
+    getSandbox(mockNamespace, 'test-sandbox', {
+      transport: 'http'
+    });
+
+    expect(mockStub.configure).toHaveBeenCalledWith({
+      sandboxName: {
+        name: 'test-sandbox',
+        normalizeId: undefined
+      },
+      transport: 'http'
+    });
+  });
+
+  it('should not include transport when option is not provided', () => {
+    const mockNamespace = {} as any;
+    getSandbox(mockNamespace, 'test-sandbox');
+
+    expect(mockStub.configure).toHaveBeenCalledWith({
+      sandboxName: {
+        name: 'test-sandbox',
+        normalizeId: undefined
+      }
+    });
+  });
+
+  it('should apply transport alongside other options', () => {
+    const mockNamespace = {} as any;
+    getSandbox(mockNamespace, 'test-sandbox', {
+      sleepAfter: '5m',
+      transport: 'websocket',
+      keepAlive: true
+    });
+
+    expect(mockStub.configure).toHaveBeenCalledWith({
+      sandboxName: {
+        name: 'test-sandbox',
+        normalizeId: undefined
+      },
+      sleepAfter: '5m',
+      keepAlive: true,
+      transport: 'websocket'
+    });
+  });
+
+  it('should skip repeated transport configuration for the same sandbox', async () => {
+    const mockNamespace = {} as any;
+
+    getSandbox(mockNamespace, 'test-sandbox', { transport: 'websocket' });
+    await Promise.resolve();
+
+    getSandbox(mockNamespace, 'test-sandbox', { transport: 'websocket' });
+
+    expect(mockStub.configure).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reconfigure when transport changes', async () => {
+    const mockNamespace = {} as any;
+
+    getSandbox(mockNamespace, 'test-sandbox', { transport: 'http' });
+    await Promise.resolve();
+
+    getSandbox(mockNamespace, 'test-sandbox', { transport: 'websocket' });
+
+    expect(mockStub.configure).toHaveBeenCalledTimes(2);
+    expect(mockStub.configure).toHaveBeenNthCalledWith(2, {
+      transport: 'websocket'
+    });
+  });
+
   describe('proxy method routing', () => {
     it('should preserve this binding for fetch()', async () => {
       // fetch() is a native DurableObjectStub method that requires correct

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1933,4 +1933,214 @@ describe('Sandbox - Automatic Session Management', () => {
       expect(createArchiveSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe('transport configuration', () => {
+    it('defaults to http transport', async () => {
+      await vi.waitFor(() => {
+        expect(mockCtx.blockConcurrencyWhile).toHaveBeenCalled();
+      });
+
+      expect((sandbox as any).transport).toBe('http');
+      expect(sandbox.client.getTransportMode()).toBe('http');
+    });
+
+    it('reads websocket transport from SANDBOX_TRANSPORT env var', async () => {
+      const wsCtx = {
+        ...mockCtx,
+        blockConcurrencyWhile: vi
+          .fn()
+          .mockImplementation(
+            <T>(callback: () => Promise<T>): Promise<T> => callback()
+          ),
+        storage: {
+          get: vi.fn().mockResolvedValue(null),
+          put: vi.fn().mockResolvedValue(undefined),
+          delete: vi.fn().mockResolvedValue(undefined),
+          list: vi.fn().mockResolvedValue(new Map())
+        } as any
+      };
+
+      const instance = new Sandbox(
+        wsCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+        { SANDBOX_TRANSPORT: 'websocket' }
+      );
+
+      await vi.waitFor(() => {
+        expect(wsCtx.blockConcurrencyWhile).toHaveBeenCalled();
+      });
+
+      expect((instance as any).transport).toBe('websocket');
+      expect(instance.client.getTransportMode()).toBe('websocket');
+    });
+
+    it('setTransport switches from http to websocket', async () => {
+      await vi.waitFor(() => {
+        expect(mockCtx.blockConcurrencyWhile).toHaveBeenCalled();
+      });
+
+      expect((sandbox as any).transport).toBe('http');
+
+      await sandbox.setTransport('websocket');
+
+      expect((sandbox as any).transport).toBe('websocket');
+      expect(sandbox.client.getTransportMode()).toBe('websocket');
+    });
+
+    it('setTransport switches from websocket to http', async () => {
+      const wsCtx = {
+        ...mockCtx,
+        blockConcurrencyWhile: vi
+          .fn()
+          .mockImplementation(
+            <T>(callback: () => Promise<T>): Promise<T> => callback()
+          ),
+        storage: {
+          get: vi.fn().mockResolvedValue(null),
+          put: vi.fn().mockResolvedValue(undefined),
+          delete: vi.fn().mockResolvedValue(undefined),
+          list: vi.fn().mockResolvedValue(new Map())
+        } as any
+      };
+
+      const instance = new Sandbox(
+        wsCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+        { SANDBOX_TRANSPORT: 'websocket' }
+      );
+
+      await vi.waitFor(() => {
+        expect(wsCtx.blockConcurrencyWhile).toHaveBeenCalled();
+      });
+
+      expect((instance as any).transport).toBe('websocket');
+
+      await instance.setTransport('http');
+
+      expect((instance as any).transport).toBe('http');
+      expect(instance.client.getTransportMode()).toBe('http');
+    });
+
+    it('setTransport is a no-op when transport has been stored and value is unchanged', async () => {
+      await vi.waitFor(() => {
+        expect(mockCtx.blockConcurrencyWhile).toHaveBeenCalled();
+      });
+
+      // First call persists (hasStoredTransport is false)
+      await sandbox.setTransport('http');
+      const putCallsAfterFirst = mockCtx.storage.put.mock.calls.length;
+      const clientBefore = sandbox.client;
+
+      // Second identical call is a no-op
+      await sandbox.setTransport('http');
+
+      expect(mockCtx.storage.put.mock.calls.length).toBe(putCallsAfterFirst);
+      expect(sandbox.client).toBe(clientBefore);
+    });
+
+    it('setTransport recreates the client with new transport', async () => {
+      await vi.waitFor(() => {
+        expect(mockCtx.blockConcurrencyWhile).toHaveBeenCalled();
+      });
+
+      const clientBefore = sandbox.client;
+
+      await sandbox.setTransport('websocket');
+
+      // Client should be a new instance
+      expect(sandbox.client).not.toBe(clientBefore);
+    });
+
+    it('setTransport recreates the CodeInterpreter so it uses the new client', async () => {
+      await vi.waitFor(() => {
+        expect(mockCtx.blockConcurrencyWhile).toHaveBeenCalled();
+      });
+
+      const interpreterBefore = (sandbox as any).codeInterpreter;
+
+      await sandbox.setTransport('websocket');
+
+      const interpreterAfter = (sandbox as any).codeInterpreter;
+      expect(interpreterAfter).not.toBe(interpreterBefore);
+    });
+
+    it('setTransport disconnects the previous client', async () => {
+      await vi.waitFor(() => {
+        expect(mockCtx.blockConcurrencyWhile).toHaveBeenCalled();
+      });
+
+      const previousClient = sandbox.client;
+      const disconnectSpy = vi.spyOn(previousClient, 'disconnect');
+
+      await sandbox.setTransport('websocket');
+
+      expect(disconnectSpy).toHaveBeenCalledOnce();
+    });
+
+    it('persists transport to storage before updating in-memory state', async () => {
+      await vi.waitFor(() => {
+        expect(mockCtx.blockConcurrencyWhile).toHaveBeenCalled();
+      });
+
+      await sandbox.setTransport('websocket');
+
+      expect(mockCtx.storage.put).toHaveBeenCalledWith(
+        'transport',
+        'websocket'
+      );
+    });
+
+    it('persists on first explicit call even when value matches env-derived default', async () => {
+      await vi.waitFor(() => {
+        expect(mockCtx.blockConcurrencyWhile).toHaveBeenCalled();
+      });
+
+      // Default transport is 'http'; calling setTransport('http') must still persist
+      await sandbox.setTransport('http');
+
+      expect(mockCtx.storage.put).toHaveBeenCalledWith('transport', 'http');
+
+      // Second identical call is a no-op
+      const putCallsBefore = mockCtx.storage.put.mock.calls.length;
+      await sandbox.setTransport('http');
+      expect(mockCtx.storage.put.mock.calls.length).toBe(putCallsBefore);
+    });
+
+    it('restores transport from storage on cold start, overriding env var', async () => {
+      const coldCtx = {
+        ...mockCtx,
+        blockConcurrencyWhile: vi
+          .fn()
+          .mockImplementation(
+            <T>(callback: () => Promise<T>): Promise<T> => callback()
+          ),
+        storage: {
+          get: vi.fn().mockImplementation(async (key: string) => {
+            if (key === 'transport') return 'websocket';
+            return null;
+          }),
+          put: vi.fn().mockResolvedValue(undefined),
+          delete: vi.fn().mockResolvedValue(undefined),
+          list: vi.fn().mockResolvedValue(new Map())
+        } as any
+      };
+
+      // Env says 'http' but storage says 'websocket'
+      const instance = new Sandbox(
+        coldCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+        {}
+      );
+
+      await vi.waitFor(() => {
+        expect(coldCtx.blockConcurrencyWhile).toHaveBeenCalled();
+      });
+      await Promise.all(
+        (coldCtx.blockConcurrencyWhile as any).mock.results.map(
+          (r: { value: unknown }) => r.value
+        )
+      );
+
+      expect((instance as any).transport).toBe('websocket');
+      expect((instance as any).hasStoredTransport).toBe(true);
+      expect(instance.client.getTransportMode()).toBe('websocket');
+    });
+  });
 });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -531,6 +531,24 @@ export interface SandboxOptions {
      */
     waitIntervalMS?: number;
   };
+
+  /**
+   * Transport protocol for communication between the Sandbox DO and the container runtime.
+   *
+   * - `"http"` (default): Standard HTTP request/response. Works everywhere.
+   * - `"websocket"`: Multiplexes requests over a single WebSocket connection,
+   *   avoiding sub-request limits in Workers and Durable Objects.
+   *
+   * When set via `getSandbox()` options, this overrides the `SANDBOX_TRANSPORT` env var.
+   *
+   * **Important:** Set this once at creation time and pass the same value on every
+   * subsequent `getSandbox()` call for a given sandbox ID. Changing the transport after
+   * the sandbox is in use disconnects the active client, which drops any in-flight
+   * requests and resets WebSocket connections.
+   *
+   * @default "http"
+   */
+  transport?: 'http' | 'websocket';
 }
 
 /**

--- a/tests/e2e/helpers/test-fixtures.ts
+++ b/tests/e2e/helpers/test-fixtures.ts
@@ -49,7 +49,8 @@ export function createTestHeaders(
 ): Record<string, string> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
-    'X-Sandbox-Id': sandboxId
+    'X-Sandbox-Id': sandboxId,
+    'X-Sandbox-Transport': process.env.TEST_TRANSPORT ?? 'http'
   };
 
   if (sessionId) {

--- a/tests/e2e/test-worker/generate-config.sh
+++ b/tests/e2e/test-worker/generate-config.sh
@@ -64,6 +64,9 @@ echo "    Standalone: $IMAGE_STANDALONE"
 echo "    Musl: $IMAGE_MUSL"
 echo "    Desktop: $IMAGE_DESKTOP"
 
+# Write transport into file and pull it in in vite config.
+echo "$TRANSPORT" > TEST_TRANSPORT;
+
 # Read template and replace placeholders
 # Using | as delimiter since image URLs contain /
 sed -e "s|{{WORKER_NAME}}|$WORKER_NAME|g" \

--- a/tests/e2e/test-worker/generate-config.sh
+++ b/tests/e2e/test-worker/generate-config.sh
@@ -64,9 +64,6 @@ echo "    Standalone: $IMAGE_STANDALONE"
 echo "    Musl: $IMAGE_MUSL"
 echo "    Desktop: $IMAGE_DESKTOP"
 
-# Write transport into file and pull it in in vite config.
-echo "$TRANSPORT" > TEST_TRANSPORT;
-
 # Read template and replace placeholders
 # Using | as delimiter since image URLs contain /
 sed -e "s|{{WORKER_NAME}}|$WORKER_NAME|g" \

--- a/tests/e2e/test-worker/index.ts
+++ b/tests/e2e/test-worker/index.ts
@@ -187,10 +187,18 @@ export default {
 
     // Get sandbox ID from header or query param (WebSocket can't send headers)
     // Sandbox ID determines which container instance (Durable Object)
-    const sandboxId =
+    const baseSandboxId =
       request.headers.get('X-Sandbox-Id') ||
       url.searchParams.get('sandboxId') ||
       'default-test-sandbox';
+
+    const transport: 'http' | 'websocket' =
+      request.headers.get('X-Sandbox-Transport') === 'websocket'
+        ? 'websocket'
+        : 'http';
+
+    // Suffix sandbox ID with transport so each transport gets its own DO instance
+    const sandboxId = `${baseSandboxId}-${transport}`;
 
     // Check if keepAlive is requested
     const keepAliveHeader = request.headers.get('X-Sandbox-KeepAlive');
@@ -216,6 +224,7 @@ export default {
 
     const sandbox = getSandbox(sandboxNamespace, sandboxId, {
       keepAlive,
+      transport,
       ...(sleepAfter !== null && { sleepAfter })
     });
 

--- a/tests/e2e/test-worker/wrangler.template.jsonc
+++ b/tests/e2e/test-worker/wrangler.template.jsonc
@@ -7,7 +7,6 @@
 
   "vars": {
     "SANDBOX_LOG_LEVEL": "debug",
-    "SANDBOX_TRANSPORT": "{{TRANSPORT}}",
     "BACKUP_BUCKET_NAME": "sandbox-e2e-test"
   },
   "observability": {

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,7 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { config } from 'dotenv';
 import { defineConfig } from 'vitest/config';
 
 config();
+
+if (!process.env.TEST_TRANSPORT) {
+  try {
+    // Temporary workaround so existing CI still works with new format. The generate_config script will
+    // write this file instead of setting the SANDBOX_TRANSPORT var in the worker config.
+    process.env.TEST_TRANSPORT = readFileSync(
+      join(__dirname, './tests/e2e/test-worker/TEST_TRANSPORT'),
+      'utf-8'
+    ).trim();
+  } catch (err) {
+    throw new Error('Missing TEST_TRANSPORT environment variable');
+  }
+}
 
 /**
  * E2E tests with per-file sandbox isolation - runs in parallel.

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,5 +1,4 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import assert from 'node:assert';
 import { config } from 'dotenv';
 import { defineConfig } from 'vitest/config';
 
@@ -7,12 +6,14 @@ config();
 
 if (!process.env.TEST_TRANSPORT) {
   try {
-    // Temporary workaround so existing CI still works with new format. The generate_config script will
-    // write this file instead of setting the SANDBOX_TRANSPORT var in the worker config.
-    process.env.TEST_TRANSPORT = readFileSync(
-      join(__dirname, './tests/e2e/test-worker/TEST_TRANSPORT'),
-      'utf-8'
-    ).trim();
+    // Attempt to extract the transport from the worker URL for backwards
+    const workerURL = new URL(process.env.TEST_WORKER_URL ?? '');
+    const transportRegexp =
+      /sandbox-e2e-test-worker-(?:.+)-(?<transport>http|websocket).(?:[^.]+)[.]workers[.]dev/;
+    process.env.TEST_TRANSPORT = transportRegexp.exec(
+      workerURL.host
+    )?.groups?.transport;
+    assert(['http', 'websocket'].includes(process.env.TEST_TRANSPORT ?? ''));
   } catch (err) {
     throw new Error('Missing TEST_TRANSPORT environment variable');
   }


### PR DESCRIPTION
This adds a new `transport` config option to the `getSandbox()` interface. Which allows custom transport to be specified per instance rather than for all sandbox instances via a worker level environment variable.

This enables two things:

 1. Different sandboxes to use different transports.
 2. The use of multiple transports on the same sandbox.

Primarily this will enable us to reduce the number of workers and container images down to a single set in CI. Ideally the entire transport mechanism will go away shortly when we replace with a unified websocket based transport.

The integration tests have been updated to use this method via a `TEST_TRANSPORT` file written into the test worker directory and loaded into the environment via the vite env. The follow up will remove the dual tests in actions. Then this hack can go away.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
