### PR TITLE
Quality: Timeout env parsing allows NaN values to propagate

### DIFF
--- a/packages/sandbox-container/src/config.ts
+++ b/packages/sandbox-container/src/config.ts
@@ -6,10 +6,10 @@
  * Default: 60 seconds
  * Environment variable: INTERPRETER_SPAWN_TIMEOUT_MS
  */
-const INTERPRETER_SPAWN_TIMEOUT_MS = parseInt(
-  process.env.INTERPRETER_SPAWN_TIMEOUT_MS || '60000',
-  10
-);
+const INTERPRETER_SPAWN_TIMEOUT_MS = (() => {
+  const val = parseInt(process.env.INTERPRETER_SPAWN_TIMEOUT_MS || '60000', 10);
+  return Number.isFinite(val) ? val : 60000;
+})();
 
 /**
  * Timeout for interpreter code execution (Python/JS/TS).
@@ -21,7 +21,7 @@ const INTERPRETER_SPAWN_TIMEOUT_MS = parseInt(
  */
 const INTERPRETER_EXECUTION_TIMEOUT_MS = (() => {
   const val = parseInt(process.env.INTERPRETER_EXECUTION_TIMEOUT_MS || '0', 10);
-  return val === 0 ? undefined : val;
+  return !Number.isFinite(val) || val === 0 ? undefined : val;
 })();
 
 /**
@@ -34,7 +34,7 @@ const INTERPRETER_EXECUTION_TIMEOUT_MS = (() => {
  */
 const COMMAND_TIMEOUT_MS = (() => {
   const val = parseInt(process.env.COMMAND_TIMEOUT_MS || '0', 10);
-  return val === 0 ? undefined : val;
+  return !Number.isFinite(val) || val === 0 ? undefined : val;
 })();
 
 /**


### PR DESCRIPTION
## Summary

Quality: Timeout env parsing allows NaN values to propagate

## Problem

**Severity**: `Medium` | **File**: `packages/sandbox-container/src/config.ts:L10`

`parseInt(...)` is used for timeout env vars without validating the result. Invalid values (e.g. non-numeric strings) can produce `NaN`, which may cause unexpected timeout behavior downstream.

## Solution

Validate parsed values with `Number.isFinite(...)` and fallback to defaults on invalid input. Consider centralizing env parsing with explicit schema validation.

## Changes

- `packages/sandbox-container/src/config.ts` (modified)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
