### PR TITLE
Separate container control from route transports

### DIFF
--- a/.agents/skills/architecture/SKILL.md
+++ b/.agents/skills/architecture/SKILL.md
@@ -26,22 +26,52 @@ description: Use when navigating the codebase for the first time, adding a new c
 
 ## Request Flow
 
+Primary control path:
+
 ```
 Worker
   → Sandbox DO (packages/sandbox)
-    → Container HTTP API on port 3000 (packages/sandbox-container)
-      → Bun runtime
-        → Shell commands / filesystem
+    → ContainerControlClient (packages/sandbox/src/container-control/)
+      → capnweb over /rpc WebSocket
+        → SandboxControlAPI (packages/sandbox-container/src/control-plane/)
+          → container services
+            → Shell commands / filesystem
+```
+
+Route-based compatibility path:
+
+```
+Worker
+  → Sandbox DO (packages/sandbox)
+    → SandboxClient / clients/transport
+      → Container HTTP API on port 3000 (packages/sandbox-container)
+        → Router / handlers
+          → container services
+            → Shell commands / filesystem
 ```
 
 Errors flow back the same path: container → Sandbox DO → Worker, using the custom error classes in `packages/shared/src/errors/` keyed by the `ErrorCode` enum.
 
-## Client Architecture (`packages/sandbox/src/clients/`)
+## Primary Control Path
 
-The SDK uses a modular client pattern:
+The primary Sandbox Durable Object to container control path is the container-control/control-plane path:
 
-- **`BaseClient`** — abstract HTTP client with shared request/response handling
-- **`SandboxClient`** — aggregator that exposes all specialized clients
+- SDK side: `packages/sandbox/src/container-control/`
+- Container side: `packages/sandbox-container/src/control-plane/`
+- Current wire implementation: capnweb RPC over the `/rpc` WebSocket route
+
+Control-channel/transport-layer capabilities belong in this path. Treat capnweb/RPC as the current implementation detail, not the architectural boundary.
+
+The shared `@repo/shared` `SandboxAPI` interface remains named `SandboxAPI` because it defines the current control API contract used by both sides.
+
+## Route-Based Compatibility Path (`packages/sandbox/src/clients/`)
+
+`packages/sandbox/src/clients/` and `packages/sandbox/src/clients/transport/` implement the HTTP and custom WebSocket route-based compatibility API. Maintain these for compatibility, debugging, local development, fallback behavior, and bug fixes, but do not add new control-plane capabilities there by default.
+
+The route-based client pattern is:
+
+- **`BaseHttpClient`** — abstract route-based HTTP/WebSocket client with shared request/response handling
+- **`SandboxClient`** — compatibility aggregator that exposes all specialized route-based clients
 - **Specialized clients** — one per domain:
   - `CommandClient` — exec / execStream
   - `FileClient` — read, write, list, delete
@@ -51,25 +81,27 @@ The SDK uses a modular client pattern:
   - `UtilityClient` — ping, metadata
   - `InterpreterClient` — code interpreter sessions
 
-When adding a new SDK capability, add a new specialized client (or extend an existing one) and wire it into `SandboxClient`.
+When maintaining route-based compatibility, add or extend specialized clients under `packages/sandbox/src/clients/`. DO-to-container control capabilities belong in `packages/sandbox/src/container-control/` and `packages/sandbox-container/src/control-plane/`.
 
 ## Container Runtime (`packages/sandbox-container/src/`)
 
 - **DI container** (`core/container.ts`) — manages service lifecycle and wiring
 - **Router** — simple HTTP router with middleware
-- **Handlers** (`handlers/`) — route handlers, thin layer that parses requests
+- **Control plane** (`control-plane/`) — primary container-side API called by the Sandbox DO
+- **Handlers** (`handlers/`) — route-based compatibility handlers, thin layer that parses requests
 - **Services** (`services/`) — business logic (`CommandService`, `FileService`, `ProcessService`, …)
 - **Managers** (`managers/`) — stateful coordinators (`ProcessManager`, `PortManager`)
 
 Entry point: `packages/sandbox-container/src/index.ts` starts a Bun HTTP server on port 3000.
 
-When adding a new container endpoint:
+When adding a new container control operation:
 
 1. Add/extend a service in `services/` for the business logic.
-2. Add a handler in `handlers/` that parses the request and calls the service.
-3. Register the route in the router.
-4. Mirror the call in a SDK client under `packages/sandbox/src/clients/`.
-5. Add unit tests on both sides; add an E2E test if it touches real shell/filesystem behavior.
+2. Add the control-plane method in `packages/sandbox-container/src/control-plane/`.
+3. Mirror the call in `packages/sandbox/src/container-control/`.
+4. Add unit tests on both sides; add an E2E test if it touches real shell/filesystem behavior.
+
+Only add a route handler in `handlers/` and a route-based SDK client in `packages/sandbox/src/clients/` when maintaining HTTP/WebSocket compatibility.
 
 ## Monorepo Structure
 

--- a/packages/sandbox-container/src/control-plane/AGENTS.md
+++ b/packages/sandbox-container/src/control-plane/AGENTS.md
@@ -1,0 +1,11 @@
+# Control plane
+
+This directory is the primary home for container-side control API methods used
+by the Sandbox Durable Object.
+
+Add control operations here. Use service methods directly rather than routing
+through HTTP handlers. Keep `/rpc` as the external WebSocket route unless a task
+explicitly changes the wire protocol.
+
+The route handlers and `ws-adapter.ts` are compatibility paths for the
+route-based API and do not receive control-plane capabilities by default.

--- a/packages/sandbox-container/src/control-plane/README.md
+++ b/packages/sandbox-container/src/control-plane/README.md
@@ -1,0 +1,14 @@
+# Control plane
+
+This directory owns the container-side control API called by the Sandbox Durable
+Object.
+
+The current implementation is exposed through capnweb over the `/rpc` WebSocket
+route, but the architectural boundary is the container control plane, not the
+transport mechanism.
+
+Container control operations are implemented here and call the underlying
+services directly. Route handlers under `handlers/` and `routes/` are kept for
+route-based HTTP/WebSocket compatibility.
+
+The shared `@repo/shared` `SandboxAPI` interface remains named `SandboxAPI` because it defines the current control API contract used by both sides.

--- a/packages/sandbox-container/src/control-plane/api.ts
+++ b/packages/sandbox-container/src/control-plane/api.ts
@@ -23,7 +23,7 @@ import type {
   Logger,
   OutputMessage,
   Result,
-  SandboxAPI as SandboxAPIInterface,
+  SandboxAPI,
   WatchRequest
 } from '@repo/shared';
 import { ErrorCode } from '@repo/shared/errors';
@@ -92,13 +92,13 @@ function extractData<T>(result: ServiceResult<any, any>): T {
 }
 
 /**
- * Native RPC API exposed to capnweb clients.
+ * Container control-plane API exposed over capnweb.
  *
  * Each domain is exposed as a nested RpcTarget so the client can access
- * them directly as `rpc.commands`, `rpc.files`, etc. Top-level methods
- * handle utility and session management.
+ * them directly as `commands`, `files`, etc. Top-level methods handle
+ * utility and session management.
  */
