### PR TITLE
Redeploy release E2E on workflow changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,9 @@ jobs:
             'tests/e2e/test-worker/Dockerfile.*',
             'packages/sandbox/src/**',
             'tests/e2e/test-worker/**',
-            'vitest.e2e.config.ts'
+            'vitest.e2e.config.ts',
+            '.github/workflows/release.yml',
+            '.github/workflows/reusable-e2e.yml'
           ) }}" >> $GITHUB_OUTPUT
 
   # --- Build (always runs everything on release) ---
@@ -112,7 +114,7 @@ jobs:
     uses: ./.github/workflows/reusable-e2e.yml
     with:
       worker_name_prefix: sandbox-e2e-test-worker-main
-      image_tag: main
+      image_tag: ci-${{ needs.hashes.outputs.docker }}
       images_changed: ${{ needs.build.outputs.images_changed }}
       deploy_hash: ${{ needs.hashes.outputs.deploy }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- point release E2E at the immutable `ci-${docker_hash}` image instead of the mutable `main` tag
- include `release.yml` and `reusable-e2e.yml` in the release deploy hash so workflow-only changes force a redeploy
- prevent the release lane from skipping deploy after an E2E workflow change and then testing stale main worker state

## Testing
- not run locally; workflow-only change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
