### PR TITLE
Hoist performance workflow secret into env

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -226,7 +226,7 @@ jobs:
       - name: Call notifier webhook
         if: always() && env.PERF_NOTIFIER_WEBHOOK_URL != ''
         env:
-          WEBHOOK_URL: ${{ secrets.PERF_NOTIFIER_WEBHOOK_URL }}
+          WEBHOOK_URL: ${{ env.PERF_NOTIFIER_WEBHOOK_URL }}
           WEBHOOK_SECRET: ${{ secrets.PERF_NOTIFIER_API_SECRET }}
           CF_ACCESS_CLIENT_ID: ${{ secrets.PERF_CF_ACCESS_CLIENT_ID }}
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.PERF_CF_ACCESS_CLIENT_SECRET }}

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -148,6 +148,8 @@ jobs:
     needs: setup
     runs-on: ubuntu-24.04-8core
     timeout-minutes: 60
+    env:
+      PERF_NOTIFIER_WEBHOOK_URL: ${{ secrets.PERF_NOTIFIER_WEBHOOK_URL }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -222,7 +224,7 @@ jobs:
         run: npx tsx tests/perf/scripts/ingest-to-d1.ts perf-results/latest.json
 
       - name: Call notifier webhook
-        if: always() && secrets.PERF_NOTIFIER_WEBHOOK_URL != ''
+        if: always() && env.PERF_NOTIFIER_WEBHOOK_URL != ''
         env:
           WEBHOOK_URL: ${{ secrets.PERF_NOTIFIER_WEBHOOK_URL }}
           WEBHOOK_SECRET: ${{ secrets.PERF_NOTIFIER_API_SECRET }}


### PR DESCRIPTION
# Summary

Change the `performance.yml` notifier webhook call to validate through env, instead of secrets as GitHub runs stricter workflow validation on `workflow_dispatch` against the default branch (main). Branch-level dispatches get looser validation so branch testing succeeded.