### PR TITLE
Refactor desktop management + shutdown logic

### DIFF
--- a/packages/sandbox-container/src/managers/desktop-manager.ts
+++ b/packages/sandbox-container/src/managers/desktop-manager.ts
@@ -158,17 +158,19 @@ export class DesktopManager {
     }
 
     // 2. Wait for all to exit, bounded by STOP_DEADLINE_MS.
+    // allSettled never rejects — a single process crashing won't
+    // short-circuit the wait or skip the SIGKILL escalation.
     const exitPromises = allProcs
       .filter((p) => p.proc && !p.proc.killed)
       .map((p) => p.proc!.exited);
 
-    const allExited = Promise.all(exitPromises);
+    const allSettled = Promise.allSettled(exitPromises);
     const deadline = new Promise<'timeout'>((resolve) =>
       setTimeout(() => resolve('timeout'), STOP_DEADLINE_MS)
     );
 
     const result = await Promise.race([
-      allExited.then(() => 'exited' as const),
+      allSettled.then(() => 'exited' as const),
       deadline
     ]);
 

--- a/packages/sandbox-container/src/managers/desktop-manager.ts
+++ b/packages/sandbox-container/src/managers/desktop-manager.ts
@@ -3,14 +3,17 @@ import type {
   DesktopStartRequest,
   Logger
 } from '@repo/shared';
+import type { Subprocess } from 'bun';
 
 interface DesktopProcess {
   name: string;
   command: string;
   args: string[];
   priority: number;
-  proc: import('bun').Subprocess | null;
+  proc: Subprocess<'ignore', 'pipe', 'pipe'> | null;
   pid: number | undefined;
+  /** PGID for group-kill. Equals the child PID when spawned with `detached`. */
+  pgid: number | undefined;
   startTime: Date | null;
 }
 
@@ -18,13 +21,18 @@ const DEFAULT_RESOLUTION: [number, number] = [1024, 768];
 const DEFAULT_DPI = 96;
 const READINESS_TIMEOUT_MS = 15000;
 const READINESS_POLL_INTERVAL_MS = 200;
