### PR TITLE
Add bridge test suite to CI

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -1,0 +1,56 @@
+name: Bridge
+
+# Runs on PRs that touch the cloudflare-sandbox-bridge Worker (bridge/**) or
+# this workflow itself. The bridge Worker depends on @cloudflare/sandbox via
+# its built dist/ output, so the SDK is built first and the bridge unit tests
+# (bridge/worker, vitest + @cloudflare/vitest-pool-workers) are then run
+# against it.
+
+on:
+  pull_request:
+    paths:
+      - 'bridge/**'
+      - '.github/workflows/bridge.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bridge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  worker-tests:
+    name: bridge/worker unit tests
+    runs-on: ubuntu-24.04-4core
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+
+      - uses: actions/cache/restore@v5
+        id: nm-cache
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+            bridge/worker/node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+
+      - run: npm ci --prefer-offline --no-audit --no-fund
+        if: steps.nm-cache.outputs.cache-hit != 'true'
+
+      # The bridge Worker imports from @cloudflare/sandbox/bridge, which
+      # resolves to packages/sandbox/dist/. Build the SDK before running tests.
+      - name: Build @cloudflare/sandbox
+        run: npx turbo run build --filter=@cloudflare/sandbox
+
+      - name: Worker unit tests
+        run: npm test -w @cloudflare/sandbox-bridge

--- a/.github/workflows/pr-privileged.yml
+++ b/.github/workflows/pr-privileged.yml
@@ -273,6 +273,30 @@ jobs:
       cache_readonly: true
     secrets: inherit
 
+  # --- Bridge E2E tests (authorized + 'run-e2e-bridge' label) ---
+  # Opt-in: a maintainer applies the 'run-e2e-bridge' label to deploy the
+  # cloudflare-sandbox-bridge Worker for this PR and run the integration
+  # suite against it. The Worker is named with a -bridge-pr-<n> suffix so
+  # capacity tracking can distinguish bridge deployments from the e2e
+  # test-worker fleet.
+  bridge-e2e:
+    needs: [policy, detect-changes, build]
+    permissions:
+      actions: read
+      contents: read
+    if: |
+      needs.policy.outputs.run_privileged == 'true' &&
+      contains(github.event.pull_request.labels.*.name, 'run-e2e-bridge') &&
+      !contains(github.event.pull_request.title, 'Version Packages')
+    uses: ./.github/workflows/reusable-bridge-e2e.yml
+    with:
+      worker_name: sandbox-e2e-test-worker-bridge-pr-${{ github.event.pull_request.number }}
+      image_tag: ci-${{ needs.detect-changes.outputs.docker-hash }}
+      checkout_ref: ${{ github.event.pull_request.head.sha }}
+      checkout_repo: ${{ github.event.pull_request.head.repo.full_name }}
+      cache_readonly: true
+    secrets: inherit
+
   # --- Publish preview packages + Docker images (authorized only) ---
   publish-preview:
     needs: [policy, detect-changes, build]
@@ -432,7 +456,7 @@ jobs:
   gate:
     name: ci/gate
     if: always()
-    needs: [policy, detect-changes, build, e2e, publish-preview]
+    needs: [policy, detect-changes, build, e2e, bridge-e2e, publish-preview]
     runs-on: ubuntu-latest
     permissions: {}
     timeout-minutes: 1
@@ -444,6 +468,7 @@ jobs:
           echo "detect-changes: ${{ needs.detect-changes.result }}"
           echo "build: ${{ needs.build.result }}"
           echo "e2e: ${{ needs.e2e.result }}"
+          echo "bridge-e2e: ${{ needs.bridge-e2e.result }}"
           echo "publish-preview: ${{ needs.publish-preview.result }}"
           # Gate 1: Authorization
           if [[ "${{ needs.policy.outputs.authorized }}" != "true" ]]; then
@@ -461,7 +486,7 @@ jobs:
 
           # Gate 3: Privileged jobs must not have failed or been cancelled
           # (skipped is OK — means change detection determined they weren't needed)
