### PR TITLE
Normalize globstar exclude patterns for backups

### DIFF
--- a/.changeset/backup-globstar-excludes.md
+++ b/.changeset/backup-globstar-excludes.md
@@ -1,0 +1,7 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Fix `createBackup()` excludes that use gitignore-style `**` globstars.
+
+Normalize globstar excludes to the mksquashfs-compatible patterns used by the backup pipeline so local and production backups handle them consistently.

--- a/packages/sandbox-container/src/services/backup-service.ts
+++ b/packages/sandbox-container/src/services/backup-service.ts
@@ -1,6 +1,9 @@
 import type { Logger } from '@repo/shared';
 import { logCanonicalEvent, shellEscape } from '@repo/shared';
-import { BACKUP_ALLOWED_PREFIXES } from '@repo/shared/backup';
+import {
+  BACKUP_ALLOWED_PREFIXES,
+  normalizeBackupExcludePattern
+} from '@repo/shared/backup';
 import { ErrorCode, Operation } from '@repo/shared/errors';
 import type { ServiceResult } from '../core/types';
 import { serviceError, serviceSuccess } from '../core/types';
@@ -173,7 +176,26 @@ export class BackupService {
         ? await this.resolveGitignoreExcludePatterns(dir, sessionId, opLogger)
         : [];
 
-      const userExcludePatterns = excludes.flatMap((pattern) => [
+      const normalizedExcludes: string[] = [];
+      for (const pattern of excludes) {
+        const normalized = BackupService.normalizeMksquashfsPattern(pattern);
+        if (normalized === null) {
+          opLogger.warn(
+            'Exclude pattern reduced to empty after globstar normalization; skipping',
+            { original: pattern }
+          );
+          continue;
+        }
+        if (normalized !== pattern) {
+          opLogger.warn(
+            'Exclude pattern contained ** (globstar) which mksquashfs does not support; normalized automatically',
+            { original: pattern, normalized }
+          );
+        }
+        normalizedExcludes.push(normalized);
+      }
+
+      const userExcludePatterns = normalizedExcludes.flatMap((pattern) => [
         pattern,
         `... ${pattern}`
       ]);
@@ -373,6 +395,16 @@ export class BackupService {
 
   private static escapeMksquashfsWildcardLiteral(path: string): string {
     return path.replace(/\\/g, '\\\\').replace(/([*?[\]])/g, '\\$1');
+  }
+
+  /**
+   * Normalize a user-provided exclude pattern for mksquashfs compatibility.
+   * mksquashfs uses fnmatch-style wildcards which do not support ** (globstar).
+   * The mksquashfs "... " prefix already provides recursive directory matching,
+   * making leading ** redundant. Returns null if the pattern reduces to empty.
+   */
+  static normalizeMksquashfsPattern(pattern: string): string | null {
+    return normalizeBackupExcludePattern(pattern);
   }
 
   /**

--- a/packages/sandbox-container/tests/services/backup-service.test.ts
+++ b/packages/sandbox-container/tests/services/backup-service.test.ts
@@ -484,6 +484,7 @@ describe('BackupService', () => {
       expect(BackupService.normalizeMksquashfsPattern('src/**/test')).toBe(
         'src/test'
       );
+      expect(BackupService.normalizeMksquashfsPattern('a/**/**/b')).toBe('a/b');
       expect(BackupService.normalizeMksquashfsPattern('a/**/b/**/c')).toBe(
         'a/b/c'
       );

--- a/packages/sandbox-container/tests/services/backup-service.test.ts
+++ b/packages/sandbox-container/tests/services/backup-service.test.ts
@@ -461,6 +461,125 @@ describe('BackupService', () => {
     ).toBe(true);
   });
 
+  describe('normalizeMksquashfsPattern', () => {
+    it('strips leading **/', () => {
+      expect(BackupService.normalizeMksquashfsPattern('**/node_modules')).toBe(
+        'node_modules'
+      );
+      expect(
+        BackupService.normalizeMksquashfsPattern('**/node_modules/.cache')
+      ).toBe('node_modules/.cache');
+      expect(BackupService.normalizeMksquashfsPattern('**/.next/cache')).toBe(
+        '.next/cache'
+      );
+    });
+
+    it('strips repeated leading **/', () => {
+      expect(
+        BackupService.normalizeMksquashfsPattern('**/**/node_modules')
+      ).toBe('node_modules');
+    });
+
+    it('replaces mid-pattern /**/ with /', () => {
+      expect(BackupService.normalizeMksquashfsPattern('src/**/test')).toBe(
+        'src/test'
+      );
+      expect(BackupService.normalizeMksquashfsPattern('a/**/b/**/c')).toBe(
+        'a/b/c'
+      );
+    });
+
+    it('strips trailing /**', () => {
+      expect(BackupService.normalizeMksquashfsPattern('dist/**')).toBe('dist');
+    });
+
+    it('handles combined leading and trailing **', () => {
+      expect(BackupService.normalizeMksquashfsPattern('**/dist/**')).toBe(
+        'dist'
+      );
+    });
+
+    it('returns null for pure ** patterns', () => {
+      expect(BackupService.normalizeMksquashfsPattern('**')).toBeNull();
+      expect(BackupService.normalizeMksquashfsPattern('**/**')).toBeNull();
+    });
+
+    it('passes through patterns without **', () => {
+      expect(BackupService.normalizeMksquashfsPattern('node_modules')).toBe(
+        'node_modules'
+      );
+      expect(BackupService.normalizeMksquashfsPattern('*.log')).toBe('*.log');
+      expect(BackupService.normalizeMksquashfsPattern('.cache')).toBe('.cache');
+    });
+  });
+
+  it('normalizes globstar excludes before passing to mksquashfs', async () => {
+    const dir = '/workspace/app';
+    const archivePath = '/var/backups/globstar-excludes.sqsh';
+
+    mocked(mockSessionManager.executeInSession).mockImplementation(
+      async (_sessionId: string, command: string) => {
+        if (command.startsWith('mkdir -p ')) return execSuccess();
+        if (command.startsWith('test -d ')) return execSuccess();
+        if (command.includes('test -x /usr/bin/mksquashfs'))
+          return execSuccess('exists\n');
+        if (command.startsWith("printf '%s\\n' ")) return execSuccess();
+        if (command.includes('/usr/bin/mksquashfs')) return execSuccess();
+        if (command.startsWith('rm -f ')) return execSuccess();
+        if (command.startsWith('stat -c %s ')) return execSuccess('500\n');
+
+        return {
+          success: false,
+          error: {
+            message: `Unexpected command in test: ${command}`,
+            code: 'TEST_ERROR',
+            details: {}
+          }
+        };
+      }
+    );
+
+    const result = await service.createArchive(
+      dir,
+      archivePath,
+      'default',
+      false,
+      ['**/node_modules/.cache', '**/.next/cache', '**/.turbo', '**/dist']
+    );
+    expect(result.success).toBe(true);
+
+    const callArgs = mocked(mockSessionManager.executeInSession)
+      .mock.calls.map(([, command]) => command)
+      .filter((command): command is string => typeof command === 'string');
+
+    const writeExcludeCommand = callArgs.find((command) =>
+      command.startsWith("printf '%s\\n' ")
+    );
+    expect(writeExcludeCommand).toBeDefined();
+
+    // Patterns should be normalized: no ** prefixes
+    expect(writeExcludeCommand).toContain("'node_modules/.cache'");
+    expect(writeExcludeCommand).toContain("'... node_modules/.cache'");
+    expect(writeExcludeCommand).toContain("'.next/cache'");
+    expect(writeExcludeCommand).toContain("'.turbo'");
+    expect(writeExcludeCommand).toContain("'dist'");
+
+    // Original ** patterns must NOT appear
+    expect(writeExcludeCommand).not.toContain('**/node_modules');
+    expect(writeExcludeCommand).not.toContain('**/.next');
+    expect(writeExcludeCommand).not.toContain('**/.turbo');
+    expect(writeExcludeCommand).not.toContain('**/dist');
+
+    // Should have logged warnings about normalization
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'Exclude pattern contained ** (globstar) which mksquashfs does not support; normalized automatically',
+      expect.objectContaining({
+        original: '**/node_modules/.cache',
+        normalized: 'node_modules/.cache'
+      })
+    );
+  });
+
   it('does not add exclude flags when gitignore is false in non-git directories', async () => {
     const dir = '/workspace/non-git-dir';
     const archivePath = '/var/backups/test-no-exclude.sqsh';

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -43,7 +43,10 @@ import {
   shellEscape,
   TraceContext
 } from '@repo/shared';
-import { BACKUP_ALLOWED_PREFIXES } from '@repo/shared/backup';
+import {
+  BACKUP_ALLOWED_PREFIXES,
+  normalizeBackupExcludePattern
+} from '@repo/shared/backup';
 import { AwsClient } from 'aws4fetch';
 import { type Desktop, type ExecuteResponse, SandboxClient } from './clients';
 import { RPCSandboxClient } from './clients/rpc-sandbox-client';
@@ -4128,6 +4131,30 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     return this.backupBucket;
   }
 
+  private normalizeBackupExcludes(excludes: string[]): string[] {
+    const normalizedExcludes: string[] = [];
+
+    for (const pattern of excludes) {
+      const normalized = normalizeBackupExcludePattern(pattern);
+      if (normalized === null) {
+        this.logger.warn(
+          'Exclude pattern reduced to empty after globstar normalization; skipping',
+          { original: pattern }
+        );
+        continue;
+      }
+      if (normalized !== pattern) {
+        this.logger.warn(
+          'Exclude pattern contained ** (globstar) which mksquashfs does not support; normalized automatically',
+          { original: pattern, normalized }
+        );
+      }
+      normalizedExcludes.push(normalized);
+    }
+
+    return normalizedExcludes;
+  }
+
   private static readonly PRESIGNED_URL_EXPIRY_SECONDS = 3600;
 
   /**
@@ -4456,6 +4483,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         });
       }
 
+      const normalizedExcludes = this.normalizeBackupExcludes(excludes);
+
       backupSession = await this.ensureBackupSession();
       backupId = crypto.randomUUID();
       const archivePath = `${BACKUP_CONTAINER_DIR}/${backupId}.sqsh`;
@@ -4464,7 +4493,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         dir,
         archivePath,
         backupSession,
-        { gitignore, excludes }
+        { gitignore, excludes: normalizedExcludes }
       );
 
       if (!createResult.success) {
@@ -4639,6 +4668,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         });
       }
 
+      const normalizedExcludes = this.normalizeBackupExcludes(excludes);
+
       backupSession = await this.ensureBackupSession();
       backupId = crypto.randomUUID();
       const archivePath = `${BACKUP_CONTAINER_DIR}/${backupId}.sqsh`;
@@ -4648,7 +4679,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         dir,
         archivePath,
         backupSession,
-        { gitignore, excludes }
+        { gitignore, excludes: normalizedExcludes }
       );
 
       if (!createResult.success) {

--- a/packages/sandbox/tests/local-backup.test.ts
+++ b/packages/sandbox/tests/local-backup.test.ts
@@ -323,6 +323,46 @@ describe('Local Backup & Restore', () => {
       expect(result.id).toBeDefined();
       expect(result.localBucket).toBe(true);
     });
+
+    it('should normalize globstar excludes before calling createArchive', async () => {
+      vi.spyOn(sandbox.client.backup, 'createArchive').mockResolvedValue({
+        success: true,
+        archivePath: '/var/backups/test.sqsh',
+        sizeBytes: 4
+      } as any);
+
+      const archiveContent = new Uint8Array([0x68, 0x73, 0x71, 0x73]);
+      const ssePayload = [
+        `data: ${JSON.stringify({ type: 'metadata', mimeType: 'application/octet-stream', size: archiveContent.length, isBinary: true, encoding: 'base64' })}\n\n`,
+        `data: ${JSON.stringify({ type: 'chunk', data: btoa(String.fromCharCode(...archiveContent)) })}\n\n`,
+        `data: ${JSON.stringify({ type: 'complete' })}\n\n`
+      ].join('');
+
+      vi.spyOn(sandbox.client.files, 'readFileStream').mockResolvedValue(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(ssePayload));
+            controller.close();
+          }
+        })
+      );
+
+      await sandbox.createBackup({
+        dir: '/workspace/myapp',
+        localBucket: true,
+        excludes: ['**/node_modules/.cache', '**/.next/cache', 'dist/**', '**']
+      });
+
+      expect(sandbox.client.backup.createArchive).toHaveBeenCalledWith(
+        '/workspace/myapp',
+        expect.stringContaining('/var/backups/'),
+        expect.any(String),
+        {
+          gitignore: false,
+          excludes: ['node_modules/.cache', '.next/cache', 'dist']
+        }
+      );
+    });
   });
 
   describe('restoreBackup with localBucket', () => {

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1917,6 +1917,51 @@ describe('Sandbox - Automatic Session Management', () => {
       expect(bucket.put).toHaveBeenCalled();
     });
 
+    it('should normalize globstar excludes before calling createArchive', async () => {
+      const { backupSandbox } = await createBackupSandbox();
+
+      vi.spyOn(backupSandbox.client.utils, 'createSession').mockResolvedValue({
+        success: true,
+        id: 'backup-session',
+        message: 'Created'
+      } as any);
+      vi.spyOn(backupSandbox.client.utils, 'deleteSession').mockResolvedValue({
+        success: true,
+        id: 'backup-session',
+        message: 'Deleted'
+      } as any);
+      const createArchiveSpy = vi
+        .spyOn(backupSandbox.client.backup, 'createArchive')
+        .mockResolvedValue({
+          success: true,
+          sizeBytes: 42,
+          archivePath: '/var/backups/mock.sqsh'
+        });
+      vi.spyOn(backupSandbox as any, 'uploadBackupPresigned').mockResolvedValue(
+        undefined
+      );
+      vi.spyOn(backupSandbox as any, 'execWithSession').mockResolvedValue({
+        stdout: '',
+        stderr: '',
+        exitCode: 0
+      });
+
+      await backupSandbox.createBackup({
+        dir: '/app/project',
+        excludes: ['**/node_modules/.cache', '**/.next/cache', 'dist/**', '**']
+      });
+
+      expect(createArchiveSpy).toHaveBeenCalledWith(
+        '/app/project',
+        expect.stringMatching(/^\/var\/backups\/.+\.sqsh$/),
+        expect.stringMatching(/^__sandbox_backup_/),
+        {
+          gitignore: false,
+          excludes: ['node_modules/.cache', '.next/cache', 'dist']
+        }
+      );
+    });
+
     it('should allow restoring a backup into /app', async () => {
       const { backupSandbox, bucket } = await createBackupSandbox();
       const backupId = crypto.randomUUID();

--- a/packages/shared/src/backup.ts
+++ b/packages/shared/src/backup.ts
@@ -8,3 +8,23 @@ export const BACKUP_ALLOWED_PREFIXES = [
   '/var/tmp',
   '/app'
 ] as const;
+
+export function normalizeBackupExcludePattern(pattern: string): string | null {
+  let normalized = pattern;
+
+  while (normalized.startsWith('**/')) {
+    normalized = normalized.slice(3);
+  }
+
+  normalized = normalized.replace(/\/\*\*\//g, '/');
+
+  if (normalized.endsWith('/**')) {
+    normalized = normalized.slice(0, -3);
+  }
+
+  if (!normalized || normalized === '**') {
+    return null;
+  }
+
+  return normalized;
+}

--- a/packages/shared/src/backup.ts
+++ b/packages/shared/src/backup.ts
@@ -16,7 +16,9 @@ export function normalizeBackupExcludePattern(pattern: string): string | null {
     normalized = normalized.slice(3);
   }
 
-  normalized = normalized.replace(/\/\*\*\//g, '/');
+  while (normalized.includes('/**/')) {
+    normalized = normalized.replace(/\/\*\*\//g, '/');
+  }
 
   if (normalized.endsWith('/**')) {
     normalized = normalized.slice(0, -3);


### PR DESCRIPTION
# Summary
This PR fixes `createBackup()` excludes that use gitignore-style globstar patterns like `**/node_modules` and `dist/**`.

Previously, these patterns could make it through to the backup pipeline in a form that `mksquashfs` does not support, which could produce empty archives. This change normalizes those exclude patterns before archive creation and applies the same behavior in both the Durable Object and container backup paths so local and production flows stay consistent.

# Testing
- Added regression coverage for SDK backup paths
- Verified container backup-service tests still pass
- Verified targeted SDK backup tests pass