-export class SandboxAPI extends RpcTarget implements SandboxAPIInterface {
+export class SandboxControlAPI extends RpcTarget implements SandboxAPI {
   #deps: SandboxAPIDeps;
 
   constructor(deps: SandboxAPIDeps) {

--- a/packages/sandbox-container/src/control-plane/index.ts
+++ b/packages/sandbox-container/src/control-plane/index.ts
@@ -1,0 +1,1 @@
+export { type SandboxAPIDeps, SandboxControlAPI } from './api';

--- a/packages/sandbox-container/src/handlers/ws-adapter.ts
+++ b/packages/sandbox-container/src/handlers/ws-adapter.ts
@@ -1,9 +1,10 @@
 /**
- * WebSocket Protocol Adapter for Container
+ * WebSocket adapter for the route-based compatibility API.
  *
- * Adapts WebSocket messages to HTTP requests for routing through existing handlers.
- * This enables multiplexing multiple requests over a single WebSocket connection,
- * reducing sub-request count when the SDK runs inside Workers/Durable Objects.
+ * This adapts custom WebSocket messages to HTTP requests and routes them through
+ * the existing handlers. It supports the route-based API. Container
+ * control-plane operations live under `control-plane/` and are called through
+ * the container-control client.
  */
 
 import type { Logger } from '@repo/shared';
@@ -301,7 +302,7 @@ export class WebSocketAdapter {
   /**
    * Handle a streaming (SSE) HTTP response with a pre-acquired reader
    *
-   * This variant receives the reader instead of the Response, allowing the caller
+   * This variant receives a pre-acquired reader from the Response, allowing the caller
    * to acquire the reader synchronously before any await points. This is critical
    * for WebSocket streaming because Bun's message handler may invalidate the
    * Response body if the reader is acquired after the handler returns.

--- a/packages/sandbox-container/src/server.ts
+++ b/packages/sandbox-container/src/server.ts
@@ -3,6 +3,7 @@ import type { ServerWebSocket } from 'bun';
 import { serve } from 'bun';
 import { trustRuntimeCert } from './cert';
 import { CONFIG } from './config';
+import { SandboxControlAPI } from './control-plane';
 import { Container } from './core/container';
 import { Router } from './core/router';
 import type { PtyWSData } from './handlers/pty-ws-handler';
@@ -16,7 +17,6 @@ import {
   newBunWebSocketRpcSession
 } from './lib/capnweb-bun';
 import { setupRoutes } from './routes/setup';
-import { SandboxAPI } from './rpc/sandbox-api';
 
 export type CapnwebWSData = {
   type: 'capnweb';
@@ -60,7 +60,7 @@ async function createApplication(): Promise<{
   ) => Promise<Response>;
   container: Container;
   wsAdapter: WebSocketAdapter;
-  rpcAPI: SandboxAPI;
+  controlPlaneAPI: SandboxControlAPI;
 }> {
   const container = new Container();
   await container.initialize();
@@ -72,8 +72,8 @@ async function createApplication(): Promise<{
   // Create WebSocket adapter with the router for control plane multiplexing
   const wsAdapter = new WebSocketAdapter(router, logger);
 
-  // Create native RPC API that calls services directly (bypasses HTTP routing)
-  const rpcAPI = new SandboxAPI({
+  // Create the control-plane API that calls services directly.
+  const controlPlaneAPI = new SandboxControlAPI({
     processService: container.get('processService'),
     fileService: container.get('fileService'),
     portService: container.get('portService'),
@@ -160,7 +160,7 @@ async function createApplication(): Promise<{
     },
     container,
     wsAdapter,
-    rpcAPI
+    controlPlaneAPI
   };
 }
 
@@ -200,7 +200,10 @@ export async function startServer(): Promise<ServerInstance> {
                 } catch {}
               });
           } else if (ws.data.type === 'capnweb') {
-            const { transport } = newBunWebSocketRpcSession(ws, app.rpcAPI);
+            const { transport } = newBunWebSocketRpcSession(
+              ws,
+              app.controlPlaneAPI
+            );
             ws.data.transport = transport;
             logger.debug('capnweb session initialized', {
               connectionId: ws.data.connectionId

--- a/packages/sandbox-container/tests/rpc/sandbox-api-utils.test.ts
+++ b/packages/sandbox-container/tests/rpc/sandbox-api-utils.test.ts
@@ -2,9 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
 import type { Logger } from '@repo/shared';
 import { ErrorCode } from '@repo/shared/errors';
 import {
-  SandboxAPI,
-  type SandboxAPIDeps
-} from '@sandbox-container/rpc/sandbox-api';
+  type SandboxAPIDeps,
+  SandboxControlAPI
+} from '@sandbox-container/control-plane';
 import type { SessionManager } from '@sandbox-container/services/session-manager';
 import type { Session } from '@sandbox-container/session';
 
@@ -17,16 +17,16 @@ const mockLogger = {
 } as Logger;
 mockLogger.child = vi.fn(() => mockLogger);
 
-function buildApi(sessionManager: SessionManager): SandboxAPI {
+function buildApi(sessionManager: SessionManager): SandboxControlAPI {
   // Domains other than sessionManager are unused by utils.createSession; cast
   // through unknown so the test does not have to construct real services.
-  return new SandboxAPI({
+  return new SandboxControlAPI({
     sessionManager,
     logger: mockLogger
   } as unknown as SandboxAPIDeps);
 }
 
-describe('SandboxAPI utils.createSession', () => {
+describe('SandboxControlAPI utils.createSession', () => {
   let mockSessionManager: SessionManager;
 
   beforeEach(() => {

--- a/packages/sandbox/src/clients/base-client.ts
+++ b/packages/sandbox/src/clients/base-client.ts
@@ -10,15 +10,15 @@ import {
 import type { HttpClientOptions, ResponseHandler } from './types';
 
 /**
- * Abstract base class providing common HTTP/WebSocket functionality for all domain clients
+ * Abstract base class for route-based HTTP/WebSocket compatibility clients.
  *
- * All requests go through the Transport abstraction layer, which handles:
- * - HTTP and WebSocket modes transparently
- * - Automatic retry for 503 errors (container starting)
- * - Streaming responses
+ * Requests go through the Transport abstraction layer, which handles:
+ * - HTTP and WebSocket route-based modes transparently
+ * - Automatic retry for 503 errors while the container is starting
+ * - Streaming responses for the existing route API
  *
- * WebSocket mode is useful when running inside Workers/Durable Objects
- * where sub-request limits apply.
+ * DO-to-container control-channel capabilities live in `container-control/`.
+ * This layer supports the route-based compatibility API.
  */
 export abstract class BaseHttpClient {
   protected options: HttpClientOptions;
@@ -209,7 +209,7 @@ export abstract class BaseHttpClient {
   /**
    * Stream request handler
    *
-   * For HTTP mode, uses doFetch + handleStreamResponse to get proper error typing.
+   * HTTP mode uses doFetch + handleStreamResponse for typed error handling.
    * For WebSocket mode, uses Transport's streaming support.
    *
    * @param path - The API path to call
@@ -234,7 +234,7 @@ export abstract class BaseHttpClient {
       return this.transport.fetchStream(path, body, method, streamHeaders);
     }
 
-    // HTTP mode: use doFetch + handleStreamResponse for proper error typing
+    // HTTP mode uses doFetch + handleStreamResponse for typed error handling.
     const response = await this.doFetch(path, {
       method,
       headers: { 'Content-Type': 'application/json' },

--- a/packages/sandbox/src/clients/index.ts
+++ b/packages/sandbox/src/clients/index.ts
@@ -26,6 +26,7 @@ export { WatchClient } from './watch-client';
 
 export type {
   ITransport,
+  RouteTransportMode,
   TransportConfig,
   TransportMode,
   TransportOptions

--- a/packages/sandbox/src/clients/sandbox-client.ts
+++ b/packages/sandbox/src/clients/sandbox-client.ts
@@ -10,20 +10,20 @@ import { ProcessClient } from './process-client';
 import {
   createTransport,
   type ITransport,
-  type TransportMode
+  type RouteTransportMode
 } from './transport';
 import type { HttpClientOptions } from './types';
 import { UtilityClient } from './utility-client';
 import { WatchClient } from './watch-client';
 
 /**
- * Main sandbox client that composes all domain-specific clients.
- * Provides organized access to all sandbox functionality.
+ * Route-based compatibility sandbox client that composes all domain-specific
+ * HTTP API clients.
  *
- * Supports two transport modes:
- * - HTTP (default): Each request is a separate HTTP call
- * - WebSocket: All requests multiplexed over a single connection,
- *   reducing sub-request count inside Workers/Durable Objects
+ * This client supports the route-based HTTP and custom WebSocket transports.
+ * The primary DO-to-container control path is ContainerControlClient under
+ * `container-control/`. This client supports route-based compatibility,
+ * debugging, local development, and fallback behavior.
  */
 export class SandboxClient {
   public readonly backup: BackupClient;
@@ -103,7 +103,7 @@ export class SandboxClient {
   /**
    * Get the current transport mode
    */
-  getTransportMode(): TransportMode {
+  getTransportMode(): RouteTransportMode {
     return this.transport?.getMode() ?? 'http';
   }
 
@@ -117,9 +117,9 @@ export class SandboxClient {
   /**
    * Stream a file directly to the container over a binary RPC channel.
    *
-   * Requires the capnweb transport (`useWebSocket: 'rpc'`). Calling this
-   * method with the HTTP or WebSocket transports throws an error because those
-   * transports do not support binary streaming.
+   * Requires the container-control path (`transport: 'rpc'`). Calling this
+   * method with the HTTP or WebSocket route transports throws an error because
+   * those transports do not support binary streaming.
    */
   writeFileStream(
     _path: string,
@@ -159,7 +159,7 @@ export class SandboxClient {
 }
 
 // Compile-time check: SandboxClient exposes every top-level field that SandboxAPI requires.
-// Deep structural compatibility is not enforced because the HTTP sub-clients
-// (e.g. FileClient) lack streaming methods only available via capnweb.
+// Checks top-level API coverage. The HTTP sub-clients and RPC stubs
+// intentionally have different concrete method shapes.
 type PublicKeys<T> = { [K in keyof T]: unknown };
 void (0 as unknown as PublicKeys<SandboxClient> satisfies PublicKeys<SandboxAPI>);

--- a/packages/sandbox/src/clients/transport/AGENTS.md
+++ b/packages/sandbox/src/clients/transport/AGENTS.md
@@ -1,0 +1,9 @@
+# Route-based compatibility transports
+
+This directory is compatibility-only for the HTTP and custom WebSocket
+route-based API.
+
+Do not add transport-layer capabilities here unless the task explicitly requires
+HTTP/WebSocket compatibility maintenance. DO-to-container control-channel work
+belongs in `packages/sandbox/src/container-control/` and the matching container
+API belongs in `packages/sandbox-container/src/control-plane/`.

--- a/packages/sandbox/src/clients/transport/README.md
+++ b/packages/sandbox/src/clients/transport/README.md
@@ -1,0 +1,18 @@
+# Route-based compatibility transports
+
+This directory implements the HTTP and custom WebSocket transports for the
+route-based container API.
+
+These transports are maintained for compatibility, debugging, local development,
+and fallback behavior. They are not the primary extension point for Sandbox
+Durable Object to container control-channel work.
+
+Transport-layer/control-channel capabilities belong in
+`packages/sandbox/src/container-control/` and
+`packages/sandbox-container/src/control-plane/`.
+
+Only make changes here when:
+
+- maintaining an existing HTTP/WebSocket compatibility behavior;
+- preserving behavior for route-based clients;
+- maintaining startup/retry behavior shared by existing route-based clients.

--- a/packages/sandbox/src/clients/transport/base-transport.ts
+++ b/packages/sandbox/src/clients/transport/base-transport.ts
@@ -2,8 +2,8 @@ import type { Logger } from '@repo/shared';
 import { createNoOpLogger } from '@repo/shared';
 import type {
   ITransport,
+  RouteTransportMode,
   TransportConfig,
-  TransportMode,
   TransportRequestInit
 } from './types';
 
@@ -30,7 +30,7 @@ export abstract class BaseTransport implements ITransport {
     this.retryTimeoutMs = config.retryTimeoutMs ?? DEFAULT_RETRY_TIMEOUT_MS;
   }
 
-  abstract getMode(): TransportMode;
+  abstract getMode(): RouteTransportMode;
   abstract connect(): Promise<void>;
   abstract disconnect(): void;
   abstract isConnected(): boolean;

--- a/packages/sandbox/src/clients/transport/factory.ts
+++ b/packages/sandbox/src/clients/transport/factory.ts
@@ -1,20 +1,20 @@
 import { HttpTransport } from './http-transport';
-import type { ITransport, TransportConfig, TransportMode } from './types';
+import type { ITransport, RouteTransportMode, TransportConfig } from './types';
 import { WebSocketTransport } from './ws-transport';
 
 /**
  * Transport options with mode selection
  */
 export interface TransportOptions extends TransportConfig {
-  /** Transport mode */
-  mode: TransportMode;
+  /** Route-based transport mode */
+  mode: RouteTransportMode;
 }
 
 /**
- * Create a transport instance based on mode
+ * Create a route-based compatibility transport instance based on mode.
  *
- * This is the primary API for creating transports. It handles
- * the selection of HTTP or WebSocket transport based on the mode.
+ * Selects the HTTP or custom WebSocket transport for the route-based client
+ * layer.
  *
  * @example
  * ```typescript
@@ -33,10 +33,9 @@ export interface TransportOptions extends TransportConfig {
  */
 export function createTransport(options: TransportOptions): ITransport {
   switch (options.mode) {
+    case 'http':
+      return new HttpTransport(options);
     case 'websocket':
       return new WebSocketTransport(options);
-
-    default:
-      return new HttpTransport(options);
   }
 }

--- a/packages/sandbox/src/clients/transport/http-transport.ts
+++ b/packages/sandbox/src/clients/transport/http-transport.ts
@@ -1,5 +1,5 @@
 import { BaseTransport } from './base-transport';
-import type { TransportMode, TransportRequestInit } from './types';
+import type { RouteTransportMode, TransportRequestInit } from './types';
 
 /**
  * HTTP transport implementation
@@ -12,7 +12,7 @@ import type { TransportMode, TransportRequestInit } from './types';
  * the abstract `doFetch` / `fetchStream` hooks to those shared helpers.
  */
 export class HttpTransport extends BaseTransport {
-  getMode(): TransportMode {
+  getMode(): RouteTransportMode {
     return 'http';
   }
 

--- a/packages/sandbox/src/clients/transport/index.ts
+++ b/packages/sandbox/src/clients/transport/index.ts
@@ -5,6 +5,7 @@
 export type { TransportOptions } from './factory';
 export type {
   ITransport,
+  RouteTransportMode,
   TransportConfig,
   TransportMode,
   TransportRequestInit

--- a/packages/sandbox/src/clients/transport/types.ts
+++ b/packages/sandbox/src/clients/transport/types.ts
@@ -2,9 +2,12 @@ import type { Logger } from '@repo/shared';
 import type { ContainerStub } from '../types';
 
 /**
- * Transport mode for SDK communication
+ * Transport modes supported by the route-based compatibility layer.
  */
-export type TransportMode = 'http' | 'websocket' | 'rpc';
+export type RouteTransportMode = 'http' | 'websocket';
+
+/** Alias for the transport package API. */
+export type TransportMode = RouteTransportMode;
 
 /**
  * Configuration options for creating a transport
@@ -52,10 +55,11 @@ export interface TransportRequestInit extends RequestInit {
 }
 
 /**
- * Transport interface - all transports must implement this
+ * Route transport interface.
  *
- * Provides a unified abstraction over HTTP and WebSocket communication.
- * Both transports support fetch-compatible requests and streaming.
+ * Provides a unified abstraction over the route-based HTTP and custom
+ * WebSocket compatibility paths. Both transports support fetch-compatible
+ * requests and streaming.
  */
 export interface ITransport {
   /**
@@ -78,7 +82,7 @@ export interface ITransport {
   /**
    * Get the transport mode
    */
-  getMode(): TransportMode;
+  getMode(): RouteTransportMode;
 
   /**
    * Connect the transport (no-op for HTTP)

--- a/packages/sandbox/src/clients/transport/ws-transport.ts
+++ b/packages/sandbox/src/clients/transport/ws-transport.ts
@@ -11,8 +11,8 @@ import {
 } from '@repo/shared';
 import { BaseTransport } from './base-transport';
 import type {
+  RouteTransportMode,
   TransportConfig,
-  TransportMode,
   TransportRequestInit
 } from './types';
 
@@ -73,7 +73,7 @@ export class WebSocketTransport extends BaseTransport {
     this.boundHandleClose = this.handleClose.bind(this);
   }
 
-  getMode(): TransportMode {
+  getMode(): RouteTransportMode {
     return 'websocket';
   }
 

--- a/packages/sandbox/src/clients/types.ts
+++ b/packages/sandbox/src/clients/types.ts
@@ -1,5 +1,5 @@
 import type { Logger } from '@repo/shared';
-import type { ITransport, TransportMode } from './transport';
+import type { ITransport, RouteTransportMode } from './transport';
 
 /**
  * Minimal interface for container fetch functionality
@@ -36,11 +36,10 @@ export interface HttpClientOptions {
   onError?: (error: string, command?: string) => void;
 
   /**
-   * Transport mode: 'http' (default) or 'websocket'
-   * WebSocket mode multiplexes all requests over a single connection,
-   * reducing sub-request count in Workers/Durable Objects.
+   * Route-based transport mode: 'http' (default) or 'websocket'.
+   * WebSocket mode multiplexes HTTP API requests over a single connection.
    */
-  transportMode?: TransportMode;
+  transportMode?: RouteTransportMode;
 
   /**
    * WebSocket URL for WebSocket transport mode.

--- a/packages/sandbox/src/container-control/AGENTS.md
+++ b/packages/sandbox/src/container-control/AGENTS.md
@@ -1,0 +1,13 @@
+# Container control
+
+This directory is the primary home for Sandbox Durable Object to container
+control-channel code.
+
+Use role-based names such as `ContainerControlClient`,
+`ContainerControlConnection`, and `SandboxControlAPI`. Treat capnweb/RPC as an
+implementation detail unless the code directly interacts with capnweb types.
+
+Transport-layer/control-channel capabilities land here and in
+`packages/sandbox-container/src/control-plane/`. Do not add capabilities to the
+route-based HTTP/WebSocket compatibility transports unless the task is explicitly
+compatibility maintenance.

--- a/packages/sandbox/src/container-control/README.md
+++ b/packages/sandbox/src/container-control/README.md
@@ -1,0 +1,15 @@
+# Container control
+
+This directory owns the primary Sandbox Durable Object to container control path.
+
+The current implementation uses capnweb RPC over a WebSocket connection, but the
+architectural boundary is not "RPC". The boundary is the control channel used by
+the Sandbox Durable Object to call the sandbox container's control API.
+
+DO-to-container control behavior is implemented here and mirrored in
+`packages/sandbox-container/src/control-plane/`.
+
+The shared `@repo/shared` `SandboxAPI` interface remains named `SandboxAPI` because it defines the current control API contract used by both sides.
+
+Do not add new control-plane capabilities to `packages/sandbox/src/clients/transport/`.
+That directory contains the route-based HTTP/WebSocket compatibility transports.

--- a/packages/sandbox/src/container-control/client.ts
+++ b/packages/sandbox/src/container-control/client.ts
@@ -6,7 +6,7 @@
  * can use `rpc.commands`, `rpc.files`, etc. directly without any
  * per-method boilerplate.
  *
- * Manages its own connection lifecycle: creates a fresh ContainerConnection
+ * Manages its own connection lifecycle: creates a fresh ContainerControlConnection
  * on demand and disconnects it after a configurable idle period. Idle
  * detection uses capnweb's `RpcSession.getStats()` which naturally tracks
  * all in-flight RPC calls, streams, and peer-held references — no manual
@@ -79,6 +79,7 @@ import type {
   SandboxInterpreterAPI,
   SandboxPortsAPI,
   SandboxProcessesAPI,
+  SandboxTransport,
   SandboxUtilsAPI,
   SandboxWatchAPI
 } from '@repo/shared';
@@ -91,13 +92,12 @@ import {
   type RPCTransportContext,
   type RPCTransportErrorKind
 } from '@repo/shared/errors';
-import {
-  ContainerConnection,
-  type ContainerConnectionOptions
-} from '../container-connection';
+import type { SandboxClient } from '../clients/sandbox-client';
 import { createErrorFromResponse } from '../errors/adapter';
-import type { SandboxClient } from './sandbox-client';
-import type { TransportMode } from './transport';
+import {
+  ContainerControlConnection,
+  type ContainerControlConnectionOptions
+} from './connection';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -175,8 +175,7 @@ export function translateRPCError(error: unknown): never {
       });
     }
     // Map capnweb / DeferredTransport messages onto a typed RPCTransportError
-    // so consumers get a structured `code` + `kind` instead of substring
-    // matching on a free-form Error.message.
+    // so consumers get structured `code` and `kind` fields.
     // Preserve the underlying capnweb/transport Error as `cause` so callers
     // can reach the original via `err.cause` (and it shows up in toString /
     // toJSON output) without having to substring-match the message.
@@ -200,7 +199,7 @@ export function translateRPCError(error: unknown): never {
  * Inspect a transport-level Error's message and produce the ErrorResponse
  * that becomes an RPCTransportError. Pattern strings are pinned to the exact
  * messages emitted by capnweb's WebSocketTransport (see capnweb's
- * src/websocket.ts) and our DeferredTransport in container-connection.ts —
+ * src/websocket.ts) and our DeferredTransport in container-control/connection.ts —
  * notably the trailing period in `WebSocket connection failed.` matches
  * capnweb verbatim. The DeferredTransport tests in
  * tests/container-connection.test.ts pin the literal strings.
@@ -217,10 +216,9 @@ function buildTransportErrorResponse(
   // First pass: classify by `error.name`. capnweb preserves the name
   // across the wire for the standard built-ins (see ERROR_TYPES in
   // capnweb's serialize.ts), and an unambiguous name beats substring
-  // matching on a free-form message that future capnweb versions might
-  // reword. It also dodges the cross-realm `instanceof` trap: a TypeError
-  // raised inside capnweb's serializer lives in capnweb's realm, not the
-  // SDK's, so `error instanceof TypeError` would falsely return false.
+  // matching on a free-form message. It also handles the cross-realm
+  // `instanceof` trap: a TypeError raised inside capnweb's serializer lives
+  // in capnweb's realm, not the SDK's.
   if (errorName === 'TypeError') {
     // Only DeferredTransport / capnweb's WebSocketTransport raise a
     // TypeError on the receive path — always a non-string frame.
@@ -233,7 +231,7 @@ function buildTransportErrorResponse(
   } else {
     // Second pass: plain Errors. capnweb's transport layer and our
     // DeferredTransport both emit unnamed Errors with these specific
-    // messages — the message is the only signal we have.
+    // messages; the message is the only signal we have.
     const peerCloseMatch = message.match(
       /^Peer closed WebSocket: (\d+) ?(.*)$/
     );
@@ -244,7 +242,7 @@ function buildTransportErrorResponse(
     } else if (message === 'WebSocket connection failed.') {
       kind = 'connection_failed';
     } else if (message.startsWith('WebSocket upgrade failed')) {
-      // ContainerConnection.doConnect throws this when the HTTP upgrade
+      // ContainerControlConnection.doConnect throws this when the HTTP upgrade
       // returns a non-101 status.
       kind = 'upgrade_failed';
     } else if (message === 'No WebSocket in upgrade response') {
@@ -283,7 +281,7 @@ function buildTransportErrorResponse(
  * activity at call start.
  *
  * `onCallStarted` fires synchronously when an RPC method is invoked. The
- * RPCSandboxClient uses this to renew the DO's activity timeout
+ * ContainerControlClient uses this to renew the DO's activity timeout
  * immediately, so even a call that completes entirely between two
  * busy-poll ticks still pushes the sleepAfter deadline forward.
  *
@@ -297,7 +295,7 @@ function wrapStub<T extends object>(stub: T, onCallStarted: () => void): T {
     get(target, prop, receiver) {
       const value = Reflect.get(target, prop, receiver);
       if (typeof value !== 'function') return value;
-      // Use Reflect.apply instead of value.apply() because capnweb
+      // Reflect.apply preserves the method call target because capnweb
       // stubs are Proxies that interpret .apply as an RPC property access.
       return (...args: unknown[]) => {
         onCallStarted();
@@ -328,7 +326,7 @@ function wrapStub<T extends object>(stub: T, onCallStarted: () => void): T {
 // Public client
 // ---------------------------------------------------------------------------
 
-export interface RPCSandboxClientOptions extends ContainerConnectionOptions {
+export interface ContainerControlClientOptions extends ContainerControlConnectionOptions {
   /** Idle timeout before disconnecting the WebSocket (ms). Defaults to 1 000. */
   idleDisconnectMs?: number;
   /** Busy/idle poll interval (ms). Defaults to 1 000. */
@@ -357,21 +355,20 @@ export interface RPCSandboxClientOptions extends ContainerConnectionOptions {
 }
 
 /**
- * SandboxClient backed by direct capnweb RPC.
+ * SandboxClient-compatible facade backed by direct capnweb RPC.
  *
- * Drop-in replacement for SandboxClient when the capnweb transport is active.
- * All operations call the container's SandboxRPCAPI directly over capnweb,
- * bypassing the HTTP handler/router layer entirely.
+ * All operations call the container's SandboxAPI control interface directly
+ * over capnweb, bypassing the HTTP handler/router layer entirely.
  *
- * Manages its own WebSocket lifecycle: a fresh `ContainerConnection` is
+ * Manages its own WebSocket lifecycle: a fresh `ContainerControlConnection` is
  * created on demand and torn down after `idleDisconnectMs` of inactivity.
  * Busy/idle detection relies on `RpcSession.getStats()` which tracks all
  * in-flight RPC calls and stream exports — including long-lived streaming
  * RPCs that would be invisible to a simple per-call request counter (see
  * the file-level comment for the full rationale).
  */
-export class RPCSandboxClient {
-  private readonly connOptions: ContainerConnectionOptions;
+export class ContainerControlClient {
+  private readonly connOptions: ContainerControlConnectionOptions;
   private readonly idleDisconnectMs: number;
   private readonly busyPollIntervalMs: number;
   private readonly logger: Logger;
@@ -379,7 +376,7 @@ export class RPCSandboxClient {
   private readonly onSessionBusy: (() => void) | undefined;
   private readonly onSessionIdle: (() => void) | undefined;
 
-  private conn: ContainerConnection | null = null;
+  private conn: ContainerControlConnection | null = null;
   private idleTimer: ReturnType<typeof setTimeout> | null = null;
   private busyPollTimer: ReturnType<typeof setInterval> | null = null;
   /** Tracks whether we currently believe the session is busy. */
@@ -392,7 +389,7 @@ export class RPCSandboxClient {
    */
   private wasEverConnected = false;
 
-  constructor(options: RPCSandboxClientOptions) {
+  constructor(options: ContainerControlClientOptions) {
     this.connOptions = {
       stub: options.stub,
       port: options.port,
@@ -413,13 +410,12 @@ export class RPCSandboxClient {
   // -------------------------------------------------------------------------
 
   /**
-   * Return the current connection, creating a new one if none exists or the
-   * previous one was torn down by an idle disconnect. Starts the busy-poll
-   * timer the first time a connection is materialized.
+   * Return the current connection, creating one when the client is disconnected.
+   * Starts the busy-poll timer the first time a connection is materialized.
    */
-  private getConnection(): ContainerConnection {
+  private getConnection(): ContainerControlConnection {
     if (!this.conn) {
-      this.conn = new ContainerConnection(this.connOptions);
+      this.conn = new ContainerControlConnection(this.connOptions);
       this.startBusyPoll();
     }
     return this.conn;
@@ -559,8 +555,8 @@ export class RPCSandboxClient {
 
   // Each getter returns the corresponding nested RpcTarget stub
   // wrapped in a Proxy that translates RPC errors into SandboxError
-  // subclasses. Explicit return types prevent capnweb's recursive
-  // type machinery from expanding in .d.ts output (causes OOM).
+  // subclasses. Explicit return types keep capnweb's recursive
+  // type machinery out of .d.ts output.
 
   get commands(): SandboxCommandsAPI {
     return wrapStub(this.getConnection().rpc().commands, this.renewActivity);
@@ -597,7 +593,7 @@ export class RPCSandboxClient {
     // RPC transport does not use HTTP retry budgets
   }
 
-  getTransportMode(): TransportMode {
+  getTransportMode(): SandboxTransport {
     return 'rpc';
   }
 
@@ -629,11 +625,11 @@ export class RPCSandboxClient {
 
 /**
  * Extracts the public key set of a type. Used to verify that
- * RPCSandboxClient exposes the same top-level properties and methods
- * as SandboxClient without requiring deep structural compatibility
- * (sub-clients are capnweb stubs, not HTTP client class instances).
+ * ContainerControlClient exposes the same top-level properties and methods
+ * as SandboxClient with top-level key coverage. Sub-clients are capnweb stubs, not HTTP
+ * client class instances.
  */
 type PublicKeys<T> = { [K in keyof T]: unknown };
 
-// Compile-time check: RPCSandboxClient has every public key that SandboxClient has.
-void (0 as unknown as PublicKeys<RPCSandboxClient> satisfies PublicKeys<SandboxClient>);
+// Compile-time check: ContainerControlClient has every public key that SandboxClient has.
+void (0 as unknown as PublicKeys<ContainerControlClient> satisfies PublicKeys<SandboxClient>);

--- a/packages/sandbox/src/container-control/connection.ts
+++ b/packages/sandbox/src/container-control/connection.ts
@@ -2,8 +2,8 @@
  * Capnweb RPC connection to the container.
  *
  * Manages a single WebSocket session and exposes typed methods that map
- * 1:1 to the container's SandboxAPI. The Sandbox DO calls these
- * directly instead of going through the HTTP client layer.
+ * 1:1 to the container's SandboxAPI. The Sandbox DO calls these directly,
+ * bypassing the route-based HTTP client layer.
  */
 
 import type {
@@ -34,7 +34,7 @@ export interface ContainerFetchStub {
   fetch(request: Request): Promise<Response>;
 }
 
-export interface ContainerConnectionOptions {
+export interface ContainerControlConnectionOptions {
   stub: ContainerFetchStub;
   port?: number;
   logger?: Logger;
@@ -47,7 +47,7 @@ export interface ContainerConnectionOptions {
  * transport. Calls made before `connect()` completes are queued in the
  * transport and flushed once the WebSocket is established.
  */
-export class ContainerConnection {
+export class ContainerControlConnection {
   private readonly stub: RpcStub<SandboxAPI>;
   private readonly session: RpcSession<SandboxAPI>;
   private readonly transport: DeferredTransport;
@@ -58,7 +58,7 @@ export class ContainerConnection {
   private readonly port: number;
   private readonly logger: Logger;
 
-  constructor(options: ContainerConnectionOptions) {
+  constructor(options: ContainerControlConnectionOptions) {
     this.containerStub = options.stub;
     this.port = options.port ?? 3000;
     this.logger = options.logger ?? createNoOpLogger();
@@ -171,7 +171,7 @@ export class ContainerConnection {
       ws.addEventListener('close', () => {
         this.connected = false;
         this.ws = null;
-        this.logger.debug('ContainerConnection WebSocket closed');
+        this.logger.debug('ContainerControlConnection WebSocket closed');
       });
 
       ws.addEventListener('error', () => {
@@ -183,7 +183,7 @@ export class ContainerConnection {
       this.transport.activate(ws);
       this.connected = true;
 
-      this.logger.debug('ContainerConnection established', {
+      this.logger.debug('ContainerControlConnection established', {
         port: this.port
       });
     } catch (error) {
@@ -191,7 +191,7 @@ export class ContainerConnection {
       this.connected = false;
       this.transport.abort(error);
       this.logger.error(
-        'ContainerConnection failed',
+        'ContainerControlConnection failed',
         error instanceof Error ? error : new Error(String(error))
       );
       throw error;

--- a/packages/sandbox/src/container-control/index.ts
+++ b/packages/sandbox/src/container-control/index.ts
@@ -1,0 +1,12 @@
+export {
+  ContainerControlClient,
+  type ContainerControlClientOptions,
+  translateRPCError
+} from './client';
+
+export {
+  ContainerControlConnection,
+  type ContainerControlConnectionOptions,
+  type ContainerFetchStub,
+  DeferredTransport
+} from './connection';

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -53,6 +53,7 @@ export type {
   RestoreBackupResult,
   RunCodeOptions,
   SandboxOptions,
+  SandboxTransport,
   SessionOptions,
   StreamOptions,
   WaitForLogResult,

--- a/packages/sandbox/src/local-mount-sync.ts
+++ b/packages/sandbox/src/local-mount-sync.ts
@@ -1,7 +1,7 @@
 import path from 'node:path/posix';
 import type { FileWatchSSEEvent, Logger } from '@repo/shared';
 import type { SandboxClient } from './clients';
-import type { RPCSandboxClient } from './clients/rpc-sandbox-client';
+import type { ContainerControlClient } from './container-control';
 import { parseSSEStream } from './sse-parser';
 import { validatePrefix } from './storage-mount';
 
@@ -20,7 +20,7 @@ interface LocalMountSyncOptions {
   mountPath: string;
   prefix: string | undefined;
   readOnly: boolean;
-  client: SandboxClient | RPCSandboxClient;
+  client: SandboxClient | ContainerControlClient;
   sessionId: string;
   logger: Logger;
   pollIntervalMs?: number;
@@ -38,7 +38,7 @@ export class LocalMountSyncManager {
   private readonly mountPath: string;
   private readonly prefix: string | undefined;
   private readonly readOnly: boolean;
-  private readonly client: SandboxClient | RPCSandboxClient;
+  private readonly client: SandboxClient | ContainerControlClient;
   private readonly sessionId: string;
   private readonly logger: Logger;
   private readonly pollIntervalMs: number;

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -26,6 +26,7 @@ import type {
   RestoreBackupResult,
   RunCodeOptions,
   SandboxOptions,
+  SandboxTransport,
   SessionOptions,
   StreamOptions,
   WaitForExitResult,
@@ -49,7 +50,7 @@ import {
 } from '@repo/shared/backup';
 import { AwsClient } from 'aws4fetch';
 import { type Desktop, type ExecuteResponse, SandboxClient } from './clients';
-import { RPCSandboxClient } from './clients/rpc-sandbox-client';
+import { ContainerControlClient } from './container-control';
 import type { ErrorResponse } from './errors';
 import {
   BackupCreateError,
@@ -113,7 +114,7 @@ type SandboxConfiguration = {
   sleepAfter?: string | number;
   keepAlive?: boolean;
   containerTimeouts?: NonNullable<SandboxOptions['containerTimeouts']>;
-  transport?: 'http' | 'websocket' | 'rpc';
+  transport?: SandboxTransport;
 };
 
 type CachedSandboxConfiguration = {
@@ -122,7 +123,7 @@ type CachedSandboxConfiguration = {
   sleepAfter?: string | number;
   keepAlive?: boolean;
   containerTimeouts?: NonNullable<SandboxOptions['containerTimeouts']>;
-  transport?: 'http' | 'websocket' | 'rpc';
+  transport?: SandboxTransport;
 };
 
 type ConfigurableSandboxStub = {
@@ -133,7 +134,7 @@ type ConfigurableSandboxStub = {
   setContainerTimeouts?: (
     timeouts: NonNullable<SandboxOptions['containerTimeouts']>
   ) => Promise<void>;
-  setTransport?: (transport: 'http' | 'websocket' | 'rpc') => Promise<void>;
+  setTransport?: (transport: SandboxTransport) => Promise<void>;
 };
 
 const sandboxConfigurationCache = new WeakMap<
@@ -441,7 +442,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   defaultPort = 3000; // Default port for the container's Bun server
   sleepAfter: string | number = '10m'; // Sleep the sandbox if no requests are made in this timeframe
 
-  client: SandboxClient | RPCSandboxClient;
+  client: SandboxClient | ContainerControlClient;
 
   private codeInterpreter: CodeInterpreter;
   private sandboxName: string | null = null;
@@ -460,7 +461,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   private logger: ReturnType<typeof createLogger>;
   private keepAliveEnabled: boolean = false;
   private activeMounts: Map<string, MountInfo> = new Map();
-  private transport: 'http' | 'websocket' | 'rpc' = 'http';
+  private transport: SandboxTransport = 'http';
 
   /**
    * True once transport has been written to storage at least once (either
@@ -597,7 +598,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   /**
-   * Create a SandboxClient with current transport settings
+   * Create the route-based compatibility client with current HTTP/WebSocket
+   * transport settings.
    */
   private createSandboxClient(): SandboxClient {
     return new SandboxClient({
@@ -616,18 +618,21 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   /**
-   * Create the appropriate client for a given transport protocol.
+   * Create the appropriate client for the configured control path.
+   *
+   * `rpc` currently selects the primary container-control client. `http` and
+   * `websocket` select the route-based compatibility client.
    */
   private createClientForTransport(
-    transport: 'http' | 'websocket' | 'rpc'
-  ): SandboxClient | RPCSandboxClient {
+    transport: SandboxTransport
+  ): SandboxClient | ContainerControlClient {
     if (transport === 'rpc') {
       // Access the base Container's private inflightRequests counter so
       // the alarm loop's isActivityExpired() check sees active work and
       // skips the sleepAfterMs comparison while RPC calls or returned
       // streams are still active over the capnweb session.
       const self = this as unknown as { inflightRequests: number };
-      return new RPCSandboxClient({
+      return new ContainerControlClient({
         stub: this,
         port: 3000,
         logger: this.logger,
@@ -638,11 +643,11 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         // transport multiplexes all work over a single capnweb WebSocket,
         // so we can't bracket per-request — and a method that returns a
         // ReadableStream resolves its promise long before the stream is
-        // actually drained. Instead, RPCSandboxClient polls capnweb's
+        // actually drained. Instead, ContainerControlClient polls capnweb's
         // session stats and reports busy/idle *transitions* of the whole
         // session. We treat one transition as equivalent to one in-flight
         // request: increment on busy, decrement on idle. See the
-        // file-level comment in rpc-sandbox-client.ts for details.
+        // file-level comment in container-control/client.ts for details.
         onActivity: () => {
           // Called at the start of each RPC call AND on every busy-poll
           // tick while the session has work in flight. Equivalent to
@@ -761,9 +766,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       }
 
       // Restore transport setting from storage (overrides env var default)
-      const storedTransport = await this.ctx.storage.get<
-        'http' | 'websocket' | 'rpc'
-      >('transport');
+      const storedTransport =
+        await this.ctx.storage.get<SandboxTransport>('transport');
       if (storedTransport && storedTransport !== this.transport) {
         this.transport = storedTransport;
         const previousClient = this.client;
@@ -966,7 +970,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    * has been persisted: re-applying the same transport is a no-op.
    * Storage is written before the in-memory state and client are updated.
    */
-  async setTransport(transport: 'http' | 'websocket' | 'rpc'): Promise<void> {
+  async setTransport(transport: SandboxTransport): Promise<void> {
     if (
       transport !== 'http' &&
       transport !== 'websocket' &&
@@ -1821,7 +1825,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     this.defaultSession = null;
     this.defaultSessionInit = null;
 
-    // Disconnect capnweb transport so the WebSocket doesn't hold the DO alive
+    // Disconnect the active client so open sockets do not hold the DO alive.
     this.client.disconnect();
 
     // Stop local sync managers before clearing the map.

--- a/packages/sandbox/tests/base-client.test.ts
+++ b/packages/sandbox/tests/base-client.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { BaseApiResponse, HttpClientOptions } from '../src/clients';
 import { BaseHttpClient } from '../src/clients/base-client';
-import type { ITransport, TransportMode } from '../src/clients/transport';
+import type { ITransport, RouteTransportMode } from '../src/clients/transport';
 import type { ErrorResponse } from '../src/errors';
 import {
   CommandError,
@@ -44,7 +44,7 @@ class MockTransport implements ITransport {
   public isConnectedMock = vi.fn<() => boolean>();
   public setRetryTimeoutMsMock = vi.fn<(ms: number) => void>();
 
-  constructor(private mode: TransportMode = 'http') {
+  constructor(private mode: RouteTransportMode = 'http') {
     this.connectMock.mockResolvedValue(undefined);
     this.isConnectedMock.mockReturnValue(true);
   }
@@ -62,7 +62,7 @@ class MockTransport implements ITransport {
     return this.fetchStreamMock(path, body, method, headers);
   }
 
-  getMode(): TransportMode {
+  getMode(): RouteTransportMode {
     return this.mode;
   }
 

--- a/packages/sandbox/tests/container-connection.test.ts
+++ b/packages/sandbox/tests/container-connection.test.ts
@@ -1,26 +1,26 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
-  ContainerConnection,
+  ContainerControlConnection,
   DeferredTransport
-} from '../src/container-connection';
+} from '../src/container-control/connection';
 
 /**
- * Tests for ContainerConnection — the capnweb RPC connection manager.
+ * Tests for ContainerControlConnection — the capnweb RPC connection manager.
  *
  * These tests verify connection lifecycle and RPC stub access.
  * The actual RPC methods are tested via E2E tests against a real container.
  */
-describe('ContainerConnection', () => {
+describe('ContainerControlConnection', () => {
   describe('initial state', () => {
     it('should not be connected after construction', () => {
-      const conn = new ContainerConnection({
+      const conn = new ContainerControlConnection({
         stub: { fetch: vi.fn() }
       });
       expect(conn.isConnected()).toBe(false);
     });
 
     it('should have a stub available immediately after construction', () => {
-      const conn = new ContainerConnection({
+      const conn = new ContainerControlConnection({
         stub: { fetch: vi.fn() }
       });
       expect(conn.rpc()).toBeDefined();
@@ -29,7 +29,7 @@ describe('ContainerConnection', () => {
 
   describe('disconnect', () => {
     it('should be safe to call disconnect when not connected', () => {
-      const conn = new ContainerConnection({
+      const conn = new ContainerControlConnection({
         stub: { fetch: vi.fn() }
       });
       conn.disconnect();
@@ -37,7 +37,7 @@ describe('ContainerConnection', () => {
     });
 
     it('should be safe to call disconnect multiple times', () => {
-      const conn = new ContainerConnection({
+      const conn = new ContainerControlConnection({
         stub: { fetch: vi.fn() }
       });
       conn.disconnect();
@@ -49,7 +49,7 @@ describe('ContainerConnection', () => {
 
   describe('connect', () => {
     it('should fail when WebSocket upgrade is rejected', async () => {
-      const conn = new ContainerConnection({
+      const conn = new ContainerControlConnection({
         stub: {
           fetch: vi
             .fn()
@@ -64,7 +64,7 @@ describe('ContainerConnection', () => {
     });
 
     it('should reject pending RPC calls when connection fails', async () => {
-      const conn = new ContainerConnection({
+      const conn = new ContainerControlConnection({
         stub: {
           fetch: vi
             .fn()
@@ -89,7 +89,7 @@ describe('ContainerConnection', () => {
       const fetchMock = vi
         .fn()
         .mockResolvedValue(new Response('Not Found', { status: 404 }));
-      const conn = new ContainerConnection({
+      const conn = new ContainerControlConnection({
         stub: { fetch: fetchMock }
       });
 
@@ -102,7 +102,7 @@ describe('ContainerConnection', () => {
 
   describe('connection lifecycle with mocked internals', () => {
     it('should return connected after successful connect', async () => {
-      const conn = new ContainerConnection({
+      const conn = new ContainerControlConnection({
         stub: { fetch: vi.fn() }
       });
       const internals = conn as unknown as {
@@ -121,7 +121,7 @@ describe('ContainerConnection', () => {
     });
 
     it('should return the same stub before and after connect', async () => {
-      const conn = new ContainerConnection({
+      const conn = new ContainerControlConnection({
         stub: { fetch: vi.fn() }
       });
       const internals = conn as unknown as {
@@ -143,7 +143,7 @@ describe('ContainerConnection', () => {
     });
 
     it('should disconnect and reconnect', async () => {
-      const conn = new ContainerConnection({
+      const conn = new ContainerControlConnection({
         stub: { fetch: vi.fn() }
       });
       const internals = conn as unknown as {
@@ -170,7 +170,7 @@ describe('ContainerConnection', () => {
     });
 
     it('should share connection across concurrent connect() calls', async () => {
-      const conn = new ContainerConnection({
+      const conn = new ContainerControlConnection({
         stub: { fetch: vi.fn() }
       });
       const internals = conn as unknown as {

--- a/packages/sandbox/tests/rpc-sandbox-client.test.ts
+++ b/packages/sandbox/tests/rpc-sandbox-client.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
  * after the call promise has resolved) keeps `onActivity` firing past
  * `sleepAfter` and only fires `onSessionIdle` once stats return to baseline.
  *
- * We mock ContainerConnection so we can drive `getStats()` directly. The
+ * We mock ContainerControlConnection so we can drive `getStats()` directly. The
  * test never actually opens a WebSocket.
  */
 
@@ -14,8 +14,8 @@ let stats = { imports: 1, exports: 1 };
 let connected = true;
 const disconnects: number[] = [];
 
-vi.mock('../src/container-connection', () => ({
-  ContainerConnection: class {
+vi.mock('../src/container-control/connection', () => ({
+  ContainerControlConnection: class {
     isConnected() {
       return connected;
     }
@@ -35,9 +35,12 @@ vi.mock('../src/container-connection', () => ({
   }
 }));
 
-import { RPCSandboxClient } from '../src/clients/rpc-sandbox-client';
+import {
+  ContainerControlClient,
+  translateRPCError
+} from '../src/container-control/client';
 
-describe('RPCSandboxClient busy/idle tracking', () => {
+describe('ContainerControlClient busy/idle tracking', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     stats = { imports: 1, exports: 1 };
@@ -54,7 +57,7 @@ describe('RPCSandboxClient busy/idle tracking', () => {
     const onSessionBusy = vi.fn();
     const onSessionIdle = vi.fn();
 
-    const client = new RPCSandboxClient({
+    const client = new ContainerControlClient({
       stub: { fetch: vi.fn() },
       onActivity,
       onSessionBusy,
@@ -102,7 +105,7 @@ describe('RPCSandboxClient busy/idle tracking', () => {
     const onSessionBusy = vi.fn();
     const onSessionIdle = vi.fn();
 
-    const client = new RPCSandboxClient({
+    const client = new ContainerControlClient({
       stub: { fetch: vi.fn() },
       onSessionBusy,
       onSessionIdle,
@@ -126,7 +129,7 @@ describe('RPCSandboxClient busy/idle tracking', () => {
     const onSessionBusy = vi.fn();
     const onSessionIdle = vi.fn();
 
-    const client = new RPCSandboxClient({
+    const client = new ContainerControlClient({
       stub: { fetch: vi.fn() },
       onSessionBusy,
       onSessionIdle,
@@ -165,7 +168,7 @@ describe('RPCSandboxClient busy/idle tracking', () => {
     connected = false;
 
     const onSessionIdle = vi.fn();
-    const client = new RPCSandboxClient({
+    const client = new ContainerControlClient({
       stub: { fetch: vi.fn() },
       onSessionIdle,
       busyPollIntervalMs: 1_000,
@@ -195,8 +198,7 @@ describe('RPCSandboxClient busy/idle tracking', () => {
 
 describe('translateRPCError', () => {
   async function loadFn() {
-    const mod = await import('../src/clients/rpc-sandbox-client');
-    return mod.translateRPCError;
+    return translateRPCError;
   }
 
   async function loadErr() {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -195,6 +195,7 @@ export type {
   RestoreBackupResult,
   // Sandbox configuration options
   SandboxOptions,
+  SandboxTransport,
   // Session management result types
   SessionCreateResult,
   SessionDeleteResult,

--- a/packages/shared/src/rpc-types.ts
+++ b/packages/shared/src/rpc-types.ts
@@ -1,9 +1,8 @@
 /**
- * Shared RPC interface types for the capnweb transport layer.
+ * Shared interface types for the container-control path.
  *
- * Defines the contract between the SDK client (ContainerConnection) and the
- * container server (SandboxAPI). Both sides must implement or satisfy
- * these interfaces to ensure type-safe communication.
+ * Defines the contract between the SDK control client and the container
+ * control-plane API. The current wire implementation uses capnweb RPC.
  */
 
 import type {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -439,6 +439,8 @@ export interface SessionOptions {
 }
 
 // Sandbox configuration options
+export type SandboxTransport = 'http' | 'websocket' | 'rpc';
+
 export interface SandboxOptions {
   /**
    * Duration after which the sandbox instance will sleep if no requests are received
@@ -533,13 +535,13 @@ export interface SandboxOptions {
   };
 
   /**
-   * Transport protocol for communication between the Sandbox DO and the container runtime.
+   * Transport/control path for communication between the Sandbox DO and the
+   * container runtime.
    *
-   * - `"http"` (default): Standard HTTP request/response. Works everywhere.
-   * - `"websocket"`: Multiplexes requests over a single WebSocket connection,
-   *   avoiding sub-request limits in Workers and Durable Objects.
-   * - `"capnweb"`: Direct RPC over a single WebSocket using the capnweb protocol.
-   *   Lowest latency; automatically disconnects when idle to respect `sleepAfter`.
+   * - `"http"` (default): Route-based HTTP compatibility path.
+   * - `"websocket"`: Route-based compatibility path multiplexed over a custom
+   *   WebSocket connection.
+   * - `"rpc"`: Primary container-control path over capnweb RPC.
    *
    * When set via `getSandbox()` options, this overrides the `SANDBOX_TRANSPORT` env var.
    *
@@ -550,7 +552,7 @@ export interface SandboxOptions {
    *
    * @default "http"
    */
-  transport?: 'http' | 'websocket' | 'rpc';
+  transport?: SandboxTransport;
 }
 
 /**

--- a/tests/e2e/file-operations-workflow.test.ts
+++ b/tests/e2e/file-operations-workflow.test.ts
@@ -312,9 +312,9 @@ describe('File Operations Error Handling', () => {
   }, 90000);
 });
 
-const isCapnweb = process.env.TEST_TRANSPORT === 'rpc';
+const isRPCTransport = process.env.TEST_TRANSPORT === 'rpc';
 
-describe.skipIf(!isCapnweb)('File Streaming Write (capnweb)', () => {
+describe.skipIf(!isRPCTransport)('File Streaming Write (rpc)', () => {
   let sandbox: TestSandbox | null = null;
   let workerUrl: string;
   let headers: Record<string, string>;
@@ -332,7 +332,7 @@ describe.skipIf(!isCapnweb)('File Streaming Write (capnweb)', () => {
 
   test('should stream-write a file and read it back', async () => {
     const testPath = sandbox!.uniquePath('stream-write.txt');
-    const testContent = 'Streamed content for capnweb transport ✨';
+    const testContent = 'Streamed content for rpc transport ✨';
     const body = new TextEncoder().encode(testContent);
 
     const writeResponse = await fetch(`${workerUrl}/api/file/write-stream`, {

--- a/tests/e2e/rpc-container-control.test.ts
+++ b/tests/e2e/rpc-container-control.test.ts
@@ -1,15 +1,15 @@
 /**
- * Cap'n Web Transport E2E Tests
+ * RPC Container Control E2E Tests
  *
- * Validates core sandbox operations work end-to-end through the capnweb
- * transport layer. These tests exercise:
+ * Validates core sandbox operations work end-to-end through the
+ * container-control path. These tests exercise:
  * - Command execution (exec)
  * - Streaming output (execStream)
  * - File operations (write, read, list, delete)
  * - Session isolation
  *
- * Skipped unless TEST_TRANSPORT=capnweb. Transport selection flows through
- * the X-Sandbox-Transport header to the test worker, which passes it to
+ * Skipped unless TEST_TRANSPORT=rpc. Transport selection flows through the
+ * X-Sandbox-Transport header to the test worker, which passes it to
  * getSandbox() as a per-instance transport option.
  */
 
@@ -28,9 +28,9 @@ import {
   type TestSandbox
 } from './helpers/global-sandbox';
 
-const isCapnweb = process.env.TEST_TRANSPORT === 'rpc';
+const isRPCTransport = process.env.TEST_TRANSPORT === 'rpc';
 
-describe.skipIf(!isCapnweb)("Cap'n Web Transport", () => {
+describe.skipIf(!isRPCTransport)('RPC Container Control', () => {
   let sandbox: TestSandbox | null = null;
   let workerUrl: string;
   let headers: Record<string, string>;
@@ -50,13 +50,13 @@ describe.skipIf(!isCapnweb)("Cap'n Web Transport", () => {
     const response = await fetch(`${workerUrl}/api/execute`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ command: 'echo hello-capnweb' })
+      body: JSON.stringify({ command: 'echo hello-rpc' })
     });
 
     expect(response.status).toBe(200);
     const result = (await response.json()) as ExecResult;
     expect(result.exitCode).toBe(0);
-    expect(result.stdout.trim()).toBe('hello-capnweb');
+    expect(result.stdout.trim()).toBe('hello-rpc');
   });
 
   test('should handle command with non-zero exit code', async () => {
@@ -72,8 +72,8 @@ describe.skipIf(!isCapnweb)("Cap'n Web Transport", () => {
   });
 
   test('should write and read a file', async () => {
-    const testPath = sandbox!.uniquePath('capnweb-test.txt');
-    const testContent = 'Hello from capnweb transport! 🚀';
+    const testPath = sandbox!.uniquePath('rpc-test.txt');
+    const testContent = 'Hello from rpc transport! 🚀';
 
     // Write
     const writeResponse = await fetch(`${workerUrl}/api/file/write`, {
@@ -95,7 +95,7 @@ describe.skipIf(!isCapnweb)("Cap'n Web Transport", () => {
   });
 
   test('should list files in a directory', async () => {
-    const testDir = sandbox!.uniquePath('capnweb-list');
+    const testDir = sandbox!.uniquePath('rpc-list');
 
     // Create directory with files
     await fetch(`${workerUrl}/api/execute`, {
@@ -164,7 +164,7 @@ describe.skipIf(!isCapnweb)("Cap'n Web Transport", () => {
   });
 
   test('should delete a file', async () => {
-    const testPath = sandbox!.uniquePath('capnweb-delete.txt');
+    const testPath = sandbox!.uniquePath('rpc-delete.txt');
 
     // Create file
     await fetch(`${workerUrl}/api/file/write`, {
@@ -206,7 +206,7 @@ describe.skipIf(!isCapnweb)("Cap'n Web Transport", () => {
       headers: sandbox!.headers(),
       body: JSON.stringify({
         id: sessionId,
-        env: { CAPNWEB_TEST: 'transport-works' }
+        env: { RPC_TEST: 'transport-works' }
       })
     });
     expect(createResponse.status).toBe(200);
@@ -216,7 +216,7 @@ describe.skipIf(!isCapnweb)("Cap'n Web Transport", () => {
     const execResponse = await fetch(`${workerUrl}/api/execute`, {
       method: 'POST',
       headers: sessionHeaders,
-      body: JSON.stringify({ command: 'echo $CAPNWEB_TEST' })
+      body: JSON.stringify({ command: 'echo $RPC_TEST' })
     });
     expect(execResponse.status).toBe(200);
     const result = (await execResponse.json()) as ExecResult;
@@ -226,7 +226,7 @@ describe.skipIf(!isCapnweb)("Cap'n Web Transport", () => {
     const defaultExecResponse = await fetch(`${workerUrl}/api/execute`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ command: 'echo $CAPNWEB_TEST' })
+      body: JSON.stringify({ command: 'echo $RPC_TEST' })
     });
     const defaultResult = (await defaultExecResponse.json()) as ExecResult;
     expect(defaultResult.stdout.trim()).toBe('');


### PR DESCRIPTION
The primary Sandbox Durable Object to container path was named around the capnweb/RPC implementation, while the route-based HTTP/WebSocket compatibility transports lived nearby. That made it harder to tell where future control-plane work belongs and which code exists for compatibility.

This renames the SDK side to `container-control` and the container side to `control-plane`, removes shim-only compatibility files, and documents the route-based HTTP/WebSocket transports as compatibility paths. The public `SandboxOptions.transport` contract still supports `rpc`; the route transport helpers remain internal to the route-based client layer.

No changeset is included because the package-level runtime API is unchanged.