-          for result in "${{ needs.build.result }}" "${{ needs.e2e.result }}" "${{ needs.publish-preview.result }}"; do
+          for result in "${{ needs.build.result }}" "${{ needs.e2e.result }}" "${{ needs.bridge-e2e.result }}" "${{ needs.publish-preview.result }}"; do
             if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
               echo "::error::One or more privileged CI jobs failed or were cancelled"
               exit 1

--- a/.github/workflows/reusable-bridge-e2e.yml
+++ b/.github/workflows/reusable-bridge-e2e.yml
@@ -1,0 +1,183 @@
+name: Bridge E2E
+
+# Deploys the cloudflare-sandbox-bridge Worker to a per-PR (or per-main)
+# Cloudflare account and runs the integration suite against it. Mirrors
+# reusable-e2e.yml in shape and security posture (fork-PR inputs, opt-in
+# cache writes), but is bridge-specific:
+#
+#   - Worker name comes from the caller as <prefix>-bridge-<pr> /
+#     <prefix>-bridge-main, so capacity-management greps stay precise.
+#   - Image source is bridge/worker/Dockerfile, optionally rebased onto
+#     the PR's sandbox image via the image_tag input.
+#   - Auth is on; SANDBOX_API_KEY is generated per-run, injected via
+#     `wrangler secret bulk`, and reused as the test client's bearer token.
+#   - Tests are bridge/script/integration with BASE_URL pointing at the
+#     deployed worker.
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        type: string
+        default: 'ubuntu-24.04-4core'
+      worker_name:
+        type: string
+        required: true
+        description: 'Full worker name. Must follow <prefix>-bridge-<pr> or <prefix>-bridge-main.'
+      image_tag:
+        type: string
+        default: ''
+        description: 'Optional. CF registry tag of the sandbox base image to rebase bridge/worker/Dockerfile onto (e.g. ci-<hash>). Empty = use the pinned base in the Dockerfile.'
+      checkout_ref:
+        type: string
+        default: ''
+        description: 'Git ref to checkout (for fork PRs via pull_request_target). Empty = default behavior.'
+      checkout_repo:
+        type: string
+        default: ''
+        description: 'Repository to checkout (for fork PRs). Empty = default behavior.'
+      cache_readonly:
+        type: boolean
+        default: false
+        description: 'When true, skip cache writes (security: prevents cache poisoning from fork PRs).'
+
+env:
+  CF_ACCOUNT_SUBDOMAIN: agents-b8a
+
+jobs:
+  deploy-and-test:
+    permissions:
+      contents: read
+      actions: read
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 15
+    steps:
+      - name: Validate worker name
+        run: |
+          NAME="${{ inputs.worker_name }}"
+          # Worker name must contain "-bridge-" and end with "main" or "pr-<digits>".
+          if ! [[ "$NAME" =~ -bridge-(main|pr-[0-9]+)$ ]]; then
+            echo "::error::worker_name '$NAME' does not match required pattern <prefix>-bridge-(main|pr-<n>)"
+            exit 1
+          fi
+          echo "Worker name: $NAME"
+
+      - uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.checkout_repo || github.repository }}
+          ref: ${{ inputs.checkout_ref || '' }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - uses: actions/cache/restore@v5
+        id: nm-cache
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+            bridge/worker/node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+
+      - run: npm ci --prefer-offline --no-audit --no-fund
+        if: steps.nm-cache.outputs.cache-hit != 'true'
+
+      # The bridge Worker imports from @cloudflare/sandbox/bridge, which
+      # resolves to packages/sandbox/dist/. The privileged build job
+      # uploads dist/ as the build-${{ github.sha }} artifact.
+      - uses: actions/download-artifact@v8
+        with:
+          name: build-${{ github.sha }}
+          path: packages
+
+      - name: Generate per-run SANDBOX_API_KEY
+        id: apikey
+        run: |
+          KEY=$(openssl rand -hex 32)
+          echo "::add-mask::$KEY"
+          echo "key=$KEY" >> $GITHUB_OUTPUT
+
+      - name: Rewrite wrangler.jsonc worker name
+        working-directory: bridge/worker
+        run: |
+          NAME="${{ inputs.worker_name }}"
+          # Replace the "name" field with the deploy target. The default value
+          # is "cloudflare-sandbox-bridge"; we substitute the full string so
+          # the substitution stays anchored to the intended field.
+          sed -i 's|"name": "cloudflare-sandbox-bridge"|"name": "'"$NAME"'"|' wrangler.jsonc
+          if ! grep -q "\"name\": \"$NAME\"" wrangler.jsonc; then
+            echo "::error::Failed to set worker name in wrangler.jsonc"
+            exit 1
+          fi
+
+      - name: Rebase Dockerfile onto PR sandbox image
+        if: ${{ inputs.image_tag != '' }}
+        working-directory: bridge/worker
+        run: |
+          TAG="${{ inputs.image_tag }}"
+          IMAGE="registry.cloudflare.com/${CLOUDFLARE_ACCOUNT_ID}/sandbox:${TAG}"
+          # Replace the FROM line so the bridge image layers on top of the
+          # PR's sandbox build instead of the pinned Docker Hub release.
+          sed -i 's|^FROM docker.io/cloudflare/sandbox:.*|FROM '"$IMAGE"'|' Dockerfile
+          echo "Rebased Dockerfile FROM:"
+          grep '^FROM ' Dockerfile
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Login to CF registry (for rebased base image)
+        if: ${{ inputs.image_tag != '' }}
+        run: |
+          source .github/cf-registry-login.sh
+          cf_registry_credentials 15 '["pull"]'
+          echo "$CF_REGISTRY_PASSWORD" | docker login registry.cloudflare.com \
+            -u "$CF_REGISTRY_USERNAME" --password-stdin
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Deploy bridge worker
+        working-directory: bridge/worker
+        run: |
+          npx wrangler deploy \
+            ${{ inputs.image_tag != '' && '--containers-rollout immediate' || '' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Inject SANDBOX_API_KEY secret
+        working-directory: bridge/worker
+        run: |
+          jq -n --arg k "$SANDBOX_API_KEY" '{SANDBOX_API_KEY:$k}' \
+            | npx wrangler secret bulk
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          SANDBOX_API_KEY: ${{ steps.apikey.outputs.key }}
+
+      - name: Wait for worker readiness
+        run: |
+          URL="https://${{ inputs.worker_name }}.${{ env.CF_ACCOUNT_SUBDOMAIN }}.workers.dev/health"
+          for i in $(seq 1 30); do
+            if curl -sf --max-time 5 "$URL" >/dev/null; then
+              echo "Worker ready at $URL"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Worker did not respond at $URL within 60s"
+          exit 1
+
+      - name: Run integration tests against deployed worker
+        working-directory: bridge
+        run: bun script/integration
+        env:
+          BASE_URL: https://${{ inputs.worker_name }}.${{ env.CF_ACCOUNT_SUBDOMAIN }}.workers.dev
+          SANDBOX_API_KEY: ${{ steps.apikey.outputs.key }}

--- a/bridge/worker/src/__tests__/middleware.test.ts
+++ b/bridge/worker/src/__tests__/middleware.test.ts
@@ -53,12 +53,6 @@ describe('Auth middleware — /v1/sandbox/*', () => {
     const res = await makeRequest(sandboxUrl('test', 'running'), {}, createMockEnv());
     expect(res.status).toBe(200);
   });
-
-  it('logs a warning when SANDBOX_API_KEY is not set', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    await makeRequest(sandboxUrl('test', 'running'), {}, createMockEnv());
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[security] SANDBOX_API_KEY is not set'));
-  });
 });
 
 describe('Sandbox ID validation', () => {


### PR DESCRIPTION
Currently e2e tests will only run when `run-e2e-bridge` label is applied
to the PR (for testing).
