### PR TITLE
Fix production backup restore mounts

### DIFF
--- a/.changeset/restore-backup-mount-paths.md
+++ b/.changeset/restore-backup-mount-paths.md
@@ -2,4 +2,4 @@
 '@cloudflare/sandbox': patch
 ---
 
-Fix production backup restores so live restored files remain available after `restoreBackup()` returns, and restore mount paths use the real backup ID instead of deriving one from the archive path.
+Fix production backup restores so restored files are materialized before `restoreBackup()` returns, and restore mount paths use the real backup ID instead of deriving one from the archive path.

--- a/.changeset/restore-backup-mount-paths.md
+++ b/.changeset/restore-backup-mount-paths.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Fix production backup restores so live restored files remain available after `restoreBackup()` returns, and restore mount paths use the real backup ID instead of deriving one from the archive path.

--- a/packages/sandbox-container/src/handlers/backup-handler.ts
+++ b/packages/sandbox-container/src/handlers/backup-handler.ts
@@ -88,6 +88,22 @@ export class BackupHandler extends BaseHandler<Request, Response> {
     return undefined;
   }
 
+  /**
+   * Validate backup IDs before they are used in restore mount paths.
+   */
+  private static validateBackupId(backupId: string): string | undefined {
+    if (!backupId || typeof backupId !== 'string') {
+      return 'Missing or invalid field: backupId';
+    }
+    if (backupId.includes('/') || backupId.includes('..')) {
+      return 'backupId must not contain path traversal sequences';
+    }
+    if (backupId.includes('\0')) {
+      return 'backupId must not contain null bytes';
+    }
+    return undefined;
+  }
+
   private async handleCreate(
     request: Request,
     context: RequestContext
@@ -198,12 +214,24 @@ export class BackupHandler extends BaseHandler<Request, Response> {
         Operation.BACKUP_RESTORE
       );
     }
+    const backupIdError = BackupHandler.validateBackupId(body.backupId);
+    if (backupIdError) {
+      return this.createErrorResponse(
+        {
+          message: backupIdError,
+          code: ErrorCode.INVALID_BACKUP_CONFIG
+        },
+        context,
+        Operation.BACKUP_RESTORE
+      );
+    }
 
     const sessionId = body.sessionId ?? context.sessionId ?? 'default';
 
     const result = await this.backupService.restoreArchive(
       body.dir,
       body.archivePath,
+      body.backupId,
       sessionId
     );
 

--- a/packages/sandbox-container/src/rpc/sandbox-api.ts
+++ b/packages/sandbox-container/src/rpc/sandbox-api.ts
@@ -1015,8 +1015,18 @@ class BackupRPCAPI extends RpcTarget {
     };
   }
 
-  async restoreArchive(dir: string, archivePath: string, sessionId: string) {
-    const result = await this.#svc.restoreArchive(dir, archivePath, sessionId);
+  async restoreArchive(
+    dir: string,
+    archivePath: string,
+    backupId: string,
+    sessionId: string
+  ) {
+    const result = await this.#svc.restoreArchive(
+      dir,
+      archivePath,
+      backupId,
+      sessionId
+    );
     throwIfError(result);
     return { success: true, dir };
   }

