### PR TITLE
Serialize Bonk per pull request

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+      group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
       cancel-in-progress: false
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Change the Bonk workflow concurrency key to use the PR issue number for `issue_comment` events.
- Allows Bonk runs on different PRs to run concurrently while keeping multiple Bonk requests on the same PR queued in order.

## Context
`issue_comment` events do not populate `github.event.pull_request.number`, so the previous concurrency group fell back to `github.ref`. For `/bonk` comments this effectively grouped runs by `main`, causing Bonk requests from unrelated PRs to block each other.

## Testing
- Pre-commit workflow formatting hook ran successfully during commit.
- `actionlint` was not run because it is not installed locally.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
