### PR TITLE
Use ci image tag over main to prevent stale image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
     uses: ./.github/workflows/reusable-e2e.yml
     with:
       worker_name_prefix: sandbox-e2e-test-worker-main
-      image_tag: main
+      image_tag: ci-${{ needs.hashes.outputs.docker }}
       images_changed: ${{ needs.build.outputs.images_changed }}
       deploy_hash: ${{ needs.hashes.outputs.deploy }}
     secrets: inherit


### PR DESCRIPTION
# Summary

The PR E2E tests use the immutable ci-<hash> tag, but main E2E still uses the mutable main tag, which the CF container runtime can serve stale from cache.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
