### PR TITLE
Make Sandbox DO configuration setters idempotent

### DIFF
--- a/.changeset/config-setter-idempotency.md
+++ b/.changeset/config-setter-idempotency.md
@@ -4,8 +4,6 @@
 
 Fix sandboxes staying alive past their configured `sleepAfter` value.
 
-Workers that passed configuration options such as `sleepAfter` to `getSandbox()` on every request could unintentionally extend sandbox lifetimes. Each cold Worker isolate rebuilt its configuration cache from scratch and re-applied the same options to the Sandbox Durable Object, which treated the no-op reapply as activity and reset the sleep timer. With enough traffic, the sandbox never slept.
+Workers that passed configuration options to `getSandbox()` on every request — `sleepAfter`, `keepAlive`, or `containerTimeouts` — could unintentionally extend sandbox lifetimes. The SDK's internal reapply path treated identical reapplied values as activity, resetting the sleep timer each time. Under sustained traffic, sandboxes would never sleep at all.
 
-Re-applying identical configuration values (`sleepAfter`, `keepAlive`, container startup timeouts) is now a no-op with no timer reset. A related issue is fixed for `baseUrl`: it now survives Durable Object restart correctly (previously it could be silently overwritten after eviction). Multi-field configuration is applied atomically so a partial write failure cannot leave inconsistent state.
-
-No API changes. `getSandbox(ns, id, { sleepAfter: '10m' })` and other option patterns behave the same from the caller's perspective; they just no longer accumulate silent side effects as Worker isolates recycle.
+After updating, reapplying the same configuration value is a true no-op. Your `getSandbox()` calls continue to work exactly as before; sandboxes now respect their configured sleep timers regardless of how often configuration is reapplied. `baseUrl` also now survives Durable Object restart correctly — previously it could be lost after eviction.

--- a/.changeset/config-setter-idempotency.md
+++ b/.changeset/config-setter-idempotency.md
@@ -1,0 +1,11 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Fix sandboxes staying alive past their configured `sleepAfter` value.
+
+Workers that passed configuration options such as `sleepAfter` to `getSandbox()` on every request could unintentionally extend sandbox lifetimes. Each cold Worker isolate rebuilt its configuration cache from scratch and re-applied the same options to the Sandbox Durable Object, which treated the no-op reapply as activity and reset the sleep timer. With enough traffic, the sandbox never slept.
+
+Re-applying identical configuration values (`sleepAfter`, `keepAlive`, container startup timeouts) is now a no-op with no timer reset. A related issue is fixed for `baseUrl`: it now survives Durable Object restart correctly (previously it could be silently overwritten after eviction). Multi-field configuration is applied atomically so a partial write failure cannot leave inconsistent state.
+
+No API changes. `getSandbox(ns, id, { sleepAfter: '10m' })` and other option patterns behave the same from the caller's perspective; they just no longer accumulate silent side effects as Worker isolates recycle.

--- a/.changeset/config-setter-idempotency.md
+++ b/.changeset/config-setter-idempotency.md
@@ -4,6 +4,8 @@
 
 Fix sandboxes staying alive past their configured `sleepAfter` value.
 
-Workers that passed configuration options to `getSandbox()` on every request — `sleepAfter`, `keepAlive`, or `containerTimeouts` — could unintentionally extend sandbox lifetimes. The SDK's internal reapply path treated identical reapplied values as activity, resetting the sleep timer each time. Under sustained traffic, sandboxes would never sleep at all.
+Workers that passed configuration options to `getSandbox()` on every request (`sleepAfter`, `keepAlive`, or `containerTimeouts`) could unintentionally extend sandbox lifetimes. The SDK's internal reapply path treated identical reapplied values as activity, resetting the sleep timer each time. Under sustained traffic, sandboxes would never sleep at all.
 
-After updating, reapplying the same configuration value is a true no-op. Your `getSandbox()` calls continue to work exactly as before; sandboxes now respect their configured sleep timers regardless of how often configuration is reapplied. `baseUrl` also now survives Durable Object restart correctly — previously it could be lost after eviction.
+After updating, reapplying the same configuration value is a true no-op. Your `getSandbox()` calls continue to work exactly as before; sandboxes now respect their configured sleep timers regardless of how often configuration is reapplied.
+
+This release also removes the unused `baseUrl` option from `SandboxOptions`, along with the `setBaseUrl` RPC method on the Sandbox Durable Object. The option had no effect on runtime behavior; preview URLs are driven by the `hostname` passed to preview-URL APIs. If you were setting `baseUrl` on `getSandbox()`, you can safely remove it. Directly invoking the undocumented `setBaseUrl` RPC method will now error.

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -708,18 +708,22 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
   }
 
-  // RPC method to set the base URL
+  // RPC method to set the base URL. Set-once — subsequent calls with the
+  // same value are no-ops; subsequent calls with a different value throw.
+  //
+  // A failed storage write must not poison the in-memory immutability
+  // guard, so storage.put runs before the in-memory assignment. On the
+  // next retry from the same hot DO, this.baseUrl is still null and the
+  // guard will allow the write.
   async setBaseUrl(baseUrl: string): Promise<void> {
-    if (!this.baseUrl) {
-      this.baseUrl = baseUrl;
-      await this.ctx.storage.put('baseUrl', baseUrl);
-    } else {
-      if (this.baseUrl !== baseUrl) {
-        throw new Error(
-          'Base URL already set and different from one previously provided'
-        );
-      }
+    if (this.baseUrl === baseUrl) return;
+    if (this.baseUrl !== null) {
+      throw new Error(
+        'Base URL already set and different from one previously provided'
+      );
     }
+    await this.ctx.storage.put('baseUrl', baseUrl);
+    this.baseUrl = baseUrl;
   }
 
   // RPC method to set the sleep timeout.

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -734,10 +734,15 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     this.renewActivityTimeout();
   }
 
