### PR TITLE
Improve handling of transport errors when using RPC transport

### DIFF
--- a/packages/sandbox-container/tests/rpc/websocket-termination.test.ts
+++ b/packages/sandbox-container/tests/rpc/websocket-termination.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Reproduces the production stack trace where translateRPCError() throws a
+ * SyntaxError because the underlying capnweb error message is a transport-
+ * level string ("WebSocket connection failed", "Peer closed WebSocket: ...")
+ * rather than the JSON-encoded structured error format the container emits.
+ *
+ * We stand up a minimal Bun WebSocket server hosting a capnweb session,
+ * connect a client, start an in-flight RPC call, then forcibly tear down the
+ * server. Whatever error the client surfaces is what hits translateRPCError
+ * in production.
+ */
+import { afterEach, describe, expect, it } from 'bun:test';
+import { newWebSocketRpcSession, RpcTarget } from 'capnweb';
+import { newBunWebSocketRpcSession } from '../../src/lib/capnweb-bun';
+
+class TestAPI extends RpcTarget {
+  /** Long-running call: never resolves on its own. The test tears down the
+   *  server while this is in flight and observes the resulting client error. */
+  async hang(): Promise<string> {
+    return new Promise(() => {});
+  }
+
+  async ping(): Promise<string> {
+    return 'pong';
+  }
+}
+
+interface ServerHandle {
+  url: string;
+  stop: (closeActiveConnections?: boolean) => Promise<void>;
+}
+
+interface TestWSData {
+  transport?: {
+    dispatchMessage: (m: string | Buffer) => void;
+    dispatchClose: (c: number, r: string) => void;
+  };
+}
+
+function startServer(): ServerHandle {
+  const server = Bun.serve<TestWSData>({
+    port: 0,
+    fetch(req, srv) {
+      if (req.headers.get('upgrade') === 'websocket') {
+        if (srv.upgrade(req, { data: {} as TestWSData })) {
+          return undefined as unknown as Response;
+        }
+      }
+      return new Response('not found', { status: 404 });
+    },
+    websocket: {
+      open(ws) {
+        const { transport } = newBunWebSocketRpcSession(ws, new TestAPI());
+        ws.data.transport = transport as unknown as TestWSData['transport'];
+      },
+      message(ws, message) {
+        ws.data.transport?.dispatchMessage(message);
+      },
+      close(ws, code, reason) {
+        ws.data.transport?.dispatchClose(code, reason);
+      }
+    }
+  });
+  return {
+    url: `ws://localhost:${server.port}/`,
+    stop: async (closeActive = true) => {
+      server.stop(closeActive);
+    }
+  };
+}
+
+describe('capnweb client error surface on WebSocket termination', () => {
+  let server: ServerHandle | null = null;
+
+  afterEach(async () => {
+    await server?.stop(true);
+    server = null;
+  });
+
+  it('surfaces a transport-level Error (not a JSON-encoded SandboxError) when the server forcibly closes the connection mid-RPC', async () => {
+    server = startServer();
+
+    const ws = new WebSocket(server.url);
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener('open', () => resolve(), { once: true });
+      ws.addEventListener(
+        'error',
+        () => reject(new Error('failed to open ws')),
+        { once: true }
+      );
+    });
+
+    const stub = newWebSocketRpcSession<TestAPI>(ws as unknown as WebSocket);
+
+    // Sanity: a normal call completes successfully.
+    expect(await stub.ping()).toBe('pong');
+
+    // Start a never-resolving call.
+    const inflight = stub.hang();
+
+    // Give the RPC message a tick to leave the queue and reach the server.
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Forcibly tear down the server, closing the active socket.
+    await server.stop(true);
+
+    let err: unknown;
+    try {
+      await inflight;
+    } catch (e) {
+      err = e;
+    }
+
+    // What we actually observe:
+    //  - error is an Error instance
+    //  - error.message is a transport-level human string ("Peer closed
+    //    WebSocket: ..." or "WebSocket connection failed"), NOT JSON
+    //  - JSON.parse(error.message) would throw SyntaxError, exactly as seen
+    //    in the production logs
+    expect(err).toBeInstanceOf(Error);
+    const message = (err as Error).message;
+    console.log(
+      '[repro] capnweb client error message:',
+      JSON.stringify(message)
+    );
+    expect(typeof message).toBe('string');
+    expect(message.length).toBeGreaterThan(0);
+    expect(() => JSON.parse(message)).toThrow();
+    expect(
+      message.includes('WebSocket') ||
+        message.includes('closed') ||
+        message.includes('failed')
+    ).toBe(true);
+  });
+});

