### PR TITLE
Fix production backup restore mounts

### DIFF
--- a/.changeset/restore-backup-mount-paths.md
+++ b/.changeset/restore-backup-mount-paths.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Fix production backup restores so live restored files remain available after `restoreBackup()` returns, and restore mount paths use the real backup ID instead of deriving one from the archive path.

--- a/packages/sandbox-container/src/handlers/backup-handler.ts
+++ b/packages/sandbox-container/src/handlers/backup-handler.ts
@@ -88,6 +88,22 @@ export class BackupHandler extends BaseHandler<Request, Response> {
     return undefined;
   }
 
+  /**
+   * Validate backup IDs before they are used in restore mount paths.
+   */
+  private static validateBackupId(backupId: string): string | undefined {
+    if (!backupId || typeof backupId !== 'string') {
+      return 'Missing or invalid field: backupId';
+    }
+    if (backupId.includes('/') || backupId.includes('..')) {
+      return 'backupId must not contain path traversal sequences';
+    }
+    if (backupId.includes('\0')) {
+      return 'backupId must not contain null bytes';
+    }
+    return undefined;
+  }
+
   private async handleCreate(
     request: Request,
     context: RequestContext
@@ -198,12 +214,24 @@ export class BackupHandler extends BaseHandler<Request, Response> {
         Operation.BACKUP_RESTORE
       );
     }
+    const backupIdError = BackupHandler.validateBackupId(body.backupId);
+    if (backupIdError) {
+      return this.createErrorResponse(
+        {
+          message: backupIdError,
+          code: ErrorCode.INVALID_BACKUP_CONFIG
+        },
+        context,
+        Operation.BACKUP_RESTORE
+      );
+    }
 
     const sessionId = body.sessionId ?? context.sessionId ?? 'default';
 
     const result = await this.backupService.restoreArchive(
       body.dir,
       body.archivePath,
+      body.backupId,
       sessionId
     );
 

--- a/packages/sandbox-container/src/rpc/sandbox-api.ts
+++ b/packages/sandbox-container/src/rpc/sandbox-api.ts
@@ -1015,8 +1015,18 @@ class BackupRPCAPI extends RpcTarget {
     };
   }
 
-  async restoreArchive(dir: string, archivePath: string, sessionId: string) {
-    const result = await this.#svc.restoreArchive(dir, archivePath, sessionId);
+  async restoreArchive(
+    dir: string,
+    archivePath: string,
+    backupId: string,
+    sessionId: string
+  ) {
+    const result = await this.#svc.restoreArchive(
+      dir,
+      archivePath,
+      backupId,
+      sessionId
+    );
     throwIfError(result);
     return { success: true, dir };
   }