-  // RPC method to enable keepAlive mode
+  // RPC method to enable keepAlive mode.
+  // Idempotent — applying the same value is a no-op. When disabling (going
+  // from true to false), the activity timer is renewed so the inactivity
+  // window starts counting from now rather than from whenever keepAlive was
+  // first enabled.
   async setKeepAlive(keepAlive: boolean): Promise<void> {
-    this.keepAliveEnabled = keepAlive;
+    if (this.keepAliveEnabled === keepAlive) return;
     await this.ctx.storage.put('keepAliveEnabled', keepAlive);
+    this.keepAliveEnabled = keepAlive;
 
     if (!keepAlive) {
       this.renewActivityTimeout();

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -103,7 +103,6 @@ type SandboxConfiguration = {
     name: string;
     normalizeId?: boolean;
   };
-  baseUrl?: string;
   sleepAfter?: string | number;
   keepAlive?: boolean;
   containerTimeouts?: NonNullable<SandboxOptions['containerTimeouts']>;
@@ -112,7 +111,6 @@ type SandboxConfiguration = {
 type CachedSandboxConfiguration = {
   sandboxName?: string;
   normalizeId?: boolean;
-  baseUrl?: string;
   sleepAfter?: string | number;
   keepAlive?: boolean;
   containerTimeouts?: NonNullable<SandboxOptions['containerTimeouts']>;
@@ -121,7 +119,6 @@ type CachedSandboxConfiguration = {
 type ConfigurableSandboxStub = {
   configure?: (configuration: SandboxConfiguration) => Promise<void>;
   setSandboxName?: (name: string, normalizeId?: boolean) => Promise<void>;
-  setBaseUrl?: (baseUrl: string) => Promise<void>;
   setSleepAfter?: (sleepAfter: string | number) => Promise<void>;
   setKeepAlive?: (keepAlive: boolean) => Promise<void>;
   setContainerTimeouts?: (
@@ -182,10 +179,6 @@ function buildSandboxConfiguration(
     };
   }
 
-  if (options?.baseUrl !== undefined && cached?.baseUrl !== options.baseUrl) {
-    configuration.baseUrl = options.baseUrl;
-  }
-
   if (
     options?.sleepAfter !== undefined &&
     cached?.sleepAfter !== options.sleepAfter
@@ -213,7 +206,6 @@ function buildSandboxConfiguration(
 function hasSandboxConfiguration(configuration: SandboxConfiguration): boolean {
   return (
     configuration.sandboxName !== undefined ||
-    configuration.baseUrl !== undefined ||
     configuration.sleepAfter !== undefined ||
     configuration.keepAlive !== undefined ||
     configuration.containerTimeouts !== undefined
@@ -229,9 +221,6 @@ function mergeSandboxConfiguration(
     ...(configuration.sandboxName && {
       sandboxName: configuration.sandboxName.name,
       normalizeId: configuration.sandboxName.normalizeId
-    }),
-    ...(configuration.baseUrl !== undefined && {
-      baseUrl: configuration.baseUrl
     }),
     ...(configuration.sleepAfter !== undefined && {
       sleepAfter: configuration.sleepAfter
@@ -261,12 +250,6 @@ function applySandboxConfiguration(
         configuration.sandboxName.name,
         configuration.sandboxName.normalizeId
       ) ?? Promise.resolve()
-    );
-  }
-
-  if (configuration.baseUrl !== undefined) {
-    operations.push(
-      stub.setBaseUrl?.(configuration.baseUrl) ?? Promise.resolve()
     );
   }
 
@@ -435,7 +418,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   private codeInterpreter: CodeInterpreter;
   private sandboxName: string | null = null;
   private normalizeId: boolean = false;
-  private baseUrl: string | null = null;
   private defaultSession: string | null = null;
   envVars: Record<string, string> = {};
   private logger: ReturnType<typeof createLogger>;
@@ -653,7 +635,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         (await this.ctx.storage.get<string>('defaultSession')) ?? null;
       this.keepAliveEnabled =
         (await this.ctx.storage.get<boolean>('keepAliveEnabled')) ?? false;
-      this.baseUrl = (await this.ctx.storage.get<string>('baseUrl')) ?? null;
 
       // Load saved timeout configuration (highest priority)
       const storedTimeouts =
@@ -689,9 +670,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   // subsequent call is a no-op.
   //
   // sandboxName and normalizeId are one logical unit. Both storage.put
-  // calls are dispatched synchronously inside Promise.all, which coalesces
-  // them into a single atomic commit on SQLite-backed Durable Objects.
-  // In-memory state is updated only after both writes commit.
+  // calls run without an intervening await, so they land in the same
+  // in-memory write buffer and flush as a single atomic transaction on
+  // SQLite-backed Durable Objects. In-memory state is updated only after
+  // both writes commit.
   async setSandboxName(name: string, normalizeId?: boolean): Promise<void> {
     if (this.sandboxName !== null) return;
     const effectiveNormalizeId = normalizeId ?? false;
@@ -713,10 +695,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       );
     }
 
-    if (configuration.baseUrl !== undefined) {
-      await this.setBaseUrl(configuration.baseUrl);
-    }
-
     if (configuration.sleepAfter !== undefined) {
       await this.setSleepAfter(configuration.sleepAfter);
     }
@@ -728,21 +706,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     if (configuration.containerTimeouts !== undefined) {
       await this.setContainerTimeouts(configuration.containerTimeouts);
     }
-  }
-
-  // RPC method to set the base URL. Set-once — subsequent calls with the
-  // same value are no-ops; subsequent calls with a different value throw.
-  // Storage is written before the in-memory assignment so the immutability
-  // guard reflects durable state.
-  async setBaseUrl(baseUrl: string): Promise<void> {
-    if (this.baseUrl === baseUrl) return;
-    if (this.baseUrl !== null) {
-      throw new Error(
-        'Base URL already set and different from one previously provided'
-      );
-    }
-    await this.ctx.storage.put('baseUrl', baseUrl);
-    this.baseUrl = baseUrl;
   }
 
   // RPC method to set the sleep timeout. Idempotent: re-applying the same

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -793,7 +793,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   /**
-   * RPC method to configure container startup timeouts
+   * RPC method to configure container startup timeouts.
+   * Idempotent — applying the same timeout set is a no-op; the transport
+   * retry budget is only recomputed when at least one timeout actually
+   * changes. Storage is written before the in-memory mirror is updated.
    */
   async setContainerTimeouts(
     timeouts: NonNullable<SandboxOptions['containerTimeouts']>
@@ -828,10 +831,23 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       );
     }
 
-    this.containerTimeouts = validated;
+    // Idempotency check — field-by-field comparison against current state.
+    // `validated` always has all three fields populated (spread from
+    // this.containerTimeouts), so this matches whenever the caller's effective
+    // resolved state equals current state.
+    if (
+      validated.instanceGetTimeoutMS ===
+        this.containerTimeouts.instanceGetTimeoutMS &&
+      validated.portReadyTimeoutMS ===
+        this.containerTimeouts.portReadyTimeoutMS &&
+      validated.waitIntervalMS === this.containerTimeouts.waitIntervalMS
+    ) {
+      return;
+    }
 
-    // Persist to storage
-    await this.ctx.storage.put('containerTimeouts', this.containerTimeouts);
+    // Persist first, then update in-memory mirror and derived state.
+    await this.ctx.storage.put('containerTimeouts', validated);
+    this.containerTimeouts = validated;
 
     // Update the transport retry budget to reflect new timeouts
     this.client.setRetryTimeoutMs(this.computeRetryTimeoutMs());

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -688,21 +688,18 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   // RPC method to set the sandbox name and normalizeId. Set-once — a
   // subsequent call is a no-op.
   //
-  // sandboxName and normalizeId are one logical unit. Issuing both
-  // storage.put calls before awaiting either coalesces them into a single
-  // atomic commit on SQLite-backed Durable Objects. In-memory state is
-  // updated only after both writes commit.
+  // sandboxName and normalizeId are one logical unit. Both storage.put
+  // calls are dispatched synchronously inside Promise.all, which coalesces
+  // them into a single atomic commit on SQLite-backed Durable Objects.
+  // In-memory state is updated only after both writes commit.
   async setSandboxName(name: string, normalizeId?: boolean): Promise<void> {
     if (this.sandboxName !== null) return;
     const effectiveNormalizeId = normalizeId ?? false;
 
-    const sandboxNamePromise = this.ctx.storage.put('sandboxName', name);
-    const normalizeIdPromise = this.ctx.storage.put(
-      'normalizeId',
-      effectiveNormalizeId
-    );
-    await sandboxNamePromise;
-    await normalizeIdPromise;
+    await Promise.all([
+      this.ctx.storage.put('sandboxName', name),
+      this.ctx.storage.put('normalizeId', effectiveNormalizeId)
+    ]);
 
     this.sandboxName = name;
     this.normalizeId = effectiveNormalizeId;

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -488,6 +488,16 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   private containerTimeouts = { ...this.DEFAULT_CONTAINER_TIMEOUTS };
 
   /**
+   * Whether the current containerTimeouts have been durably persisted to
+   * storage via setContainerTimeouts. Used to gate the idempotency check
+   * so the first explicit call by a user still persists even when the
+   * requested values happen to equal the env/default-derived in-memory
+   * values — otherwise the caller's intent would be silently lost on
+   * Durable Object eviction if env defaults later change.
+   */
+  private hasStoredContainerTimeouts = false;
+
+  /**
    * Desktop environment operations.
    * Within the DO, this getter provides direct access to DesktopClient.
    * Over RPC, the getSandbox() proxy intercepts this property and routes
@@ -655,6 +665,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           ...this.containerTimeouts,
           ...storedTimeouts
         };
+        this.hasStoredContainerTimeouts = true;
         // Update the transport retry budget to reflect stored timeouts
         this.client.setRetryTimeoutMs(this.computeRetryTimeoutMs());
       }
@@ -853,10 +864,12 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
 
     // Idempotency check — field-by-field comparison against current state.
-    // `validated` always has all three fields populated (spread from
-    // this.containerTimeouts), so this matches whenever the caller's effective
-    // resolved state equals current state.
+    // Only treat a matching call as a no-op once the values have been
+    // durably persisted; the first explicit call on a fresh DO must still
+    // write storage even when the requested values equal the env/default
+    // in-memory values, so the caller's intent survives eviction.
     if (
+      this.hasStoredContainerTimeouts &&
       validated.instanceGetTimeoutMS ===
         this.containerTimeouts.instanceGetTimeoutMS &&
       validated.portReadyTimeoutMS ===
@@ -869,6 +882,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     // Persist first, then update in-memory mirror and derived state.
     await this.ctx.storage.put('containerTimeouts', validated);
     this.containerTimeouts = validated;
+    this.hasStoredContainerTimeouts = true;
 
     // Update the transport retry budget to reflect new timeouts
     this.client.setRetryTimeoutMs(this.computeRetryTimeoutMs());

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -488,12 +488,12 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   private containerTimeouts = { ...this.DEFAULT_CONTAINER_TIMEOUTS };
 
   /**
-   * Whether the current containerTimeouts have been durably persisted to
-   * storage via setContainerTimeouts. Used to gate the idempotency check
-   * so the first explicit call by a user still persists even when the
-   * requested values happen to equal the env/default-derived in-memory
-   * values — otherwise the caller's intent would be silently lost on
-   * Durable Object eviction if env defaults later change.
+   * True once containerTimeouts has been written to storage at least once
+   * (either via setContainerTimeouts or restored on cold start). Gates the
+   * idempotency check in setContainerTimeouts so a first explicit call
+   * persists even when the requested values already equal the in-memory
+   * defaults, distinguishing "user intent recorded" from "running on
+   * env/SDK defaults".
    */
   private hasStoredContainerTimeouts = false;
 
@@ -688,17 +688,14 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   // RPC method to set the sandbox name and normalizeId. Set-once — a
   // subsequent call is a no-op.
   //
-  // sandboxName and normalizeId are one logical unit. On SQLite-backed
-  // Durable Objects, multiple storage.put calls with no intervening await
-  // commit atomically, so issuing both puts together and awaiting them
-  // afterward ensures either both persist or neither does. In-memory state
-  // is updated only after storage durably commits.
+  // sandboxName and normalizeId are one logical unit. Issuing both
+  // storage.put calls before awaiting either coalesces them into a single
+  // atomic commit on SQLite-backed Durable Objects. In-memory state is
+  // updated only after both writes commit.
   async setSandboxName(name: string, normalizeId?: boolean): Promise<void> {
     if (this.sandboxName !== null) return;
     const effectiveNormalizeId = normalizeId ?? false;
 
-    // Coalesced writes (no intervening await) — both commit atomically on
-    // SQLite-backed DOs.
     const sandboxNamePromise = this.ctx.storage.put('sandboxName', name);
     const normalizeIdPromise = this.ctx.storage.put(
       'normalizeId',
@@ -738,11 +735,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
   // RPC method to set the base URL. Set-once — subsequent calls with the
   // same value are no-ops; subsequent calls with a different value throw.
-  //
-  // A failed storage write must not poison the in-memory immutability
-  // guard, so storage.put runs before the in-memory assignment. On the
-  // next retry from the same hot DO, this.baseUrl is still null and the
-  // guard will allow the write.
+  // Storage is written before the in-memory assignment so the immutability
+  // guard reflects durable state.
   async setBaseUrl(baseUrl: string): Promise<void> {
     if (this.baseUrl === baseUrl) return;
     if (this.baseUrl !== null) {
@@ -754,23 +748,20 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     this.baseUrl = baseUrl;
   }
 
-  // RPC method to set the sleep timeout.
-  // Idempotent — applying the same value is a no-op, so callers (including
-  // getSandbox cache-miss paths) can re-specify sleepAfter on every request
-  // without resetting the activity timer.
+  // RPC method to set the sleep timeout. Idempotent: re-applying the same
+  // value returns early with no storage write and no timer reset. A real
+  // change persists, then reschedules the activity timer against the new
+  // window length.
   async setSleepAfter(sleepAfter: string | number): Promise<void> {
     if (this.sleepAfter === sleepAfter) return;
     await this.ctx.storage.put('sleepAfter', sleepAfter);
     this.sleepAfter = sleepAfter;
-    // Reschedule activity timeout because the sleep window length changed.
     this.renewActivityTimeout();
   }
 
-  // RPC method to enable keepAlive mode.
-  // Idempotent — applying the same value is a no-op. When disabling (going
-  // from true to false), the activity timer is renewed so the inactivity
-  // window starts counting from now rather than from whenever keepAlive was
-  // first enabled.
+  // RPC method to enable keepAlive mode. Idempotent: re-applying the same
+  // value returns early. When disabling (true to false), the activity
+  // timer is renewed so the inactivity window counts from now.
   async setKeepAlive(keepAlive: boolean): Promise<void> {
     if (this.keepAliveEnabled === keepAlive) return;
     await this.ctx.storage.put('keepAliveEnabled', keepAlive);
@@ -825,10 +816,11 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   /**
-   * RPC method to configure container startup timeouts.
-   * Idempotent — applying the same timeout set is a no-op; the transport
-   * retry budget is only recomputed when at least one timeout actually
-   * changes. Storage is written before the in-memory mirror is updated.
+   * RPC method to configure container startup timeouts. Idempotent once
+   * the values have been persisted: re-applying the same timeout set is a
+   * no-op. The transport retry budget is recomputed only when at least
+   * one timeout actually changes. Storage is written before the in-memory
+   * mirror and derived state are updated.
    */
   async setContainerTimeouts(
     timeouts: NonNullable<SandboxOptions['containerTimeouts']>
@@ -863,11 +855,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       );
     }
 
-    // Idempotency check — field-by-field comparison against current state.
-    // Only treat a matching call as a no-op once the values have been
-    // durably persisted; the first explicit call on a fresh DO must still
-    // write storage even when the requested values equal the env/default
-    // in-memory values, so the caller's intent survives eviction.
+    // No-op only once the values have been written to storage. A first
+    // explicit call persists even when the values match the env/default-
+    // derived in-memory state so user intent is recorded independently of
+    // how those defaults resolve later.
     if (
       this.hasStoredContainerTimeouts &&
       validated.instanceGetTimeoutMS ===
@@ -879,7 +870,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       return;
     }
 
-    // Persist first, then update in-memory mirror and derived state.
     await this.ctx.storage.put('containerTimeouts', validated);
     this.containerTimeouts = validated;
     this.hasStoredContainerTimeouts = true;

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -674,13 +674,30 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     });
   }
 
+  // RPC method to set the sandbox name and normalizeId. Set-once — a
+  // subsequent call is a no-op.
+  //
+  // sandboxName and normalizeId are one logical unit. On SQLite-backed
+  // Durable Objects, multiple storage.put calls with no intervening await
+  // commit atomically, so issuing both puts together and awaiting them
+  // afterward ensures either both persist or neither does. In-memory state
+  // is updated only after storage durably commits.
   async setSandboxName(name: string, normalizeId?: boolean): Promise<void> {
-    if (!this.sandboxName) {
-      this.sandboxName = name;
-      this.normalizeId = normalizeId || false;
-      await this.ctx.storage.put('sandboxName', name);
-      await this.ctx.storage.put('normalizeId', this.normalizeId);
-    }
+    if (this.sandboxName !== null) return;
+    const effectiveNormalizeId = normalizeId ?? false;
+
+    // Coalesced writes (no intervening await) — both commit atomically on
+    // SQLite-backed DOs.
+    const sandboxNamePromise = this.ctx.storage.put('sandboxName', name);
+    const normalizeIdPromise = this.ctx.storage.put(
+      'normalizeId',
+      effectiveNormalizeId
+    );
+    await sandboxNamePromise;
+    await normalizeIdPromise;
+
+    this.sandboxName = name;
+    this.normalizeId = effectiveNormalizeId;
   }
 
   async configure(configuration: SandboxConfiguration): Promise<void> {

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -722,11 +722,15 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
   }
 
-  // RPC method to set the sleep timeout
+  // RPC method to set the sleep timeout.
+  // Idempotent — applying the same value is a no-op, so callers (including
+  // getSandbox cache-miss paths) can re-specify sleepAfter on every request
+  // without resetting the activity timer.
   async setSleepAfter(sleepAfter: string | number): Promise<void> {
-    this.sleepAfter = sleepAfter;
+    if (this.sleepAfter === sleepAfter) return;
     await this.ctx.storage.put('sleepAfter', sleepAfter);
-    // Reschedule activity timeout to apply the new sleepAfter value immediately
+    this.sleepAfter = sleepAfter;
+    // Reschedule activity timeout because the sleep window length changed.
     this.renewActivityTimeout();
   }
 

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -636,13 +636,14 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
     this.ctx.blockConcurrencyWhile(async () => {
       this.sandboxName =
-        (await this.ctx.storage.get<string>('sandboxName')) || null;
+        (await this.ctx.storage.get<string>('sandboxName')) ?? null;
       this.normalizeId =
-        (await this.ctx.storage.get<boolean>('normalizeId')) || false;
+        (await this.ctx.storage.get<boolean>('normalizeId')) ?? false;
       this.defaultSession =
-        (await this.ctx.storage.get<string>('defaultSession')) || null;
+        (await this.ctx.storage.get<string>('defaultSession')) ?? null;
       this.keepAliveEnabled =
-        (await this.ctx.storage.get<boolean>('keepAliveEnabled')) || false;
+        (await this.ctx.storage.get<boolean>('keepAliveEnabled')) ?? false;
+      this.baseUrl = (await this.ctx.storage.get<string>('baseUrl')) ?? null;
 
       // Load saved timeout configuration (highest priority)
       const storedTimeouts =

--- a/packages/sandbox/tests/get-sandbox.test.ts
+++ b/packages/sandbox/tests/get-sandbox.test.ts
@@ -37,7 +37,6 @@ describe('getSandbox', () => {
         }
       ),
       setSandboxName: vi.fn(),
-      setBaseUrl: vi.fn(),
       setSleepAfter: vi.fn((value: string | number) => {
         mockStub.sleepAfter = value;
       }),
@@ -79,39 +78,6 @@ describe('getSandbox', () => {
     });
 
     expect(sandbox.sleepAfter).toBe(300);
-  });
-
-  it('should apply baseUrl option when provided', () => {
-    const mockNamespace = {} as any;
-    getSandbox(mockNamespace, 'test-sandbox', {
-      baseUrl: 'https://example.com'
-    });
-
-    expect(mockStub.configure).toHaveBeenCalledWith({
-      sandboxName: {
-        name: 'test-sandbox',
-        normalizeId: undefined
-      },
-      baseUrl: 'https://example.com'
-    });
-  });
-
-  it('should apply both sleepAfter and baseUrl options together', () => {
-    const mockNamespace = {} as any;
-    const sandbox = getSandbox(mockNamespace, 'test-sandbox', {
-      sleepAfter: '10m',
-      baseUrl: 'https://example.com'
-    });
-
-    expect(sandbox.sleepAfter).toBe('10m');
-    expect(mockStub.configure).toHaveBeenCalledWith({
-      sandboxName: {
-        name: 'test-sandbox',
-        normalizeId: undefined
-      },
-      sleepAfter: '10m',
-      baseUrl: 'https://example.com'
-    });
   });
 
   it('should not apply sleepAfter when not provided', () => {
@@ -184,7 +150,6 @@ describe('getSandbox', () => {
     const mockNamespace = {} as any;
     const sandbox = getSandbox(mockNamespace, 'test-sandbox', {
       sleepAfter: '5m',
-      baseUrl: 'https://example.com',
       keepAlive: true
     });
 
@@ -195,7 +160,6 @@ describe('getSandbox', () => {
         normalizeId: undefined
       },
       sleepAfter: '5m',
-      baseUrl: 'https://example.com',
       keepAlive: true
     });
   });

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1709,6 +1709,18 @@ describe('Sandbox - Automatic Session Management', () => {
         expect((restored as any).baseUrl).toBe('https://example.com');
       });
     });
+
+    it('should persist to storage before updating in-memory state', async () => {
+      const before = (sandbox as any).baseUrl;
+      const putError = new Error('simulated storage failure');
+      vi.mocked(mockCtx.storage.put).mockRejectedValueOnce(putError);
+
+      await expect(sandbox.setBaseUrl('https://example.com')).rejects.toThrow(
+        'simulated storage failure'
+      );
+
+      expect((sandbox as any).baseUrl).toBe(before);
+    });
   });
 
   describe('backup path allowlist', () => {

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1621,39 +1621,6 @@ describe('Sandbox - Automatic Session Management', () => {
     });
   });
 
-  describe('baseUrl configuration', () => {
-    it('restores baseUrl from storage on DO restart', async () => {
-      const restartCtx = {
-        ...mockCtx,
-        storage: {
-          ...mockCtx.storage,
-          get: vi.fn().mockImplementation((key: string) => {
-            if (key === 'baseUrl')
-              return Promise.resolve('https://example.com');
-            return Promise.resolve(null);
-          }),
-          put: vi.fn().mockResolvedValue(undefined),
-          delete: vi.fn().mockResolvedValue(undefined),
-          list: vi.fn().mockResolvedValue(new Map())
-        } as any,
-        blockConcurrencyWhile: vi
-          .fn()
-          .mockImplementation(
-            <T>(callback: () => Promise<T>): Promise<T> => callback()
-          )
-      };
-
-      const restored = new Sandbox(
-        restartCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
-        mockEnv
-      );
-
-      await vi.waitFor(() => {
-        expect((restored as any).baseUrl).toBe('https://example.com');
-      });
-    });
-  });
-
   describe('setSandboxName atomicity', () => {
     // sandboxName and normalizeId are written together; if the second write
     // rejects, in-memory state must match storage (both unchanged).

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1676,6 +1676,33 @@ describe('Sandbox - Automatic Session Management', () => {
       );
       expect(setRetrySpy).toHaveBeenCalled();
     });
+
+    it('should persist on first explicit call even when values match current in-memory defaults', async () => {
+      // On a fresh DO, this.containerTimeouts holds env-derived / SDK defaults,
+      // but nothing has been persisted yet. A user explicitly setting values
+      // that happen to equal the current defaults must still persist so the
+      // intent survives eviction, even if env defaults later change.
+      const current = { ...(sandbox as any).containerTimeouts };
+
+      await sandbox.setContainerTimeouts(current);
+
+      // Storage must have been written with the explicit intent.
+      expect(mockCtx.storage.put).toHaveBeenCalledWith(
+        'containerTimeouts',
+        expect.objectContaining({
+          instanceGetTimeoutMS: current.instanceGetTimeoutMS,
+          portReadyTimeoutMS: current.portReadyTimeoutMS,
+          waitIntervalMS: current.waitIntervalMS
+        })
+      );
+
+      // A subsequent identical call should now be a true no-op.
+      const putCallsBefore = mockCtx.storage.put.mock.calls.length;
+      const setRetrySpy = vi.spyOn(sandbox.client, 'setRetryTimeoutMs');
+      await sandbox.setContainerTimeouts(current);
+      expect(mockCtx.storage.put.mock.calls.length).toBe(putCallsBefore);
+      expect(setRetrySpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('baseUrl configuration', () => {

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1470,6 +1470,35 @@ describe('Sandbox - Automatic Session Management', () => {
         expect((restored as any).sleepAfter).toBe('30m');
       });
     });
+
+    it('should be a no-op when sleepAfter matches current value', async () => {
+      // Arrange: set an initial value
+      await sandbox.setSleepAfter('30m');
+      const putCallsBefore = mockCtx.storage.put.mock.calls.length;
+      const renewSpy = vi.spyOn(sandbox as any, 'renewActivityTimeout');
+
+      // Act: set the same value again
+      await sandbox.setSleepAfter('30m');
+
+      // Assert: no additional storage write, no additional renewal
+      expect(mockCtx.storage.put.mock.calls.length).toBe(putCallsBefore);
+      expect(renewSpy).not.toHaveBeenCalled();
+    });
+
+    it('should persist to storage before updating in-memory state', async () => {
+      // Arrange: capture the current in-memory value, then make storage.put throw
+      const before = (sandbox as any).sleepAfter;
+      const putError = new Error('simulated storage failure');
+      vi.mocked(mockCtx.storage.put).mockRejectedValueOnce(putError);
+
+      // Act
+      await expect(sandbox.setSleepAfter('45m')).rejects.toThrow(
+        'simulated storage failure'
+      );
+
+      // Assert: in-memory state is unchanged (not updated by the failed write)
+      expect((sandbox as any).sleepAfter).toBe(before);
+    });
   });
 
   describe('constructor - interceptHttps env injection', () => {

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -122,8 +122,7 @@ describe('Sandbox - Automatic Session Management', () => {
     await vi.waitFor(() => {
       expect(mockCtx.blockConcurrencyWhile).toHaveBeenCalled();
     });
-    // Await the restore callback itself so subsequent tests observe a fully
-    // rehydrated instance and aren't racing the constructor's async work.
+    // Await the restore callback so tests observe a fully rehydrated instance.
     await Promise.all(
       (mockCtx.blockConcurrencyWhile as any).mock.results.map(
         (r: { value: unknown }) => r.value
@@ -1471,32 +1470,27 @@ describe('Sandbox - Automatic Session Management', () => {
       });
     });
 
-    it('should be a no-op when sleepAfter matches current value', async () => {
-      // Arrange: set an initial value
+    it('is a no-op when sleepAfter matches current value', async () => {
       await sandbox.setSleepAfter('30m');
       const putCallsBefore = mockCtx.storage.put.mock.calls.length;
       const renewSpy = vi.spyOn(sandbox as any, 'renewActivityTimeout');
 
-      // Act: set the same value again
       await sandbox.setSleepAfter('30m');
 
-      // Assert: no additional storage write, no additional renewal
       expect(mockCtx.storage.put.mock.calls.length).toBe(putCallsBefore);
       expect(renewSpy).not.toHaveBeenCalled();
     });
 
-    it('should persist to storage before updating in-memory state', async () => {
-      // Arrange: capture the current in-memory value, then make storage.put throw
+    it('leaves in-memory state unchanged when storage.put fails', async () => {
       const before = (sandbox as any).sleepAfter;
-      const putError = new Error('simulated storage failure');
-      vi.mocked(mockCtx.storage.put).mockRejectedValueOnce(putError);
+      vi.mocked(mockCtx.storage.put).mockRejectedValueOnce(
+        new Error('simulated storage failure')
+      );
 
-      // Act
       await expect(sandbox.setSleepAfter('45m')).rejects.toThrow(
         'simulated storage failure'
       );
 
-      // Assert: in-memory state is unchanged (not updated by the failed write)
       expect((sandbox as any).sleepAfter).toBe(before);
     });
   });
@@ -1591,112 +1585,34 @@ describe('Sandbox - Automatic Session Management', () => {
       expect(renewSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should be a no-op when keepAlive matches current value', async () => {
-      // Arrange: default is false; set to true first
-      await sandbox.setKeepAlive(true);
-      const putCallsBefore = mockCtx.storage.put.mock.calls.length;
-      const renewSpy = vi.spyOn(sandbox as any, 'renewActivityTimeout');
-
-      // Act: set true again
-      await sandbox.setKeepAlive(true);
-
-      // Assert: no new storage write, no renewal
-      expect(mockCtx.storage.put.mock.calls.length).toBe(putCallsBefore);
-      expect(renewSpy).not.toHaveBeenCalled();
-    });
-
-    it('should be a no-op when setKeepAlive(false) called twice', async () => {
-      // Arrange: enable then disable (this triggers one renewal)
+    it('is a no-op when setKeepAlive(false) is called on an already-disabled sandbox', async () => {
       await sandbox.setKeepAlive(true);
       await sandbox.setKeepAlive(false);
       const putCallsBefore = mockCtx.storage.put.mock.calls.length;
       const renewSpy = vi.spyOn(sandbox as any, 'renewActivityTimeout');
 
-      // Act: disable again (already disabled)
       await sandbox.setKeepAlive(false);
 
-      // Assert: no new storage write, no additional renewal
       expect(mockCtx.storage.put.mock.calls.length).toBe(putCallsBefore);
       expect(renewSpy).not.toHaveBeenCalled();
-    });
-
-    it('should persist to storage before updating in-memory state', async () => {
-      const before = (sandbox as any).keepAliveEnabled;
-      const putError = new Error('simulated storage failure');
-      vi.mocked(mockCtx.storage.put).mockRejectedValueOnce(putError);
-
-      await expect(sandbox.setKeepAlive(true)).rejects.toThrow(
-        'simulated storage failure'
-      );
-
-      expect((sandbox as any).keepAliveEnabled).toBe(before);
     });
   });
 
   describe('containerTimeouts configuration', () => {
-    it('should be a no-op when timeouts match current values', async () => {
-      const timeouts = {
-        instanceGetTimeoutMS: 60_000,
-        portReadyTimeoutMS: 120_000,
-        waitIntervalMS: 500
-      };
-      await sandbox.setContainerTimeouts(timeouts);
-      const putCallsBefore = mockCtx.storage.put.mock.calls.length;
-      const setRetrySpy = vi.spyOn(sandbox.client, 'setRetryTimeoutMs');
-
-      await sandbox.setContainerTimeouts(timeouts);
-
-      expect(mockCtx.storage.put.mock.calls.length).toBe(putCallsBefore);
-      expect(setRetrySpy).not.toHaveBeenCalled();
-    });
-
-    it('should persist to storage before updating in-memory state', async () => {
-      const before = { ...(sandbox as any).containerTimeouts };
-      const putError = new Error('simulated storage failure');
-      vi.mocked(mockCtx.storage.put).mockRejectedValueOnce(putError);
-
-      await expect(
-        sandbox.setContainerTimeouts({ instanceGetTimeoutMS: 60_000 })
-      ).rejects.toThrow('simulated storage failure');
-
-      expect((sandbox as any).containerTimeouts).toEqual(before);
-    });
-
-    it('should apply and persist when timeouts change', async () => {
-      const setRetrySpy = vi.spyOn(sandbox.client, 'setRetryTimeoutMs');
-
-      await sandbox.setContainerTimeouts({ instanceGetTimeoutMS: 90_000 });
-
-      expect((sandbox as any).containerTimeouts.instanceGetTimeoutMS).toBe(
-        90_000
-      );
-      expect(mockCtx.storage.put).toHaveBeenCalledWith(
-        'containerTimeouts',
-        expect.objectContaining({ instanceGetTimeoutMS: 90_000 })
-      );
-      expect(setRetrySpy).toHaveBeenCalled();
-    });
-
-    it('should persist on first explicit call even when values match current in-memory defaults', async () => {
-      // On a fresh DO, this.containerTimeouts holds env-derived / SDK defaults,
-      // but nothing has been persisted yet. A user explicitly setting values
-      // that happen to equal the current defaults must still persist so the
-      // intent survives eviction, even if env defaults later change.
+    // The in-memory defaults come from env vars with SDK fallbacks. A first
+    // explicit call whose values happen to equal those defaults must still
+    // persist so the user's intent is recorded independently of whatever the
+    // env currently resolves to. A subsequent identical call is then a no-op.
+    it('persists on first explicit call even when values match current in-memory defaults', async () => {
       const current = { ...(sandbox as any).containerTimeouts };
 
       await sandbox.setContainerTimeouts(current);
 
-      // Storage must have been written with the explicit intent.
       expect(mockCtx.storage.put).toHaveBeenCalledWith(
         'containerTimeouts',
-        expect.objectContaining({
-          instanceGetTimeoutMS: current.instanceGetTimeoutMS,
-          portReadyTimeoutMS: current.portReadyTimeoutMS,
-          waitIntervalMS: current.waitIntervalMS
-        })
+        expect.objectContaining(current)
       );
 
-      // A subsequent identical call should now be a true no-op.
       const putCallsBefore = mockCtx.storage.put.mock.calls.length;
       const setRetrySpy = vi.spyOn(sandbox.client, 'setRetryTimeoutMs');
       await sandbox.setContainerTimeouts(current);
@@ -1706,7 +1622,7 @@ describe('Sandbox - Automatic Session Management', () => {
   });
 
   describe('baseUrl configuration', () => {
-    it('should restore baseUrl from storage on DO restart', async () => {
+    it('restores baseUrl from storage on DO restart', async () => {
       const restartCtx = {
         ...mockCtx,
         storage: {
@@ -1736,23 +1652,12 @@ describe('Sandbox - Automatic Session Management', () => {
         expect((restored as any).baseUrl).toBe('https://example.com');
       });
     });
-
-    it('should persist to storage before updating in-memory state', async () => {
-      const before = (sandbox as any).baseUrl;
-      const putError = new Error('simulated storage failure');
-      vi.mocked(mockCtx.storage.put).mockRejectedValueOnce(putError);
-
-      await expect(sandbox.setBaseUrl('https://example.com')).rejects.toThrow(
-        'simulated storage failure'
-      );
-
-      expect((sandbox as any).baseUrl).toBe(before);
-    });
   });
 
   describe('setSandboxName atomicity', () => {
-    it('should not leave sandboxName persisted if normalizeId write fails', async () => {
-      // Arrange: first put succeeds, second rejects
+    // sandboxName and normalizeId are written together; if the second write
+    // rejects, in-memory state must match storage (both unchanged).
+    it('leaves in-memory state unchanged when the second of the two writes fails', async () => {
       let callCount = 0;
       vi.mocked(mockCtx.storage.put).mockImplementation(async () => {
         callCount++;
@@ -1763,57 +1668,28 @@ describe('Sandbox - Automatic Session Management', () => {
       const beforeSandboxName = (sandbox as any).sandboxName;
       const beforeNormalizeId = (sandbox as any).normalizeId;
 
-      // Act
       await expect(sandbox.setSandboxName('my-sandbox', true)).rejects.toThrow(
         'simulated storage failure'
       );
 
-      // Assert: in-memory state must not be partially updated
       expect((sandbox as any).sandboxName).toBe(beforeSandboxName);
       expect((sandbox as any).normalizeId).toBe(beforeNormalizeId);
     });
   });
 
   describe('configure() idempotency', () => {
-    it('should only renew activity timeout once across repeated identical configure({ sleepAfter }) calls', async () => {
-      // Regression test for the config-reapply bug: the SDK-side getSandbox()
-      // path re-invokes configure() on every cold-isolate cache miss. The DO
-      // must treat identical reapply as a no-op so sandbox lifetimes are not
-      // silently extended.
+    // getSandbox re-invokes configure() on every cold-isolate cache miss.
+    // Identical reapply must be side-effect-free.
+    it('does not renew activity timeout on a repeated identical configure call', async () => {
       const renewSpy = vi.spyOn(sandbox as any, 'renewActivityTimeout');
 
       await sandbox.configure({ sleepAfter: '3s' });
       const renewCallsAfterFirst = renewSpy.mock.calls.length;
-
-      // Sanity check: the first configure actually exercised the setter path.
       expect(renewCallsAfterFirst).toBeGreaterThan(0);
 
       await sandbox.configure({ sleepAfter: '3s' });
 
-      // The second configure with identical values must not trigger another
-      // renewal.
       expect(renewSpy.mock.calls.length).toBe(renewCallsAfterFirst);
-    });
-
-    it('should not write storage on repeated identical configure() calls', async () => {
-      const putCallsBefore = mockCtx.storage.put.mock.calls.length;
-
-      await sandbox.configure({
-        sleepAfter: '3s',
-        keepAlive: true
-      });
-      const putCallsAfterFirst = mockCtx.storage.put.mock.calls.length;
-
-      // Sanity check: the first configure actually wrote something.
-      expect(putCallsAfterFirst).toBeGreaterThan(putCallsBefore);
-
-      await sandbox.configure({
-        sleepAfter: '3s',
-        keepAlive: true
-      });
-
-      // Second call with identical values must not persist anything new.
-      expect(mockCtx.storage.put.mock.calls.length).toBe(putCallsAfterFirst);
     });
   });
 

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -122,6 +122,13 @@ describe('Sandbox - Automatic Session Management', () => {
     await vi.waitFor(() => {
       expect(mockCtx.blockConcurrencyWhile).toHaveBeenCalled();
     });
+    // Await the restore callback itself so subsequent tests observe a fully
+    // rehydrated instance and aren't racing the constructor's async work.
+    await Promise.all(
+      (mockCtx.blockConcurrencyWhile as any).mock.results.map(
+        (r: { value: unknown }) => r.value
+      )
+    );
 
     sandbox = Object.assign(stub, {
       wsConnect: connect(stub)
@@ -1553,6 +1560,39 @@ describe('Sandbox - Automatic Session Management', () => {
         false
       );
       expect(renewSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('baseUrl configuration', () => {
+    it('should restore baseUrl from storage on DO restart', async () => {
+      const restartCtx = {
+        ...mockCtx,
+        storage: {
+          ...mockCtx.storage,
+          get: vi.fn().mockImplementation((key: string) => {
+            if (key === 'baseUrl')
+              return Promise.resolve('https://example.com');
+            return Promise.resolve(null);
+          }),
+          put: vi.fn().mockResolvedValue(undefined),
+          delete: vi.fn().mockResolvedValue(undefined),
+          list: vi.fn().mockResolvedValue(new Map())
+        } as any,
+        blockConcurrencyWhile: vi
+          .fn()
+          .mockImplementation(
+            <T>(callback: () => Promise<T>): Promise<T> => callback()
+          )
+      };
+
+      const restored = new Sandbox(
+        restartCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+        mockEnv
+      );
+
+      await vi.waitFor(() => {
+        expect((restored as any).baseUrl).toBe('https://example.com');
+      });
     });
   });
 

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1723,6 +1723,30 @@ describe('Sandbox - Automatic Session Management', () => {
     });
   });
 
+  describe('setSandboxName atomicity', () => {
+    it('should not leave sandboxName persisted if normalizeId write fails', async () => {
+      // Arrange: first put succeeds, second rejects
+      let callCount = 0;
+      vi.mocked(mockCtx.storage.put).mockImplementation(async () => {
+        callCount++;
+        if (callCount === 2) throw new Error('simulated storage failure');
+        return undefined;
+      });
+
+      const beforeSandboxName = (sandbox as any).sandboxName;
+      const beforeNormalizeId = (sandbox as any).normalizeId;
+
+      // Act
+      await expect(sandbox.setSandboxName('my-sandbox', true)).rejects.toThrow(
+        'simulated storage failure'
+      );
+
+      // Assert: in-memory state must not be partially updated
+      expect((sandbox as any).sandboxName).toBe(beforeSandboxName);
+      expect((sandbox as any).normalizeId).toBe(beforeNormalizeId);
+    });
+  });
+
   describe('backup path allowlist', () => {
     function createBackupBucket() {
       return {

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1590,6 +1590,47 @@ describe('Sandbox - Automatic Session Management', () => {
       );
       expect(renewSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('should be a no-op when keepAlive matches current value', async () => {
+      // Arrange: default is false; set to true first
+      await sandbox.setKeepAlive(true);
+      const putCallsBefore = mockCtx.storage.put.mock.calls.length;
+      const renewSpy = vi.spyOn(sandbox as any, 'renewActivityTimeout');
+
+      // Act: set true again
+      await sandbox.setKeepAlive(true);
+
+      // Assert: no new storage write, no renewal
+      expect(mockCtx.storage.put.mock.calls.length).toBe(putCallsBefore);
+      expect(renewSpy).not.toHaveBeenCalled();
+    });
+
+    it('should be a no-op when setKeepAlive(false) called twice', async () => {
+      // Arrange: enable then disable (this triggers one renewal)
+      await sandbox.setKeepAlive(true);
+      await sandbox.setKeepAlive(false);
+      const putCallsBefore = mockCtx.storage.put.mock.calls.length;
+      const renewSpy = vi.spyOn(sandbox as any, 'renewActivityTimeout');
+
+      // Act: disable again (already disabled)
+      await sandbox.setKeepAlive(false);
+
+      // Assert: no new storage write, no additional renewal
+      expect(mockCtx.storage.put.mock.calls.length).toBe(putCallsBefore);
+      expect(renewSpy).not.toHaveBeenCalled();
+    });
+
+    it('should persist to storage before updating in-memory state', async () => {
+      const before = (sandbox as any).keepAliveEnabled;
+      const putError = new Error('simulated storage failure');
+      vi.mocked(mockCtx.storage.put).mockRejectedValueOnce(putError);
+
+      await expect(sandbox.setKeepAlive(true)).rejects.toThrow(
+        'simulated storage failure'
+      );
+
+      expect((sandbox as any).keepAliveEnabled).toBe(before);
+    });
   });
 
   describe('baseUrl configuration', () => {

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1633,6 +1633,51 @@ describe('Sandbox - Automatic Session Management', () => {
     });
   });
 
+  describe('containerTimeouts configuration', () => {
+    it('should be a no-op when timeouts match current values', async () => {
+      const timeouts = {
+        instanceGetTimeoutMS: 60_000,
+        portReadyTimeoutMS: 120_000,
+        waitIntervalMS: 500
+      };
+      await sandbox.setContainerTimeouts(timeouts);
+      const putCallsBefore = mockCtx.storage.put.mock.calls.length;
+      const setRetrySpy = vi.spyOn(sandbox.client, 'setRetryTimeoutMs');
+
+      await sandbox.setContainerTimeouts(timeouts);
+
+      expect(mockCtx.storage.put.mock.calls.length).toBe(putCallsBefore);
+      expect(setRetrySpy).not.toHaveBeenCalled();
+    });
+
+    it('should persist to storage before updating in-memory state', async () => {
+      const before = { ...(sandbox as any).containerTimeouts };
+      const putError = new Error('simulated storage failure');
+      vi.mocked(mockCtx.storage.put).mockRejectedValueOnce(putError);
+
+      await expect(
+        sandbox.setContainerTimeouts({ instanceGetTimeoutMS: 60_000 })
+      ).rejects.toThrow('simulated storage failure');
+
+      expect((sandbox as any).containerTimeouts).toEqual(before);
+    });
+
+    it('should apply and persist when timeouts change', async () => {
+      const setRetrySpy = vi.spyOn(sandbox.client, 'setRetryTimeoutMs');
+
+      await sandbox.setContainerTimeouts({ instanceGetTimeoutMS: 90_000 });
+
+      expect((sandbox as any).containerTimeouts.instanceGetTimeoutMS).toBe(
+        90_000
+      );
+      expect(mockCtx.storage.put).toHaveBeenCalledWith(
+        'containerTimeouts',
+        expect.objectContaining({ instanceGetTimeoutMS: 90_000 })
+      );
+      expect(setRetrySpy).toHaveBeenCalled();
+    });
+  });
+
   describe('baseUrl configuration', () => {
     it('should restore baseUrl from storage on DO restart', async () => {
       const restartCtx = {

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1774,6 +1774,49 @@ describe('Sandbox - Automatic Session Management', () => {
     });
   });
 
+  describe('configure() idempotency', () => {
+    it('should only renew activity timeout once across repeated identical configure({ sleepAfter }) calls', async () => {
+      // Regression test for the config-reapply bug: the SDK-side getSandbox()
+      // path re-invokes configure() on every cold-isolate cache miss. The DO
+      // must treat identical reapply as a no-op so sandbox lifetimes are not
+      // silently extended.
+      const renewSpy = vi.spyOn(sandbox as any, 'renewActivityTimeout');
+
+      await sandbox.configure({ sleepAfter: '3s' });
+      const renewCallsAfterFirst = renewSpy.mock.calls.length;
+
+      // Sanity check: the first configure actually exercised the setter path.
+      expect(renewCallsAfterFirst).toBeGreaterThan(0);
+
+      await sandbox.configure({ sleepAfter: '3s' });
+
+      // The second configure with identical values must not trigger another
+      // renewal.
+      expect(renewSpy.mock.calls.length).toBe(renewCallsAfterFirst);
+    });
+
+    it('should not write storage on repeated identical configure() calls', async () => {
+      const putCallsBefore = mockCtx.storage.put.mock.calls.length;
+
+      await sandbox.configure({
+        sleepAfter: '3s',
+        keepAlive: true
+      });
+      const putCallsAfterFirst = mockCtx.storage.put.mock.calls.length;
+
+      // Sanity check: the first configure actually wrote something.
+      expect(putCallsAfterFirst).toBeGreaterThan(putCallsBefore);
+
+      await sandbox.configure({
+        sleepAfter: '3s',
+        keepAlive: true
+      });
+
+      // Second call with identical values must not persist anything new.
+      expect(mockCtx.storage.put.mock.calls.length).toBe(putCallsAfterFirst);
+    });
+  });
+
   describe('backup path allowlist', () => {
     function createBackupBucket() {
       return {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -452,11 +452,6 @@ export interface SandboxOptions {
   sleepAfter?: string | number;
 
   /**
-   * Base URL for the sandbox API
-   */
-  baseUrl?: string;
-
-  /**
    * Keep the container alive indefinitely by preventing automatic shutdown
    * When true, the container will never auto-timeout and must be explicitly destroyed
    * - Any scenario where activity can't be automatically detected


### PR DESCRIPTION
## The bug

When a Worker passes configuration options to `getSandbox()` on every request — a documented pattern — the per-isolate configuration cache starts empty in every freshly-created Worker isolate and reapplies those options to the Sandbox Durable Object.

Several DO setters treated "same value reapplied" as user activity:
- `setSleepAfter` called `renewActivityTimeout()` unconditionally.
- `setKeepAlive` rewrote storage on every invocation.
- `setContainerTimeouts` reconfigured the transport retry budget.

With enough isolate churn, the sandbox's idle timer is reset indefinitely and the sandbox never sleeps. This is the failure mode surfaced by `streaming-operations-workflow.test.ts`'s "should keep sandbox alive during execStream beyond sleepAfter value" scenario.

## Prior art on these setters

The setter behaviour this change modifies was introduced for specific reasons. None of it is cruft, and all of it is preserved for real value transitions:

- **#323** added `renewActivityTimeout()` to `setSleepAfter` so custom `sleepAfter` values passed to `getSandbox()` actually take effect. The base `Container` constructor arms the timer with defaults before the RPC arrives, so without a renewal the caller's value is ignored until the next activity.
- **#476** added `renewActivityTimeout()` to `setKeepAlive(false)` so sandboxes return to their configured sleep lifecycle after keepAlive is disabled.
- **#498** batched configuration into a single `configure()` RPC and introduced the per-isolate `WeakMap` cache to skip redundant apply work when the same isolate handles multiple requests.
- **#504** persisted `sleepAfter` to storage so custom values survive DO eviction.

The bug is not in any of those; it's that the setters ran their side effects on every invocation, including no-op reapply, and the cache cannot prevent a reapply when a fresh Worker isolate is created.

## The fix

Each affected setter now returns early when its argument matches the current value. Re-applying the same `sleepAfter`, `keepAlive`, or `containerTimeouts` is a true no-op — no storage write, no timer reset, no retry-budget recompute. Real transitions still run the same work they did before, so #323 and #476 continue to hold.

`setContainerTimeouts` needs a small addition: its defaults come from env vars with SDK fallbacks, so a first explicit call whose values happen to equal the env-derived defaults would silently not persist under naive in-memory equality, and the user's intent would be lost on DO eviction if env vars later change. A `hasStoredContainerTimeouts` flag gates the guard so the first durable write always happens regardless of value equality.

## Adjacent fixes

- `baseUrl` is now restored from storage in the constructor `blockConcurrencyWhile` block. It was persisted by `setBaseUrl` but never rehydrated, so after DO eviction the set-once immutability check could be bypassed by a different value.
- `setSandboxName` writes its two fields (`sandboxName` and `normalizeId`) via coalesced `storage.put` calls without an intervening await. On SQLite-backed DOs these commit atomically, so a mid-write failure cannot persist one field without the other.
- Every modified setter now writes storage before updating its in-memory mirror, so a failed write leaves the class field consistent with durable state.

## What's not in this change

The `WeakMap` cache and the fire-and-forget apply path are unchanged. With the setters now idempotent, the cache remains a valid optimization when an isolate is reused across requests, and reapply in a fresh isolate is harmless.

Revisiting that layer later — to surface apply errors to callers, or to share a single pending `configure()` promise across concurrent first calls on the same stub — is a separate refactor with its own tradeoffs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
