### PR TITLE
Two fixes for rpc transport

### DIFF
--- a/packages/sandbox/src/clients/backup-client.ts
+++ b/packages/sandbox/src/clients/backup-client.ts
@@ -24,14 +24,13 @@ export class BackupClient extends BaseHttpClient {
     dir: string,
     archivePath: string,
     sessionId: string,
-    gitignore = false,
-    excludes: string[] = []
+    options?: { excludes?: string[]; gitignore?: boolean }
   ): Promise<CreateBackupResponse> {
     const data: CreateBackupRequest = {
       dir,
       archivePath,
-      gitignore,
-      excludes,
+      gitignore: options?.gitignore ?? false,
+      excludes: options?.excludes ?? [],
       sessionId
     };
 

--- a/packages/sandbox/src/clients/rpc-sandbox-client.ts
+++ b/packages/sandbox/src/clients/rpc-sandbox-client.ts
@@ -331,10 +331,18 @@ export class RPCSandboxClient {
    * activity timeout each tick so an in-flight stream keeps pushing the
    * sleepAfter deadline forward. On the busy → idle edge, fires
    * `onSessionIdle` and schedules the WebSocket disconnect.
+   *
+   * If the WebSocket has dropped underneath us (container crash, network
+   * blip) we tear the connection down here. `destroyConnection()` fires
+   * `onSessionIdle` if we were busy, so the DO's inflight counter doesn't
+   * stay pinned forever waiting for a peer that's never going to reply.
    */
   private pollBusyState = (): void => {
     const conn = this.conn;
-    if (!conn || !conn.isConnected()) return;
+    if (!conn || !conn.isConnected()) {
+      this.destroyConnection();
+      return;
+    }
 
     const { imports, exports } = conn.getStats();
     const isBusy =

--- a/packages/sandbox/src/clients/rpc-sandbox-client.ts
+++ b/packages/sandbox/src/clients/rpc-sandbox-client.ts
@@ -279,6 +279,13 @@ export class RPCSandboxClient {
   private busyPollTimer: ReturnType<typeof setInterval> | null = null;
   /** Tracks whether we currently believe the session is busy. */
   private busy = false;
+  /**
+   * Set the first time the poller observes `conn.isConnected() === true`,
+   * cleared in `destroyConnection()`. Lets us distinguish "the WebSocket
+   * upgrade is still in progress" (don't tear down) from "we were
+   * connected and the peer went away" (do tear down).
+   */
+  private wasEverConnected = false;
 
   constructor(options: RPCSandboxClientOptions) {
     this.connOptions = {
@@ -339,10 +346,25 @@ export class RPCSandboxClient {
    */
   private pollBusyState = (): void => {
     const conn = this.conn;
-    if (!conn || !conn.isConnected()) {
-      this.destroyConnection();
+    if (!conn) return;
+    if (!conn.isConnected()) {
+      // Two distinct cases share the same `isConnected() === false`
+      // signal:
+      //   1. The WebSocket upgrade is still in progress — we constructed
+      //      the connection in getConnection() but doConnect() hasn't
+      //      resolved yet. Sends are queued in the deferred transport.
+      //      Tearing down here would drop those queued calls on the floor.
+      //   2. We were connected and the peer went away (container crash,
+      //      network blip). The session is dead, we must release
+      //      inflight and stop polling.
+      // `wasEverConnected` distinguishes them: it flips to true the first
+      // time we observe a live connection below.
+      if (this.wasEverConnected) {
+        this.destroyConnection();
+      }
       return;
     }
+    this.wasEverConnected = true;
 
     const { imports, exports } = conn.getStats();
     const isBusy =
@@ -423,6 +445,7 @@ export class RPCSandboxClient {
       this.conn.disconnect();
       this.conn = null;
     }
+    this.wasEverConnected = false;
   }
 
   // -------------------------------------------------------------------------

--- a/packages/sandbox/src/clients/rpc-sandbox-client.ts
+++ b/packages/sandbox/src/clients/rpc-sandbox-client.ts
@@ -11,6 +11,62 @@
  * detection uses capnweb's `RpcSession.getStats()` which naturally tracks
  * all in-flight RPC calls, streams, and peer-held references — no manual
  * operation counting required.
+ *
+ * ---------------------------------------------------------------------------
+ * How capnweb tracks in-flight work (and why we poll getStats)
+ * ---------------------------------------------------------------------------
+ *
+ * Every capnweb session maintains two tables: `imports` (references the
+ * peer is exposing to us) and `exports` (references we are exposing to the
+ * peer). `getStats()` returns the live count of each.
+ *
+ * At rest, both contain exactly one entry — the bootstrap "main" stub each
+ * side exposes to reach the other. We treat `imports <= 1 && exports <= 1`
+ * as the idle baseline.
+ *
+ * Each kind of in-flight work bumps these counts:
+ *
+ *   - **Pending RPC call.** `sendCall()` allocates a new import slot for
+ *     the return value; the slot is released when the response arrives and
+ *     the caller disposes the promise. So a regular call shows up as
+ *     `imports = 2` for its lifetime.
+ *
+ *   - **Returned ReadableStream.** When the peer (the container) returns a
+ *     `ReadableStream` from an RPC method (e.g. `commands.executeStream`),
+ *     capnweb serializes it via `createPipe()`: the *server* allocates an
+ *     import slot, pumps `readable.pipeTo(writable)` over the wire, and
+ *     only releases the slot in `pipeTo().finally(() => hook.dispose())`
+ *     once the source stream ends or is canceled. On *our* side this
+ *     materializes as an export entry held for the same duration. So an
+ *     active stream return keeps `exports = 2` even after the RPC promise
+ *     that delivered the stream has already resolved.
+ *
+ *   - **Stubs / RpcTargets passed across the wire.** Anything the peer
+ *     hands us (or we hand the peer) that isn't a plain value adds an
+ *     entry until both sides dispose it.
+ *
+ * The practical consequence for sleepAfter: the per-call promise lifecycle
+ * is *not* a reliable signal of "the container is done with this work".
+ * `commands.executeStream(...)` resolves in milliseconds with a stream
+ * reference, but the container then writes to that stream for seconds. The
+ * only signal that survives across the promise boundary is the export
+ * entry — i.e. `getStats()`.
+ *
+ * So the strategy is:
+ *
+ *   1. Run a periodic poll while the WebSocket is connected.
+ *   2. While `imports > 1 || exports > 1`, treat the session as busy:
+ *      hold the DO's `inflightRequests` counter at >= 1 and renew the
+ *      activity timeout each tick so the sleepAfter alarm gets pushed
+ *      forward.
+ *   3. When the poll observes idle, decrement back to 0, renew once more
+ *      to reset the inactivity window from now, and schedule the WS
+ *      disconnect.
+ *
+ * On top of that, every RPC method invocation also fires `onActivity`
+ * synchronously at call start. That keeps fast calls from racing the
+ * poll cadence: even if a call begins and ends entirely between two
+ * polls, the activity timeout was renewed at the start.
  */
 
 import type {
@@ -46,6 +102,28 @@ import type { TransportMode } from './transport';
 
 /** Close the idle capnweb WebSocket promptly so the DO can sleep. */
 const DEFAULT_IDLE_DISCONNECT_MS = 1_000;
+
+/**
+ * How often the busy/idle poller samples `getStats()`.
+ *
+ * Sets two worst-case bounds:
+ *
+ *   1. **Idle-detection lag.** Time between the session going idle on
+ *      the wire and the DO observing it (and arming the disconnect).
+ *      Bounded by `pollInterval`.
+ *   2. **Activity-renewal lag while busy.** While a stream is active we
+ *      renew the DO's activity timeout once per tick. The alarm could
+ *      fire as late as `sleepAfter` after the last renew, so the
+ *      effective margin against a mid-stream sleep is
+ *      `sleepAfter - pollInterval`.
+ *
+ * **Invariant: `pollInterval` must be comfortably less than the
+ * smallest configurable `sleepAfter`.** Aim for at least 2-3× headroom.
+ * The minimum `sleepAfter` exercised by the E2E suite is 3s, so 1s gives
+ * 3× margin and at least two renewals during a 3s window. If a smaller
+ * `sleepAfter` is ever supported, drop this proportionally.
+ */
+const BUSY_POLL_INTERVAL_MS = 1_000;
 
 /**
  * Baseline getStats() values for an idle session. The bootstrap stub on each
@@ -96,27 +174,28 @@ function translateRPCError(error: unknown): never {
 
 /**
  * Wrap a capnweb RPC stub so that every method call translates errors
- * from the `[CODE] message` wire format into typed SandboxError instances.
+ * from the JSON wire format into typed SandboxError instances and signals
+ * activity at call start.
  *
- * `onCallStarted` fires synchronously when an RPC method is invoked.
- * `onCallSettled` fires after each promise-returning call resolves or
- * rejects. The RPCSandboxClient uses these to renew the DO activity
- * timeout (start) and check for idle disconnect (settle).
+ * `onCallStarted` fires synchronously when an RPC method is invoked. The
+ * RPCSandboxClient uses this to renew the DO's activity timeout
+ * immediately, so even a call that completes entirely between two
+ * busy-poll ticks still pushes the sleepAfter deadline forward.
+ *
+ * Note: there is no `onCallSettled` hook. A method whose returned promise
+ * resolves with a `ReadableStream` is *not* finished when the promise
+ * settles — capnweb keeps the export alive until the stream ends. The
+ * busy/idle poll on `getStats()` is the source of truth for that.
  */
-function wrapStub<T extends object>(
-  stub: T,
-  onCallStarted?: () => void,
-  onCallSettled?: () => void
-): T {
+function wrapStub<T extends object>(stub: T, onCallStarted: () => void): T {
   return new Proxy(stub, {
     get(target, prop, receiver) {
       const value = Reflect.get(target, prop, receiver);
       if (typeof value !== 'function') return value;
-      // Return a wrapper that catches errors from the RPC call.
       // Use Reflect.apply instead of value.apply() because capnweb
       // stubs are Proxies that interpret .apply as an RPC property access.
       return (...args: unknown[]) => {
-        onCallStarted?.();
+        onCallStarted();
         try {
           const result = Reflect.apply(
             value as (...a: unknown[]) => unknown,
@@ -129,24 +208,17 @@ function wrapStub<T extends object>(
             result != null &&
             typeof (result as { then?: unknown }).then === 'function'
           ) {
-            return (result as Promise<unknown>)
-              .catch(translateRPCError)
-              .finally(() => onCallSettled?.());
+            return (result as Promise<unknown>).catch(translateRPCError);
           }
-          // Non-promise return: settle immediately so the inflight
-          // counter doesn't drift.
-          onCallSettled?.();
           return result;
         } catch (err) {
-          // Synchronous throw: settle before re-throwing so the
-          // inflight counter doesn't drift.
-          onCallSettled?.();
           translateRPCError(err);
         }
       };
     }
   });
 }
+
 // ---------------------------------------------------------------------------
 // Public client
 // ---------------------------------------------------------------------------
@@ -154,18 +226,29 @@ function wrapStub<T extends object>(
 export interface RPCSandboxClientOptions extends ContainerConnectionOptions {
   /** Idle timeout before disconnecting the WebSocket (ms). Defaults to 1 000. */
   idleDisconnectMs?: number;
+  /** Busy/idle poll interval (ms). Defaults to 1 000. */
+  busyPollIntervalMs?: number;
   /**
-   * Fires at the start of each RPC call. The Sandbox DO wires this to
-   * increment inflightRequests and renew the activity timeout, matching
-   * what containerFetch() does for the HTTP transport.
+   * Renew the DO's activity timeout. Fires at the start of every RPC call
+   * and on every busy-poll tick while the session has work in flight.
+   * Mirrors what `containerFetch()` does at the top of each HTTP request.
    */
   onActivity?: () => void;
   /**
-   * Fires after each RPC call settles. The Sandbox DO wires this to
-   * decrement inflightRequests and renew the activity timeout when the
-   * count reaches zero, matching containerFetch's finally block.
+   * Fires once when the capnweb session transitions from idle to busy
+   * (an RPC call was started or a stream return is now in flight). The
+   * Sandbox DO wires this to `inflightRequests++`, which makes
+   * `isActivityExpired()` skip the sleepAfter comparison.
    */
-  onIdle?: () => void;
+  onSessionBusy?: () => void;
+  /**
+   * Fires once when the session transitions from busy back to idle
+   * (all RPC promises settled and all stream exports released). The
+   * Sandbox DO wires this to `inflightRequests = max(0, n-1)` and a
+   * final `renewActivityTimeout()`, matching containerFetch's finally
+   * block.
+   */
+  onSessionIdle?: () => void;
 }
 
 /**
@@ -177,19 +260,25 @@ export interface RPCSandboxClientOptions extends ContainerConnectionOptions {
  *
  * Manages its own WebSocket lifecycle: a fresh `ContainerConnection` is
  * created on demand and torn down after `idleDisconnectMs` of inactivity.
- * Idle detection relies on `RpcSession.getStats()` which tracks all in-flight
- * RPC calls and streams — including long-lived streaming RPCs that would be
- * invisible to a simple request counter.
+ * Busy/idle detection relies on `RpcSession.getStats()` which tracks all
+ * in-flight RPC calls and stream exports — including long-lived streaming
+ * RPCs that would be invisible to a simple per-call request counter (see
+ * the file-level comment for the full rationale).
  */
 export class RPCSandboxClient {
   private readonly connOptions: ContainerConnectionOptions;
   private readonly idleDisconnectMs: number;
+  private readonly busyPollIntervalMs: number;
   private readonly logger: Logger;
   private readonly onActivity: (() => void) | undefined;
-  private readonly onIdle: (() => void) | undefined;
+  private readonly onSessionBusy: (() => void) | undefined;
+  private readonly onSessionIdle: (() => void) | undefined;
 
   private conn: ContainerConnection | null = null;
   private idleTimer: ReturnType<typeof setTimeout> | null = null;
+  private busyPollTimer: ReturnType<typeof setInterval> | null = null;
+  /** Tracks whether we currently believe the session is busy. */
+  private busy = false;
 
   constructor(options: RPCSandboxClientOptions) {
     this.connOptions = {
@@ -199,9 +288,12 @@ export class RPCSandboxClient {
     };
     this.idleDisconnectMs =
       options.idleDisconnectMs ?? DEFAULT_IDLE_DISCONNECT_MS;
+    this.busyPollIntervalMs =
+      options.busyPollIntervalMs ?? BUSY_POLL_INTERVAL_MS;
     this.logger = options.logger ?? createNoOpLogger();
     this.onActivity = options.onActivity;
-    this.onIdle = options.onIdle;
+    this.onSessionBusy = options.onSessionBusy;
+    this.onSessionIdle = options.onSessionIdle;
   }
 
   // -------------------------------------------------------------------------
@@ -210,17 +302,19 @@ export class RPCSandboxClient {
 
   /**
    * Return the current connection, creating a new one if none exists or the
-   * previous one was torn down by an idle disconnect.
+   * previous one was torn down by an idle disconnect. Starts the busy-poll
+   * timer the first time a connection is materialized.
    */
   private getConnection(): ContainerConnection {
     if (!this.conn) {
       this.conn = new ContainerConnection(this.connOptions);
+      this.startBusyPoll();
     }
     return this.conn;
   }
 
   // -------------------------------------------------------------------------
-  // Idle disconnect
+  // Activity & busy/idle tracking
   // -------------------------------------------------------------------------
 
   /**
@@ -233,32 +327,63 @@ export class RPCSandboxClient {
   };
 
   /**
-   * Called after each RPC promise settles. Decrements the DO's inflight
-   * counter via onIdle, then checks whether the capnweb session is idle
-   * enough to disconnect the WebSocket.
+   * Sample `getStats()` and update busy/idle state. While busy, renews the
+   * activity timeout each tick so an in-flight stream keeps pushing the
+   * sleepAfter deadline forward. On the busy → idle edge, fires
+   * `onSessionIdle` and schedules the WebSocket disconnect.
    */
-  private checkIdle = (): void => {
-    this.onIdle?.();
+  private pollBusyState = (): void => {
     const conn = this.conn;
     if (!conn || !conn.isConnected()) return;
 
     const { imports, exports } = conn.getStats();
-    if (imports <= IDLE_IMPORT_THRESHOLD && exports <= IDLE_EXPORT_THRESHOLD) {
+    const isBusy =
+      imports > IDLE_IMPORT_THRESHOLD || exports > IDLE_EXPORT_THRESHOLD;
+
+    if (isBusy) {
+      if (!this.busy) {
+        this.busy = true;
+        this.onSessionBusy?.();
+      }
+      // Renew on every busy tick — this is what keeps a long-lived stream
+      // alive past sleepAfter.
+      this.onActivity?.();
+      this.clearIdleTimer();
+    } else if (this.busy) {
+      this.busy = false;
+      this.onSessionIdle?.();
       this.scheduleIdleDisconnect();
     } else {
-      // Still busy — clear any pending timer and wait for the next settle.
-      this.clearIdleTimer();
+      // Already idle, no state change. Still ensure the disconnect timer
+      // is armed (covers the case where we connected but never observed
+      // any activity).
+      if (!this.idleTimer) this.scheduleIdleDisconnect();
     }
   };
+
+  private startBusyPoll(): void {
+    if (this.busyPollTimer) return;
+    this.busyPollTimer = setInterval(
+      this.pollBusyState,
+      this.busyPollIntervalMs
+    );
+  }
+
+  private stopBusyPoll(): void {
+    if (this.busyPollTimer) {
+      clearInterval(this.busyPollTimer);
+      this.busyPollTimer = null;
+    }
+  }
 
   private scheduleIdleDisconnect(): void {
     this.clearIdleTimer();
     this.idleTimer = setTimeout(() => {
       this.idleTimer = null;
-      // Re-check before disconnecting — a new call may have started.
       const conn = this.conn;
       if (!conn || !conn.isConnected()) return;
 
+      // Re-check before disconnecting — a new call may have started.
       const { imports, exports } = conn.getStats();
       if (
         imports <= IDLE_IMPORT_THRESHOLD &&
@@ -278,6 +403,14 @@ export class RPCSandboxClient {
   }
 
   private destroyConnection(): void {
+    this.stopBusyPoll();
+    this.clearIdleTimer();
+    // If we tear down while still believing the session is busy, fire the
+    // idle transition so the DO's inflight counter doesn't leak.
+    if (this.busy) {
+      this.busy = false;
+      this.onSessionIdle?.();
+    }
     if (this.conn) {
       this.conn.disconnect();
       this.conn = null;
@@ -294,74 +427,34 @@ export class RPCSandboxClient {
   // type machinery from expanding in .d.ts output (causes OOM).
 
   get commands(): SandboxCommandsAPI {
-    return wrapStub(
-      this.getConnection().rpc().commands,
-      this.renewActivity,
-      this.checkIdle
-    );
+    return wrapStub(this.getConnection().rpc().commands, this.renewActivity);
   }
   get files(): SandboxFilesAPI {
-    return wrapStub(
-      this.getConnection().rpc().files,
-      this.renewActivity,
-      this.checkIdle
-    );
+    return wrapStub(this.getConnection().rpc().files, this.renewActivity);
   }
   get processes(): SandboxProcessesAPI {
-    return wrapStub(
-      this.getConnection().rpc().processes,
-      this.renewActivity,
-      this.checkIdle
-    );
+    return wrapStub(this.getConnection().rpc().processes, this.renewActivity);
   }
   get ports(): SandboxPortsAPI {
-    return wrapStub(
-      this.getConnection().rpc().ports,
-      this.renewActivity,
-      this.checkIdle
-    );
+    return wrapStub(this.getConnection().rpc().ports, this.renewActivity);
   }
   get git(): SandboxGitAPI {
-    return wrapStub(
-      this.getConnection().rpc().git,
-      this.renewActivity,
-      this.checkIdle
-    );
+    return wrapStub(this.getConnection().rpc().git, this.renewActivity);
   }
   get utils(): SandboxUtilsAPI {
-    return wrapStub(
-      this.getConnection().rpc().utils,
-      this.renewActivity,
-      this.checkIdle
-    );
+    return wrapStub(this.getConnection().rpc().utils, this.renewActivity);
   }
   get backup(): SandboxBackupAPI {
-    return wrapStub(
-      this.getConnection().rpc().backup,
-      this.renewActivity,
-      this.checkIdle
-    );
+    return wrapStub(this.getConnection().rpc().backup, this.renewActivity);
   }
   get desktop(): SandboxDesktopAPI {
-    return wrapStub(
-      this.getConnection().rpc().desktop,
-      this.renewActivity,
-      this.checkIdle
-    );
+    return wrapStub(this.getConnection().rpc().desktop, this.renewActivity);
   }
   get watch(): SandboxWatchAPI {
-    return wrapStub(
-      this.getConnection().rpc().watch,
-      this.renewActivity,
-      this.checkIdle
-    );
+    return wrapStub(this.getConnection().rpc().watch, this.renewActivity);
   }
   get interpreter(): SandboxInterpreterAPI {
-    return wrapStub(
-      this.getConnection().rpc().interpreter,
-      this.renewActivity,
-      this.checkIdle
-    );
+    return wrapStub(this.getConnection().rpc().interpreter, this.renewActivity);
   }
 
   setRetryTimeoutMs(_ms: number): void {
@@ -381,7 +474,6 @@ export class RPCSandboxClient {
   }
 
   disconnect(): void {
-    this.clearIdleTimer();
     this.destroyConnection();
   }
 

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -621,31 +621,43 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     if (transport === 'rpc') {
       // Access the base Container's private inflightRequests counter so
       // the alarm loop's isActivityExpired() check sees active work and
-      // skips the sleepAfterMs comparison while RPC calls are in flight.
+      // skips the sleepAfterMs comparison while RPC calls or returned
+      // streams are still active over the capnweb session.
       const self = this as unknown as { inflightRequests: number };
       return new RPCSandboxClient({
         stub: this,
         port: 3000,
         logger: this.logger,
         // Mirrors containerFetch()'s request lifecycle for the RPC transport.
-        // The HTTP transport increments inflightRequests at the start of each
-        // containerFetch() call and renews the activity timeout so the alarm
-        // loop sees active work and pushes sleepAfter forward. The RPC
-        // transport bypasses containerFetch() entirely (all calls multiplex
-        // over a single WebSocket), so we replicate the same bookkeeping here.
+        //
+        // The HTTP transport bumps inflightRequests at the top of each
+        // containerFetch() call and decrements in `finally`. The RPC
+        // transport multiplexes all work over a single capnweb WebSocket,
+        // so we can't bracket per-request — and a method that returns a
+        // ReadableStream resolves its promise long before the stream is
+        // actually drained. Instead, RPCSandboxClient polls capnweb's
+        // session stats and reports busy/idle *transitions* of the whole
+        // session. We treat one transition as equivalent to one in-flight
+        // request: increment on busy, decrement on idle. See the
+        // file-level comment in rpc-sandbox-client.ts for details.
         onActivity: () => {
-          // Called at the start of each RPC method invocation.
-          // Equivalent to the top of containerFetch(): mark the DO as busy
-          // so isActivityExpired() returns false, and push the sleepAfter
-          // deadline forward.
-          self.inflightRequests++;
+          // Called at the start of each RPC call AND on every busy-poll
+          // tick while the session has work in flight. Equivalent to
+          // the top of containerFetch(): push the sleepAfter deadline
+          // forward.
           this.renewActivityTimeout();
         },
-        onIdle: () => {
-          // Called when an RPC method promise settles.
-          // Equivalent to containerFetch()'s finally block: decrement the
-          // inflight counter, and when it reaches zero restart the inactivity
-          // window from now — the same behavior as decrementInflight().
+        onSessionBusy: () => {
+          // Idle → busy: a new RPC call started or a stream return is
+          // now in flight. Mark the DO busy so isActivityExpired()
+          // returns false until the session goes idle again.
+          self.inflightRequests++;
+        },
+        onSessionIdle: () => {
+          // Busy → idle: all RPC promises have settled and all stream
+          // exports have been released. Equivalent to containerFetch's
+          // finally block — decrement and restart the inactivity window
+          // from now.
           self.inflightRequests = Math.max(0, self.inflightRequests - 1);
           if (self.inflightRequests === 0) {
             this.renewActivityTimeout();

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -4359,8 +4359,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         dir,
         archivePath,
         backupSession,
-        gitignore,
-        excludes
+        { gitignore, excludes }
       );
 
       if (!createResult.success) {
@@ -4544,8 +4543,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         dir,
         archivePath,
         backupSession,
-        gitignore,
-        excludes
+        { gitignore, excludes }
       );
 
       if (!createResult.success) {

--- a/packages/sandbox/tests/local-backup.test.ts
+++ b/packages/sandbox/tests/local-backup.test.ts
@@ -213,8 +213,7 @@ describe('Local Backup & Restore', () => {
         '/workspace/myapp',
         expect.stringContaining('/var/backups/'),
         expect.any(String), // backup session ID
-        false, // gitignore default
-        [] // excludes default
+        { gitignore: false, excludes: [] }
       );
 
       // Verify archive was uploaded to R2 via binding

--- a/packages/sandbox/tests/rpc-sandbox-client.test.ts
+++ b/packages/sandbox/tests/rpc-sandbox-client.test.ts
@@ -121,4 +121,39 @@ describe('RPCSandboxClient busy/idle tracking', () => {
     client.disconnect();
     expect(onSessionIdle).toHaveBeenCalledTimes(1);
   });
+
+  it('releases inflight when the WebSocket drops while busy', () => {
+    const onSessionBusy = vi.fn();
+    const onSessionIdle = vi.fn();
+
+    const client = new RPCSandboxClient({
+      stub: { fetch: vi.fn() },
+      onSessionBusy,
+      onSessionIdle,
+      busyPollIntervalMs: 1_000,
+      idleDisconnectMs: 60_000
+    });
+    void client.commands;
+
+    stats = { imports: 1, exports: 2 };
+    vi.advanceTimersByTime(1_000);
+    expect(onSessionBusy).toHaveBeenCalledTimes(1);
+
+    // Container crash / WebSocket peer-close: connection reports
+    // disconnected on the next poll.
+    connected = false;
+    vi.advanceTimersByTime(1_000);
+
+    // The poller must observe the dead connection, fire onSessionIdle so
+    // the DO's inflight counter unwinds, and tear down so it isn't
+    // looping over a corpse forever.
+    expect(onSessionIdle).toHaveBeenCalledTimes(1);
+    expect(disconnects).toHaveLength(1);
+
+    // Subsequent ticks must be a no-op — if the poller fired again it
+    // would attempt destroyConnection() repeatedly.
+    vi.advanceTimersByTime(5_000);
+    expect(onSessionIdle).toHaveBeenCalledTimes(1);
+    expect(disconnects).toHaveLength(1);
+  });
 });

--- a/packages/sandbox/tests/rpc-sandbox-client.test.ts
+++ b/packages/sandbox/tests/rpc-sandbox-client.test.ts
@@ -156,4 +156,39 @@ describe('RPCSandboxClient busy/idle tracking', () => {
     expect(onSessionIdle).toHaveBeenCalledTimes(1);
     expect(disconnects).toHaveLength(1);
   });
+
+  it('does not tear down a connection that has not finished its WebSocket upgrade', () => {
+    // Simulate the upgrade still being in flight: isConnected() returns
+    // false from the moment the connection is constructed until
+    // doConnect() resolves. While in this state the deferred transport
+    // is queueing sends — tearing the connection down would discard them.
+    connected = false;
+
+    const onSessionIdle = vi.fn();
+    const client = new RPCSandboxClient({
+      stub: { fetch: vi.fn() },
+      onSessionIdle,
+      busyPollIntervalMs: 1_000,
+      idleDisconnectMs: 60_000
+    });
+    void client.commands;
+
+    // Several poll ticks while the upgrade is still pending. Must not
+    // dispose the connection — the deferred transport's queue is the
+    // only thing standing between the user's RPC call and the wire.
+    vi.advanceTimersByTime(5_000);
+    expect(disconnects).toHaveLength(0);
+    expect(onSessionIdle).not.toHaveBeenCalled();
+
+    // Upgrade completes. From here on the poller treats subsequent
+    // disconnections as real peer-gone events.
+    connected = true;
+    stats = { imports: 1, exports: 2 };
+    vi.advanceTimersByTime(1_000); // observed busy
+
+    connected = false;
+    vi.advanceTimersByTime(1_000); // peer-gone — now we tear down
+    expect(disconnects).toHaveLength(1);
+    expect(onSessionIdle).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/sandbox/tests/rpc-sandbox-client.test.ts
+++ b/packages/sandbox/tests/rpc-sandbox-client.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Verifies the RPC client's busy/idle bookkeeping — specifically that a
+ * streaming RPC return (modeled by elevated capnweb stats sticking around
+ * after the call promise has resolved) keeps `onActivity` firing past
+ * `sleepAfter` and only fires `onSessionIdle` once stats return to baseline.
+ *
+ * We mock ContainerConnection so we can drive `getStats()` directly. The
+ * test never actually opens a WebSocket.
+ */
+
+let stats = { imports: 1, exports: 1 };
+let connected = true;
+const disconnects: number[] = [];
+
+vi.mock('../src/container-connection', () => ({
+  ContainerConnection: class {
+    isConnected() {
+      return connected;
+    }
+    getStats() {
+      return stats;
+    }
+    disconnect() {
+      connected = false;
+      disconnects.push(Date.now());
+    }
+    rpc() {
+      // Stub sub-clients so wrapStub() has something to Proxy. Tests in
+      // this file don't actually invoke any RPC method.
+      return new Proxy({}, { get: () => ({}) });
+    }
+    async connect() {}
+  }
+}));
+
+import { RPCSandboxClient } from '../src/clients/rpc-sandbox-client';
+
+describe('RPCSandboxClient busy/idle tracking', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    stats = { imports: 1, exports: 1 };
+    connected = true;
+    disconnects.length = 0;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps the session marked busy while a stream export is held', () => {
+    const onActivity = vi.fn();
+    const onSessionBusy = vi.fn();
+    const onSessionIdle = vi.fn();
+
+    const client = new RPCSandboxClient({
+      stub: { fetch: vi.fn() },
+      onActivity,
+      onSessionBusy,
+      onSessionIdle,
+      busyPollIntervalMs: 1_000,
+      idleDisconnectMs: 1_000
+    });
+
+    // Touching a sub-client constructs the connection and starts the poller.
+    void client.commands;
+
+    // Simulate executeStream returning a ReadableStream: capnweb has
+    // allocated an export for the pipe, and it stays elevated for the
+    // entire duration of the stream.
+    stats = { imports: 1, exports: 2 };
+
+    // Tick 1: idle -> busy edge.
+    vi.advanceTimersByTime(1_000);
+    expect(onSessionBusy).toHaveBeenCalledTimes(1);
+    expect(onSessionIdle).not.toHaveBeenCalled();
+    expect(onActivity).toHaveBeenCalledTimes(1);
+
+    // Three more ticks while still streaming. No edge transitions, but
+    // each tick must renew activity — this is what keeps the DO awake
+    // past sleepAfter.
+    vi.advanceTimersByTime(3_000);
+    expect(onSessionBusy).toHaveBeenCalledTimes(1);
+    expect(onSessionIdle).not.toHaveBeenCalled();
+    expect(onActivity).toHaveBeenCalledTimes(4);
+
+    // Stream finishes: stats fall back to the bootstrap baseline.
+    stats = { imports: 1, exports: 1 };
+
+    // Tick: busy -> idle edge. inflight gets decremented exactly once.
+    vi.advanceTimersByTime(1_000);
+    expect(onSessionIdle).toHaveBeenCalledTimes(1);
+    expect(onSessionBusy).toHaveBeenCalledTimes(1);
+
+    // Idle disconnect timer fires after idleDisconnectMs.
+    vi.advanceTimersByTime(1_000);
+    expect(disconnects).toHaveLength(1);
+  });
+
+  it('fires onSessionIdle on explicit disconnect to avoid leaking inflight', () => {
+    const onSessionBusy = vi.fn();
+    const onSessionIdle = vi.fn();
+
+    const client = new RPCSandboxClient({
+      stub: { fetch: vi.fn() },
+      onSessionBusy,
+      onSessionIdle,
+      busyPollIntervalMs: 1_000,
+      idleDisconnectMs: 60_000
+    });
+    void client.commands;
+
+    stats = { imports: 1, exports: 2 };
+    vi.advanceTimersByTime(1_000);
+    expect(onSessionBusy).toHaveBeenCalledTimes(1);
+    expect(onSessionIdle).not.toHaveBeenCalled();
+
+    // Tearing down while busy must release the inflight slot, otherwise
+    // the DO's counter stays elevated forever.
+    client.disconnect();
+    expect(onSessionIdle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1846,8 +1846,7 @@ describe('Sandbox - Automatic Session Management', () => {
         '/app/project',
         expect.stringMatching(/^\/var\/backups\/.+\.sqsh$/),
         expect.stringMatching(/^__sandbox_backup_/),
-        false,
-        []
+        { gitignore: false, excludes: [] }
       );
       expect(bucket.put).toHaveBeenCalled();
     });


### PR DESCRIPTION
- **Fix dropped backup options on RPC transport** - the backup options were not being passed via capnweb interface.
- **Use capnweb stats to track in-flight RPC work** - the original import/export tracking by calling `getStats()` wasn't enough to keep the connection alive. Now instead we supplement this by polling `getStats()`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