--- a/packages/sandbox-container/src/services/backup-service.ts
+++ b/packages/sandbox-container/src/services/backup-service.ts
@@ -391,19 +391,29 @@ export class BackupService {
   async restoreArchive(
     dir: string,
     archivePath: string,
+    backupId: string,
     sessionId = 'default'
   ): Promise<ServiceResult<RestoreArchiveResult>> {
-    // Extract backup ID from archive path (e.g., /var/backups/abc123.sqsh -> abc123)
-    const backupId = archivePath
-      .replace(`${BACKUP_WORK_DIR}/`, '')
-      .replace('.sqsh', '');
-
     const startTime = Date.now();
     let outcome: 'success' | 'error' = 'error';
     let caughtError: Error | undefined;
     let errorMessage: string | undefined;
 
     try {
+      if (
+        !backupId ||
+        backupId.includes('/') ||
+        backupId.includes('..') ||
+        backupId.includes('\0')
+      ) {
+        errorMessage = `Invalid backupId for restore: ${backupId}`;
+        return serviceError({
+          message: errorMessage,
+          code: ErrorCode.INVALID_BACKUP_CONFIG,
+          details: { dir, archivePath, backupId }
+        });
+      }
+
       const pathError = validateBackupPaths(dir, archivePath);
       if (pathError) {
         errorMessage = pathError;

--- a/packages/sandbox-container/tests/services/backup-service.test.ts
+++ b/packages/sandbox-container/tests/services/backup-service.test.ts
@@ -91,6 +91,7 @@ describe('BackupService', () => {
   it('allows restoring an archive into /app', async () => {
     const dir = '/app/project';
     const archivePath = '/var/backups/app-dir.sqsh';
+    const backupId = 'app-dir';
 
     mocked(mockSessionManager.executeInSession).mockImplementation(
       async (_sessionId: string, command: string) => {
@@ -114,9 +115,56 @@ describe('BackupService', () => {
       }
     );
 
-    const result = await service.restoreArchive(dir, archivePath);
+    const result = await service.restoreArchive(dir, archivePath, backupId);
 
     expect(result.success).toBe(true);
+  });
+
+  it('uses explicit backup ID for production restore mount paths', async () => {
+    const backupId = '12345678-1234-1234-1234-123456789012';
+    const dir = '/workspace/project';
+    const archivePath = `/var/backups/r2mount/${backupId}/data.sqsh`;
+
+    mocked(mockSessionManager.executeInSession).mockImplementation(
+      async (_sessionId: string, command: string) => {
+        if (command.startsWith('test -f ')) return execSuccess();
+        if (command.includes('/usr/bin/fusermount3 -u ')) return execSuccess();
+        if (command.startsWith('for d in ')) return execSuccess();
+        if (command.startsWith('rm -rf ')) return execSuccess();
+        if (command.startsWith('mkdir -p ')) return execSuccess();
+        if (command.startsWith('/usr/bin/squashfuse ')) return execSuccess();
+        if (command.startsWith('/usr/bin/fuse-overlayfs '))
+          return execSuccess();
+
+        return {
+          success: false,
+          error: {
+            message: `Unexpected command in test: ${command}`,
+            code: 'TEST_ERROR',
+            details: {}
+          }
+        };
+      }
+    );
+
+    const result = await service.restoreArchive(dir, archivePath, backupId);
+
+    expect(result.success).toBe(true);
+
+    const callArgs = mocked(mockSessionManager.executeInSession)
+      .mock.calls.map(([, command]) => command)
+      .filter((command): command is string => typeof command === 'string');
+
+    expect(
+      callArgs.some((command) =>
+        command.includes(`'/var/backups/mounts/${backupId}_`)
+      )
+    ).toBe(true);
+    expect(
+      callArgs.some((command) =>
+        command.includes('/var/backups/mounts/r2mount')
+      )
+    ).toBe(false);
   });
 
   it('uses wildcard exclude mode for gitignore-derived excludes', async () => {

--- a/packages/sandbox/src/clients/backup-client.ts
+++ b/packages/sandbox/src/clients/backup-client.ts
@@ -47,15 +47,18 @@ export class BackupClient extends BaseHttpClient {
    * Tell the container to restore a squashfs archive into a directory.
    * @param dir - Target directory
    * @param archivePath - Path to the archive file in the container
+   * @param backupId - Backup identifier used for restore mount paths
    * @param sessionId - Session context
    */
   async restoreArchive(
     dir: string,
     archivePath: string,
+    backupId: string,
     sessionId: string
   ): Promise<RestoreBackupResponse> {
     const data: RestoreBackupRequest = {
       dir,
+      backupId,
       archivePath,
       sessionId
     };

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -4028,8 +4028,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   /**
    * Create a unique, dedicated session for a single backup operation.
    * Each call produces a fresh session ID so concurrent or sequential
-   * operations never share shell state. Callers must destroy the session
-   * in a finally block via `client.utils.deleteSession()`.
+   * operations never share shell state. Callers must destroy the session when
+   * the operation does not leave live mounts behind.
    */
   private async ensureBackupSession(): Promise<string> {
     const sessionId = `__sandbox_backup_${crypto.randomUUID()}`;
@@ -4817,6 +4817,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       const restoreResult = await this.client.backup.restoreArchive(
         dir,
         archivePath,
+        id,
         backupSession
       );
 
@@ -4841,7 +4842,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       caughtError = error instanceof Error ? error : new Error(String(error));
       throw error;
     } finally {
-      if (backupSession) {
+      if (backupSession && outcome !== 'success') {
         await this.client.utils.deleteSession(backupSession).catch(() => {});
       }
       logCanonicalEvent(this.logger, {

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1818,11 +1818,13 @@ describe('Sandbox - Automatic Session Management', () => {
         id: 'backup-session',
         message: 'Created'
       } as any);
-      vi.spyOn(backupSandbox.client.utils, 'deleteSession').mockResolvedValue({
-        success: true,
-        id: 'backup-session',
-        message: 'Deleted'
-      } as any);
+      const deleteSessionSpy = vi
+        .spyOn(backupSandbox.client.utils, 'deleteSession')
+        .mockResolvedValue({
+          success: true,
+          id: 'backup-session',
+          message: 'Deleted'
+        } as any);
       const createArchiveSpy = vi
         .spyOn(backupSandbox.client.backup, 'createArchive')
         .mockResolvedValue({
@@ -1900,6 +1902,7 @@ describe('Sandbox - Automatic Session Management', () => {
       expect(restoreArchiveSpy).toHaveBeenCalledWith(
         '/app/project',
         `/var/backups/r2mount/${backupId}/data.sqsh`,
+        backupId,
         expect.stringMatching(/^__sandbox_backup_/)
       );
       expect(mountBackupR2Spy).toHaveBeenCalledWith(
@@ -1907,6 +1910,7 @@ describe('Sandbox - Automatic Session Management', () => {
         `backups/${backupId}/`,
         expect.stringMatching(/^__sandbox_backup_/)
       );
+      expect(deleteSessionSpy).not.toHaveBeenCalled();
       expect(
         (backupSandbox as any).execWithSession.mock.calls.some(
           ([command]: [string]) =>

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1818,13 +1818,11 @@ describe('Sandbox - Automatic Session Management', () => {
         id: 'backup-session',
         message: 'Created'
       } as any);
-      const deleteSessionSpy = vi
-        .spyOn(backupSandbox.client.utils, 'deleteSession')
-        .mockResolvedValue({
-          success: true,
-          id: 'backup-session',
-          message: 'Deleted'
-        } as any);
+      vi.spyOn(backupSandbox.client.utils, 'deleteSession').mockResolvedValue({
+        success: true,
+        id: 'backup-session',
+        message: 'Deleted'
+      } as any);
       const createArchiveSpy = vi
         .spyOn(backupSandbox.client.backup, 'createArchive')
         .mockResolvedValue({
@@ -1872,11 +1870,13 @@ describe('Sandbox - Automatic Session Management', () => {
         id: 'backup-session',
         message: 'Created'
       } as any);
-      vi.spyOn(backupSandbox.client.utils, 'deleteSession').mockResolvedValue({
-        success: true,
-        id: 'backup-session',
-        message: 'Deleted'
-      } as any);
+      const deleteSessionSpy = vi
+        .spyOn(backupSandbox.client.utils, 'deleteSession')
+        .mockResolvedValue({
+          success: true,
+          id: 'backup-session',
+          message: 'Deleted'
+        } as any);
       const restoreArchiveSpy = vi
         .spyOn(backupSandbox.client.backup, 'restoreArchive')
         .mockResolvedValue({ success: true, dir: '/app/project' });

--- a/packages/shared/src/request-types.ts
+++ b/packages/shared/src/request-types.ts
@@ -180,6 +180,8 @@ export interface CreateBackupResponse {
 export interface RestoreBackupRequest {
   /** Directory to restore into */
   dir: string;
+  /** Backup identifier used for restore mount paths */
+  backupId: string;
   /** Path to the archive file in the container */
   archivePath: string;
   sessionId?: string;

--- a/packages/shared/src/rpc-types.ts
+++ b/packages/shared/src/rpc-types.ts
@@ -237,6 +237,7 @@ export interface SandboxBackupAPI {
   restoreArchive(
     dir: string,
     archivePath: string,
+    backupId: string,
     sessionId: string
   ): Promise<RestoreBackupResponse>;
 }

--- a/tests/e2e/backup-workflow.test.ts
+++ b/tests/e2e/backup-workflow.test.ts
@@ -190,6 +190,67 @@ describe('Backup Workflow E2E', () => {
       // Cleanup (unmounts FUSE overlay if present, then removes directory)
       await cleanupDir(workerUrl, headers, TEST_DIR);
     }, 60000);
+
+    test('should keep restored backup mounted after restore returns', async () => {
+      if (!backupBucketAvailable) return;
+
+      const testDir = `/workspace/restore-lifetime-${crypto.randomUUID().slice(0, 8)}`;
+      const content = `restore lifetime ${crypto.randomUUID()}`;
+
+      await fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          command: `mkdir -p ${testDir} && printf '%s' '${content}' > ${testDir}/file.txt`
+        })
+      });
+
+      const backupResponse = await fetch(`${workerUrl}/api/backup/create`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ dir: testDir })
+      });
+      expect(backupResponse.ok).toBe(true);
+      const backup = (await backupResponse.json()) as BackupResponse;
+
+      await fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ command: `rm -rf ${testDir}/*` })
+      });
+
+      const restoreResponse = await fetch(`${workerUrl}/api/backup/restore`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ id: backup.id, dir: testDir })
+      });
+      expect(restoreResponse.ok).toBe(true);
+
+      const immediateRead = await fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ command: `cat ${testDir}/file.txt` })
+      });
+      const immediateResult = (await immediateRead.json()) as ExecuteResponse;
+      expect(immediateResult.exitCode).toBe(0);
+      expect(immediateResult.stdout).toBe(content);
+
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      const delayedRead = await fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          command: `cat ${testDir}/file.txt && printf '\n' && printf 'changed' > ${testDir}/cow.txt && cat ${testDir}/cow.txt`
+        })
+      });
+      const delayedResult = (await delayedRead.json()) as ExecuteResponse;
+      expect(delayedResult.exitCode).toBe(0);
+      expect(delayedResult.stdout).toContain(content);
+      expect(delayedResult.stdout).toContain('changed');
+
+      await cleanupDir(workerUrl, headers, testDir);
+    }, 60000);
   });
 
   describe('Backup excludes', () => {


### PR DESCRIPTION
## Summary
- Keep successful production restores backed by their live backup session so FUSE-mounted restored files remain available after `restoreBackup()` returns.
- Pass the real backup ID through the restore API instead of deriving mount paths from `/var/backups/r2mount/<id>/data.sqsh`.
- Add unit and E2E regression coverage for production restore mount paths and post-restore readability/writability.

## Testing
- `bun test packages/sandbox-container/tests/services/backup-service.test.ts`
- `npm run typecheck -w @cloudflare/sandbox`
- `npm run typecheck` via pre-push hook

## Notes
Focused E2E was added but local execution previously stopped during Docker image build before the test ran; CI should exercise it in the configured environment.