--- a/packages/sandbox-container/tests/rpc/websocket-termination.test.ts
+++ b/packages/sandbox-container/tests/rpc/websocket-termination.test.ts
@@ -119,10 +119,6 @@ describe('capnweb client error surface on WebSocket termination', () => {
     //    in the production logs
     expect(err).toBeInstanceOf(Error);
     const message = (err as Error).message;
-    console.log(
-      '[repro] capnweb client error message:',
-      JSON.stringify(message)
-    );
     expect(typeof message).toBe('string');
     expect(message.length).toBeGreaterThan(0);
     expect(() => JSON.parse(message)).toThrow();

--- a/packages/sandbox/src/clients/rpc-sandbox-client.ts
+++ b/packages/sandbox/src/clients/rpc-sandbox-client.ts
@@ -84,9 +84,12 @@ import type {
 } from '@repo/shared';
 import { createNoOpLogger } from '@repo/shared';
 import {
-  type ErrorCode,
+  ErrorCode,
   type ErrorResponse,
-  getHttpStatus
+  getHttpStatus,
+  getSuggestion,
+  type RPCTransportContext,
+  type RPCTransportErrorKind
 } from '@repo/shared/errors';
 import {
   ContainerConnection,
@@ -155,9 +158,8 @@ export function translateRPCError(error: unknown): never {
     try {
       payload = JSON.parse(error.message) as RPCErrorPayload;
     } catch {
-      // Not a JSON-encoded structured error (e.g. a transport-level
-      // failure like 'WebSocket connection failed' or 'Peer closed
-      // WebSocket: ...'). Fall through and rethrow the original error.
+      // Not a JSON-encoded structured error. Fall through to transport-
+      // level classification below.
     }
     if (
       payload &&
@@ -172,8 +174,81 @@ export function translateRPCError(error: unknown): never {
         timestamp: new Date().toISOString()
       });
     }
+    // Map capnweb / DeferredTransport messages onto a typed RPCTransportError
+    // so consumers get a structured `code` + `kind` instead of substring
+    // matching on a free-form Error.message.
+    // Preserve the underlying capnweb/transport Error as `cause` so callers
+    // can reach the original via `err.cause` (and it shows up in toString /
+    // toJSON output) without having to substring-match the message.
+    throw createErrorFromResponse(
+      buildTransportErrorResponse(error) as unknown as ErrorResponse,
+      { cause: error }
+    );
   }
   throw error;
+}
+
+/**
+ * Inspect a transport-level Error's message and produce the ErrorResponse
+ * that becomes an RPCTransportError. Pattern strings are pinned to the exact
+ * messages emitted by capnweb's WebSocketTransport (vendored at
+ * /repos/capnweb/src/websocket.ts) and our DeferredTransport in
+ * container-connection.ts. The DeferredTransport tests in
+ * tests/container-connection.test.ts pin the literal strings.
+ */
+function buildTransportErrorResponse(
+  error: Error
+): ErrorResponse<RPCTransportContext> {
+  const message = error.message;
+  let kind: RPCTransportErrorKind = 'unknown';
+  let closeCode: number | undefined;
+  let closeReason: string | undefined;
+
+  // "Peer closed WebSocket: <code> <reason>" — emitted by both
+  // DeferredTransport (container-connection.ts) and capnweb's own
+  // WebSocketTransport on a `close` event.
+  const peerCloseMatch = message.match(/^Peer closed WebSocket: (\d+) ?(.*)$/);
+  if (peerCloseMatch) {
+    kind = 'peer_closed';
+    closeCode = Number(peerCloseMatch[1]);
+    closeReason = peerCloseMatch[2] || undefined;
+  } else if (message === 'WebSocket connection failed') {
+    kind = 'connection_failed';
+  } else if (message.startsWith('WebSocket upgrade failed')) {
+    // ContainerConnection.doConnect throws this when the HTTP upgrade
+    // returns a non-101 status.
+    kind = 'upgrade_failed';
+  } else if (message === 'No WebSocket in upgrade response') {
+    kind = 'upgrade_failed';
+  } else if (
+    error instanceof TypeError &&
+    message === 'Received non-string message from WebSocket.'
+  ) {
+    kind = 'invalid_frame';
+  } else if (
+    message === 'RPC session was shut down by disposing the main stub' ||
+    message === 'RPC was canceled because the RpcPromise was disposed.'
+  ) {
+    kind = 'session_disposed';
+  }
+
+  const context: RPCTransportContext = {
+    kind,
+    originalMessage: message,
+    ...(closeCode !== undefined ? { closeCode } : {}),
+    ...(closeReason !== undefined ? { closeReason } : {})
+  };
+  return {
+    code: ErrorCode.RPC_TRANSPORT_ERROR,
+    message,
+    context,
+    httpStatus: getHttpStatus(ErrorCode.RPC_TRANSPORT_ERROR),
+    suggestion: getSuggestion(
+      ErrorCode.RPC_TRANSPORT_ERROR,
+      context as unknown as Record<string, unknown>
+    ),
+    timestamp: new Date().toISOString()
+  };
 }
 
 /**

--- a/packages/sandbox/src/clients/rpc-sandbox-client.ts
+++ b/packages/sandbox/src/clients/rpc-sandbox-client.ts
@@ -185,7 +185,15 @@ export function translateRPCError(error: unknown): never {
       { cause: error }
     );
   }
-  throw error;
+  // Non-Error throw (rare — capnweb's deserializer always constructs Error
+  // instances, but defensively handle anything else that bubbles up).
+  // Coerce to an Error so the kind=unknown context still has a usable
+  // originalMessage, and preserve the raw value as `cause`.
+  const wrapped = new Error(String(error));
+  throw createErrorFromResponse(
+    buildTransportErrorResponse(wrapped) as unknown as ErrorResponse,
+    { cause: error }
+  );
 }
 
 /**

--- a/packages/sandbox/src/clients/rpc-sandbox-client.ts
+++ b/packages/sandbox/src/clients/rpc-sandbox-client.ts
@@ -149,24 +149,28 @@ interface RPCErrorPayload {
  * The container encodes the full error as a JSON object in the message
  * string: `{"code":"...","message":"...","context":{...}}`.
  */
-function translateRPCError(error: unknown): never {
+export function translateRPCError(error: unknown): never {
   if (error instanceof Error) {
+    let payload: RPCErrorPayload | undefined;
     try {
-      const payload = JSON.parse(error.message) as RPCErrorPayload;
-      if (
-        typeof payload.code === 'string' &&
-        typeof payload.message === 'string'
-      ) {
-        throw createErrorFromResponse({
-          code: payload.code as ErrorCode,
-          message: payload.message,
-          context: payload.context ?? {},
-          httpStatus: getHttpStatus(payload.code as ErrorCode),
-          timestamp: new Date().toISOString()
-        });
-      }
-    } catch (e) {
-      if (e instanceof Error && e !== error) throw e;
+      payload = JSON.parse(error.message) as RPCErrorPayload;
+    } catch {
+      // Not a JSON-encoded structured error (e.g. a transport-level
+      // failure like 'WebSocket connection failed' or 'Peer closed
+      // WebSocket: ...'). Fall through and rethrow the original error.
+    }
+    if (
+      payload &&
+      typeof payload.code === 'string' &&
+      typeof payload.message === 'string'
+    ) {
+      throw createErrorFromResponse({
+        code: payload.code as ErrorCode,
+        message: payload.message,
+        context: payload.context ?? {},
+        httpStatus: getHttpStatus(payload.code as ErrorCode),
+        timestamp: new Date().toISOString()
+      });
     }
   }
   throw error;

--- a/packages/sandbox/src/clients/rpc-sandbox-client.ts
+++ b/packages/sandbox/src/clients/rpc-sandbox-client.ts
@@ -200,41 +200,58 @@ function buildTransportErrorResponse(
   error: Error
 ): ErrorResponse<RPCTransportContext> {
   const message = error.message;
+  const errorName = error.name;
   let kind: RPCTransportErrorKind = 'unknown';
   let closeCode: number | undefined;
   let closeReason: string | undefined;
 
-  // "Peer closed WebSocket: <code> <reason>" — emitted by both
-  // DeferredTransport (container-connection.ts) and capnweb's own
-  // WebSocketTransport on a `close` event.
-  const peerCloseMatch = message.match(/^Peer closed WebSocket: (\d+) ?(.*)$/);
-  if (peerCloseMatch) {
-    kind = 'peer_closed';
-    closeCode = Number(peerCloseMatch[1]);
-    closeReason = peerCloseMatch[2] || undefined;
-  } else if (message === 'WebSocket connection failed') {
-    kind = 'connection_failed';
-  } else if (message.startsWith('WebSocket upgrade failed')) {
-    // ContainerConnection.doConnect throws this when the HTTP upgrade
-    // returns a non-101 status.
-    kind = 'upgrade_failed';
-  } else if (message === 'No WebSocket in upgrade response') {
-    kind = 'upgrade_failed';
-  } else if (
-    error instanceof TypeError &&
-    message === 'Received non-string message from WebSocket.'
-  ) {
+  // First pass: classify by `error.name`. capnweb preserves the name
+  // across the wire for the standard built-ins (see ERROR_TYPES in
+  // capnweb's serialize.ts), and an unambiguous name beats substring
+  // matching on a free-form message that future capnweb versions might
+  // reword. It also dodges the cross-realm `instanceof` trap: a TypeError
+  // raised inside capnweb's serializer lives in capnweb's realm, not the
+  // SDK's, so `error instanceof TypeError` would falsely return false.
+  if (errorName === 'TypeError') {
+    // Only DeferredTransport / capnweb's WebSocketTransport raise a
+    // TypeError on the receive path — always a non-string frame.
     kind = 'invalid_frame';
-  } else if (
-    message === 'RPC session was shut down by disposing the main stub' ||
-    message === 'RPC was canceled because the RpcPromise was disposed.'
-  ) {
-    kind = 'session_disposed';
+  } else if (errorName === 'SyntaxError') {
+    // capnweb's readLoop calls JSON.parse on each incoming frame; if the
+    // peer sends garbage that's not parseable JSON, the SyntaxError flows
+    // through abort() to every in-flight call.
+    kind = 'protocol_error';
+  } else {
+    // Second pass: plain Errors. capnweb's transport layer and our
+    // DeferredTransport both emit unnamed Errors with these specific
+    // messages — the message is the only signal we have.
+    const peerCloseMatch = message.match(
+      /^Peer closed WebSocket: (\d+) ?(.*)$/
+    );
+    if (peerCloseMatch) {
+      kind = 'peer_closed';
+      closeCode = Number(peerCloseMatch[1]);
+      closeReason = peerCloseMatch[2] || undefined;
+    } else if (message === 'WebSocket connection failed') {
+      kind = 'connection_failed';
+    } else if (message.startsWith('WebSocket upgrade failed')) {
+      // ContainerConnection.doConnect throws this when the HTTP upgrade
+      // returns a non-101 status.
+      kind = 'upgrade_failed';
+    } else if (message === 'No WebSocket in upgrade response') {
+      kind = 'upgrade_failed';
+    } else if (
+      message === 'RPC session was shut down by disposing the main stub' ||
+      message === 'RPC was canceled because the RpcPromise was disposed.'
+    ) {
+      kind = 'session_disposed';
+    }
   }
 
   const context: RPCTransportContext = {
     kind,
     originalMessage: message,
+    errorName,
     ...(closeCode !== undefined ? { closeCode } : {}),
     ...(closeReason !== undefined ? { closeReason } : {})
   };

--- a/packages/sandbox/src/clients/rpc-sandbox-client.ts
+++ b/packages/sandbox/src/clients/rpc-sandbox-client.ts
@@ -199,9 +199,10 @@ export function translateRPCError(error: unknown): never {
 /**
  * Inspect a transport-level Error's message and produce the ErrorResponse
  * that becomes an RPCTransportError. Pattern strings are pinned to the exact
- * messages emitted by capnweb's WebSocketTransport (vendored at
- * /repos/capnweb/src/websocket.ts) and our DeferredTransport in
- * container-connection.ts. The DeferredTransport tests in
+ * messages emitted by capnweb's WebSocketTransport (see capnweb's
+ * src/websocket.ts) and our DeferredTransport in container-connection.ts —
+ * notably the trailing period in `WebSocket connection failed.` matches
+ * capnweb verbatim. The DeferredTransport tests in
  * tests/container-connection.test.ts pin the literal strings.
  */
 function buildTransportErrorResponse(
@@ -240,7 +241,7 @@ function buildTransportErrorResponse(
       kind = 'peer_closed';
       closeCode = Number(peerCloseMatch[1]);
       closeReason = peerCloseMatch[2] || undefined;
-    } else if (message === 'WebSocket connection failed') {
+    } else if (message === 'WebSocket connection failed.') {
       kind = 'connection_failed';
     } else if (message.startsWith('WebSocket upgrade failed')) {
       // ContainerConnection.doConnect throws this when the HTTP upgrade

--- a/packages/sandbox/src/container-connection.ts
+++ b/packages/sandbox/src/container-connection.ts
@@ -246,7 +246,7 @@ export class DeferredTransport implements RpcTransport {
       );
     });
     ws.addEventListener('error', () => {
-      this.#fail(new Error('WebSocket connection failed'));
+      this.#fail(new Error('WebSocket connection failed.'));
     });
 
     // Flush queued sends

--- a/packages/sandbox/src/container-connection.ts
+++ b/packages/sandbox/src/container-connection.ts
@@ -208,7 +208,7 @@ export class ContainerConnection {
  * is provided via `activate()`. Allows the RPC stub to be created before
  * the connection is established — queued calls flush automatically.
  */
-class DeferredTransport implements RpcTransport {
+export class DeferredTransport implements RpcTransport {
   #ws: WebSocket | null = null;
   #sendQueue: string[] = [];
   #receiveQueue: string[] = [];
@@ -229,6 +229,15 @@ class DeferredTransport implements RpcTransport {
         } else {
           this.#receiveQueue.push(event.data);
         }
+      } else {
+        // Mirrors capnweb's WebSocketTransport. capnweb's wire format is
+        // strictly text (JSON), so a binary frame indicates a misbehaving
+        // peer. Failing the transport here surfaces the problem to in-flight
+        // RPC calls; without it `receive()` would hang forever waiting for
+        // a string that is never going to arrive.
+        this.#fail(
+          new TypeError('Received non-string message from WebSocket.')
+        );
       }
     });
     ws.addEventListener('close', (event: CloseEvent) => {

--- a/packages/sandbox/src/errors/adapter.ts
+++ b/packages/sandbox/src/errors/adapter.ts
@@ -34,6 +34,7 @@ import type {
   PortNotExposedContext,
   ProcessErrorContext,
   ProcessNotFoundContext,
+  RPCTransportContext,
   SessionAlreadyExistsContext,
   SessionDestroyedContext,
   SessionTerminatedContext,
@@ -79,6 +80,7 @@ import {
   PortNotExposedError,
   ProcessError,
   ProcessNotFoundError,
+  RPCTransportError,
   SandboxError,
   ServiceNotRespondingError,
   SessionAlreadyExistsError,
@@ -91,7 +93,10 @@ import {
  * Convert ErrorResponse to appropriate Error class
  * Simple switch statement - we trust the container sends correct context
  */
-export function createErrorFromResponse(errorResponse: ErrorResponse): Error {
+export function createErrorFromResponse(
+  errorResponse: ErrorResponse,
+  options?: { cause?: unknown }
+): Error {
   // We trust the container sends correct context, use type assertions
   switch (errorResponse.code) {
     // File System Errors
@@ -314,6 +319,14 @@ export function createErrorFromResponse(errorResponse: ErrorResponse): Error {
     case ErrorCode.DESKTOP_INVALID_COORDINATES:
       return new DesktopInvalidCoordinatesError(
         errorResponse as unknown as ErrorResponse<DesktopCoordinateErrorContext>
+      );
+
+    // RPC Transport Errors (SDK-side, raised by translateRPCError on
+    // capnweb / DeferredTransport WebSocket failures).
+    case ErrorCode.RPC_TRANSPORT_ERROR:
+      return new RPCTransportError(
+        errorResponse as unknown as ErrorResponse<RPCTransportContext>,
+        options
       );
 
     // Validation Errors

--- a/packages/sandbox/src/errors/classes.ts
+++ b/packages/sandbox/src/errors/classes.ts
@@ -36,6 +36,8 @@ import type {
   ProcessExitedBeforeReadyContext,
   ProcessNotFoundContext,
   ProcessReadyTimeoutContext,
+  RPCTransportContext,
+  RPCTransportErrorKind,
   SessionAlreadyExistsContext,
   SessionDestroyedContext,
   SessionTerminatedContext,
@@ -47,8 +49,13 @@ import type {
  * Preserves all error information from container
  */
 export class SandboxError<TContext = Record<string, unknown>> extends Error {
-  constructor(public readonly errorResponse: ErrorResponse<TContext>) {
-    super(errorResponse.message);
+  constructor(
+    public readonly errorResponse: ErrorResponse<TContext>,
+    options?: { cause?: unknown }
+  ) {
+    // Forward `cause` through the standard ES2022 Error options bag so
+    // `error.cause` is set natively and shows up in toString()/serialization.
+    super(errorResponse.message, options);
     this.name = 'SandboxError';
   }
 
@@ -85,6 +92,7 @@ export class SandboxError<TContext = Record<string, unknown>> extends Error {
       httpStatus: this.httpStatus,
       operation: this.operation,
       suggestion: this.suggestion,
+      cause: this.cause,
       timestamp: this.timestamp,
       documentation: this.documentation,
       stack: this.stack
@@ -858,5 +866,39 @@ export class DesktopInvalidCoordinatesError extends SandboxError<DesktopCoordina
   constructor(errorResponse: ErrorResponse<DesktopCoordinateErrorContext>) {
     super(errorResponse);
     this.name = 'DesktopInvalidCoordinatesError';
+  }
+}
+
+// ============================================================================
+// RPC Transport Errors (SDK-side)
+// ============================================================================
+
+/**
+ * Raised when the capnweb WebSocket session itself fails on the SDK side.
+ * Unlike the rest of the SandboxError tree, the container never produces
+ * this error — it is synthesised by `translateRPCError` from the plain
+ * Errors capnweb / DeferredTransport raise when the connection dies.
+ *
+ * `kind` distinguishes the failure mode (peer close, upgrade failed, etc.)
+ * so callers can branch on a structured code instead of substring-matching
+ * on the message.
+ *
+ * Always retryable: the SDK opens a fresh connection on the next call.
+ */
+export class RPCTransportError extends SandboxError<RPCTransportContext> {
+  constructor(
+    errorResponse: ErrorResponse<RPCTransportContext>,
+    options?: { cause?: unknown }
+  ) {
+    super(errorResponse, options);
+    this.name = 'RPCTransportError';
+  }
+
+  get kind(): RPCTransportErrorKind {
+    return this.errorResponse.context.kind;
+  }
+
+  get originalMessage(): string {
+    return this.errorResponse.context.originalMessage;
   }
 }

--- a/packages/sandbox/src/errors/classes.ts
+++ b/packages/sandbox/src/errors/classes.ts
@@ -54,7 +54,11 @@ export class SandboxError<TContext = Record<string, unknown>> extends Error {
     options?: { cause?: unknown }
   ) {
     // Forward `cause` through the standard ES2022 Error options bag so
-    // `error.cause` is set natively and shows up in toString()/serialization.
+    // `error.cause` is set natively for in-memory inspection (debugger,
+    // util.inspect, manual `.cause` walks). It is intentionally omitted
+    // from toJSON() — Error instances are not JSON-serializable (their
+    // own properties are non-enumerable), so emitting `cause: <Error>`
+    // would log `cause: {}` and mislead operators.
     super(errorResponse.message, options);
     this.name = 'SandboxError';
   }
@@ -92,7 +96,6 @@ export class SandboxError<TContext = Record<string, unknown>> extends Error {
       httpStatus: this.httpStatus,
       operation: this.operation,
       suggestion: this.suggestion,
-      cause: this.cause,
       timestamp: this.timestamp,
       documentation: this.documentation,
       stack: this.stack

--- a/packages/sandbox/src/errors/index.ts
+++ b/packages/sandbox/src/errors/index.ts
@@ -71,6 +71,8 @@ export type {
   ProcessExitedBeforeReadyContext,
   ProcessNotFoundContext,
   ProcessReadyTimeoutContext,
+  RPCTransportContext,
+  RPCTransportErrorKind,
   SessionDestroyedContext,
   SessionTerminatedContext,
   ValidationFailedContext
@@ -130,6 +132,8 @@ export {
   // Process Errors
   ProcessNotFoundError,
   ProcessReadyTimeoutError,
+  // RPC Transport Errors (SDK-side, raised on WebSocket failures)
+  RPCTransportError,
   SandboxError,
   ServiceNotRespondingError,
   // Session Errors

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -130,6 +130,7 @@ export type {
   ExecutionCallbacks,
   InterpreterClient
 } from './clients/interpreter-client.js';
+export type { RPCTransportContext, RPCTransportErrorKind } from './errors';
 // Export backup and process readiness errors
 export {
   BackupCreateError,
@@ -145,6 +146,8 @@ export {
   InvalidBackupConfigError,
   ProcessExitedBeforeReadyError,
   ProcessReadyTimeoutError,
+  // RPC transport error (raised on capnweb WebSocket session failures)
+  RPCTransportError,
   SessionTerminatedError
 } from './errors';
 // Export file streaming utilities for binary file support

--- a/packages/sandbox/tests/container-connection.test.ts
+++ b/packages/sandbox/tests/container-connection.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { ContainerConnection } from '../src/container-connection';
+import {
+  ContainerConnection,
+  DeferredTransport
+} from '../src/container-connection';
 
 /**
  * Tests for ContainerConnection — the capnweb RPC connection manager.
@@ -185,6 +188,101 @@ describe('ContainerConnection', () => {
 
       await Promise.all([conn.connect(), conn.connect()]);
       expect(doConnect).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /**
+   * Minimal EventTarget-based fake that satisfies the bits of WebSocket the
+   * DeferredTransport actually uses: addEventListener('message'|'close'|'error')
+   * and `send()`. Avoids the workerd test environment's restriction on
+   * constructing real WebSockets in unit tests.
+   */
+  function createFakeWebSocket(): {
+    ws: WebSocket;
+    emitMessage: (data: unknown) => void;
+    emitClose: (code: number, reason: string) => void;
+    emitError: () => void;
+    sent: string[];
+  } {
+    const target = new EventTarget();
+    const sent: string[] = [];
+    const ws = Object.assign(target, {
+      send: (msg: string) => {
+        sent.push(msg);
+      },
+      close: () => {}
+    }) as unknown as WebSocket;
+    return {
+      ws,
+      emitMessage: (data) =>
+        target.dispatchEvent(
+          Object.assign(new Event('message'), { data }) as MessageEvent
+        ),
+      emitClose: (code, reason) =>
+        target.dispatchEvent(
+          Object.assign(new Event('close'), { code, reason }) as CloseEvent
+        ),
+      emitError: () => target.dispatchEvent(new Event('error')),
+      sent
+    };
+  }
+
+  describe('DeferredTransport', () => {
+    it('rejects pending receive() with a TypeError when a non-string frame arrives', async () => {
+      const fake = createFakeWebSocket();
+      const transport = new DeferredTransport();
+      transport.activate(fake.ws);
+
+      const recv = transport.receive();
+      fake.emitMessage(new ArrayBuffer(8));
+
+      await expect(recv).rejects.toBeInstanceOf(TypeError);
+      await expect(recv).rejects.toThrow(
+        'Received non-string message from WebSocket.'
+      );
+    });
+
+    it('fails subsequent receive() calls after a binary frame, matching capnweb parity', async () => {
+      const fake = createFakeWebSocket();
+      const transport = new DeferredTransport();
+      transport.activate(fake.ws);
+
+      fake.emitMessage(new Uint8Array([1, 2, 3]));
+
+      // The transport is now poisoned: any further receive() must reject
+      // immediately rather than hang waiting for a frame that won't come.
+      await expect(transport.receive()).rejects.toBeInstanceOf(TypeError);
+    });
+
+    it('still passes through string frames before any binary frame', async () => {
+      const fake = createFakeWebSocket();
+      const transport = new DeferredTransport();
+      transport.activate(fake.ws);
+
+      fake.emitMessage('hello');
+      await expect(transport.receive()).resolves.toBe('hello');
+    });
+
+    it('surfaces close events as a Peer closed WebSocket error', async () => {
+      const fake = createFakeWebSocket();
+      const transport = new DeferredTransport();
+      transport.activate(fake.ws);
+
+      const recv = transport.receive();
+      fake.emitClose(1006, 'gone');
+
+      await expect(recv).rejects.toThrow(/Peer closed WebSocket: 1006 gone/);
+    });
+
+    it('surfaces error events as a WebSocket connection failed error', async () => {
+      const fake = createFakeWebSocket();
+      const transport = new DeferredTransport();
+      transport.activate(fake.ws);
+
+      const recv = transport.receive();
+      fake.emitError();
+
+      await expect(recv).rejects.toThrow('WebSocket connection failed');
     });
   });
 });

--- a/packages/sandbox/tests/container-connection.test.ts
+++ b/packages/sandbox/tests/container-connection.test.ts
@@ -282,7 +282,7 @@ describe('ContainerConnection', () => {
       const recv = transport.receive();
       fake.emitError();
 
-      await expect(recv).rejects.toThrow('WebSocket connection failed');
+      await expect(recv).rejects.toThrow('WebSocket connection failed.');
     });
   });
 });

--- a/packages/sandbox/tests/rpc-sandbox-client.test.ts
+++ b/packages/sandbox/tests/rpc-sandbox-client.test.ts
@@ -464,11 +464,24 @@ describe('translateRPCError', () => {
     );
   });
 
-  it('rethrows non-Error values as-is (not wrapped in RPCTransportError)', async () => {
+  it('wraps non-Error values in RPCTransportError with kind=unknown', async () => {
     const translateRPCError = await loadFn();
-    expect(() => translateRPCError('boom')).toThrow('boom');
-    expect(() => translateRPCError(42)).toThrow();
-    expect(() => translateRPCError(undefined)).toThrow();
+    const { RPCTransportError } = await loadErr();
+    for (const value of ['boom', 42, undefined, null, { weird: true }]) {
+      let thrown: unknown;
+      try {
+        translateRPCError(value);
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeInstanceOf(RPCTransportError);
+      const err = thrown as InstanceType<typeof RPCTransportError>;
+      expect(err.kind).toBe('unknown');
+      // The raw value is preserved as `cause` for diagnostics.
+      expect(err.cause).toBe(value);
+      // originalMessage is the String() coercion of the value.
+      expect(err.context.originalMessage).toBe(String(value));
+    }
   });
 
   it('produces an RPCTransportError that carries a helpful suggestion', async () => {

--- a/packages/sandbox/tests/rpc-sandbox-client.test.ts
+++ b/packages/sandbox/tests/rpc-sandbox-client.test.ts
@@ -316,7 +316,12 @@ describe('translateRPCError', () => {
     );
   });
 
-  it('classifies a TypeError("Received non-string message from WebSocket.") as kind=invalid_frame', async () => {
+  it('classifies any Error with name="TypeError" as kind=invalid_frame', async () => {
+    // The dispatcher introspects error.name (preserved across the wire by
+    // capnweb) rather than `instanceof TypeError`. This is robust to
+    // cross-realm errors — a TypeError raised inside capnweb's serializer
+    // would not satisfy `instanceof TypeError` in the SDK realm but will
+    // still carry name="TypeError".
     const translateRPCError = await loadFn();
     const { RPCTransportError } = await loadErr();
     let thrown: unknown;
@@ -328,15 +333,53 @@ describe('translateRPCError', () => {
       thrown = e;
     }
     expect(thrown).toBeInstanceOf(RPCTransportError);
+    const err = thrown as InstanceType<typeof RPCTransportError>;
+    expect(err.kind).toBe('invalid_frame');
+    expect(err.context.errorName).toBe('TypeError');
+  });
+
+  it('classifies a name-only TypeError-shaped Error as kind=invalid_frame', async () => {
+    // Cross-realm scenario: `instanceof TypeError` would return false, but
+    // capnweb still ships the name across the wire. We trust the name.
+    const translateRPCError = await loadFn();
+    const { RPCTransportError } = await loadErr();
+    const err = new Error('whatever');
+    err.name = 'TypeError';
+    let thrown: unknown;
+    try {
+      translateRPCError(err);
+    } catch (e) {
+      thrown = e;
+    }
     expect((thrown as InstanceType<typeof RPCTransportError>).kind).toBe(
       'invalid_frame'
     );
   });
 
+  it('classifies SyntaxError as kind=protocol_error', async () => {
+    // capnweb's readLoop calls JSON.parse on each incoming frame; a peer
+    // that sends a non-JSON payload raises a SyntaxError that propagates
+    // through abort() to every in-flight call.
+    const translateRPCError = await loadFn();
+    const { RPCTransportError } = await loadErr();
+    let thrown: unknown;
+    try {
+      translateRPCError(
+        new SyntaxError('Unexpected token x in JSON at position 0')
+      );
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(RPCTransportError);
+    const err = thrown as InstanceType<typeof RPCTransportError>;
+    expect(err.kind).toBe('protocol_error');
+    expect(err.context.errorName).toBe('SyntaxError');
+    expect(err.suggestion).toContain('malformed');
+  });
+
   it('does NOT misclassify a plain Error with the invalid_frame message as invalid_frame', async () => {
-    // The TypeError check is part of the gate: only an actual TypeError
-    // surfaced from DeferredTransport / capnweb counts. A coincidence of
-    // message text on a plain Error stays as kind=unknown.
+    // Now gated on error.name rather than instanceof. A plain Error with
+    // the message but name="Error" stays as kind=unknown.
     const translateRPCError = await loadFn();
     const { RPCTransportError } = await loadErr();
     let thrown: unknown;
@@ -351,6 +394,20 @@ describe('translateRPCError', () => {
     expect((thrown as InstanceType<typeof RPCTransportError>).kind).toBe(
       'unknown'
     );
+  });
+
+  it('exposes errorName in context for diagnostic purposes', async () => {
+    const translateRPCError = await loadFn();
+    const { RPCTransportError } = await loadErr();
+    let thrown: unknown;
+    try {
+      translateRPCError(new Error('Peer closed WebSocket: 1006 gone'));
+    } catch (e) {
+      thrown = e;
+    }
+    expect(
+      (thrown as InstanceType<typeof RPCTransportError>).context.errorName
+    ).toBe('Error');
   });
 
   it('classifies capnweb session-disposed errors as kind=session_disposed', async () => {

--- a/packages/sandbox/tests/rpc-sandbox-client.test.ts
+++ b/packages/sandbox/tests/rpc-sandbox-client.test.ts
@@ -197,23 +197,22 @@ describe('translateRPCError', () => {
   // We import translateRPCError lazily here to avoid the top-level vi.mock
   // affecting test isolation. The function is a pure transform and does not
   // depend on ContainerConnection.
-  it('rethrows transport-level errors verbatim when the message is not JSON', async () => {
-    const { translateRPCError } =
-      await import('../src/clients/rpc-sandbox-client');
-    const original = new Error('WebSocket connection failed');
-    expect(() => translateRPCError(original)).toThrow(original);
-  });
+  async function loadFn() {
+    const mod = await import('../src/clients/rpc-sandbox-client');
+    return mod.translateRPCError;
+  }
 
-  it('rethrows peer-close errors verbatim when the message is not JSON', async () => {
-    const { translateRPCError } =
-      await import('../src/clients/rpc-sandbox-client');
-    const original = new Error('Peer closed WebSocket: 1006 ');
-    expect(() => translateRPCError(original)).toThrow(original);
-  });
+  async function loadErr() {
+    return await import('../src/errors');
+  }
+
+  // -------------------------------------------------------------------------
+  // Structured (container-side) errors
+  // -------------------------------------------------------------------------
 
   it('translates JSON-encoded structured errors into typed SandboxErrors', async () => {
-    const { translateRPCError } =
-      await import('../src/clients/rpc-sandbox-client');
+    const translateRPCError = await loadFn();
+    const { FileNotFoundError } = await loadErr();
     const payload = JSON.stringify({
       code: 'FILE_NOT_FOUND',
       message: 'no such file',
@@ -225,21 +224,254 @@ describe('translateRPCError', () => {
     } catch (e) {
       thrown = e;
     }
-    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown).toBeInstanceOf(FileNotFoundError);
     expect((thrown as Error).message).toContain('no such file');
   });
 
-  it('rethrows the original error when JSON parses but lacks required fields', async () => {
-    const { translateRPCError } =
-      await import('../src/clients/rpc-sandbox-client');
-    // Valid JSON, but not a structured RPCErrorPayload.
-    const original = new Error('{"foo":"bar"}');
-    expect(() => translateRPCError(original)).toThrow(original);
+  // -------------------------------------------------------------------------
+  // Transport-level errors — each `kind` of RPCTransportError
+  // -------------------------------------------------------------------------
+
+  it('classifies "Peer closed WebSocket: <code> <reason>" as kind=peer_closed', async () => {
+    const translateRPCError = await loadFn();
+    const { RPCTransportError, ErrorCode } = await loadErr();
+    let thrown: unknown;
+    try {
+      translateRPCError(
+        new Error('Peer closed WebSocket: 1006 Connection ended')
+      );
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(RPCTransportError);
+    const err = thrown as InstanceType<typeof RPCTransportError>;
+    expect(err.code).toBe(ErrorCode.RPC_TRANSPORT_ERROR);
+    expect(err.kind).toBe('peer_closed');
+    expect(err.context.closeCode).toBe(1006);
+    expect(err.context.closeReason).toBe('Connection ended');
+    expect(err.originalMessage).toBe(
+      'Peer closed WebSocket: 1006 Connection ended'
+    );
+    expect(err.httpStatus).toBe(503);
   });
 
-  it('rethrows non-Error values as-is', async () => {
-    const { translateRPCError } =
-      await import('../src/clients/rpc-sandbox-client');
+  it('handles peer_closed with no reason text', async () => {
+    const translateRPCError = await loadFn();
+    const { RPCTransportError } = await loadErr();
+    let thrown: unknown;
+    try {
+      translateRPCError(new Error('Peer closed WebSocket: 1006 '));
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(RPCTransportError);
+    const err = thrown as InstanceType<typeof RPCTransportError>;
+    expect(err.kind).toBe('peer_closed');
+    expect(err.context.closeCode).toBe(1006);
+    expect(err.context.closeReason).toBeUndefined();
+  });
+
+  it('classifies "WebSocket connection failed" as kind=connection_failed', async () => {
+    const translateRPCError = await loadFn();
+    const { RPCTransportError } = await loadErr();
+    let thrown: unknown;
+    try {
+      translateRPCError(new Error('WebSocket connection failed'));
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(RPCTransportError);
+    expect((thrown as InstanceType<typeof RPCTransportError>).kind).toBe(
+      'connection_failed'
+    );
+  });
+
+  it('classifies "WebSocket upgrade failed: 502 Bad Gateway" as kind=upgrade_failed', async () => {
+    const translateRPCError = await loadFn();
+    const { RPCTransportError } = await loadErr();
+    let thrown: unknown;
+    try {
+      translateRPCError(new Error('WebSocket upgrade failed: 502 Bad Gateway'));
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(RPCTransportError);
+    expect((thrown as InstanceType<typeof RPCTransportError>).kind).toBe(
+      'upgrade_failed'
+    );
+  });
+
+  it('classifies "No WebSocket in upgrade response" as kind=upgrade_failed', async () => {
+    const translateRPCError = await loadFn();
+    const { RPCTransportError } = await loadErr();
+    let thrown: unknown;
+    try {
+      translateRPCError(new Error('No WebSocket in upgrade response'));
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(RPCTransportError);
+    expect((thrown as InstanceType<typeof RPCTransportError>).kind).toBe(
+      'upgrade_failed'
+    );
+  });
+
+  it('classifies a TypeError("Received non-string message from WebSocket.") as kind=invalid_frame', async () => {
+    const translateRPCError = await loadFn();
+    const { RPCTransportError } = await loadErr();
+    let thrown: unknown;
+    try {
+      translateRPCError(
+        new TypeError('Received non-string message from WebSocket.')
+      );
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(RPCTransportError);
+    expect((thrown as InstanceType<typeof RPCTransportError>).kind).toBe(
+      'invalid_frame'
+    );
+  });
+
+  it('does NOT misclassify a plain Error with the invalid_frame message as invalid_frame', async () => {
+    // The TypeError check is part of the gate: only an actual TypeError
+    // surfaced from DeferredTransport / capnweb counts. A coincidence of
+    // message text on a plain Error stays as kind=unknown.
+    const translateRPCError = await loadFn();
+    const { RPCTransportError } = await loadErr();
+    let thrown: unknown;
+    try {
+      translateRPCError(
+        new Error('Received non-string message from WebSocket.')
+      );
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(RPCTransportError);
+    expect((thrown as InstanceType<typeof RPCTransportError>).kind).toBe(
+      'unknown'
+    );
+  });
+
+  it('classifies capnweb session-disposed errors as kind=session_disposed', async () => {
+    const translateRPCError = await loadFn();
+    const { RPCTransportError } = await loadErr();
+
+    for (const message of [
+      'RPC session was shut down by disposing the main stub',
+      'RPC was canceled because the RpcPromise was disposed.'
+    ]) {
+      let thrown: unknown;
+      try {
+        translateRPCError(new Error(message));
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeInstanceOf(RPCTransportError);
+      expect((thrown as InstanceType<typeof RPCTransportError>).kind).toBe(
+        'session_disposed'
+      );
+    }
+  });
+
+  it('falls back to kind=unknown for unrecognised Error.message strings', async () => {
+    const translateRPCError = await loadFn();
+    const { RPCTransportError } = await loadErr();
+    let thrown: unknown;
+    try {
+      translateRPCError(new Error('totally bizarre socket failure'));
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(RPCTransportError);
+    const err = thrown as InstanceType<typeof RPCTransportError>;
+    expect(err.kind).toBe('unknown');
+    expect(err.originalMessage).toBe('totally bizarre socket failure');
+  });
+
+  it('treats valid-JSON-but-not-an-RPCErrorPayload as a transport error', async () => {
+    // Valid JSON, but doesn't have the {code, message} shape we recognise.
+    // Falls through to transport classification; with no message match, lands
+    // in kind=unknown with the JSON string preserved as originalMessage.
+    const translateRPCError = await loadFn();
+    const { RPCTransportError } = await loadErr();
+    let thrown: unknown;
+    try {
+      translateRPCError(new Error('{"foo":"bar"}'));
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(RPCTransportError);
+    expect((thrown as InstanceType<typeof RPCTransportError>).kind).toBe(
+      'unknown'
+    );
+  });
+
+  it('rethrows non-Error values as-is (not wrapped in RPCTransportError)', async () => {
+    const translateRPCError = await loadFn();
     expect(() => translateRPCError('boom')).toThrow('boom');
+    expect(() => translateRPCError(42)).toThrow();
+    expect(() => translateRPCError(undefined)).toThrow();
+  });
+
+  it('produces an RPCTransportError that carries a helpful suggestion', async () => {
+    const translateRPCError = await loadFn();
+    const { RPCTransportError } = await loadErr();
+    let thrown: unknown;
+    try {
+      translateRPCError(new Error('Peer closed WebSocket: 1006 '));
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(RPCTransportError);
+    expect(
+      (thrown as InstanceType<typeof RPCTransportError>).suggestion
+    ).toContain('container');
+  });
+
+  it('preserves the underlying transport Error as `cause`', async () => {
+    const translateRPCError = await loadFn();
+    const { RPCTransportError } = await loadErr();
+    const original = new Error('Peer closed WebSocket: 1006 Connection ended');
+    let thrown: unknown;
+    try {
+      translateRPCError(original);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(RPCTransportError);
+    expect((thrown as Error).cause).toBe(original);
+  });
+
+  it('exposes `cause` on toJSON output for logging', async () => {
+    const translateRPCError = await loadFn();
+    const original = new Error('WebSocket connection failed');
+    let thrown: unknown;
+    try {
+      translateRPCError(original);
+    } catch (e) {
+      thrown = e;
+    }
+    const json = (thrown as { toJSON: () => Record<string, unknown> }).toJSON();
+    expect(json.cause).toBe(original);
+  });
+
+  it('does not set `cause` on errors translated from JSON-encoded structured payloads', async () => {
+    // The container-side errors flow through createErrorFromResponse without
+    // an `options` argument, so `cause` stays unset (matching pre-fix
+    // behaviour for that path).
+    const translateRPCError = await loadFn();
+    const payload = JSON.stringify({
+      code: 'FILE_NOT_FOUND',
+      message: 'no such file',
+      context: { path: '/missing' }
+    });
+    let thrown: unknown;
+    try {
+      translateRPCError(new Error(payload));
+    } catch (e) {
+      thrown = e;
+    }
+    expect((thrown as Error).cause).toBeUndefined();
   });
 });

--- a/packages/sandbox/tests/rpc-sandbox-client.test.ts
+++ b/packages/sandbox/tests/rpc-sandbox-client.test.ts
@@ -194,9 +194,6 @@ describe('RPCSandboxClient busy/idle tracking', () => {
 });
 
 describe('translateRPCError', () => {
-  // We import translateRPCError lazily here to avoid the top-level vi.mock
-  // affecting test isolation. The function is a pure transform and does not
-  // depend on ContainerConnection.
   async function loadFn() {
     const mod = await import('../src/clients/rpc-sandbox-client');
     return mod.translateRPCError;
@@ -271,12 +268,12 @@ describe('translateRPCError', () => {
     expect(err.context.closeReason).toBeUndefined();
   });
 
-  it('classifies "WebSocket connection failed" as kind=connection_failed', async () => {
+  it('classifies "WebSocket connection failed." as kind=connection_failed', async () => {
     const translateRPCError = await loadFn();
     const { RPCTransportError } = await loadErr();
     let thrown: unknown;
     try {
-      translateRPCError(new Error('WebSocket connection failed'));
+      translateRPCError(new Error('WebSocket connection failed.'));
     } catch (e) {
       thrown = e;
     }
@@ -513,9 +510,13 @@ describe('translateRPCError', () => {
     expect((thrown as Error).cause).toBe(original);
   });
 
-  it('exposes `cause` on toJSON output for logging', async () => {
+  it('omits `cause` from toJSON output (Error instances are not JSON-serializable)', async () => {
+    // `cause` is intentionally absent from toJSON(): JSON.stringify(new Error())
+    // emits `{}` because Error own properties are non-enumerable, so logging
+    // `cause: <Error>` would surface a misleading empty object. The cause is
+    // still reachable in-memory via `err.cause` for debugger/inspect.
     const translateRPCError = await loadFn();
-    const original = new Error('WebSocket connection failed');
+    const original = new Error('WebSocket connection failed.');
     let thrown: unknown;
     try {
       translateRPCError(original);
@@ -523,7 +524,9 @@ describe('translateRPCError', () => {
       thrown = e;
     }
     const json = (thrown as { toJSON: () => Record<string, unknown> }).toJSON();
-    expect(json.cause).toBe(original);
+    expect('cause' in json).toBe(false);
+    // But the live instance still carries it for in-memory inspection.
+    expect((thrown as Error).cause).toBe(original);
   });
 
   it('does not set `cause` on errors translated from JSON-encoded structured payloads', async () => {

--- a/packages/sandbox/tests/rpc-sandbox-client.test.ts
+++ b/packages/sandbox/tests/rpc-sandbox-client.test.ts
@@ -192,3 +192,54 @@ describe('RPCSandboxClient busy/idle tracking', () => {
     expect(onSessionIdle).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('translateRPCError', () => {
+  // We import translateRPCError lazily here to avoid the top-level vi.mock
+  // affecting test isolation. The function is a pure transform and does not
+  // depend on ContainerConnection.
+  it('rethrows transport-level errors verbatim when the message is not JSON', async () => {
+    const { translateRPCError } =
+      await import('../src/clients/rpc-sandbox-client');
+    const original = new Error('WebSocket connection failed');
+    expect(() => translateRPCError(original)).toThrow(original);
+  });
+
+  it('rethrows peer-close errors verbatim when the message is not JSON', async () => {
+    const { translateRPCError } =
+      await import('../src/clients/rpc-sandbox-client');
+    const original = new Error('Peer closed WebSocket: 1006 ');
+    expect(() => translateRPCError(original)).toThrow(original);
+  });
+
+  it('translates JSON-encoded structured errors into typed SandboxErrors', async () => {
+    const { translateRPCError } =
+      await import('../src/clients/rpc-sandbox-client');
+    const payload = JSON.stringify({
+      code: 'FILE_NOT_FOUND',
+      message: 'no such file',
+      context: { path: '/missing' }
+    });
+    let thrown: unknown;
+    try {
+      translateRPCError(new Error(payload));
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain('no such file');
+  });
+
+  it('rethrows the original error when JSON parses but lacks required fields', async () => {
+    const { translateRPCError } =
+      await import('../src/clients/rpc-sandbox-client');
+    // Valid JSON, but not a structured RPCErrorPayload.
+    const original = new Error('{"foo":"bar"}');
+    expect(() => translateRPCError(original)).toThrow(original);
+  });
+
+  it('rethrows non-Error values as-is', async () => {
+    const { translateRPCError } =
+      await import('../src/clients/rpc-sandbox-client');
+    expect(() => translateRPCError('boom')).toThrow('boom');
+  });
+});

--- a/packages/shared/src/errors/codes.ts
+++ b/packages/shared/src/errors/codes.ts
@@ -156,7 +156,14 @@ export const ErrorCode = {
   // Generic Errors (400/500)
   INVALID_JSON_RESPONSE: 'INVALID_JSON_RESPONSE',
   UNKNOWN_ERROR: 'UNKNOWN_ERROR',
-  INTERNAL_ERROR: 'INTERNAL_ERROR'
+  INTERNAL_ERROR: 'INTERNAL_ERROR',
+
+  // RPC Transport Errors (503) — capnweb WebSocket session-level failures
+  // raised on the SDK side, not by the container. The container went away
+  // mid-call (peer close), the WebSocket failed before/after upgrade, the
+  // peer sent a frame the transport cannot handle, or the session was
+  // disposed while a call was in flight.
+  RPC_TRANSPORT_ERROR: 'RPC_TRANSPORT_ERROR'
 } as const;
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/packages/shared/src/errors/contexts.ts
+++ b/packages/shared/src/errors/contexts.ts
@@ -254,6 +254,8 @@ export type RPCTransportErrorKind =
   | 'upgrade_failed'
   /** Peer sent a non-string frame; capnweb's wire format is JSON text only. */
   | 'invalid_frame'
+  /** Peer sent a frame the wire-format parser rejected (capnweb readLoop SyntaxError). */
+  | 'protocol_error'
   /** Session was disposed (locally or remotely) while a call was pending. */
   | 'session_disposed'
   /** Anything else that bubbled up from the transport with no recognisable shape. */
@@ -264,6 +266,12 @@ export interface RPCTransportContext {
   kind: RPCTransportErrorKind;
   /** Original error message, verbatim from capnweb / our DeferredTransport. */
   originalMessage: string;
+  /**
+   * The underlying Error's `name` property. capnweb preserves this across
+   * the wire for the standard built-ins (TypeError, SyntaxError, etc.), so
+   * it's a more reliable hint than the message string for those cases.
+   */
+  errorName: string;
   /** WebSocket close code, when available (kind === 'peer_closed'). */
   closeCode?: number;
   /** WebSocket close reason, when available (kind === 'peer_closed'). */

--- a/packages/shared/src/errors/contexts.ts
+++ b/packages/shared/src/errors/contexts.ts
@@ -241,6 +241,36 @@ export interface InternalErrorContext {
 }
 
 /**
+ * RPC transport error contexts. Surfaced when the capnweb WebSocket session
+ * fails on the SDK side rather than the container reporting a structured
+ * error. Always retryable — the next call will open a fresh connection.
+ */
+export type RPCTransportErrorKind =
+  /** Server closed the WebSocket (container crash, DO eviction, network blip). */
+  | 'peer_closed'
+  /** Underlying socket fired the `error` event. */
+  | 'connection_failed'
+  /** WebSocket upgrade failed before the session was established. */
+  | 'upgrade_failed'
+  /** Peer sent a non-string frame; capnweb's wire format is JSON text only. */
+  | 'invalid_frame'
+  /** Session was disposed (locally or remotely) while a call was pending. */
+  | 'session_disposed'
+  /** Anything else that bubbled up from the transport with no recognisable shape. */
+  | 'unknown';
+
+export interface RPCTransportContext {
+  /** Categorical bucket so callers can branch on `peer_closed` vs `upgrade_failed` etc. */
+  kind: RPCTransportErrorKind;
+  /** Original error message, verbatim from capnweb / our DeferredTransport. */
+  originalMessage: string;
+  /** WebSocket close code, when available (kind === 'peer_closed'). */
+  closeCode?: number;
+  /** WebSocket close reason, when available (kind === 'peer_closed'). */
+  closeReason?: string;
+}
+
+/**
  * Desktop error contexts
  */
 export interface DesktopErrorContext {

--- a/packages/shared/src/errors/index.ts
+++ b/packages/shared/src/errors/index.ts
@@ -66,6 +66,8 @@ export type {
   ProcessExitedBeforeReadyContext,
   ProcessNotFoundContext,
   ProcessReadyTimeoutContext,
+  RPCTransportContext,
+  RPCTransportErrorKind,
   SessionAlreadyExistsContext,
   SessionDestroyedContext,
   SessionTerminatedContext,

--- a/packages/shared/src/errors/status-map.ts
+++ b/packages/shared/src/errors/status-map.ts
@@ -78,6 +78,7 @@ export const ERROR_STATUS_MAP: Record<ErrorCode, number> = {
   // 503 Service Unavailable
   [ErrorCode.INTERPRETER_NOT_READY]: 503,
   [ErrorCode.OPENCODE_STARTUP_FAILED]: 503,
+  [ErrorCode.RPC_TRANSPORT_ERROR]: 503,
 
   // 408 Request Timeout
   [ErrorCode.PROCESS_READY_TIMEOUT]: 408,

--- a/packages/shared/src/errors/suggestions.ts
+++ b/packages/shared/src/errors/suggestions.ts
@@ -116,6 +116,24 @@ export function getSuggestion(
     case ErrorCode.DESKTOP_INVALID_COORDINATES:
       return `Coordinates (${context.x}, ${context.y}) are outside the display area (${context.displayWidth}x${context.displayHeight})`;
 
+    case ErrorCode.RPC_TRANSPORT_ERROR: {
+      const kind = context.kind as string | undefined;
+      switch (kind) {
+        case 'peer_closed':
+          return 'The container closed the WebSocket mid-call (likely a container restart, eviction, or crash). Retry the call — the SDK will open a fresh connection.';
+        case 'connection_failed':
+          return 'The WebSocket connection failed. Retry the call; if the failure persists, check container health and network connectivity.';
+        case 'upgrade_failed':
+          return 'The WebSocket upgrade was rejected by the container. Verify the container is running and reachable on the configured port.';
+        case 'invalid_frame':
+          return 'The container sent a frame the RPC transport cannot handle. This usually indicates a version mismatch between the SDK and the container image.';
+        case 'session_disposed':
+          return 'The RPC session was disposed while a call was in flight. Avoid reusing stubs after disconnect(); the next method call will reconnect automatically.';
+        default:
+          return 'The RPC transport raised an error. Retry the call — the SDK will open a fresh connection.';
+      }
+    }
+
     // Generic fallback for other errors
     default:
       return undefined;

--- a/packages/shared/src/errors/suggestions.ts
+++ b/packages/shared/src/errors/suggestions.ts
@@ -127,6 +127,8 @@ export function getSuggestion(
           return 'The WebSocket upgrade was rejected by the container. Verify the container is running and reachable on the configured port.';
         case 'invalid_frame':
           return 'The container sent a frame the RPC transport cannot handle. This usually indicates a version mismatch between the SDK and the container image.';
+        case 'protocol_error':
+          return 'The peer sent a malformed RPC message (capnweb could not parse the wire format). This usually indicates a version mismatch between the SDK and the container image.';
         case 'session_disposed':
           return 'The RPC session was disposed while a call was in flight. Avoid reusing stubs after disconnect(); the next method call will reconnect automatically.';
         default:


### PR DESCRIPTION
We were seeing some issues with terminated websocket connections bubble up as uncaught `SyntaxError`s. This PR fixes that issue and improves the handling of untyped transport errors by converting them into `SandboxError` instances with context.

Tests have been added to verify that the errors are now correctly handled and raised.

This PR is probably best reviewed by looking at the first four commits, commit by commit. The remaining changes are incremental code-review that will be rebased away.

  