### PR TITLE
fix(examples): use sandbox latest tags

### DIFF
--- a/.github/changeset-version.ts
+++ b/.github/changeset-version.ts
@@ -92,6 +92,9 @@ try {
     '**/dist/**',
     '**/build/**',
     '**/.git/**',
+    'examples/**/Dockerfile',
+    'examples/**/Dockerfile.*',
+    'examples/**/README.md',
     '**/package.json', // Don't modify package.json (changeset does this)
     '**/package-lock.json', // Don't modify package-lock.json (npm install does this)
     '**/.github/changeset-version.ts', // Don't modify this script itself

--- a/examples/alpine/Dockerfile
+++ b/examples/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1-musl
+FROM docker.io/cloudflare/sandbox:latest-musl
 
 # Documents the ports this application uses (standard Docker convention)
 EXPOSE 8080

--- a/examples/authentication/Dockerfile
+++ b/examples/authentication/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 
 # Documents the ports this application uses (standard Docker convention)
 EXPOSE 8080

--- a/examples/claude-code/Dockerfile
+++ b/examples/claude-code/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 RUN npm install -g @anthropic-ai/claude-code
 ENV COMMAND_TIMEOUT_MS=300000
 EXPOSE 3000

--- a/examples/code-interpreter/Dockerfile
+++ b/examples/code-interpreter/Dockerfile
@@ -1,1 +1,1 @@
-FROM docker.io/cloudflare/sandbox:0.9.1-python
+FROM docker.io/cloudflare/sandbox:latest-python

--- a/examples/codex-app-server/Dockerfile
+++ b/examples/codex-app-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 
 # Install the Codex CLI globally
 RUN npm install -g @openai/codex

--- a/examples/codex-app-server/README.md
+++ b/examples/codex-app-server/README.md
@@ -176,7 +176,7 @@ When deployed with `interceptHttps = true`, HTTPS requests to blocked hosts also
 
 ```
 codex-app-server/
-├── Dockerfile               cloudflare/sandbox:0.9.1 + @openai/codex CLI
+├── Dockerfile               cloudflare/sandbox:latest + @openai/codex CLI
 ├── wrangler.jsonc            Worker + Sandbox Durable Object + container config
 ├── .dev.vars.example         Environment variable template
 ├── src/

--- a/examples/collaborative-terminal/Dockerfile
+++ b/examples/collaborative-terminal/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 
 # Documents the ports this application uses (standard Docker convention)
 EXPOSE 8080

--- a/examples/minimal/Dockerfile
+++ b/examples/minimal/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 
 # Documents the ports this application uses (standard Docker convention)
 EXPOSE 8080

--- a/examples/openai-agents/Dockerfile
+++ b/examples/openai-agents/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 
 # Documents the ports this application uses (standard Docker convention)
 EXPOSE 8080

--- a/examples/opencode/Dockerfile
+++ b/examples/opencode/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1-opencode
+FROM docker.io/cloudflare/sandbox:latest-opencode
 
 # Clone sample project for the web UI to work with
 RUN git clone --depth 1 https://github.com/cloudflare/agents.git /home/user/agents

--- a/examples/time-machine/Dockerfile
+++ b/examples/time-machine/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 
 # Documents the ports this application uses (standard Docker convention)
 EXPOSE 8080

--- a/examples/typescript-validator/Dockerfile
+++ b/examples/typescript-validator/Dockerfile
@@ -1,5 +1,5 @@
 # Use Cloudflare sandbox as base
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 
 # Install esbuild for TypeScript bundling
 RUN npm install -g esbuild

--- a/examples/vite-sandbox/Dockerfile
+++ b/examples/vite-sandbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 
 WORKDIR /app
 COPY sandbox-app/package.json ./

--- a/examples/websocket-tunnel/Dockerfile
+++ b/examples/websocket-tunnel/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/cloudflare/sandbox:0.9.1
+FROM docker.io/cloudflare/sandbox:latest
 
 COPY server.js /app/server.js
 

--- a/packages/sandbox-container/tests/release/example-dockerfiles.test.ts
+++ b/packages/sandbox-container/tests/release/example-dockerfiles.test.ts
@@ -1,0 +1,41 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'bun:test';
+
+const cases = [
+  ['examples/alpine/Dockerfile', 'FROM docker.io/cloudflare/sandbox:latest-musl'],
+  ['examples/authentication/Dockerfile', 'FROM docker.io/cloudflare/sandbox:latest'],
+  ['examples/claude-code/Dockerfile', 'FROM docker.io/cloudflare/sandbox:latest'],
+  ['examples/code-interpreter/Dockerfile', 'FROM docker.io/cloudflare/sandbox:latest-python'],
+  ['examples/codex-app-server/Dockerfile', 'FROM docker.io/cloudflare/sandbox:latest'],
+  ['examples/collaborative-terminal/Dockerfile', 'FROM docker.io/cloudflare/sandbox:latest'],
+  ['examples/minimal/Dockerfile', 'FROM docker.io/cloudflare/sandbox:latest'],
+  ['examples/openai-agents/Dockerfile', 'FROM docker.io/cloudflare/sandbox:latest'],
+  ['examples/opencode/Dockerfile', 'FROM docker.io/cloudflare/sandbox:latest-opencode'],
+  ['examples/time-machine/Dockerfile', 'FROM docker.io/cloudflare/sandbox:latest'],
+  ['examples/typescript-validator/Dockerfile', 'FROM docker.io/cloudflare/sandbox:latest'],
+  ['examples/vite-sandbox/Dockerfile', 'FROM docker.io/cloudflare/sandbox:latest'],
+  ['examples/websocket-tunnel/Dockerfile', 'FROM docker.io/cloudflare/sandbox:latest']
+] as const;
+
+const releaseIgnorePatterns = [
+  'examples/**/Dockerfile',
+  'examples/**/Dockerfile.*',
+  'examples/**/README.md'
+] as const;
+
+describe('example Dockerfiles', () => {
+  for (const [file, expected] of cases) {
+    it(`uses ${expected} in ${file}`, async () => {
+      const content = await readFile(new URL(`../../../../${file}`, import.meta.url), 'utf8');
+      const fromLine = content.split('\n').find((line) => line.startsWith('FROM '));
+      expect(fromLine).toBe(expected);
+    });
+  }
+
+  it('keeps example templates out of release version rewrites', async () => {
+    const script = await readFile(new URL('../../../../.github/changeset-version.ts', import.meta.url), 'utf8');
+    for (const pattern of releaseIgnorePatterns) {
+      expect(script).toContain(pattern);
+    }
+  });
+});


### PR DESCRIPTION
The minimal example was pinned to a released image tag, which made local setup fail once that tag was unavailable on Docker Hub. This switches the example Dockerfiles to the moving sandbox aliases and keeps the release versioning script from rewriting example Dockerfiles. Verified with a Node check that all example Dockerfiles point at the expected aliases and that the release rewrite ignore list covers example Dockerfiles.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
