### PR TITLE
Pin Bonk opencode version

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -36,3 +36,4 @@ jobs:
         with:
           model: 'cloudflare-ai-gateway/anthropic/claude-opus-4-6'
           mentions: '/bonk,@ask-bonk'
+          opencode_version: '1.4.6'


### PR DESCRIPTION
## Summary
- Pin Bonk's OpenCode runtime to `1.4.6`, matching the known-good version used in cloudflare/kumo#432.
- Keep Bonk behavior stable instead of implicitly floating with upstream OpenCode releases.

## Testing
- Not run; workflow configuration only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