--- a/packages/sandbox-container/src/services/backup-service.ts
+++ b/packages/sandbox-container/src/services/backup-service.ts
@@ -391,19 +391,29 @@ export class BackupService {
   async restoreArchive(
     dir: string,
     archivePath: string,
+    backupId: string,
     sessionId = 'default'
   ): Promise<ServiceResult<RestoreArchiveResult>> {
-    // Extract backup ID from archive path (e.g., /var/backups/abc123.sqsh -> abc123)
-    const backupId = archivePath
-      .replace(`${BACKUP_WORK_DIR}/`, '')
-      .replace('.sqsh', '');
-
     const startTime = Date.now();
     let outcome: 'success' | 'error' = 'error';
     let caughtError: Error | undefined;
     let errorMessage: string | undefined;
 
     try {
+      if (
+        !backupId ||
+        backupId.includes('/') ||
+        backupId.includes('..') ||
+        backupId.includes('\0')
+      ) {
+        errorMessage = `Invalid backupId for restore: ${backupId}`;
+        return serviceError({
+          message: errorMessage,
+          code: ErrorCode.INVALID_BACKUP_CONFIG,
+          details: { dir, archivePath, backupId }
+        });
+      }
+
       const pathError = validateBackupPaths(dir, archivePath);
       if (pathError) {
         errorMessage = pathError;

--- a/packages/sandbox-container/src/services/backup-service.ts
+++ b/packages/sandbox-container/src/services/backup-service.ts
@@ -76,8 +76,7 @@ interface RestoreArchiveResult {
  *
  * Restore flow:
  *   squashfuse <archivePath> <lowerDir>
- *   fuse-overlayfs -o lowerdir=<lowerDir>,upperdir=<upperDir>,workdir=<workDir> <targetDir>
- *   Mounts the squashfs image as a read-only layer with a writable overlay on top.
+ *   Copies the mounted squashfs contents into the target directory.
  *
  * The DO (Sandbox class) handles R2 upload/download. This service only deals
  * with local filesystem operations.
@@ -376,17 +375,12 @@ export class BackupService {
   }
 
   /**
-   * Restore a squashfs archive into a directory using overlayfs.
-   *
-   * This mounts the squashfs as a read-only lower layer and uses
-   * fuse-overlayfs to provide a writable upper layer, giving instant
-   * restore with copy-on-write semantics.
+   * Restore a squashfs archive into a directory.
    *
    * Mount structure:
-   *   /var/backups/mounts/{backupId}/lower  - squashfs mount (read-only)
-   *   /var/backups/mounts/{backupId}/upper  - writable changes
-   *   /var/backups/mounts/{backupId}/work   - overlayfs workdir
-   *   {dir}                                  - merged overlay view
+   *   /var/backups/mounts/{backupId}/lower        - squashfs mount (read-only)
+   *   /var/backups/mounts/{backupId}/materialized - temporary copy source
+   *   {dir}                                       - real restored files
    */
   async restoreArchive(
     dir: string,
@@ -398,6 +392,8 @@ export class BackupService {
     let outcome: 'success' | 'error' = 'error';
     let caughtError: Error | undefined;
     let errorMessage: string | undefined;
+    let lowerDir: string | undefined;
+    let mountBase: string | undefined;
 
     try {
       if (
@@ -424,14 +420,12 @@ export class BackupService {
         });
       }
 
-      // Each restore uses a unique mount base so stale upper-layer files from a
-      // previous overlay session cannot leak into a new mount.  Old mount bases
-      // for this backup ID are torn down (best-effort) before the new mount.
+      // Each restore uses a unique mount base for temporary FUSE state. Old
+      // mount bases for this backup ID are torn down before the new mount.
       const restoreId = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-      const mountBase = `${BACKUP_MOUNTS_DIR}/${backupId}_${restoreId}`;
-      const lowerDir = `${mountBase}/lower`;
-      const upperDir = `${mountBase}/upper`;
-      const workDir = `${mountBase}/work`;
+      mountBase = `${BACKUP_MOUNTS_DIR}/${backupId}_${restoreId}`;
+      lowerDir = `${mountBase}/lower`;
+      const materializedDir = `${mountBase}/materialized`;
       // Verify the archive exists
       const checkResult = await this.sessionManager.executeInSession(
         sessionId,
@@ -447,7 +441,7 @@ export class BackupService {
         });
       }
 
-      // Unmount the overlay on `dir` (from a previous restore of any backup).
+      // Unmount the overlay on `dir` from legacy live-mount restores.
       await this.sessionManager.executeInSession(
         sessionId,
         `${BIN.fusermount} -u ${shellEscape(dir)} 2>/dev/null; ${BIN.fusermount} -uz ${shellEscape(dir)} 2>/dev/null; true`,
@@ -475,7 +469,7 @@ export class BackupService {
       // Create fresh mount directories
       const mkdirResult = await this.sessionManager.executeInSession(
         sessionId,
-        `mkdir -p ${shellEscape(lowerDir)} ${shellEscape(upperDir)} ${shellEscape(workDir)} ${shellEscape(dir)}`,
+        `mkdir -p ${shellEscape(lowerDir)} ${shellEscape(materializedDir)} ${shellEscape(dir)}`,
         { origin: 'internal' }
       );
       if (!mkdirResult.success) {
@@ -519,46 +513,25 @@ export class BackupService {
         });
       }
 
-      // Mount overlayfs to combine lower (snapshot) + upper (writable) layers
-      // Using fuse-overlayfs for userspace overlay support in containers
-      // All mount options in a single -o flag as comma-separated values
-      const overlayMountCmd = [
-        BIN.fuseOverlayfs,
-        `-o lowerdir=${shellEscape(lowerDir)},upperdir=${shellEscape(upperDir)},workdir=${shellEscape(workDir)}`,
-        shellEscape(dir)
-      ].join(' ');
-
-      const overlayMountResult = await this.sessionManager.executeInSession(
+      const materializeResult = await this.sessionManager.executeInSession(
         sessionId,
-        overlayMountCmd,
+        `cp -a ${shellEscape(`${lowerDir}/.`)} ${shellEscape(`${materializedDir}/`)} && find ${shellEscape(dir)} -mindepth 1 -maxdepth 1 -exec rm -rf -- {} + && cp -a ${shellEscape(`${materializedDir}/.`)} ${shellEscape(`${dir}/`)}`,
         { origin: 'internal' }
       );
-      if (!overlayMountResult.success) {
-        // Cleanup: unmount squashfs on failure
-        await this.sessionManager.executeInSession(
-          sessionId,
-          `${BIN.fusermount} -u ${shellEscape(lowerDir)} 2>/dev/null || true`,
-          { origin: 'internal' }
-        );
-        errorMessage = 'Failed to mount overlayfs';
+      if (!materializeResult.success) {
+        errorMessage = 'Failed to materialize restored files';
         return serviceError({
-          message: `Failed to mount overlayfs: ${overlayMountResult.error.message}`,
+          message: `Failed to materialize restored files: ${materializeResult.error.message}`,
           code: ErrorCode.BACKUP_RESTORE_FAILED,
-          details: { dir, archivePath, cmd: overlayMountCmd }
+          details: { dir, archivePath }
         });
       }
-      if (overlayMountResult.data.exitCode !== 0) {
-        // Cleanup: unmount squashfs on failure
-        await this.sessionManager.executeInSession(
-          sessionId,
-          `${BIN.fusermount} -u ${shellEscape(lowerDir)} 2>/dev/null || true`,
-          { origin: 'internal' }
-        );
-        errorMessage = 'Failed to mount overlayfs';
+      if (materializeResult.data.exitCode !== 0) {
+        errorMessage = 'Failed to materialize restored files';
         return serviceError({
-          message: `Failed to mount overlayfs: ${overlayMountResult.data.stderr}`,
+          message: `Failed to materialize restored files: ${materializeResult.data.stderr}`,
           code: ErrorCode.BACKUP_RESTORE_FAILED,
-          details: { dir, archivePath, cmd: overlayMountCmd }
+          details: { dir, archivePath }
         });
       }
 
@@ -569,8 +542,6 @@ export class BackupService {
       caughtError = error instanceof Error ? error : new Error(String(error));
       errorMessage = caughtError.message;
       // Best-effort cleanup of any FUSE mounts that may have been established.
-      // Clean up the overlay on dir; per-restore lowerDir is scoped inside try
-      // and cleaned up by the mount-base glob teardown on the next restore.
       await this.sessionManager
         .executeInSession(
           sessionId,
@@ -584,6 +555,24 @@ export class BackupService {
         details: { dir, archivePath }
       });
     } finally {
+      if (lowerDir) {
+        await this.sessionManager
+          .executeInSession(
+            sessionId,
+            `${BIN.fusermount} -u ${shellEscape(lowerDir)} 2>/dev/null; ${BIN.fusermount} -uz ${shellEscape(lowerDir)} 2>/dev/null; true`,
+            { origin: 'internal' }
+          )
+          .catch(() => {});
+      }
+      if (mountBase) {
+        await this.sessionManager
+          .executeInSession(
+            sessionId,
+            `rm -rf ${shellEscape(mountBase)} 2>/dev/null; true`,
+            { origin: 'internal' }
+          )
+          .catch(() => {});
+      }
       logCanonicalEvent(this.logger, {
         event: 'backup.restore',
         outcome,

--- a/packages/sandbox-container/tests/services/backup-service.test.ts
+++ b/packages/sandbox-container/tests/services/backup-service.test.ts
@@ -101,6 +101,7 @@ describe('BackupService', () => {
         if (command.startsWith('rm -rf ')) return execSuccess();
         if (command.startsWith('mkdir -p ')) return execSuccess();
         if (command.startsWith('/usr/bin/squashfuse ')) return execSuccess();
+        if (command.startsWith('cp -a ')) return execSuccess();
         if (command.startsWith('/usr/bin/fuse-overlayfs '))
           return execSuccess();
 
@@ -133,6 +134,7 @@ describe('BackupService', () => {
         if (command.startsWith('rm -rf ')) return execSuccess();
         if (command.startsWith('mkdir -p ')) return execSuccess();
         if (command.startsWith('/usr/bin/squashfuse ')) return execSuccess();
+        if (command.startsWith('cp -a ')) return execSuccess();
         if (command.startsWith('/usr/bin/fuse-overlayfs '))
           return execSuccess();
 
@@ -160,6 +162,9 @@ describe('BackupService', () => {
         command.includes(`'/var/backups/mounts/${backupId}_`)
       )
     ).toBe(true);
+    expect(
+      callArgs.some((command) => command.startsWith('/usr/bin/fuse-overlayfs '))
+    ).toBe(false);
     expect(
       callArgs.some((command) =>
         command.includes('/var/backups/mounts/r2mount')

--- a/packages/sandbox-container/tests/services/backup-service.test.ts
+++ b/packages/sandbox-container/tests/services/backup-service.test.ts
@@ -91,6 +91,7 @@ describe('BackupService', () => {
   it('allows restoring an archive into /app', async () => {
     const dir = '/app/project';
     const archivePath = '/var/backups/app-dir.sqsh';
+    const backupId = 'app-dir';
 
     mocked(mockSessionManager.executeInSession).mockImplementation(
       async (_sessionId: string, command: string) => {
@@ -114,9 +115,56 @@ describe('BackupService', () => {
       }
     );
 
-    const result = await service.restoreArchive(dir, archivePath);
+    const result = await service.restoreArchive(dir, archivePath, backupId);
 
     expect(result.success).toBe(true);
+  });
+
+  it('uses explicit backup ID for production restore mount paths', async () => {
+    const backupId = '12345678-1234-1234-1234-123456789012';
+    const dir = '/workspace/project';
+    const archivePath = `/var/backups/r2mount/${backupId}/data.sqsh`;
+
+    mocked(mockSessionManager.executeInSession).mockImplementation(
+      async (_sessionId: string, command: string) => {
+        if (command.startsWith('test -f ')) return execSuccess();
+        if (command.includes('/usr/bin/fusermount3 -u ')) return execSuccess();
+        if (command.startsWith('for d in ')) return execSuccess();
+        if (command.startsWith('rm -rf ')) return execSuccess();
+        if (command.startsWith('mkdir -p ')) return execSuccess();
+        if (command.startsWith('/usr/bin/squashfuse ')) return execSuccess();
+        if (command.startsWith('/usr/bin/fuse-overlayfs '))
+          return execSuccess();
+
+        return {
+          success: false,
+          error: {
+            message: `Unexpected command in test: ${command}`,
+            code: 'TEST_ERROR',
+            details: {}
+          }
+        };
+      }
+    );
+
+    const result = await service.restoreArchive(dir, archivePath, backupId);
+
+    expect(result.success).toBe(true);
+
+    const callArgs = mocked(mockSessionManager.executeInSession)
+      .mock.calls.map(([, command]) => command)
+      .filter((command): command is string => typeof command === 'string');
+
+    expect(
+      callArgs.some((command) =>
+        command.includes(`'/var/backups/mounts/${backupId}_`)
+      )
+    ).toBe(true);
+    expect(
+      callArgs.some((command) =>
+        command.includes('/var/backups/mounts/r2mount')
+      )
+    ).toBe(false);
   });
 
   it('uses wildcard exclude mode for gitignore-derived excludes', async () => {

--- a/packages/sandbox/src/clients/backup-client.ts
+++ b/packages/sandbox/src/clients/backup-client.ts
@@ -47,15 +47,18 @@ export class BackupClient extends BaseHttpClient {
    * Tell the container to restore a squashfs archive into a directory.
    * @param dir - Target directory
    * @param archivePath - Path to the archive file in the container
+   * @param backupId - Backup identifier used for restore mount paths
    * @param sessionId - Session context
    */
   async restoreArchive(
     dir: string,
     archivePath: string,
+    backupId: string,
     sessionId: string
   ): Promise<RestoreBackupResponse> {
     const data: RestoreBackupRequest = {
       dir,
+      backupId,
       archivePath,
       sessionId
     };

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -4028,8 +4028,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   /**
    * Create a unique, dedicated session for a single backup operation.
    * Each call produces a fresh session ID so concurrent or sequential
-   * operations never share shell state. Callers must destroy the session
-   * in a finally block via `client.utils.deleteSession()`.
+   * operations never share shell state. Callers must destroy the session when
+   * the operation does not leave live mounts behind.
    */
   private async ensureBackupSession(): Promise<string> {
     const sessionId = `__sandbox_backup_${crypto.randomUUID()}`;
@@ -4817,6 +4817,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       const restoreResult = await this.client.backup.restoreArchive(
         dir,
         archivePath,
+        id,
         backupSession
       );
 
@@ -4841,7 +4842,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       caughtError = error instanceof Error ? error : new Error(String(error));
       throw error;
     } finally {
-      if (backupSession) {
+      if (backupSession && outcome !== 'success') {
         await this.client.utils.deleteSession(backupSession).catch(() => {});
       }
       logCanonicalEvent(this.logger, {

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -4646,17 +4646,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    * **Production flow** (`localBucket` not set):
    *   1. DO reads metadata from R2 and checks TTL
    *   2. Container mounts the backup archive from R2 via s3fs
-   *   3. Container mounts the squashfs archive with FUSE overlayfs
-   *
-   * The target directory becomes an overlay mount with the backup as a
-   * read-only lower layer and a writable upper layer for copy-on-write.
-   * Any processes writing to the directory should be stopped first.
-   *
-   * **Mount Lifecycle**: The FUSE overlay mount persists only while the
-   * container is running. When the sandbox sleeps or the container restarts,
-   * the mount is lost and the directory becomes empty. Re-restore from the
-   * backup handle to recover. This is an ephemeral restore, not a persistent
-   * extraction.
+   *   3. Container mounts the squashfs archive temporarily and copies files
+   *      into the target directory
+   *   4. Temporary FUSE mounts and backup session are cleaned up
    *
    * **Local-dev flow** (`localBucket: true` on the originating `createBackup` call):
    *   1. DO reads metadata and checks TTL via R2 binding
@@ -4787,7 +4779,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       // Step 3: Tear down existing restore mounts before replacing the backing
       // R2 mount. squashfuse reads the archive lazily through the s3fs mount,
       // so the overlay and lower mounts must come down before the bucket mount.
-      const mountGlob = `/var/backups/mounts/r2mount/${id}/data`;
+      const mountGlob = `/var/backups/mounts/${id}`;
       await this.execWithSession(
         `/usr/bin/fusermount3 -uz ${shellEscape(dir)} 2>/dev/null || true`,
         backupSession,
@@ -4831,6 +4823,19 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         });
       }
 
+      await this.execWithSession(
+        `/usr/bin/fusermount3 -u ${shellEscape(r2MountPath)} 2>/dev/null; /usr/bin/fusermount3 -uz ${shellEscape(r2MountPath)} 2>/dev/null; true`,
+        backupSession,
+        { origin: 'internal' }
+      ).catch(() => {});
+
+      const backupMount = this.activeMounts.get(r2MountPath);
+      if (backupMount?.mountType === 'fuse') {
+        backupMount.mounted = false;
+        this.activeMounts.delete(r2MountPath);
+        await this.deletePasswordFile(backupMount.passwordFilePath);
+      }
+
       outcome = 'success';
 
       return {
@@ -4842,7 +4847,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       caughtError = error instanceof Error ? error : new Error(String(error));
       throw error;
     } finally {
-      if (backupSession && outcome !== 'success') {
+      if (backupSession) {
         await this.client.utils.deleteSession(backupSession).catch(() => {});
       }
       logCanonicalEvent(this.logger, {

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1818,11 +1818,13 @@ describe('Sandbox - Automatic Session Management', () => {
         id: 'backup-session',
         message: 'Created'
       } as any);
-      vi.spyOn(backupSandbox.client.utils, 'deleteSession').mockResolvedValue({
-        success: true,
-        id: 'backup-session',
-        message: 'Deleted'
-      } as any);
+      const deleteSessionSpy = vi
+        .spyOn(backupSandbox.client.utils, 'deleteSession')
+        .mockResolvedValue({
+          success: true,
+          id: 'backup-session',
+          message: 'Deleted'
+        } as any);
       const createArchiveSpy = vi
         .spyOn(backupSandbox.client.backup, 'createArchive')
         .mockResolvedValue({
@@ -1900,6 +1902,7 @@ describe('Sandbox - Automatic Session Management', () => {
       expect(restoreArchiveSpy).toHaveBeenCalledWith(
         '/app/project',
         `/var/backups/r2mount/${backupId}/data.sqsh`,
+        backupId,
         expect.stringMatching(/^__sandbox_backup_/)
       );
       expect(mountBackupR2Spy).toHaveBeenCalledWith(
@@ -1907,6 +1910,7 @@ describe('Sandbox - Automatic Session Management', () => {
         `backups/${backupId}/`,
         expect.stringMatching(/^__sandbox_backup_/)
       );
+      expect(deleteSessionSpy).not.toHaveBeenCalled();
       expect(
         (backupSandbox as any).execWithSession.mock.calls.some(
           ([command]: [string]) =>

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1910,7 +1910,9 @@ describe('Sandbox - Automatic Session Management', () => {
         `backups/${backupId}/`,
         expect.stringMatching(/^__sandbox_backup_/)
       );
-      expect(deleteSessionSpy).not.toHaveBeenCalled();
+      expect(deleteSessionSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/^__sandbox_backup_/)
+      );
       expect(
         (backupSandbox as any).execWithSession.mock.calls.some(
           ([command]: [string]) =>

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1818,13 +1818,11 @@ describe('Sandbox - Automatic Session Management', () => {
         id: 'backup-session',
         message: 'Created'
       } as any);
-      const deleteSessionSpy = vi
-        .spyOn(backupSandbox.client.utils, 'deleteSession')
-        .mockResolvedValue({
-          success: true,
-          id: 'backup-session',
-          message: 'Deleted'
-        } as any);
+      vi.spyOn(backupSandbox.client.utils, 'deleteSession').mockResolvedValue({
+        success: true,
+        id: 'backup-session',
+        message: 'Deleted'
+      } as any);
       const createArchiveSpy = vi
         .spyOn(backupSandbox.client.backup, 'createArchive')
         .mockResolvedValue({
@@ -1872,11 +1870,13 @@ describe('Sandbox - Automatic Session Management', () => {
         id: 'backup-session',
         message: 'Created'
       } as any);
-      vi.spyOn(backupSandbox.client.utils, 'deleteSession').mockResolvedValue({
-        success: true,
-        id: 'backup-session',
-        message: 'Deleted'
-      } as any);
+      const deleteSessionSpy = vi
+        .spyOn(backupSandbox.client.utils, 'deleteSession')
+        .mockResolvedValue({
+          success: true,
+          id: 'backup-session',
+          message: 'Deleted'
+        } as any);
       const restoreArchiveSpy = vi
         .spyOn(backupSandbox.client.backup, 'restoreArchive')
         .mockResolvedValue({ success: true, dir: '/app/project' });

--- a/packages/shared/src/request-types.ts
+++ b/packages/shared/src/request-types.ts
@@ -180,6 +180,8 @@ export interface CreateBackupResponse {
 export interface RestoreBackupRequest {
   /** Directory to restore into */
   dir: string;
+  /** Backup identifier used for restore mount paths */
+  backupId: string;
   /** Path to the archive file in the container */
   archivePath: string;
   sessionId?: string;

--- a/packages/shared/src/rpc-types.ts
+++ b/packages/shared/src/rpc-types.ts
@@ -237,6 +237,7 @@ export interface SandboxBackupAPI {
   restoreArchive(
     dir: string,
     archivePath: string,
+    backupId: string,
     sessionId: string
   ): Promise<RestoreBackupResponse>;
 }

--- a/tests/e2e/backup-workflow.test.ts
+++ b/tests/e2e/backup-workflow.test.ts
@@ -190,6 +190,67 @@ describe('Backup Workflow E2E', () => {
       // Cleanup (unmounts FUSE overlay if present, then removes directory)
       await cleanupDir(workerUrl, headers, TEST_DIR);
     }, 60000);
+
+    test('should keep restored backup mounted after restore returns', async () => {
+      if (!backupBucketAvailable) return;
+
+      const testDir = `/workspace/restore-lifetime-${crypto.randomUUID().slice(0, 8)}`;
+      const content = `restore lifetime ${crypto.randomUUID()}`;
+
+      await fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          command: `mkdir -p ${testDir} && printf '%s' '${content}' > ${testDir}/file.txt`
+        })
+      });
+
+      const backupResponse = await fetch(`${workerUrl}/api/backup/create`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ dir: testDir })
+      });
+      expect(backupResponse.ok).toBe(true);
+      const backup = (await backupResponse.json()) as BackupResponse;
+
+      await fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ command: `rm -rf ${testDir}/*` })
+      });
+
+      const restoreResponse = await fetch(`${workerUrl}/api/backup/restore`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ id: backup.id, dir: testDir })
+      });
+      expect(restoreResponse.ok).toBe(true);
+
+      const immediateRead = await fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ command: `cat ${testDir}/file.txt` })
+      });
+      const immediateResult = (await immediateRead.json()) as ExecuteResponse;
+      expect(immediateResult.exitCode).toBe(0);
+      expect(immediateResult.stdout).toBe(content);
+
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      const delayedRead = await fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          command: `cat ${testDir}/file.txt && printf '\n' && printf 'changed' > ${testDir}/cow.txt && cat ${testDir}/cow.txt`
+        })
+      });
+      const delayedResult = (await delayedRead.json()) as ExecuteResponse;
+      expect(delayedResult.exitCode).toBe(0);
+      expect(delayedResult.stdout).toContain(content);
+      expect(delayedResult.stdout).toContain('changed');
+
+      await cleanupDir(workerUrl, headers, testDir);
+    }, 60000);
   });
 
   describe('Backup excludes', () => {

--- a/tests/e2e/backup-workflow.test.ts
+++ b/tests/e2e/backup-workflow.test.ts
@@ -191,7 +191,7 @@ describe('Backup Workflow E2E', () => {
       await cleanupDir(workerUrl, headers, TEST_DIR);
     }, 60000);
 
-    test('should keep restored backup mounted after restore returns', async () => {
+    test('should materialize restored files after restore returns', async () => {
       if (!backupBucketAvailable) return;
 
       const testDir = `/workspace/restore-lifetime-${crypto.randomUUID().slice(0, 8)}`;
@@ -234,6 +234,16 @@ describe('Backup Workflow E2E', () => {
       const immediateResult = (await immediateRead.json()) as ExecuteResponse;
       expect(immediateResult.exitCode).toBe(0);
       expect(immediateResult.stdout).toBe(content);
+
+      const mountCheck = await fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          command: `mountpoint -q ${testDir} && echo mounted || echo materialized`
+        })
+      });
+      const mountResult = (await mountCheck.json()) as ExecuteResponse;
+      expect(mountResult.stdout?.trim()).toBe('materialized');
 
       await new Promise((resolve) => setTimeout(resolve, 500));
 


### PR DESCRIPTION
## Summary
- Materialize production backup restores into real target-directory files before `restoreBackup()` returns.
- Use temporary R2/squashfs FUSE mounts only as restore sources, then unmount and delete the temporary backup session.
- Pass the real backup ID through the restore API instead of deriving mount paths from `/var/backups/r2mount/<id>/data.sqsh`.
- Add unit and E2E regression coverage for production restore mount paths and post-restore materialized readability/writability.

## Why
Production restore previously did not copy files out of the backup archive. It mounted the archived data as a live filesystem view:

1. `s3fs` mounted the R2 backup prefix containing `data.sqsh`.
2. `squashfuse` mounted `data.sqsh` as the read-only lower layer.
3. `fuse-overlayfs` exposed the restored copy-on-write view at the target directory.

That made the target directory depend on hidden FUSE daemons and the temporary `__sandbox_backup_<uuid>` session that started them. If that session was deleted, or if the daemons otherwise exited, `restoreBackup()` could report success while the target path was left as an empty mountpoint/directory.

Keeping those sessions alive would fix the immediate empty-directory symptom, but it leaves unclear restore lifecycle semantics: no public unmount API, difficult cleanup for multiple restores, and target directories that depend on hidden background mounts.

There was also a second bug in the same path: the container derived `backupId` by stripping `/var/backups/` and `.sqsh` from `archivePath`. For production restores the archive path is `/var/backups/r2mount/<uuid>/data.sqsh`, so the derived ID became `r2mount/<uuid>/data` instead of `<uuid>`. That made restore mount paths depend on archive layout rather than the actual backup identity.

## Fix
Successful production restores now mount the R2 archive only temporarily, copy the mounted squashfs contents into the target directory, unmount the temporary FUSE mounts, clean up mount directories/password files, and delete the temporary backup session. After `restoreBackup()` returns, the restored path contains normal filesystem contents rather than a live FUSE overlay.

The restore API also passes the real backup ID explicitly through the SDK/client/container boundary, and the container validates it before using it in mount paths.

## Testing
- `bun test packages/sandbox-container/tests/services/backup-service.test.ts`
- `npm run typecheck -w @cloudflare/sandbox`
- `npm run typecheck -w @repo/sandbox-container`
- `npm run typecheck:e2e`
- `npm run typecheck` via pre-push hook

## Notes
Focused E2E was added but local execution previously stopped during Docker image build before the test ran; CI should exercise it in the configured environment.