### PR TITLE
fix(examples): use published sandbox image aliases

### DIFF
--- a/.github/changeset-version.ts
+++ b/.github/changeset-version.ts
@@ -92,6 +92,9 @@ try {
     '**/dist/**',
     '**/build/**',
     '**/.git/**',
+    'examples/**/Dockerfile',
+    'examples/**/Dockerfile.*',
+    'examples/**/README.md',
     '**/package.json', // Don't modify package.json (changeset does this)
     '**/package-lock.json', // Don't modify package-lock.json (npm install does this)
     '**/.github/changeset-version.ts', // Don't modify this script itself

--- a/examples/alpine/Dockerfile
+++ b/examples/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1-musl
+FROM docker.io/cloudflare/sandbox:latest-musl
 
 # Documents the ports this application uses (standard Docker convention)
 EXPOSE 8080

--- a/examples/authentication/Dockerfile
+++ b/examples/authentication/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 
 # Documents the ports this application uses (standard Docker convention)
 EXPOSE 8080

--- a/examples/claude-code/Dockerfile
+++ b/examples/claude-code/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 RUN npm install -g @anthropic-ai/claude-code
 ENV COMMAND_TIMEOUT_MS=300000
 EXPOSE 3000

--- a/examples/code-interpreter/Dockerfile
+++ b/examples/code-interpreter/Dockerfile
@@ -1,1 +1,1 @@
-FROM docker.io/cloudflare/sandbox:0.9.1-python
+FROM docker.io/cloudflare/sandbox:latest-python

--- a/examples/codex-app-server/Dockerfile
+++ b/examples/codex-app-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 
 # Install the Codex CLI globally
 RUN npm install -g @openai/codex

--- a/examples/codex-app-server/README.md
+++ b/examples/codex-app-server/README.md
@@ -176,7 +176,7 @@ When deployed with `interceptHttps = true`, HTTPS requests to blocked hosts also
 
 ```
 codex-app-server/
-├── Dockerfile               cloudflare/sandbox:0.9.1 + @openai/codex CLI
+├── Dockerfile               cloudflare/sandbox:latest + @openai/codex CLI
 ├── wrangler.jsonc            Worker + Sandbox Durable Object + container config
 ├── .dev.vars.example         Environment variable template
 ├── src/

--- a/examples/collaborative-terminal/Dockerfile
+++ b/examples/collaborative-terminal/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 
 # Documents the ports this application uses (standard Docker convention)
 EXPOSE 8080

--- a/examples/minimal/Dockerfile
+++ b/examples/minimal/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 
 # Documents the ports this application uses (standard Docker convention)
 EXPOSE 8080

--- a/examples/openai-agents/Dockerfile
+++ b/examples/openai-agents/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 
 # Documents the ports this application uses (standard Docker convention)
 EXPOSE 8080

--- a/examples/opencode/Dockerfile
+++ b/examples/opencode/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1-opencode
+FROM docker.io/cloudflare/sandbox:latest-opencode
 
 # Clone sample project for the web UI to work with
 RUN git clone --depth 1 https://github.com/cloudflare/agents.git /home/user/agents

--- a/examples/time-machine/Dockerfile
+++ b/examples/time-machine/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 
 # Documents the ports this application uses (standard Docker convention)
 EXPOSE 8080

--- a/examples/typescript-validator/Dockerfile
+++ b/examples/typescript-validator/Dockerfile
@@ -1,5 +1,5 @@
 # Use Cloudflare sandbox as base
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 
 # Install esbuild for TypeScript bundling
 RUN npm install -g esbuild

--- a/examples/vite-sandbox/Dockerfile
+++ b/examples/vite-sandbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 
 WORKDIR /app
 COPY sandbox-app/package.json ./

--- a/examples/websocket-tunnel/Dockerfile
+++ b/examples/websocket-tunnel/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 
 COPY server.js /app/server.js
 


### PR DESCRIPTION
The example templates install `@cloudflare/sandbox` as `*`, but their Dockerfiles were being rewritten to exact image tags during version PRs. If the release run fails before Docker Hub publish, `main` can point at an image tag that does not exist yet, which is what happened in #627.

This switches the example Dockerfiles to the published `latest` aliases (`latest-python`, `latest-musl`, etc.) and stops `.github/changeset-version.ts` from rewriting those template files on release bumps.

Checked by grepping the example Dockerfiles to confirm the pinned `cloudflare/sandbox:<version>` refs are gone, and by running `node --check` on a JS copy of `.github/changeset-version.ts`.

Built with ClawOSS. Fixes #627
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