-const PROCESS_KILL_TIMEOUT_MS = 5000;
+/** Overall deadline for the entire stop sequence (SIGTERM + wait + SIGKILL). */
+const STOP_DEADLINE_MS = 3000;
+/** Grace period after SIGKILL before clearing state. */
+const SIGKILL_GRACE_MS = 500;
 
 export class DesktopManager {
   private processes = new Map<string, DesktopProcess>();
   private state: 'inactive' | 'starting' | 'active' | 'stopping' = 'inactive';
   private resolution: [number, number] = DEFAULT_RESOLUTION;
   private dpi: number = DEFAULT_DPI;
+  /** Coalesces concurrent stop() calls onto a single teardown. */
+  private stopPromise: Promise<void> | null = null;
 
   constructor(private logger: Logger) {}
 
@@ -44,64 +52,62 @@ export class DesktopManager {
     const [width, height] = this.resolution;
 
     try {
-      const processDefs: Omit<DesktopProcess, 'proc' | 'pid' | 'startTime'>[] =
-        [
-          {
-            name: 'xvfb',
-            command: 'Xvfb',
-            args: [
-              ':99',
-              '-screen',
-              '0',
-              `${width}x${height}x24`,
-              '-dpi',
-              String(this.dpi),
-              '-ac'
-            ],
-            priority: 100
-          },
-          {
-            name: 'xfce4',
-            command: 'startxfce4',
-            args: [],
-            priority: 200
-          },
-          {
-            name: 'x11vnc',
-            command: 'x11vnc',
-            args: [
-              '-display',
-              ':99',
-              '-nopw',
-              '-forever',
-              '-shared',
-              '-rfbport',
-              '5900'
-            ],
-            priority: 300
-          },
-          {
-            name: 'novnc',
-            command: 'websockify',
-            args: [
-              '--web',
-              '/usr/share/novnc',
-              '0.0.0.0:6080',
-              'localhost:5900'
-            ],
-            priority: 400
-          }
-        ];
+      const processDefs: Omit<
+        DesktopProcess,
+        'proc' | 'pid' | 'pgid' | 'startTime'
+      >[] = [
+        {
+          name: 'xvfb',
+          command: 'Xvfb',
+          args: [
+            ':99',
+            '-screen',
+            '0',
+            `${width}x${height}x24`,
+            '-dpi',
+            String(this.dpi),
+            '-ac'
+          ],
+          priority: 100
+        },
+        {
+          name: 'xfce4',
+          command: 'startxfce4',
+          args: [],
+          priority: 200
+        },
+        {
+          name: 'x11vnc',
+          command: 'x11vnc',
+          args: [
+            '-display',
+            ':99',
+            '-nopw',
+            '-forever',
+            '-shared',
+            '-rfbport',
+            '5900'
+          ],
+          priority: 300
+        },
+        {
+          name: 'novnc',
+          command: 'websockify',
+          args: ['--web', '/usr/share/novnc', '0.0.0.0:6080', 'localhost:5900'],
+          priority: 400
+        }
+      ];
 
       for (const def of processDefs) {
-        const process: DesktopProcess = {
+        const desktopProcess: DesktopProcess = {
           ...def,
           proc: null,
           pid: undefined,
+          pgid: undefined,
           startTime: null
         };
-        this.processes.set(def.name, process);
-        await this.startProcess(process);
+        this.processes.set(def.name, desktopProcess);
+        await this.startProcess(desktopProcess);
       }
 
       await this.waitForHttp('http://localhost:6080', READINESS_TIMEOUT_MS);
@@ -129,15 +135,60 @@ export class DesktopManager {
 
   async stop(): Promise<void> {
     if (this.state === 'inactive') return;
+
+    // Coalesce concurrent stop() calls onto the same teardown promise.
+    if (this.stopPromise) return this.stopPromise;
+
+    this.stopPromise = this.doStop();
+    try {
+      await this.stopPromise;
+    } finally {
+      this.stopPromise = null;
+    }
+  }
+
+  private async doStop(): Promise<void> {
     this.state = 'stopping';
 
-    const sorted = [...this.processes.values()].sort(
-      (a, b) => b.priority - a.priority
-    );
-    for (const process of sorted) {
-      await this.killProcess(process);
+    const allProcs = [...this.processes.values()];
+
+    // 1. SIGTERM every process group at once.
+    for (const p of allProcs) {
+      this.signalProcessGroup(p, 'SIGTERM');
     }
 
+    // 2. Wait for all to exit, bounded by STOP_DEADLINE_MS.
+    const exitPromises = allProcs
+      .filter((p) => p.proc && !p.proc.killed)
+      .map((p) => p.proc!.exited);
+
+    const allExited = Promise.all(exitPromises);
+    const deadline = new Promise<'timeout'>((resolve) =>
+      setTimeout(() => resolve('timeout'), STOP_DEADLINE_MS)
+    );
+
+    const result = await Promise.race([
+      allExited.then(() => 'exited' as const),
+      deadline
+    ]);
+
+    if (result === 'timeout') {
+      // 3. SIGKILL survivors.
+      this.logger.warn(
+        'Desktop processes did not exit after SIGTERM, sending SIGKILL'
+      );
+      for (const p of allProcs) {
+        this.signalProcessGroup(p, 'SIGKILL');
+      }
+      await new Promise((resolve) => setTimeout(resolve, SIGKILL_GRACE_MS));
+    }
+
+    // 4. Clear state.
+    for (const p of allProcs) {
+      p.proc = null;
+      p.pid = undefined;
+      p.pgid = undefined;
+    }
     this.processes.clear();
     this.state = 'inactive';
     this.logger.info('Desktop environment stopped');
@@ -155,15 +206,15 @@ export class DesktopManager {
     let allRunning = true;
     let anyRunning = false;
 
-    for (const [name, process] of this.processes) {
-      const running = process.proc !== null && !process.proc.killed;
-      const uptime = process.startTime
-        ? Math.floor((Date.now() - process.startTime.getTime()) / 1000)
+    for (const [name, p] of this.processes) {
+      const running = p.proc !== null && !p.proc.killed;
+      const uptime = p.startTime
+        ? Math.floor((Date.now() - p.startTime.getTime()) / 1000)
         : undefined;
 
       processes[name] = {
         running,
-        pid: process.pid,
+        pid: p.pid,
         uptime
       };
 
@@ -183,26 +234,31 @@ export class DesktopManager {
     return this.state === 'active' ? this.dpi : null;
   }
 
-  private async startProcess(process: DesktopProcess): Promise<void> {
-    const childLogger = this.logger.child({ process: process.name });
+  private async startProcess(desktopProcess: DesktopProcess): Promise<void> {
+    const childLogger = this.logger.child({ process: desktopProcess.name });
     childLogger.info('Starting desktop process', {
-      command: process.command,
-      args: process.args
+      command: desktopProcess.command,
+      args: desktopProcess.args
     });
 
     const env: Record<string, string> = {
-      ...(process.name !== 'xvfb' ? { DISPLAY: ':99' } : {})
+      ...(desktopProcess.name !== 'xvfb' ? { DISPLAY: ':99' } : {})
     };
 
-    const proc = Bun.spawn([process.command, ...process.args], {
+    // `detached: true` calls setsid(2), making the child a process group
+    // leader. Its PGID equals its PID, so `kill(-pid, sig)` reaches the
+    // entire subtree (e.g. xfce4's panel, xfwm4, thunar, etc.).
+    const proc = Bun.spawn([desktopProcess.command, ...desktopProcess.args], {
       env: { ...Bun.env, ...env },
       stdout: 'pipe',
-      stderr: 'pipe'
+      stderr: 'pipe',
+      detached: true
     });
 
-    process.proc = proc;
-    process.pid = proc.pid;
-    process.startTime = new Date();
+    desktopProcess.proc = proc;
+    desktopProcess.pid = proc.pid;
+    desktopProcess.pgid = proc.pid; // group leader ⇒ pgid == pid
+    desktopProcess.startTime = new Date();
 
     this.pipeOutput(proc.stdout, childLogger, 'debug');
     this.pipeOutput(proc.stderr, childLogger, 'debug');
@@ -210,12 +266,15 @@ export class DesktopManager {
     await new Promise((resolve) => setTimeout(resolve, 500));
 
     if (proc.killed) {
-      throw new Error(`Desktop process ${process.name} exited immediately`);
+      throw new Error(
+        `Desktop process ${desktopProcess.name} exited immediately`
+      );
     }
 
     childLogger.info('Desktop process started', { pid: proc.pid });
   }
 
+  /** Drain a ReadableStream through the logger. Fire-and-forget. */
   private async pipeOutput(
     stream: ReadableStream<Uint8Array> | null,
     logger: Logger,
@@ -233,36 +292,24 @@ export class DesktopManager {
           logger[level](text);
         }
       }
-    } catch {}
+    } catch {
+      // Stream cancelled or errored — expected during stop.
+    }
   }
 
-  private async killProcess(process: DesktopProcess): Promise<void> {
-    if (!process.proc || process.proc.killed) return;
-
-    const childLogger = this.logger.child({ process: process.name });
-    childLogger.info('Stopping desktop process', { pid: process.pid });
-
+  /** Send a signal to the entire process group via kill(-pgid, sig). */
+  private signalProcessGroup(
+    desktopProcess: DesktopProcess,
+    signal: NodeJS.Signals
+  ): void {
+    const pgid = desktopProcess.pgid;
+    if (!pgid) return;
     try {
-      process.proc.kill('SIGTERM');
-
-      const exitPromise = process.proc.exited;
-      const timeoutPromise = new Promise<never>((_, reject) =>
-        setTimeout(
-          () => reject(new Error('Kill timeout')),
-          PROCESS_KILL_TIMEOUT_MS
-        )
-      );
-
-      await Promise.race([exitPromise, timeoutPromise]).catch(() => {
-        childLogger.warn('Process did not exit gracefully, sending SIGKILL');
-        process.proc?.kill('SIGKILL');
-      });
-    } catch (error) {
-      childLogger.warn('Error killing process', { error });
+      // Negative PID targets the process group.
+      process.kill(-pgid, signal);
+    } catch {
+      // ESRCH: process group already exited.
     }
-
-    process.proc = null;
-    process.pid = undefined;
   }
 
   private async waitForHttp(url: string, timeoutMs: number): Promise<void> {

--- a/packages/sandbox-container/src/managers/desktop-manager.ts
+++ b/packages/sandbox-container/src/managers/desktop-manager.ts
@@ -198,7 +198,11 @@ export class DesktopManager {
     status: 'active' | 'partial' | 'inactive';
     processes: Record<string, DesktopProcessHealth>;
   } {
-    if (this.state === 'inactive' || this.processes.size === 0) {
+    if (
+      this.state === 'inactive' ||
+      this.state === 'stopping' ||
+      this.processes.size === 0
+    ) {
       return { status: 'inactive', processes: {} };
     }
 

--- a/packages/sandbox-container/src/server.ts
+++ b/packages/sandbox-container/src/server.ts
@@ -27,8 +27,10 @@ process.on('uncaughtException', (error) => {
 
 process.on('unhandledRejection', (reason) => {
   const error = reason instanceof Error ? reason : new Error(String(reason));
-  logger.error('Unhandled rejection', error);
-  process.exit(1);
+  logger.warn('Unhandled rejection', {
+    error: error.message,
+    stack: error.stack
+  });
 });
 
 export interface ServerInstance {

--- a/packages/sandbox-container/src/services/desktop-service.ts
+++ b/packages/sandbox-container/src/services/desktop-service.ts
@@ -426,7 +426,7 @@ export class DesktopService {
         stdin: 'pipe',
         stdout: 'pipe',
         stderr: 'pipe',
-        env: { ...Bun.env, DISPLAY: ':99' }
+        env: { ...Bun.env, DISPLAY: Bun.env.DISPLAY ?? ':99' }
       });
       this.worker = worker;
 
@@ -510,7 +510,9 @@ export class DesktopService {
         const { done, value } = await reader.read();
         if (done) break;
         const text = decoder.decode(value).trim();
-        if (text) this.logger.debug('desktop-worker stderr', { text });
+        // Logged at warn since the worker only writes to stderr when
+        // something went wrong (FFI load failures, robotgo errors).
+        if (text) this.logger.warn('desktop-worker stderr', { text });
       }
     } catch {
       // Expected during shutdown

--- a/packages/sandbox-container/src/services/desktop-service.ts
+++ b/packages/sandbox-container/src/services/desktop-service.ts
@@ -20,6 +20,7 @@ import type {
   DesktopStopResult,
   DesktopTypeRequest,
   DesktopWorkerRequest,
+  DesktopWorkerResponse,
   Logger
 } from '@repo/shared';
 import type { ServiceResult } from '../core/types';
@@ -30,7 +31,6 @@ export class DesktopService {
   private manager: DesktopManager;
   private worker: import('bun').Subprocess<'pipe', 'pipe', 'pipe'> | null =
     null;
-  private workerBuffer = '';
   private pending = new Map<
     string,
     { resolve: (value: unknown) => void; reject: (reason: Error) => void }
@@ -452,31 +452,18 @@ export class DesktopService {
     if (!worker.stdout) return;
     const reader = worker.stdout.getReader();
     const decoder = new TextDecoder();
+    let buffer = '';
     try {
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
-        this.workerBuffer += decoder.decode(value);
-        let newlineIdx: number = this.workerBuffer.indexOf('\n');
+        buffer += decoder.decode(value);
+        let newlineIdx = buffer.indexOf('\n');
         while (newlineIdx !== -1) {
-          const line = this.workerBuffer.slice(0, newlineIdx);
-          this.workerBuffer = this.workerBuffer.slice(newlineIdx + 1);
-          if (!line) continue;
-          try {
-            const { id, result, error } = JSON.parse(line);
-            const handler = this.pending.get(id);
-            if (handler) {
-              this.pending.delete(id);
-              if (error) {
-                handler.reject(new Error(error));
-              } else {
-                handler.resolve(result);
-              }
-            }
-          } catch {
-            this.logger.warn('Failed to parse worker output', { line });
-          }
-          newlineIdx = this.workerBuffer.indexOf('\n');
+          const line = buffer.slice(0, newlineIdx);
+          buffer = buffer.slice(newlineIdx + 1);
+          if (line) this.handleWorkerLine(line);
+          newlineIdx = buffer.indexOf('\n');
         }
       }
     } catch {
@@ -491,6 +478,24 @@ export class DesktopService {
         this.pending.delete(id);
       }
       this.worker = null;
+    }
+  }
+
+  private handleWorkerLine(line: string): void {
+    let parsed: DesktopWorkerResponse;
+    try {
+      parsed = JSON.parse(line) as DesktopWorkerResponse;
+    } catch {
+      this.logger.warn('Failed to parse worker output', { line });
+      return;
+    }
+    const handler = this.pending.get(parsed.id);
+    if (!handler) return;
+    this.pending.delete(parsed.id);
+    if ('error' in parsed) {
+      handler.reject(new Error(parsed.error));
+    } else {
+      handler.resolve(parsed.result);
     }
   }
 

--- a/packages/sandbox-container/src/services/desktop-service.ts
+++ b/packages/sandbox-container/src/services/desktop-service.ts
@@ -19,6 +19,7 @@ import type {
   DesktopStatusResult,
   DesktopStopResult,
   DesktopTypeRequest,
+  DesktopWorkerRequest,
   Logger
 } from '@repo/shared';
 import type { ServiceResult } from '../core/types';
@@ -381,7 +382,7 @@ export class DesktopService {
   private static readonly WORKER_TERMINATE_TIMEOUT_MS = 2_000;
 
   private async sendToWorker(
-    op: string,
+    op: DesktopWorkerRequest['op'],
     args?: Record<string, unknown>
   ): Promise<unknown> {
     this.ensureDesktopActive();
@@ -408,7 +409,8 @@ export class DesktopService {
         }
       });
       if (this.worker?.stdin) {
-        this.worker.stdin.write(`${JSON.stringify({ id, op, ...args })}\n`);
+        const request = { id, op, ...args } as unknown as DesktopWorkerRequest;
+        this.worker.stdin.write(`${JSON.stringify(request)}\n`);
       }
     });
   }

--- a/packages/sandbox-container/src/services/desktop-service.ts
+++ b/packages/sandbox-container/src/services/desktop-service.ts
@@ -429,11 +429,19 @@ export class DesktopService {
         env: { ...Bun.env, DISPLAY: ':99' }
       });
 
-      // Read newline-delimited JSON responses from stdout
-      this.readWorkerOutput();
-
-      // Log stderr for diagnostics
-      this.pipeStderr();
+      // Stream readers run for the lifetime of the worker. Attaching
+      // catch handlers surfaces unexpected failures through the logger
+      // instead of becoming unhandled promise rejections.
+      this.readWorkerOutput().catch((error) => {
+        this.logger.error('Desktop worker stdout reader failed', undefined, {
+          error: error instanceof Error ? error.message : String(error)
+        });
+      });
+      this.pipeStderr().catch((error) => {
+        this.logger.warn('Desktop worker stderr reader failed', {
+          error: error instanceof Error ? error.message : String(error)
+        });
+      });
     }
   }
 

--- a/packages/sandbox-container/src/services/desktop-service.ts
+++ b/packages/sandbox-container/src/services/desktop-service.ts
@@ -463,18 +463,20 @@ export class DesktopService {
     this.worker = null;
 
     try {
+      let timer: ReturnType<typeof setTimeout> | undefined;
       await Promise.race([
         new Promise<void>((resolve) => {
           worker.terminate();
           resolve();
         }),
-        new Promise<void>((_, reject) =>
-          setTimeout(
+        new Promise<void>((_, reject) => {
+          timer = setTimeout(
             () => reject(new Error('Worker.terminate() timed out')),
             DesktopService.WORKER_TERMINATE_TIMEOUT_MS
-          )
-        )
+          );
+        })
       ]);
+      clearTimeout(timer);
     } catch (error) {
       this.logger.warn('Worker termination timed out, abandoning reference', {
         error: error instanceof Error ? error.message : String(error)

--- a/packages/sandbox-container/src/services/desktop-service.ts
+++ b/packages/sandbox-container/src/services/desktop-service.ts
@@ -382,6 +382,7 @@ export class DesktopService {
     op: string,
     args?: Record<string, unknown>
   ): Promise<unknown> {
+    this.ensureDesktopActive();
     this.ensureWorkerRunning();
     const id = crypto.randomUUID();
     return new Promise((resolve, reject) => {

--- a/packages/sandbox-container/src/services/desktop-service.ts
+++ b/packages/sandbox-container/src/services/desktop-service.ts
@@ -60,17 +60,20 @@ export class DesktopService {
 
   async stop(): Promise<ServiceResult<DesktopStopResult>> {
     try {
-      if (this.worker) {
-        this.worker.terminate();
-        this.worker = null;
-      }
+      // Kill X11 processes first so any in-flight FFI call against the
+      // display fails fast instead of blocking on a dying server.
+      await this.manager.stop();
+
+      // Terminate the worker thread with a timeout. If a synchronous FFI
+      // call is blocked (e.g. robotgo waiting on X11), terminate() may not
+      // return promptly. The process group kill above will reclaim it.
+      await this.terminateWorker();
 
       for (const [, handler] of this.pending) {
         handler.reject(new Error('Desktop service stopped'));
       }
       this.pending.clear();
 
-      await this.manager.stop();
       return serviceSuccess<DesktopStopResult>({ success: true });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -372,6 +375,9 @@ export class DesktopService {
     }
   }
 
+  private static readonly WORKER_OP_TIMEOUT_MS = 10_000;
+  private static readonly WORKER_TERMINATE_TIMEOUT_MS = 2_000;
+
   private async sendToWorker(
     op: string,
     args?: Record<string, unknown>
@@ -379,7 +385,25 @@ export class DesktopService {
     this.ensureWorkerRunning();
     const id = crypto.randomUUID();
     return new Promise((resolve, reject) => {
-      this.pending.set(id, { resolve, reject });
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(
+          new Error(
+            `Worker operation '${op}' timed out after ${DesktopService.WORKER_OP_TIMEOUT_MS}ms`
+          )
+        );
+      }, DesktopService.WORKER_OP_TIMEOUT_MS);
+
+      this.pending.set(id, {
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        reject: (reason) => {
+          clearTimeout(timer);
+          reject(reason);
+        }
+      });
       this.worker?.postMessage({ id, op, ...args });
     });
   }
@@ -418,14 +442,42 @@ export class DesktopService {
   }
 
   async destroy(): Promise<void> {
-    if (this.worker) {
-      this.worker.terminate();
-      this.worker = null;
-    }
     await this.manager.stop();
+    await this.terminateWorker();
     for (const [, handler] of this.pending) {
       handler.reject(new Error('Desktop service destroyed'));
     }
     this.pending.clear();
+  }
+
+  /**
+   * Terminate the worker thread with a bounded timeout.
+   * If terminate() blocks (e.g. stuck in a synchronous FFI call),
+   * null out the reference and move on — the process group kill
+   * in the manager will reclaim the thread.
+   */
+  private async terminateWorker(): Promise<void> {
+    if (!this.worker) return;
+    const worker = this.worker;
+    this.worker = null;
+
+    try {
+      await Promise.race([
+        new Promise<void>((resolve) => {
+          worker.terminate();
+          resolve();
+        }),
+        new Promise<void>((_, reject) =>
+          setTimeout(
+            () => reject(new Error('Worker.terminate() timed out')),
+            DesktopService.WORKER_TERMINATE_TIMEOUT_MS
+          )
+        )
+      ]);
+    } catch (error) {
+      this.logger.warn('Worker termination timed out, abandoning reference', {
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
   }
 }

--- a/packages/sandbox-container/src/services/desktop-service.ts
+++ b/packages/sandbox-container/src/services/desktop-service.ts
@@ -27,7 +27,9 @@ import { DesktopManager } from '../managers/desktop-manager';
 
 export class DesktopService {
   private manager: DesktopManager;
-  private worker: Worker | null = null;
+  private worker: import('bun').Subprocess<'pipe', 'pipe', 'pipe'> | null =
+    null;
+  private workerBuffer = '';
   private pending = new Map<
     string,
     { resolve: (value: unknown) => void; reject: (reason: Error) => void }
@@ -60,19 +62,19 @@ export class DesktopService {
 
   async stop(): Promise<ServiceResult<DesktopStopResult>> {
     try {
-      // Kill X11 processes first so any in-flight FFI call against the
-      // display fails fast instead of blocking on a dying server.
-      await this.manager.stop();
-
-      // Terminate the worker thread with a timeout. If a synchronous FFI
-      // call is blocked (e.g. robotgo waiting on X11), terminate() may not
-      // return promptly. The process group kill above will reclaim it.
+      // Terminate the worker process BEFORE killing X11 processes.
+      // The worker holds an FFI connection to X11 via robotgo. Killing
+      // Xvfb while FFI calls are in flight would leave them in an
+      // undefined state. Stopping the worker first ensures a clean
+      // teardown with no outstanding X11 operations.
       await this.terminateWorker();
 
       for (const [, handler] of this.pending) {
         handler.reject(new Error('Desktop service stopped'));
       }
       this.pending.clear();
+
+      await this.manager.stop();
 
       return serviceSuccess<DesktopStopResult>({ success: true });
     } catch (error) {
@@ -405,82 +407,131 @@ export class DesktopService {
           reject(reason);
         }
       });
-      this.worker?.postMessage({ id, op, ...args });
+      if (this.worker?.stdin) {
+        this.worker.stdin.write(`${JSON.stringify({ id, op, ...args })}\n`);
+      }
     });
   }
 
   private ensureWorkerRunning(): void {
     if (!this.worker) {
-      // Compiled binary: worker is at /container-server/workers/desktop-worker.js
-      // Dev mode: resolve relative to this source file via import.meta.url
       const compiledWorkerPath = '/container-server/workers/desktop-worker.js';
       const workerPath = existsSync(compiledWorkerPath)
         ? compiledWorkerPath
-        : new URL('../workers/desktop-worker.ts', import.meta.url).href;
-      this.worker = new Worker(workerPath);
-      this.worker.onmessage = (event: MessageEvent) => {
-        const { id, result, error } = event.data;
-        const handler = this.pending.get(id);
-        if (handler) {
-          this.pending.delete(id);
-          if (error) {
-            handler.reject(new Error(error));
-          } else {
-            handler.resolve(result);
+        : new URL('../workers/desktop-worker.ts', import.meta.url).pathname;
+
+      this.worker = Bun.spawn(['bun', 'run', workerPath], {
+        stdin: 'pipe',
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: { ...Bun.env, DISPLAY: ':99' }
+      });
+
+      // Read newline-delimited JSON responses from stdout
+      this.readWorkerOutput();
+
+      // Log stderr for diagnostics
+      this.pipeStderr();
+    }
+  }
+
+  private async readWorkerOutput(): Promise<void> {
+    if (!this.worker?.stdout) return;
+    const reader = this.worker.stdout.getReader();
+    const decoder = new TextDecoder();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        this.workerBuffer += decoder.decode(value);
+        let newlineIdx: number = this.workerBuffer.indexOf('\n');
+        while (newlineIdx !== -1) {
+          const line = this.workerBuffer.slice(0, newlineIdx);
+          this.workerBuffer = this.workerBuffer.slice(newlineIdx + 1);
+          if (!line) continue;
+          try {
+            const { id, result, error } = JSON.parse(line);
+            const handler = this.pending.get(id);
+            if (handler) {
+              this.pending.delete(id);
+              if (error) {
+                handler.reject(new Error(error));
+              } else {
+                handler.resolve(result);
+              }
+            }
+          } catch {
+            this.logger.warn('Failed to parse worker output', { line });
           }
+          newlineIdx = this.workerBuffer.indexOf('\n');
         }
-      };
-      this.worker.onerror = (event) => {
-        const message = event instanceof Error ? event.message : String(event);
-        this.logger.error('Desktop worker crashed', undefined, { message });
-        for (const [id, handler] of this.pending) {
-          handler.reject(new Error(`Worker crashed: ${message}`));
-          this.pending.delete(id);
-        }
-        this.worker = null;
-      };
+      }
+    } catch {
+      // Stream closed — expected during shutdown
+    }
+    // Worker exited — reject all pending operations
+    for (const [id, handler] of this.pending) {
+      handler.reject(new Error('Worker process exited'));
+      this.pending.delete(id);
+    }
+    this.worker = null;
+  }
+
+  private async pipeStderr(): Promise<void> {
+    if (!this.worker?.stderr) return;
+    const reader = this.worker.stderr.getReader();
+    const decoder = new TextDecoder();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        const text = decoder.decode(value).trim();
+        if (text) this.logger.debug('desktop-worker stderr', { text });
+      }
+    } catch {
+      // Expected during shutdown
     }
   }
 
   async destroy(): Promise<void> {
-    await this.manager.stop();
     await this.terminateWorker();
     for (const [, handler] of this.pending) {
       handler.reject(new Error('Desktop service destroyed'));
     }
     this.pending.clear();
+    await this.manager.stop();
   }
 
   /**
-   * Terminate the worker thread with a bounded timeout.
-   * If terminate() blocks (e.g. stuck in a synchronous FFI call),
-   * null out the reference and move on — the process group kill
-   * in the manager will reclaim the thread.
+   * Kill the worker child process.
+   * Since it runs in a separate process, a segfault in the FFI layer
+   * cannot crash the Bun HTTP server.
    */
   private async terminateWorker(): Promise<void> {
     if (!this.worker) return;
-    const worker = this.worker;
+    const proc = this.worker;
     this.worker = null;
 
     try {
-      let timer: ReturnType<typeof setTimeout> | undefined;
-      await Promise.race([
-        new Promise<void>((resolve) => {
-          worker.terminate();
-          resolve();
-        }),
-        new Promise<void>((_, reject) => {
-          timer = setTimeout(
-            () => reject(new Error('Worker.terminate() timed out')),
-            DesktopService.WORKER_TERMINATE_TIMEOUT_MS
-          );
-        })
+      proc.kill('SIGTERM');
+      const deadline = new Promise<'timeout'>((resolve) =>
+        setTimeout(
+          () => resolve('timeout'),
+          DesktopService.WORKER_TERMINATE_TIMEOUT_MS
+        )
+      );
+      const result = await Promise.race([
+        proc.exited.then(() => 'exited' as const),
+        deadline
       ]);
-      clearTimeout(timer);
-    } catch (error) {
-      this.logger.warn('Worker termination timed out, abandoning reference', {
-        error: error instanceof Error ? error.message : String(error)
-      });
+      if (result === 'timeout') {
+        this.logger.warn(
+          'Worker process did not exit after SIGTERM, sending SIGKILL'
+        );
+        proc.kill('SIGKILL');
+      }
+    } catch {
+      // Process already exited
     }
   }
 }

--- a/packages/sandbox-container/src/services/desktop-service.ts
+++ b/packages/sandbox-container/src/services/desktop-service.ts
@@ -422,22 +422,23 @@ export class DesktopService {
         ? compiledWorkerPath
         : new URL('../workers/desktop-worker.ts', import.meta.url).pathname;
 
-      this.worker = Bun.spawn(['bun', 'run', workerPath], {
+      const worker = Bun.spawn(['bun', 'run', workerPath], {
         stdin: 'pipe',
         stdout: 'pipe',
         stderr: 'pipe',
         env: { ...Bun.env, DISPLAY: ':99' }
       });
+      this.worker = worker;
 
-      // Stream readers run for the lifetime of the worker. Attaching
-      // catch handlers surfaces unexpected failures through the logger
-      // instead of becoming unhandled promise rejections.
-      this.readWorkerOutput().catch((error) => {
+      // Stream readers run for the lifetime of this worker instance.
+      // Passing the instance explicitly avoids a race where the reader's
+      // cleanup nulls a reference that already points at a newer worker.
+      this.readWorkerOutput(worker).catch((error) => {
         this.logger.error('Desktop worker stdout reader failed', undefined, {
           error: error instanceof Error ? error.message : String(error)
         });
       });
-      this.pipeStderr().catch((error) => {
+      this.pipeStderr(worker).catch((error) => {
         this.logger.warn('Desktop worker stderr reader failed', {
           error: error instanceof Error ? error.message : String(error)
         });
@@ -445,9 +446,11 @@ export class DesktopService {
     }
   }
 
-  private async readWorkerOutput(): Promise<void> {
-    if (!this.worker?.stdout) return;
-    const reader = this.worker.stdout.getReader();
+  private async readWorkerOutput(
+    worker: import('bun').Subprocess<'pipe', 'pipe', 'pipe'>
+  ): Promise<void> {
+    if (!worker.stdout) return;
+    const reader = worker.stdout.getReader();
     const decoder = new TextDecoder();
     try {
       while (true) {
@@ -479,17 +482,23 @@ export class DesktopService {
     } catch {
       // Stream closed — expected during shutdown
     }
-    // Worker exited — reject all pending operations
-    for (const [id, handler] of this.pending) {
-      handler.reject(new Error('Worker process exited'));
-      this.pending.delete(id);
+    // Only clean up if this reader still owns the active worker. If a
+    // newer worker has already been spawned (for example via start()
+    // racing with the exit of the previous one), leave its state intact.
+    if (this.worker === worker) {
+      for (const [id, handler] of this.pending) {
+        handler.reject(new Error('Worker process exited'));
+        this.pending.delete(id);
+      }
+      this.worker = null;
     }
-    this.worker = null;
   }
 
-  private async pipeStderr(): Promise<void> {
-    if (!this.worker?.stderr) return;
-    const reader = this.worker.stderr.getReader();
+  private async pipeStderr(
+    worker: import('bun').Subprocess<'pipe', 'pipe', 'pipe'>
+  ): Promise<void> {
+    if (!worker.stderr) return;
+    const reader = worker.stderr.getReader();
     const decoder = new TextDecoder();
     try {
       while (true) {

--- a/packages/sandbox-container/src/workers/desktop-worker.ts
+++ b/packages/sandbox-container/src/workers/desktop-worker.ts
@@ -1,8 +1,7 @@
-// Runs in a dedicated Bun Worker thread.
+// Runs in a dedicated child process (not a Worker thread).
 // Owns all koffi bindings to desktop.so (robotgo).
 // Operations are serialized: one at a time, in order.
-
-declare var self: Worker;
+// Communicates with the parent via newline-delimited JSON on stdin/stdout.
 
 // koffi library handle — typed as unknown since koffi types are loaded dynamically
 let lib: unknown = null;
@@ -132,40 +131,48 @@ function loadLibrary(): boolean {
   }
 }
 
-self.onmessage = (event: MessageEvent) => {
-  const { id, op, ...args } = event.data;
+function reply(data: { id: string; result?: unknown; error?: string }): void {
+  process.stdout.write(`${JSON.stringify(data)}\n`);
+}
+
+function handleMessage(msg: {
+  id: string;
+  op: string;
+  [key: string]: unknown;
+}): void {
+  const { id, op, ...args } = msg;
 
   try {
     if (!lib && !loadLibrary()) {
-      self.postMessage({
-        id,
-        error: `Desktop library not available: ${loadError}`
-      });
+      reply({ id, error: `Desktop library not available: ${loadError}` });
       return;
     }
 
     let result: unknown;
     switch (op) {
       case 'screenshot': {
-        const sx = Math.max(0, args.x ?? 0);
-        const sy = Math.max(0, args.y ?? 0);
-        const sw = args.w ?? 0;
-        const sh = args.h ?? 0;
+        const sx = Math.max(0, (args.x as number) ?? 0);
+        const sy = Math.max(0, (args.y as number) ?? 0);
+        const sw = (args.w as number) ?? 0;
+        const sh = (args.h as number) ?? 0;
         if (sw <= 0 || sh <= 0) {
           throw new Error(`Invalid screenshot dimensions: ${sw}x${sh}`);
         }
         checkError(
-          bindings.screenshot!(args.path, sx, sy, sw, sh),
+          bindings.screenshot!(args.path as string, sx, sy, sw, sh),
           'Screenshot'
         );
         result = { success: true, path: args.path };
         break;
       }
       case 'click': {
-        const btn = args.button || 'left';
-        const count = args.clickCount ?? 1;
+        const btn = (args.button as string) || 'left';
+        const count = (args.clickCount as number) ?? 1;
         checkError(
-          bindings.move!(Math.trunc(args.x), Math.trunc(args.y)),
+          bindings.move!(
+            Math.trunc(args.x as number),
+            Math.trunc(args.y as number)
+          ),
           'Move'
         );
         checkError(bindings.click!(btn, count), 'Click');
@@ -174,16 +181,24 @@ self.onmessage = (event: MessageEvent) => {
       }
       case 'move':
         checkError(
-          bindings.move!(Math.trunc(args.x), Math.trunc(args.y)),
+          bindings.move!(
+            Math.trunc(args.x as number),
+            Math.trunc(args.y as number)
+          ),
           'Move'
         );
         result = { success: true };
         break;
       case 'moveSmooth': {
-        const mx = Math.trunc(args.x);
-        const my = Math.trunc(args.y);
+        const mx = Math.trunc(args.x as number);
+        const my = Math.trunc(args.y as number);
         checkError(
-          bindings.moveSmooth!(mx, my, args.low ?? 5, args.high ?? 10),
+          bindings.moveSmooth!(
+            mx,
+            my,
+            (args.low as number) ?? 5,
+            (args.high as number) ?? 10
+          ),
           `MoveSmooth(${mx}, ${my})`
         );
         result = { success: true };
@@ -191,21 +206,36 @@ self.onmessage = (event: MessageEvent) => {
       }
       case 'scroll':
         checkError(
-          bindings.move!(Math.trunc(args.x), Math.trunc(args.y)),
+          bindings.move!(
+            Math.trunc(args.x as number),
+            Math.trunc(args.y as number)
+          ),
           'Move'
         );
         checkError(
-          bindings.scroll!(args.scrollX ?? 0, args.scrollY ?? 0),
+          bindings.scroll!(
+            (args.scrollX as number) ?? 0,
+            (args.scrollY as number) ?? 0
+          ),
           'Scroll'
         );
         result = { success: true };
         break;
       case 'type':
-        checkError(bindings.typeText!(args.text, args.pid ?? 0), 'TypeText');
+        checkError(
+          bindings.typeText!(args.text as string, (args.pid as number) ?? 0),
+          'TypeText'
+        );
         result = { success: true };
         break;
       case 'keyTap':
-        checkError(bindings.keyTap!(args.key, args.modifiers ?? ''), 'KeyTap');
+        checkError(
+          bindings.keyTap!(
+            args.key as string,
+            (args.modifiers as string) ?? ''
+          ),
+          'KeyTap'
+        );
         result = { success: true };
         break;
       case 'getScreenSize':
@@ -217,55 +247,103 @@ self.onmessage = (event: MessageEvent) => {
       case 'mouseDown':
         if (args.x !== undefined && args.y !== undefined) {
           checkError(
-            bindings.move!(Math.trunc(args.x), Math.trunc(args.y)),
+            bindings.move!(
+              Math.trunc(args.x as number),
+              Math.trunc(args.y as number)
+            ),
             'Move'
           );
         }
-        checkError(bindings.mouseDown!(args.button || 'left'), 'MouseDown');
+        checkError(
+          bindings.mouseDown!((args.button as string) || 'left'),
+          'MouseDown'
+        );
         result = { success: true };
         break;
       case 'mouseUp':
         if (args.x !== undefined && args.y !== undefined) {
           checkError(
-            bindings.move!(Math.trunc(args.x), Math.trunc(args.y)),
+            bindings.move!(
+              Math.trunc(args.x as number),
+              Math.trunc(args.y as number)
+            ),
             'Move'
           );
         }
-        checkError(bindings.mouseUp!(args.button || 'left'), 'MouseUp');
+        checkError(
+          bindings.mouseUp!((args.button as string) || 'left'),
+          'MouseUp'
+        );
         result = { success: true };
         break;
       case 'keyDown':
-        checkError(bindings.keyDown!(args.key), 'KeyDown');
+        checkError(bindings.keyDown!(args.key as string), 'KeyDown');
         result = { success: true };
         break;
       case 'keyUp':
-        checkError(bindings.keyUp!(args.key), 'KeyUp');
+        checkError(bindings.keyUp!(args.key as string), 'KeyUp');
         result = { success: true };
         break;
       case 'drag': {
-        const sx = Math.trunc(args.startX);
-        const sy = Math.trunc(args.startY);
-        const ex = Math.trunc(args.endX);
-        const ey = Math.trunc(args.endY);
+        const sx = Math.trunc(args.startX as number);
+        const sy = Math.trunc(args.startY as number);
+        const ex = Math.trunc(args.endX as number);
+        const ey = Math.trunc(args.endY as number);
         checkError(bindings.move!(sx, sy), 'Move');
-        checkError(bindings.mouseDown!(args.button || 'left'), 'MouseDown');
+        checkError(
+          bindings.mouseDown!((args.button as string) || 'left'),
+          'MouseDown'
+        );
         checkError(
           bindings.moveSmooth!(ex, ey, 5, 10),
           `MoveSmooth(${ex}, ${ey})`
         );
-        checkError(bindings.mouseUp!(args.button || 'left'), 'MouseUp');
+        checkError(
+          bindings.mouseUp!((args.button as string) || 'left'),
+          'MouseUp'
+        );
         result = { success: true };
         break;
       }
       default:
-        self.postMessage({ id, error: `Unknown operation: ${op}` });
+        reply({ id, error: `Unknown operation: ${op}` });
         return;
     }
-    self.postMessage({ id, result });
+    reply({ id, result });
   } catch (error) {
-    self.postMessage({
+    reply({
       id,
       error: error instanceof Error ? error.message : String(error)
     });
   }
-};
+}
+
+// Read newline-delimited JSON from stdin
+const reader = Bun.stdin.stream().getReader();
+const decoder = new TextDecoder();
+let buffer = '';
+
+(async () => {
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value);
+      let idx: number = buffer.indexOf('\n');
+      while (idx !== -1) {
+        const line = buffer.slice(0, idx);
+        buffer = buffer.slice(idx + 1);
+        if (!line) continue;
+        try {
+          handleMessage(JSON.parse(line));
+        } catch {
+          // Malformed input — skip
+        }
+        idx = buffer.indexOf('\n');
+      }
+    }
+  } catch {
+    // stdin closed
+  }
+  process.exit(0);
+})();

--- a/packages/sandbox-container/src/workers/desktop-worker.ts
+++ b/packages/sandbox-container/src/workers/desktop-worker.ts
@@ -3,6 +3,13 @@
 // Operations are serialized: one at a time, in order.
 // Communicates with the parent via newline-delimited JSON on stdin/stdout.
 
+import type {
+  DesktopWorkerOp,
+  DesktopWorkerRequest,
+  DesktopWorkerResponse,
+  DesktopWorkerResultMap
+} from '@repo/shared';
+
 // koffi library handle — typed as unknown since koffi types are loaded dynamically
 let lib: unknown = null;
 
@@ -131,188 +138,122 @@ function loadLibrary(): boolean {
   }
 }
 
-function reply(data: { id: string; result?: unknown; error?: string }): void {
+function reply(data: DesktopWorkerResponse): void {
   process.stdout.write(`${JSON.stringify(data)}\n`);
 }
 
-function handleMessage(msg: {
-  id: string;
-  op: string;
-  [key: string]: unknown;
-}): void {
-  const { id, op, ...args } = msg;
+type Handler<Op extends DesktopWorkerOp> = (
+  msg: Extract<DesktopWorkerRequest, { op: Op }>
+) => DesktopWorkerResultMap[Op];
 
+const handlers: { [Op in DesktopWorkerOp]: Handler<Op> } = {
+  screenshot: (msg) => {
+    const sx = Math.max(0, msg.x);
+    const sy = Math.max(0, msg.y);
+    if (msg.w <= 0 || msg.h <= 0) {
+      throw new Error(`Invalid screenshot dimensions: ${msg.w}x${msg.h}`);
+    }
+    checkError(
+      bindings.screenshot!(msg.path, sx, sy, msg.w, msg.h),
+      'Screenshot'
+    );
+    return { success: true, path: msg.path };
+  },
+  click: (msg) => {
+    const btn = msg.button ?? 'left';
+    const count = msg.clickCount ?? 1;
+    checkError(bindings.move!(Math.trunc(msg.x), Math.trunc(msg.y)), 'Move');
+    checkError(bindings.click!(btn, count), 'Click');
+    return { success: true };
+  },
+  move: (msg) => {
+    checkError(bindings.move!(Math.trunc(msg.x), Math.trunc(msg.y)), 'Move');
+    return { success: true };
+  },
+  moveSmooth: (msg) => {
+    const mx = Math.trunc(msg.x);
+    const my = Math.trunc(msg.y);
+    checkError(
+      bindings.moveSmooth!(mx, my, msg.low ?? 5, msg.high ?? 10),
+      `MoveSmooth(${mx}, ${my})`
+    );
+    return { success: true };
+  },
+  scroll: (msg) => {
+    checkError(bindings.move!(Math.trunc(msg.x), Math.trunc(msg.y)), 'Move');
+    checkError(bindings.scroll!(msg.scrollX ?? 0, msg.scrollY ?? 0), 'Scroll');
+    return { success: true };
+  },
+  type: (msg) => {
+    checkError(bindings.typeText!(msg.text, msg.pid ?? 0), 'TypeText');
+    return { success: true };
+  },
+  keyTap: (msg) => {
+    checkError(bindings.keyTap!(msg.key, msg.modifiers ?? ''), 'KeyTap');
+    return { success: true };
+  },
+  getScreenSize: () => bindings.getScreenSize!(),
+  getMousePos: () => bindings.getMousePos!(),
+  mouseDown: (msg) => {
+    if (msg.x !== undefined && msg.y !== undefined) {
+      checkError(bindings.move!(Math.trunc(msg.x), Math.trunc(msg.y)), 'Move');
+    }
+    checkError(bindings.mouseDown!(msg.button ?? 'left'), 'MouseDown');
+    return { success: true };
+  },
+  mouseUp: (msg) => {
+    if (msg.x !== undefined && msg.y !== undefined) {
+      checkError(bindings.move!(Math.trunc(msg.x), Math.trunc(msg.y)), 'Move');
+    }
+    checkError(bindings.mouseUp!(msg.button ?? 'left'), 'MouseUp');
+    return { success: true };
+  },
+  keyDown: (msg) => {
+    checkError(bindings.keyDown!(msg.key), 'KeyDown');
+    return { success: true };
+  },
+  keyUp: (msg) => {
+    checkError(bindings.keyUp!(msg.key), 'KeyUp');
+    return { success: true };
+  },
+  drag: (msg) => {
+    const sx = Math.trunc(msg.startX);
+    const sy = Math.trunc(msg.startY);
+    const ex = Math.trunc(msg.endX);
+    const ey = Math.trunc(msg.endY);
+    const btn = msg.button ?? 'left';
+    checkError(bindings.move!(sx, sy), 'Move');
+    checkError(bindings.mouseDown!(btn), 'MouseDown');
+    checkError(bindings.moveSmooth!(ex, ey, 5, 10), `MoveSmooth(${ex}, ${ey})`);
+    checkError(bindings.mouseUp!(btn), 'MouseUp');
+    return { success: true };
+  }
+};
+
+function handleMessage(msg: DesktopWorkerRequest): void {
   try {
     if (!lib && !loadLibrary()) {
-      reply({ id, error: `Desktop library not available: ${loadError}` });
+      reply({
+        id: msg.id,
+        error: `Desktop library not available: ${loadError}`
+      });
       return;
     }
-
-    let result: unknown;
-    switch (op) {
-      case 'screenshot': {
-        const sx = Math.max(0, (args.x as number) ?? 0);
-        const sy = Math.max(0, (args.y as number) ?? 0);
-        const sw = (args.w as number) ?? 0;
-        const sh = (args.h as number) ?? 0;
-        if (sw <= 0 || sh <= 0) {
-          throw new Error(`Invalid screenshot dimensions: ${sw}x${sh}`);
-        }
-        checkError(
-          bindings.screenshot!(args.path as string, sx, sy, sw, sh),
-          'Screenshot'
-        );
-        result = { success: true, path: args.path };
-        break;
-      }
-      case 'click': {
-        const btn = (args.button as string) || 'left';
-        const count = (args.clickCount as number) ?? 1;
-        checkError(
-          bindings.move!(
-            Math.trunc(args.x as number),
-            Math.trunc(args.y as number)
-          ),
-          'Move'
-        );
-        checkError(bindings.click!(btn, count), 'Click');
-        result = { success: true };
-        break;
-      }
-      case 'move':
-        checkError(
-          bindings.move!(
-            Math.trunc(args.x as number),
-            Math.trunc(args.y as number)
-          ),
-          'Move'
-        );
-        result = { success: true };
-        break;
-      case 'moveSmooth': {
-        const mx = Math.trunc(args.x as number);
-        const my = Math.trunc(args.y as number);
-        checkError(
-          bindings.moveSmooth!(
-            mx,
-            my,
-            (args.low as number) ?? 5,
-            (args.high as number) ?? 10
-          ),
-          `MoveSmooth(${mx}, ${my})`
-        );
-        result = { success: true };
-        break;
-      }
-      case 'scroll':
-        checkError(
-          bindings.move!(
-            Math.trunc(args.x as number),
-            Math.trunc(args.y as number)
-          ),
-          'Move'
-        );
-        checkError(
-          bindings.scroll!(
-            (args.scrollX as number) ?? 0,
-            (args.scrollY as number) ?? 0
-          ),
-          'Scroll'
-        );
-        result = { success: true };
-        break;
-      case 'type':
-        checkError(
-          bindings.typeText!(args.text as string, (args.pid as number) ?? 0),
-          'TypeText'
-        );
-        result = { success: true };
-        break;
-      case 'keyTap':
-        checkError(
-          bindings.keyTap!(
-            args.key as string,
-            (args.modifiers as string) ?? ''
-          ),
-          'KeyTap'
-        );
-        result = { success: true };
-        break;
-      case 'getScreenSize':
-        result = bindings.getScreenSize!();
-        break;
-      case 'getMousePos':
-        result = bindings.getMousePos!();
-        break;
-      case 'mouseDown':
-        if (args.x !== undefined && args.y !== undefined) {
-          checkError(
-            bindings.move!(
-              Math.trunc(args.x as number),
-              Math.trunc(args.y as number)
-            ),
-            'Move'
-          );
-        }
-        checkError(
-          bindings.mouseDown!((args.button as string) || 'left'),
-          'MouseDown'
-        );
-        result = { success: true };
-        break;
-      case 'mouseUp':
-        if (args.x !== undefined && args.y !== undefined) {
-          checkError(
-            bindings.move!(
-              Math.trunc(args.x as number),
-              Math.trunc(args.y as number)
-            ),
-            'Move'
-          );
-        }
-        checkError(
-          bindings.mouseUp!((args.button as string) || 'left'),
-          'MouseUp'
-        );
-        result = { success: true };
-        break;
-      case 'keyDown':
-        checkError(bindings.keyDown!(args.key as string), 'KeyDown');
-        result = { success: true };
-        break;
-      case 'keyUp':
-        checkError(bindings.keyUp!(args.key as string), 'KeyUp');
-        result = { success: true };
-        break;
-      case 'drag': {
-        const sx = Math.trunc(args.startX as number);
-        const sy = Math.trunc(args.startY as number);
-        const ex = Math.trunc(args.endX as number);
-        const ey = Math.trunc(args.endY as number);
-        checkError(bindings.move!(sx, sy), 'Move');
-        checkError(
-          bindings.mouseDown!((args.button as string) || 'left'),
-          'MouseDown'
-        );
-        checkError(
-          bindings.moveSmooth!(ex, ey, 5, 10),
-          `MoveSmooth(${ex}, ${ey})`
-        );
-        checkError(
-          bindings.mouseUp!((args.button as string) || 'left'),
-          'MouseUp'
-        );
-        result = { success: true };
-        break;
-      }
-      default:
-        reply({ id, error: `Unknown operation: ${op}` });
-        return;
+    // Dispatch through the typed handler map. The cast narrows the handler
+    // type to match the specific op, which the generic map cannot express.
+    const handler = handlers[msg.op] as Handler<DesktopWorkerOp> | undefined;
+    if (!handler) {
+      reply({
+        id: msg.id,
+        error: `Unknown operation: ${(msg as { op: string }).op}`
+      });
+      return;
     }
-    reply({ id, result });
+    const result = handler(msg);
+    reply({ id: msg.id, result });
   } catch (error) {
     reply({
-      id,
+      id: msg.id,
       error: error instanceof Error ? error.message : String(error)
     });
   }
@@ -335,7 +276,7 @@ let buffer = '';
         buffer = buffer.slice(idx + 1);
         if (!line) continue;
         try {
-          handleMessage(JSON.parse(line));
+          handleMessage(JSON.parse(line) as DesktopWorkerRequest);
         } catch {
           // Malformed input — skip
         }

--- a/packages/shared/src/desktop-worker-protocol.ts
+++ b/packages/shared/src/desktop-worker-protocol.ts
@@ -1,0 +1,102 @@
+/**
+ * Protocol for communication between the DesktopService (in the container
+ * HTTP server process) and the desktop worker child process.
+ *
+ * Messages are exchanged as newline-delimited JSON over the worker's
+ * stdin (requests) and stdout (responses). The worker owns all koffi
+ * bindings to desktop.so (robotgo) and serializes operations one at a time.
+ *
+ * Keeping this contract in the shared package ensures both sides agree on
+ * the shape of every operation without resorting to `any` or unchecked casts.
+ */
+
+import type { DesktopMouseButton, DesktopScreenSize } from './desktop-types.js';
+
+interface WithId {
+  id: string;
+}
+
+export type DesktopWorkerRequest =
+  | (WithId & {
+      op: 'screenshot';
+      path: string;
+      x: number;
+      y: number;
+      w: number;
+      h: number;
+    })
+  | (WithId & {
+      op: 'click';
+      x: number;
+      y: number;
+      button?: DesktopMouseButton;
+      clickCount?: number;
+    })
+  | (WithId & { op: 'move'; x: number; y: number })
+  | (WithId & {
+      op: 'moveSmooth';
+      x: number;
+      y: number;
+      low?: number;
+      high?: number;
+    })
+  | (WithId & {
+      op: 'scroll';
+      x: number;
+      y: number;
+      scrollX?: number;
+      scrollY?: number;
+    })
+  | (WithId & { op: 'type'; text: string; pid?: number })
+  | (WithId & { op: 'keyTap'; key: string; modifiers?: string })
+  | (WithId & { op: 'getScreenSize' })
+  | (WithId & { op: 'getMousePos' })
+  | (WithId & {
+      op: 'mouseDown';
+      x?: number;
+      y?: number;
+      button?: DesktopMouseButton;
+    })
+  | (WithId & {
+      op: 'mouseUp';
+      x?: number;
+      y?: number;
+      button?: DesktopMouseButton;
+    })
+  | (WithId & { op: 'keyDown'; key: string })
+  | (WithId & { op: 'keyUp'; key: string })
+  | (WithId & {
+      op: 'drag';
+      startX: number;
+      startY: number;
+      endX: number;
+      endY: number;
+      button?: DesktopMouseButton;
+    });
+
+export type DesktopWorkerOp = DesktopWorkerRequest['op'];
+
+/**
+ * Per-op result shape. Operations that don't return meaningful data
+ * return `{ success: true }` so the parent can await a confirmation.
+ */
+export interface DesktopWorkerResultMap {
+  screenshot: { success: true; path: string };
+  click: { success: true };
+  move: { success: true };
+  moveSmooth: { success: true };
+  scroll: { success: true };
+  type: { success: true };
+  keyTap: { success: true };
+  getScreenSize: DesktopScreenSize;
+  getMousePos: { x: number; y: number };
+  mouseDown: { success: true };
+  mouseUp: { success: true };
+  keyDown: { success: true };
+  keyUp: { success: true };
+  drag: { success: true };
+}
+
+export type DesktopWorkerResponse =
+  | { id: string; result: DesktopWorkerResultMap[DesktopWorkerOp] }
+  | { id: string; error: string };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -29,6 +29,12 @@ export type {
   DesktopStopResult,
   DesktopTypeRequest
 } from './desktop-types.js';
+export type {
+  DesktopWorkerOp,
+  DesktopWorkerRequest,
+  DesktopWorkerResponse,
+  DesktopWorkerResultMap
+} from './desktop-worker-protocol.js';
 // Export environment utilities
 export { filterEnvVars, getEnvString, partitionEnvVars } from './env.js';
 // Export git utilities

--- a/tests/e2e/desktop-environment.test.ts
+++ b/tests/e2e/desktop-environment.test.ts
@@ -236,54 +236,40 @@ describe('Desktop Environment', () => {
     );
   }, 15000);
 
-  // Known flaky: desktop stop can crash the container's Bun process,
-  // causing the subsequent status call to time out. Run but don't fail CI.
-  test('should stop desktop and report inactive status', async ({
-    annotate
-  }) => {
-    try {
-      const stopResponse = await fetch(`${workerUrl}/api/desktop/stop`, {
-        method: 'POST',
-        headers,
-        signal: AbortSignal.timeout(10000)
-      });
+  test('should stop desktop and report inactive status', async () => {
+    const stopResponse = await fetch(`${workerUrl}/api/desktop/stop`, {
+      method: 'POST',
+      headers,
+      signal: AbortSignal.timeout(10000)
+    });
 
-      expect(stopResponse.status).toBe(200);
-      await expect(stopResponse.json()).resolves.toEqual(
-        expect.objectContaining({ success: true })
-      );
+    expect(stopResponse.status).toBe(200);
+    await expect(stopResponse.json()).resolves.toEqual(
+      expect.objectContaining({ success: true })
+    );
 
-      const statusResponse = await fetch(`${workerUrl}/api/desktop/status`, {
-        method: 'GET',
-        headers,
-        signal: AbortSignal.timeout(10000)
-      });
+    const statusResponse = await fetch(`${workerUrl}/api/desktop/status`, {
+      method: 'GET',
+      headers,
+      signal: AbortSignal.timeout(10000)
+    });
 
-      expect(statusResponse.status).toBe(200);
-      await expect(statusResponse.json()).resolves.toEqual(
-        expect.objectContaining({ status: 'inactive' })
-      );
-      // Assert that attempting to make a request to a stopped instance fails.
-      const response = await fetch(`${workerUrl}/api/desktop/screenshot`, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({}),
-        signal: AbortSignal.timeout(10000)
-      });
+    expect(statusResponse.status).toBe(200);
+    await expect(statusResponse.json()).resolves.toEqual(
+      expect.objectContaining({ status: 'inactive' })
+    );
 
-      expect(response.status).toBeGreaterThanOrEqual(400);
-      await expect(response.json()).resolves.toEqual(
-        expect.objectContaining({ error: expect.anything() })
-      );
-    } catch (error) {
-      if (error instanceof Error && error.name === 'TimeoutError') {
-        await annotate(
-          `Known flakey test — desktop stop crashed container: ${error.message}`,
-          'flake'
-        );
-        return;
-      }
-      throw error;
-    }
+    // Assert that attempting to make a request to a stopped instance fails.
+    const response = await fetch(`${workerUrl}/api/desktop/screenshot`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({}),
+      signal: AbortSignal.timeout(10000)
+    });
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({ error: expect.anything() })
+    );
   }, 15000);
 });

--- a/tests/e2e/test-worker/wrangler.template.jsonc
+++ b/tests/e2e/test-worker/wrangler.template.jsonc
@@ -11,7 +11,11 @@
     "BACKUP_BUCKET_NAME": "sandbox-e2e-test"
   },
   "observability": {
-    "enabled": true
+    "enabled": true,
+    "traces": {
+      "enabled": true,
+      "head_sampling_rate": 1
+    }
   },
 
   "containers": [


### PR DESCRIPTION
This started as a pass over the desktop e2e suite to make it reliable and ended up touching a bunch of stuff covering the container-side desktop stack the tests exercise: the shutdown path, the worker process model, the IPC protocol between the service and its FFI worker, and the bun server's resilience to rogue failures bubbling up from any of them.

## E2E test refactor

Every fetch in the suite now carries an abort signal timeout so a container that stops responding fails the individual test rather than wedging the whole run. JSON body assertions use `.resolves` instead of awaiting and re-asserting, unused type aliases are gone, and the stop/error cases have been consolidated into a single sequential test — they were testing overlapping state transitions and running them as siblings produced order-dependent failures. Traces are enabled in the e2e test worker so future flakes come with a trail.

## Desktop stop determinism

The manager now spawns each managed process via `node:child_process` with `detached: true`, which makes every child its own process group leader. On stop, all groups receive SIGTERM simultaneously and a single eight-second deadline covers the entire teardown; survivors are SIGKILL'd once it expires. This replaces the old sequential `killProcess` loop and the per-process `PROCESS_KILL_TIMEOUT_MS` constant, and bounds the worst-case stop time to a predictable number.

Two follow-ups hardened the shutdown path further. The manager's shutdown now uses `Promise.allSettled` so a single failing teardown step doesn't prevent the follow-up hard shutdown from triggering. Concurrent `stop()` calls coalesce onto the same promise to avoid double-teardown races, and `stopping` is treated the same as `inactive` when gating operations so nothing slips through during the transition. A separate fix ensures the desktop has fully stopped before a new worker is spawned after a stop, closing a window where the worker could come up against half-dead X11 processes.

## Worker crash isolation

The desktop worker now runs in a dedicated child process via `Bun.spawn` instead of a Worker thread. A Worker thread shares the bun HTTP server's address space, so a segfault in the robotgo or X11 FFI layer takes everything down with it — which is exactly what was happening when X11 died while an FFI call was in flight. A child process means the kernel cleans up the crash and the parent just sees the subprocess exit.

Process isolation also made it safe to flip the stop ordering: the worker is now terminated before X11 processes die, where previously the service killed X11 first "so any in-flight FFI call fails fast." That prior ordering was a workaround for the in-process failure mode; with the worker in its own process, terminating it first is both safer and less racy. Worker termination is wrapped in a two-second SIGTERM deadline that escalates to SIGKILL, and every `sendToWorker` call carries its own ten-second timeout so no single operation can block callers indefinitely.

## Bun server resilience

Lastly, we no longer hard crash on uncaught promises. Instead we log an error. Ideally we should have Sentry or some form of telemetry here to catch this (at least in our integration tests).
