### PR TITLE
Improve backup/restore transfer speeds with parallelization

### DIFF
--- a/.changeset/improve-backup-restore-speeds.md
+++ b/.changeset/improve-backup-restore-speeds.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Speed up backup and restore for larger archives with faster default compression, multipart R2 uploads, and parallel range downloads that write directly into the restored archive.

--- a/packages/sandbox-container/src/control-plane/api.ts
+++ b/packages/sandbox-container/src/control-plane/api.ts
@@ -1055,10 +1055,12 @@ class BackupRPCAPI extends RpcTarget {
       offset: number;
       size: number;
     }>;
+    sessionId?: string;
   }) {
     const result = await this.#svc.uploadParts(
       request.archivePath,
-      request.parts
+      request.parts,
+      request.sessionId ?? 'default'
     );
     const data = extractData<{
       parts: Array<{ partNumber: number; etag: string }>;

--- a/packages/sandbox-container/src/control-plane/api.ts
+++ b/packages/sandbox-container/src/control-plane/api.ts
@@ -1018,8 +1018,10 @@ class BackupRPCAPI extends RpcTarget {
     options?: {
       excludes?: string[];
       gitignore?: boolean;
-      compression?: 'gzip' | 'lz4' | 'zstd';
-      compressThreads?: number;
+      compression?: {
+        format?: 'gzip' | 'lz4' | 'zstd';
+        threads?: number;
+      };
     }
   ) {
     const result = await this.#svc.createArchive(
@@ -1028,8 +1030,7 @@ class BackupRPCAPI extends RpcTarget {
       sessionId,
       options?.gitignore ?? false,
       options?.excludes ?? [],
-      options?.compression ?? 'lz4',
-      options?.compressThreads ?? 8
+      options?.compression
     );
     const data = extractData<{ sizeBytes: number; archivePath: string }>(
       result

--- a/packages/sandbox-container/src/control-plane/api.ts
+++ b/packages/sandbox-container/src/control-plane/api.ts
@@ -1015,14 +1015,21 @@ class BackupRPCAPI extends RpcTarget {
     dir: string,
     archivePath: string,
     sessionId: string,
-    options?: { excludes?: string[]; gitignore?: boolean }
+    options?: {
+      excludes?: string[];
+      gitignore?: boolean;
+      compression?: 'gzip' | 'lz4' | 'zstd';
+      compressThreads?: number;
+    }
   ) {
     const result = await this.#svc.createArchive(
       dir,
       archivePath,
       sessionId,
       options?.gitignore ?? false,
-      options?.excludes ?? []
+      options?.excludes ?? [],
+      options?.compression ?? 'lz4',
+      options?.compressThreads ?? 8
     );
     const data = extractData<{ sizeBytes: number; archivePath: string }>(
       result
@@ -1038,6 +1045,25 @@ class BackupRPCAPI extends RpcTarget {
     const result = await this.#svc.restoreArchive(dir, archivePath, sessionId);
     throwIfError(result);
     return { success: true, dir };
+  }
+
+  async uploadParts(request: {
+    archivePath: string;
+    parts: Array<{
+      partNumber: number;
+      url: string;
+      offset: number;
+      size: number;
+    }>;
+  }) {
+    const result = await this.#svc.uploadParts(
+      request.archivePath,
+      request.parts
+    );
+    const data = extractData<{
+      parts: Array<{ partNumber: number; etag: string }>;
+    }>(result);
+    return { success: true, parts: data.parts };
   }
 }
 

--- a/packages/sandbox-container/src/handlers/backup-handler.ts
+++ b/packages/sandbox-container/src/handlers/backup-handler.ts
@@ -15,6 +15,7 @@ import { BACKUP_WORK_DIR } from '../services/backup-service';
 import { BaseHandler } from './base-handler';
 
 type CreateBackupRequestBody = CreateBackupRequest;
+const BACKUP_ALLOWED_COMPRESSIONS = ['gzip', 'lz4', 'zstd'] as const;
 
 export class BackupHandler extends BaseHandler<Request, Response> {
   constructor(
@@ -92,6 +93,84 @@ export class BackupHandler extends BaseHandler<Request, Response> {
     return undefined;
   }
 
+  private static validateCompression(compression: unknown): string | undefined {
+    if (compression === undefined) {
+      return undefined;
+    }
+    if (
+      typeof compression !== 'string' ||
+      !BACKUP_ALLOWED_COMPRESSIONS.includes(
+        compression as (typeof BACKUP_ALLOWED_COMPRESSIONS)[number]
+      )
+    ) {
+      return `compression must be one of: ${BACKUP_ALLOWED_COMPRESSIONS.join(', ')}`;
+    }
+    return undefined;
+  }
+
+  private static validateCompressThreads(
+    compressThreads: unknown
+  ): string | undefined {
+    if (compressThreads === undefined) {
+      return undefined;
+    }
+    if (
+      typeof compressThreads !== 'number' ||
+      !Number.isInteger(compressThreads) ||
+      compressThreads < 1
+    ) {
+      return 'compressThreads must be a positive integer';
+    }
+    return undefined;
+  }
+
+  private static validateUploadPart(part: unknown): string | undefined {
+    if (typeof part !== 'object' || part === null) {
+      return 'each part must be an object';
+    }
+
+    const candidate = part as {
+      partNumber?: unknown;
+      url?: unknown;
+      offset?: unknown;
+      size?: unknown;
+    };
+
+    if (
+      typeof candidate.partNumber !== 'number' ||
+      !Number.isInteger(candidate.partNumber) ||
+      candidate.partNumber < 1
+    ) {
+      return 'partNumber must be a positive integer';
+    }
+    if (typeof candidate.url !== 'string') {
+      return 'part url must be a string';
+    }
+    try {
+      const url = new URL(candidate.url);
+      if (url.protocol !== 'https:') {
+        return 'part url must use https';
+      }
+    } catch {
+      return 'part url must be a valid URL';
+    }
+    if (
+      typeof candidate.offset !== 'number' ||
+      !Number.isInteger(candidate.offset) ||
+      candidate.offset < 0
+    ) {
+      return 'part offset must be a non-negative integer';
+    }
+    if (
+      typeof candidate.size !== 'number' ||
+      !Number.isInteger(candidate.size) ||
+      candidate.size < 1
+    ) {
+      return 'part size must be a positive integer';
+    }
+    return undefined;
+  }
+
   private async handleCreate(
     request: Request,
     context: RequestContext
@@ -146,6 +225,34 @@ export class BackupHandler extends BaseHandler<Request, Response> {
           Operation.BACKUP_CREATE
         );
       }
+    }
+
+    const compressionError = BackupHandler.validateCompression(
+      body.compression
+    );
+    if (compressionError) {
+      return this.createErrorResponse(
+        {
+          message: compressionError,
+          code: ErrorCode.INVALID_BACKUP_CONFIG
+        },
+        context,
+        Operation.BACKUP_CREATE
+      );
+    }
+
+    const compressThreadsError = BackupHandler.validateCompressThreads(
+      body.compressThreads
+    );
+    if (compressThreadsError) {
+      return this.createErrorResponse(
+        {
+          message: compressThreadsError,
+          code: ErrorCode.INVALID_BACKUP_CONFIG
+        },
+        context,
+        Operation.BACKUP_CREATE
+      );
     }
 
     const sessionId = body.sessionId ?? context.sessionId ?? 'default';
@@ -203,6 +310,20 @@ export class BackupHandler extends BaseHandler<Request, Response> {
         context,
         Operation.BACKUP_CREATE
       );
+    }
+
+    for (const part of body.parts) {
+      const partError = BackupHandler.validateUploadPart(part);
+      if (partError) {
+        return this.createErrorResponse(
+          {
+            message: partError,
+            code: ErrorCode.INVALID_BACKUP_CONFIG
+          },
+          context,
+          Operation.BACKUP_CREATE
+        );
+      }
     }
 
     const sessionId = context.sessionId ?? 'default';

--- a/packages/sandbox-container/src/handlers/backup-handler.ts
+++ b/packages/sandbox-container/src/handlers/backup-handler.ts
@@ -97,29 +97,29 @@ export class BackupHandler extends BaseHandler<Request, Response> {
     if (compression === undefined) {
       return undefined;
     }
-    if (
-      typeof compression !== 'string' ||
-      !BACKUP_ALLOWED_COMPRESSIONS.includes(
-        compression as (typeof BACKUP_ALLOWED_COMPRESSIONS)[number]
-      )
-    ) {
-      return `compression must be one of: ${BACKUP_ALLOWED_COMPRESSIONS.join(', ')}`;
+    if (typeof compression !== 'object' || compression === null) {
+      return 'compression must be an object';
     }
-    return undefined;
-  }
-
-  private static validateCompressThreads(
-    compressThreads: unknown
-  ): string | undefined {
-    if (compressThreads === undefined) {
-      return undefined;
+    const candidate = compression as {
+      format?: unknown;
+      threads?: unknown;
+    };
+    if (
+      candidate.format !== undefined &&
+      (typeof candidate.format !== 'string' ||
+        !BACKUP_ALLOWED_COMPRESSIONS.includes(
+          candidate.format as (typeof BACKUP_ALLOWED_COMPRESSIONS)[number]
+        ))
+    ) {
+      return `compression.format must be one of: ${BACKUP_ALLOWED_COMPRESSIONS.join(', ')}`;
     }
     if (
-      typeof compressThreads !== 'number' ||
-      !Number.isInteger(compressThreads) ||
-      compressThreads < 1
+      candidate.threads !== undefined &&
+      (typeof candidate.threads !== 'number' ||
+        !Number.isInteger(candidate.threads) ||
+        candidate.threads < 1)
     ) {
-      return 'compressThreads must be a positive integer';
+      return 'compression.threads must be a positive integer';
     }
     return undefined;
   }
@@ -241,20 +241,6 @@ export class BackupHandler extends BaseHandler<Request, Response> {
       );
     }
 
-    const compressThreadsError = BackupHandler.validateCompressThreads(
-      body.compressThreads
-    );
-    if (compressThreadsError) {
-      return this.createErrorResponse(
-        {
-          message: compressThreadsError,
-          code: ErrorCode.INVALID_BACKUP_CONFIG
-        },
-        context,
-        Operation.BACKUP_CREATE
-      );
-    }
-
     const sessionId = body.sessionId ?? context.sessionId ?? 'default';
 
     const result = await this.backupService.createArchive(
@@ -263,8 +249,7 @@ export class BackupHandler extends BaseHandler<Request, Response> {
       sessionId,
       body.gitignore ?? false,
       body.excludes ?? [],
-      body.compression ?? 'lz4',
-      body.compressThreads ?? 8
+      body.compression
     );
 
     if (result.success) {

--- a/packages/sandbox-container/src/handlers/backup-handler.ts
+++ b/packages/sandbox-container/src/handlers/backup-handler.ts
@@ -3,7 +3,9 @@ import type {
   CreateBackupResponse,
   Logger,
   RestoreBackupRequest,
-  RestoreBackupResponse
+  RestoreBackupResponse,
+  UploadPartsRequest,
+  UploadPartsResponse
 } from '@repo/shared';
 import { ErrorCode, Operation } from '@repo/shared/errors';
 
@@ -31,6 +33,8 @@ export class BackupHandler extends BaseHandler<Request, Response> {
         return await this.handleCreate(request, context);
       case '/api/backup/restore':
         return await this.handleRestore(request, context);
+      case '/api/backup/upload-parts':
+        return await this.handleUploadParts(request, context);
       default:
         return this.createErrorResponse(
           {
@@ -151,7 +155,9 @@ export class BackupHandler extends BaseHandler<Request, Response> {
       body.archivePath,
       sessionId,
       body.gitignore ?? false,
-      body.excludes ?? []
+      body.excludes ?? [],
+      body.compression ?? 'lz4',
+      body.compressThreads ?? 8
     );
 
     if (result.success) {
@@ -159,6 +165,57 @@ export class BackupHandler extends BaseHandler<Request, Response> {
         success: true,
         sizeBytes: result.data.sizeBytes,
         archivePath: result.data.archivePath
+      };
+      return this.createTypedResponse(response, context);
+    }
+
+    return this.createErrorResponse(
+      result.error,
+      context,
+      Operation.BACKUP_CREATE
+    );
+  }
+
+  private async handleUploadParts(
+    request: Request,
+    context: RequestContext
+  ): Promise<Response> {
+    const body = await this.parseRequestBody<UploadPartsRequest>(request);
+
+    const archiveError = BackupHandler.validateArchivePath(body.archivePath);
+    if (archiveError) {
+      return this.createErrorResponse(
+        {
+          message: archiveError,
+          code: ErrorCode.INVALID_BACKUP_CONFIG
+        },
+        context,
+        Operation.BACKUP_CREATE
+      );
+    }
+
+    if (!Array.isArray(body.parts) || body.parts.length === 0) {
+      return this.createErrorResponse(
+        {
+          message: 'parts must be a non-empty array',
+          code: ErrorCode.INVALID_BACKUP_CONFIG
+        },
+        context,
+        Operation.BACKUP_CREATE
+      );
+    }
+
+    const sessionId = context.sessionId ?? 'default';
+    const result = await this.backupService.uploadParts(
+      body.archivePath,
+      body.parts,
+      sessionId
+    );
+
+    if (result.success) {
+      const response: UploadPartsResponse = {
+        success: true,
+        parts: result.data.parts
       };
       return this.createTypedResponse(response, context);
     }

--- a/packages/sandbox-container/src/handlers/backup-handler.ts
+++ b/packages/sandbox-container/src/handlers/backup-handler.ts
@@ -326,7 +326,7 @@ export class BackupHandler extends BaseHandler<Request, Response> {
       }
     }
 
-    const sessionId = context.sessionId ?? 'default';
+    const sessionId = body.sessionId ?? context.sessionId ?? 'default';
     const result = await this.backupService.uploadParts(
       body.archivePath,
       body.parts,

--- a/packages/sandbox-container/src/routes/setup.ts
+++ b/packages/sandbox-container/src/routes/setup.ts
@@ -291,6 +291,14 @@ export function setupRoutes(router: Router, container: Container): void {
     middleware: [container.get('loggingMiddleware')]
   });
 
+  router.register({
+    method: 'POST',
+    path: '/api/backup/upload-parts',
+    handler: async (req, ctx) =>
+      container.get('backupHandler').handle(req, ctx),
+    middleware: [container.get('loggingMiddleware')]
+  });
+
   // Desktop routes
   router.register({
     method: 'POST',

--- a/packages/sandbox-container/src/services/backup-service.ts
+++ b/packages/sandbox-container/src/services/backup-service.ts
@@ -11,6 +11,8 @@ import type { SessionManager } from './session-manager';
 
 export const BACKUP_WORK_DIR = '/var/backups';
 const BACKUP_MOUNTS_DIR = '/var/backups/mounts';
+const BACKUP_ALLOWED_COMPRESSIONS = ['gzip', 'lz4', 'zstd'] as const;
+type BackupCompression = (typeof BACKUP_ALLOWED_COMPRESSIONS)[number];
 
 /**
  * Absolute paths for squashfs/FUSE binaries.
@@ -61,6 +63,10 @@ function validateBackupPaths(dir: string, archivePath: string): string | null {
   return null;
 }
 
+function isBackupCompression(value: string): value is BackupCompression {
+  return BACKUP_ALLOWED_COMPRESSIONS.includes(value as BackupCompression);
+}
+
 interface CreateArchiveResult {
   sizeBytes: number;
   archivePath: string;
@@ -101,7 +107,7 @@ export class BackupService {
     sessionId = 'default',
     gitignore = false,
     excludes: string[] = [],
-    compression: 'gzip' | 'lz4' | 'zstd' = 'lz4',
+    compression: string = 'lz4',
     compressThreads = 8
   ): Promise<ServiceResult<CreateArchiveResult>> {
     const opLogger = this.logger.child({ operation: Operation.BACKUP_CREATE });
@@ -122,6 +128,14 @@ export class BackupService {
           message: pathError,
           code: ErrorCode.INVALID_BACKUP_CONFIG,
           details: { dir, archivePath }
+        });
+      }
+      if (!isBackupCompression(compression)) {
+        errorMessage = 'Invalid compression algorithm';
+        return serviceError({
+          message: `Invalid compression algorithm: ${compression}. Expected one of: ${BACKUP_ALLOWED_COMPRESSIONS.join(', ')}`,
+          code: ErrorCode.INVALID_BACKUP_CONFIG,
+          details: { compression }
         });
       }
       // Ensure the work directory exists
@@ -451,7 +465,7 @@ export class BackupService {
         '--data-binary @-',
         shellEscape(part.url)
       ].join(' ');
-      return `${ddCmd} | ${curlCmd} & J${i}=$!`;
+      return `(set -o pipefail; ${ddCmd} | ${curlCmd}) & J${i}=$!`;
     });
 
     const waitLines = parts.map((_, i) => `wait $J${i}; E${i}=$?`);

--- a/packages/sandbox-container/src/services/backup-service.ts
+++ b/packages/sandbox-container/src/services/backup-service.ts
@@ -15,6 +15,10 @@ const BACKUP_UPLOAD_TIMEOUT_MS = 1_800_000;
 const BACKUP_UPLOAD_MAX_ATTEMPTS = 3;
 const BACKUP_ALLOWED_COMPRESSIONS = ['gzip', 'lz4', 'zstd'] as const;
 type BackupCompression = (typeof BACKUP_ALLOWED_COMPRESSIONS)[number];
+type BackupCreateCompressionOptions = {
+  format?: BackupCompression;
+  threads?: number;
+};
 
 /**
  * Absolute paths for squashfs/FUSE binaries.
@@ -125,12 +129,13 @@ export class BackupService {
     sessionId = 'default',
     gitignore = false,
     excludes: string[] = [],
-    compression: string = 'lz4',
-    compressThreads = 8
+    compression?: BackupCreateCompressionOptions
   ): Promise<ServiceResult<CreateArchiveResult>> {
     const opLogger = this.logger.child({ operation: Operation.BACKUP_CREATE });
     const excludeFilePath = `${archivePath}.exclude`;
     let shouldCleanupExcludeFile = false;
+    const compressionFormat = compression?.format ?? 'lz4';
+    const compressionThreads = compression?.threads ?? 8;
 
     const startTime = Date.now();
     let outcome: 'success' | 'error' = 'error';
@@ -148,12 +153,12 @@ export class BackupService {
           details: { dir, archivePath }
         });
       }
-      if (!isBackupCompression(compression)) {
+      if (!isBackupCompression(compressionFormat)) {
         errorMessage = 'Invalid compression algorithm';
         return serviceError({
-          message: `Invalid compression algorithm: ${compression}. Expected one of: ${BACKUP_ALLOWED_COMPRESSIONS.join(', ')}`,
+          message: `Invalid compression algorithm: ${compressionFormat}. Expected one of: ${BACKUP_ALLOWED_COMPRESSIONS.join(', ')}`,
           code: ErrorCode.INVALID_BACKUP_CONFIG,
-          details: { compression }
+          details: { compression: compressionFormat }
         });
       }
       // Ensure the work directory exists
@@ -266,8 +271,8 @@ export class BackupService {
         BIN.mksquashfs,
         shellEscape(dir),
         shellEscape(archivePath),
-        `-comp ${compression}`,
-        `-processors ${Math.max(1, compressThreads)}`,
+        `-comp ${compressionFormat}`,
+        `-processors ${Math.max(1, compressionThreads)}`,
         '-no-progress',
         '-noappend'
       ];

--- a/packages/sandbox-container/src/services/backup-service.ts
+++ b/packages/sandbox-container/src/services/backup-service.ts
@@ -100,7 +100,9 @@ export class BackupService {
     archivePath: string,
     sessionId = 'default',
     gitignore = false,
-    excludes: string[] = []
+    excludes: string[] = [],
+    compression: 'gzip' | 'lz4' | 'zstd' = 'lz4',
+    compressThreads = 8
   ): Promise<ServiceResult<CreateArchiveResult>> {
     const opLogger = this.logger.child({ operation: Operation.BACKUP_CREATE });
     const excludeFilePath = `${archivePath}.exclude`;
@@ -225,14 +227,15 @@ export class BackupService {
         shouldCleanupExcludeFile = true;
       }
 
-      // Create squashfs archive with zstd compression
+      // Create squashfs archive with configurable compression
       // -no-progress suppresses progress output
       // -noappend creates a fresh archive (no appending to existing)
       const squashCmdParts = [
         BIN.mksquashfs,
         shellEscape(dir),
         shellEscape(archivePath),
-        '-comp zstd',
+        `-comp ${compression}`,
+        `-processors ${Math.max(1, compressThreads)}`,
         '-no-progress',
         '-noappend'
       ];
@@ -405,6 +408,105 @@ export class BackupService {
    */
   static normalizeMksquashfsPattern(pattern: string): string | null {
     return normalizeBackupExcludePattern(pattern);
+  }
+
+  /**
+   * Upload parts of a backup archive to presigned URLs in parallel.
+   * The caller (DO) has already created a multipart upload and generated
+   * presigned PUT URLs for each part. This method extracts each byte range
+   * with `dd` and pipes it to `curl`, running all parts concurrently.
+   */
+  async uploadParts(
+    archivePath: string,
+    parts: Array<{
+      partNumber: number;
+      url: string;
+      offset: number;
+      size: number;
+    }>,
+    sessionId = 'default'
+  ): Promise<
+    ServiceResult<{ parts: Array<{ partNumber: number; etag: string }> }>
+  > {
+    if (parts.length === 0) {
+      return serviceSuccess({ parts: [] });
+    }
+
+    const hdrFiles = parts.map((p) => `/tmp/bp_${p.partNumber}.hdr`);
+
+    const launchLines = parts.map((part, i) => {
+      const ddCmd = [
+        'dd',
+        `if=${shellEscape(archivePath)}`,
+        'iflag=skip_bytes,count_bytes',
+        `skip=${part.offset}`,
+        `count=${part.size}`,
+        '2>/dev/null'
+      ].join(' ');
+      const curlCmd = [
+        'curl -sSf -X PUT',
+        `-H ${shellEscape(`Content-Length: ${part.size}`)}`,
+        `-H 'Content-Type: application/octet-stream'`,
+        `-D ${shellEscape(hdrFiles[i])}`,
+        '--data-binary @-',
+        shellEscape(part.url)
+      ].join(' ');
+      return `${ddCmd} | ${curlCmd} & J${i}=$!`;
+    });
+
+    const waitLines = parts.map((_, i) => `wait $J${i}; E${i}=$?`);
+    const exitVars = parts.map((_, i) => `$E${i}`).join(' + ');
+    const etagLines = parts.map(
+      (part, i) =>
+        `printf 'PART:%d:%s\\n' ${part.partNumber} "$(grep -i '^etag:' ${shellEscape(hdrFiles[i])} 2>/dev/null | tr -d '\\r' | awk '{print $2}')"`
+    );
+    const cleanupCmd = `rm -f ${hdrFiles.map(shellEscape).join(' ')}`;
+
+    const script = [
+      ...launchLines,
+      ...waitLines,
+      `FAILED=$(( ${exitVars} ))`,
+      `if [ "$FAILED" -ne 0 ]; then ${cleanupCmd}; exit 1; fi`,
+      ...etagLines,
+      cleanupCmd
+    ].join('; ');
+
+    const result = await this.sessionManager.executeInSession(
+      sessionId,
+      script,
+      {
+        origin: 'internal'
+      }
+    );
+
+    if (!result.success || result.data.exitCode !== 0) {
+      return serviceError({
+        message: `Multipart upload failed: ${result.success ? result.data.stderr : result.error.message}`,
+        code: ErrorCode.BACKUP_CREATE_FAILED,
+        details: { archivePath }
+      });
+    }
+
+    const uploadedParts: Array<{ partNumber: number; etag: string }> = [];
+    for (const line of result.data.stdout.split('\n')) {
+      const match = line.match(/^PART:(\d+):(.+)$/);
+      if (match) {
+        uploadedParts.push({
+          partNumber: parseInt(match[1], 10),
+          etag: match[2]
+        });
+      }
+    }
+
+    if (uploadedParts.length !== parts.length) {
+      return serviceError({
+        message: `Expected ${parts.length} part ETags, got ${uploadedParts.length}`,
+        code: ErrorCode.BACKUP_CREATE_FAILED,
+        details: { archivePath }
+      });
+    }
+
+    return serviceSuccess({ parts: uploadedParts });
   }
 
   /**

--- a/packages/sandbox-container/src/services/backup-service.ts
+++ b/packages/sandbox-container/src/services/backup-service.ts
@@ -11,6 +11,8 @@ import type { SessionManager } from './session-manager';
 
 export const BACKUP_WORK_DIR = '/var/backups';
 const BACKUP_MOUNTS_DIR = '/var/backups/mounts';
+const BACKUP_UPLOAD_TIMEOUT_MS = 1_800_000;
+const BACKUP_UPLOAD_MAX_ATTEMPTS = 3;
 const BACKUP_ALLOWED_COMPRESSIONS = ['gzip', 'lz4', 'zstd'] as const;
 type BackupCompression = (typeof BACKUP_ALLOWED_COMPRESSIONS)[number];
 
@@ -54,6 +56,10 @@ function validateBackupPaths(dir: string, archivePath: string): string | null {
   if (!isAllowed) {
     return `Directory not in allowed paths (${BACKUP_ALLOWED_PREFIXES.join(', ')}): ${dir}`;
   }
+  return validateArchivePath(archivePath);
+}
+
+function validateArchivePath(archivePath: string): string | null {
   if (!archivePath.startsWith(`${BACKUP_WORK_DIR}/`)) {
     return 'Invalid archivePath: must use designated backup directory';
   }
@@ -74,6 +80,18 @@ interface CreateArchiveResult {
 
 interface RestoreArchiveResult {
   dir: string;
+}
+
+interface BackupUploadPart {
+  partNumber: number;
+  url: string;
+  offset: number;
+  size: number;
+}
+
+interface UploadedBackupPart {
+  partNumber: number;
+  etag: string;
 }
 
 /**
@@ -424,101 +442,110 @@ export class BackupService {
     return normalizeBackupExcludePattern(pattern);
   }
 
+  private async uploadPart(
+    archiveFile: ReturnType<typeof Bun.file>,
+    part: BackupUploadPart
+  ): Promise<UploadedBackupPart> {
+    let lastError: Error | undefined;
+
+    for (let attempt = 1; attempt <= BACKUP_UPLOAD_MAX_ATTEMPTS; attempt++) {
+      try {
+        const body = archiveFile.slice(part.offset, part.offset + part.size);
+        const response = await fetch(part.url, {
+          method: 'PUT',
+          headers: {
+            'Content-Length': String(part.size),
+            'Content-Type': 'application/octet-stream'
+          },
+          body,
+          signal: AbortSignal.timeout(BACKUP_UPLOAD_TIMEOUT_MS)
+        });
+
+        if (!response.ok) {
+          throw new Error(
+            `part ${part.partNumber} failed with HTTP ${response.status}`
+          );
+        }
+
+        const etag = response.headers.get('etag')?.trim();
+        if (!etag) {
+          throw Object.assign(
+            new Error(
+              `part ${part.partNumber} response did not include an ETag header`
+            ),
+            { retryable: false }
+          );
+        }
+
+        return {
+          partNumber: part.partNumber,
+          etag
+        };
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        if ((error as { retryable?: boolean }).retryable === false) {
+          throw err;
+        }
+        lastError = err;
+        if (attempt < BACKUP_UPLOAD_MAX_ATTEMPTS) {
+          this.logger.warn(
+            `backup upload part ${part.partNumber} failed on attempt ${attempt}, retrying`,
+            { error: err.message }
+          );
+        }
+      }
+    }
+
+    throw lastError ?? new Error(`part ${part.partNumber} failed`);
+  }
+
   /**
    * Upload parts of a backup archive to presigned URLs in parallel.
    * The caller (DO) has already created a multipart upload and generated
-   * presigned PUT URLs for each part. This method extracts each byte range
-   * with `dd` and pipes it to `curl`, running all parts concurrently.
+   * presigned PUT URLs for each part. This method uploads each byte range
+   * directly from the local archive using concurrent PUT requests.
    */
   async uploadParts(
     archivePath: string,
-    parts: Array<{
-      partNumber: number;
-      url: string;
-      offset: number;
-      size: number;
-    }>,
-    sessionId = 'default'
-  ): Promise<
-    ServiceResult<{ parts: Array<{ partNumber: number; etag: string }> }>
-  > {
+    parts: BackupUploadPart[],
+    _sessionId = 'default'
+  ): Promise<ServiceResult<{ parts: UploadedBackupPart[] }>> {
     if (parts.length === 0) {
       return serviceSuccess({ parts: [] });
     }
 
-    const hdrFiles = parts.map((p) => `/tmp/bp_${p.partNumber}.hdr`);
-
-    const launchLines = parts.map((part, i) => {
-      const ddCmd = [
-        'dd',
-        `if=${shellEscape(archivePath)}`,
-        'iflag=skip_bytes,count_bytes',
-        `skip=${part.offset}`,
-        `count=${part.size}`,
-        '2>/dev/null'
-      ].join(' ');
-      const curlCmd = [
-        'curl -sSf -X PUT',
-        `-H ${shellEscape(`Content-Length: ${part.size}`)}`,
-        `-H 'Content-Type: application/octet-stream'`,
-        `-D ${shellEscape(hdrFiles[i])}`,
-        '--data-binary @-',
-        shellEscape(part.url)
-      ].join(' ');
-      return `(set -o pipefail; ${ddCmd} | ${curlCmd}) & J${i}=$!`;
-    });
-
-    const waitLines = parts.map((_, i) => `wait $J${i}; E${i}=$?`);
-    const exitVars = parts.map((_, i) => `$E${i}`).join(' + ');
-    const etagLines = parts.map(
-      (part, i) =>
-        `printf 'PART:%d:%s\\n' ${part.partNumber} "$(grep -i '^etag:' ${shellEscape(hdrFiles[i])} 2>/dev/null | tr -d '\\r' | awk '{print $2}')"`
-    );
-    const cleanupCmd = `rm -f ${hdrFiles.map(shellEscape).join(' ')}`;
-
-    const script = [
-      ...launchLines,
-      ...waitLines,
-      `FAILED=$(( ${exitVars} ))`,
-      `if [ "$FAILED" -ne 0 ]; then ${cleanupCmd}; exit 1; fi`,
-      ...etagLines,
-      cleanupCmd
-    ].join('; ');
-
-    const result = await this.sessionManager.executeInSession(
-      sessionId,
-      script,
-      {
-        origin: 'internal'
-      }
-    );
-
-    if (!result.success || result.data.exitCode !== 0) {
+    const archivePathError = validateArchivePath(archivePath);
+    if (archivePathError) {
       return serviceError({
-        message: `Multipart upload failed: ${result.success ? result.data.stderr : result.error.message}`,
+        message: archivePathError,
+        code: ErrorCode.INVALID_BACKUP_CONFIG,
+        details: { archivePath }
+      });
+    }
+
+    const archiveFile = Bun.file(archivePath);
+    if (!(await archiveFile.exists())) {
+      return serviceError({
+        message: `Backup archive does not exist: ${archivePath}`,
         code: ErrorCode.BACKUP_CREATE_FAILED,
         details: { archivePath }
       });
     }
 
-    const uploadedParts: Array<{ partNumber: number; etag: string }> = [];
-    for (const line of result.data.stdout.split('\n')) {
-      const match = line.match(/^PART:(\d+):(.+)$/);
-      if (match) {
-        uploadedParts.push({
-          partNumber: parseInt(match[1], 10),
-          etag: match[2]
-        });
-      }
-    }
-
-    if (uploadedParts.length !== parts.length) {
+    let uploadedParts: UploadedBackupPart[];
+    try {
+      uploadedParts = await Promise.all(
+        parts.map((part) => this.uploadPart(archiveFile, part))
+      );
+    } catch (error) {
       return serviceError({
-        message: `Expected ${parts.length} part ETags, got ${uploadedParts.length}`,
+        message: `Multipart upload failed: ${error instanceof Error ? error.message : String(error)}`,
         code: ErrorCode.BACKUP_CREATE_FAILED,
         details: { archivePath }
       });
     }
+
+    uploadedParts.sort((a, b) => a.partNumber - b.partNumber);
 
     return serviceSuccess({ parts: uploadedParts });
   }

--- a/packages/sandbox-container/tests/services/backup-service.test.ts
+++ b/packages/sandbox-container/tests/services/backup-service.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
 import type { Logger } from '@repo/shared';
 import type { ServiceResult } from '@sandbox-container/core/types';
 import { BackupService } from '@sandbox-container/services/backup-service';
@@ -28,6 +28,9 @@ const mockSessionManager = {
   withSession: vi.fn()
 } as unknown as SessionManager;
 
+const mockFetch = vi.fn();
+let originalFetch: typeof fetch;
+
 function execResult(
   exitCode: number,
   stdout = '',
@@ -55,7 +58,14 @@ describe('BackupService', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    originalFetch = global.fetch;
+    global.fetch = mockFetch as unknown as typeof fetch;
     service = new BackupService(mockLogger, mockSessionManager);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
   });
 
   it('allows creating an archive from /app', async () => {
@@ -117,6 +127,197 @@ describe('BackupService', () => {
     const result = await service.restoreArchive(dir, archivePath);
 
     expect(result.success).toBe(true);
+  });
+
+  describe('uploadParts', () => {
+    it('uploads archive parts with Bun file slices and returns sorted etags', async () => {
+      const archivePath = '/var/backups/test.sqsh';
+      const sliceA = new Blob(['part-a']);
+      const sliceB = new Blob(['part-b']);
+      const bunFile = {
+        exists: async () => true,
+        slice: vi.fn().mockReturnValueOnce(sliceA).mockReturnValueOnce(sliceB)
+      } as unknown as ReturnType<typeof Bun.file>;
+      vi.spyOn(Bun, 'file').mockReturnValue(bunFile);
+
+      mockFetch
+        .mockResolvedValueOnce(
+          new Response(null, {
+            status: 200,
+            headers: { etag: '"etag-2"' }
+          })
+        )
+        .mockResolvedValueOnce(
+          new Response(null, {
+            status: 200,
+            headers: { etag: '"etag-1"' }
+          })
+        );
+
+      const result = await service.uploadParts(archivePath, [
+        {
+          partNumber: 2,
+          url: 'https://example.com/part-2',
+          offset: 10,
+          size: 5
+        },
+        {
+          partNumber: 1,
+          url: 'https://example.com/part-1',
+          offset: 0,
+          size: 10
+        }
+      ]);
+
+      expect(result.success).toBe(true);
+      expect(bunFile.slice).toHaveBeenNthCalledWith(1, 10, 15);
+      expect(bunFile.slice).toHaveBeenNthCalledWith(2, 0, 10);
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        'https://example.com/part-2',
+        expect.objectContaining({
+          method: 'PUT',
+          body: sliceA,
+          headers: {
+            'Content-Length': '5',
+            'Content-Type': 'application/octet-stream'
+          }
+        })
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        'https://example.com/part-1',
+        expect.objectContaining({
+          method: 'PUT',
+          body: sliceB,
+          headers: {
+            'Content-Length': '10',
+            'Content-Type': 'application/octet-stream'
+          }
+        })
+      );
+      expect(result).toEqual({
+        success: true,
+        data: {
+          parts: [
+            { partNumber: 1, etag: '"etag-1"' },
+            { partNumber: 2, etag: '"etag-2"' }
+          ]
+        }
+      });
+    });
+
+    it('fails when the archive does not exist', async () => {
+      vi.spyOn(Bun, 'file').mockReturnValue({
+        exists: async () => false,
+        slice: vi.fn()
+      } as unknown as ReturnType<typeof Bun.file>);
+
+      const result = await service.uploadParts('/var/backups/missing.sqsh', [
+        {
+          partNumber: 1,
+          url: 'https://example.com/part-1',
+          offset: 0,
+          size: 10
+        }
+      ]);
+
+      expect(result.success).toBe(false);
+      expect(mockFetch).not.toHaveBeenCalled();
+      if (!result.success) {
+        expect(result.error.message).toContain('Backup archive does not exist');
+      }
+    });
+
+    it('retries a failed part upload and succeeds when a later attempt returns an etag', async () => {
+      const slice = new Blob(['part-a']);
+      vi.spyOn(Bun, 'file').mockReturnValue({
+        exists: async () => true,
+        slice: vi.fn().mockReturnValue(slice)
+      } as unknown as ReturnType<typeof Bun.file>);
+      mockFetch
+        .mockRejectedValueOnce(new Error('socket reset'))
+        .mockResolvedValueOnce(
+          new Response(null, {
+            status: 200,
+            headers: { etag: '"etag-1"' }
+          })
+        );
+
+      const result = await service.uploadParts('/var/backups/test.sqsh', [
+        {
+          partNumber: 1,
+          url: 'https://example.com/part-1',
+          offset: 0,
+          size: 10
+        }
+      ]);
+
+      expect(result.success).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({
+        success: true,
+        data: {
+          parts: [{ partNumber: 1, etag: '"etag-1"' }]
+        }
+      });
+    });
+
+    it('fails when a part upload does not include an etag header', async () => {
+      vi.spyOn(Bun, 'file').mockReturnValue({
+        exists: async () => true,
+        slice: vi.fn().mockReturnValue(new Blob(['part-a']))
+      } as unknown as ReturnType<typeof Bun.file>);
+      mockFetch.mockResolvedValue(
+        new Response(null, {
+          status: 200
+        })
+      );
+
+      const result = await service.uploadParts('/var/backups/test.sqsh', [
+        {
+          partNumber: 1,
+          url: 'https://example.com/part-1',
+          offset: 0,
+          size: 10
+        }
+      ]);
+
+      expect(result.success).toBe(false);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      if (!result.success) {
+        expect(result.error.message).toContain(
+          'response did not include an ETag header'
+        );
+      }
+    });
+
+    it('fails the entire upload when a part exhausts all retry attempts', async () => {
+      vi.spyOn(Bun, 'file').mockReturnValue({
+        exists: async () => true,
+        slice: vi.fn().mockReturnValue(new Blob(['part-a']))
+      } as unknown as ReturnType<typeof Bun.file>);
+      mockFetch.mockResolvedValue(
+        new Response(null, {
+          status: 503
+        })
+      );
+
+      const result = await service.uploadParts('/var/backups/test.sqsh', [
+        {
+          partNumber: 1,
+          url: 'https://example.com/part-1',
+          offset: 0,
+          size: 10
+        }
+      ]);
+
+      expect(result.success).toBe(false);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      if (!result.success) {
+        expect(result.error.message).toContain('part 1 failed with HTTP 503');
+      }
+    });
   });
 
   it('uses wildcard exclude mode for gitignore-derived excludes', async () => {

--- a/packages/sandbox/src/clients/backup-client.ts
+++ b/packages/sandbox/src/clients/backup-client.ts
@@ -2,7 +2,9 @@ import type {
   CreateBackupRequest,
   CreateBackupResponse,
   RestoreBackupRequest,
-  RestoreBackupResponse
+  RestoreBackupResponse,
+  UploadPartsRequest,
+  UploadPartsResponse
 } from '@repo/shared';
 import { BaseHttpClient } from './base-client';
 
@@ -24,13 +26,20 @@ export class BackupClient extends BaseHttpClient {
     dir: string,
     archivePath: string,
     sessionId: string,
-    options?: { excludes?: string[]; gitignore?: boolean }
+    options?: {
+      excludes?: string[];
+      gitignore?: boolean;
+      compression?: 'gzip' | 'lz4' | 'zstd';
+      compressThreads?: number;
+    }
   ): Promise<CreateBackupResponse> {
     const data: CreateBackupRequest = {
       dir,
       archivePath,
       gitignore: options?.gitignore ?? false,
       excludes: options?.excludes ?? [],
+      compression: options?.compression,
+      compressThreads: options?.compressThreads,
       sessionId
     };
 
@@ -65,5 +74,9 @@ export class BackupClient extends BaseHttpClient {
     );
 
     return response;
+  }
+
+  async uploadParts(request: UploadPartsRequest): Promise<UploadPartsResponse> {
+    return this.post<UploadPartsResponse>('/api/backup/upload-parts', request);
   }
 }

--- a/packages/sandbox/src/clients/backup-client.ts
+++ b/packages/sandbox/src/clients/backup-client.ts
@@ -29,8 +29,7 @@ export class BackupClient extends BaseHttpClient {
     options?: {
       excludes?: string[];
       gitignore?: boolean;
-      compression?: 'gzip' | 'lz4' | 'zstd';
-      compressThreads?: number;
+      compression?: CreateBackupRequest['compression'];
     }
   ): Promise<CreateBackupResponse> {
     const data: CreateBackupRequest = {
@@ -39,7 +38,6 @@ export class BackupClient extends BaseHttpClient {
       gitignore: options?.gitignore ?? false,
       excludes: options?.excludes ?? [],
       compression: options?.compression,
-      compressThreads: options?.compressThreads,
       sessionId
     };
 

--- a/packages/sandbox/src/clients/backup-client.ts
+++ b/packages/sandbox/src/clients/backup-client.ts
@@ -76,7 +76,13 @@ export class BackupClient extends BaseHttpClient {
     return response;
   }
 
-  async uploadParts(request: UploadPartsRequest): Promise<UploadPartsResponse> {
-    return this.post<UploadPartsResponse>('/api/backup/upload-parts', request);
+  async uploadParts(
+    request: UploadPartsRequest,
+    sessionId?: string
+  ): Promise<UploadPartsResponse> {
+    return this.post<UploadPartsResponse>('/api/backup/upload-parts', {
+      ...request,
+      sessionId: sessionId ?? request.sessionId
+    });
   }
 }

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -63,6 +63,7 @@ import {
   PortNotExposedError,
   ProcessExitedBeforeReadyError,
   ProcessReadyTimeoutError,
+  SandboxError,
   SessionAlreadyExistsError
 } from './errors';
 import { collectFile } from './file-stream';
@@ -148,6 +149,32 @@ const BACKUP_CONTAINER_DIR = '/var/backups';
 const BACKUP_STORAGE_PREFIX = 'backups';
 const BACKUP_ARCHIVE_OBJECT_NAME = 'data.sqsh';
 const BACKUP_METADATA_OBJECT_NAME = 'meta.json';
+const BACKUP_DEFAULT_COMPRESSION = 'lz4';
+const BACKUP_DEFAULT_COMPRESS_THREADS = 8;
+const BACKUP_MULTIPART_MIN_SIZE = 10 * 1024 * 1024;
+const BACKUP_MULTIPART_TARGET_PARTS = 16;
+const BACKUP_MULTIPART_MIN_PART_SIZE = 5 * 1024 * 1024;
+const BACKUP_MULTIPART_MAX_PARTS = 64;
+const BACKUP_DOWNLOAD_PARALLEL_PARTS = 8;
+const BACKUP_DOWNLOAD_PARALLEL_MIN_SIZE = 10 * 1024 * 1024;
+const BACKUP_DOWNLOAD_MAX_PARTS = 64;
+
+/**
+ * Calculate the optimal number of parts for multipart upload/download
+ * based on archive size. Larger archives benefit from more parallelism.
+ */
+function calculatePartCount(sizeBytes: number, defaultParts: number): number {
+  if (sizeBytes < 100 * 1024 * 1024) {
+    // < 100 MiB: use default parts
+    return defaultParts;
+  }
+  if (sizeBytes < 1024 * 1024 * 1024) {
+    // 100 MiB - 1 GiB: scale up to 32 parts
+    return Math.min(32, defaultParts * 2);
+  }
+  // >= 1 GiB: use max parts (64)
+  return BACKUP_MULTIPART_MAX_PARTS;
+}
 
 function getNamespaceConfigurationCache(
   namespace: object
@@ -4209,6 +4236,33 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   /**
+   * Generate a presigned GET URL for downloading an object from R2.
+   * The container can curl this URL directly without credentials.
+   */
+  private async generatePresignedGetUrl(r2Key: string): Promise<string> {
+    const { client, accountId, bucketName } = this.requirePresignedUrlSupport();
+
+    const encodedBucket = encodeURIComponent(bucketName);
+    const encodedKey = r2Key
+      .split('/')
+      .map((seg) => encodeURIComponent(seg))
+      .join('/');
+    const url = new URL(
+      `https://${accountId}.r2.cloudflarestorage.com/${encodedBucket}/${encodedKey}`
+    );
+    url.searchParams.set(
+      'X-Amz-Expires',
+      String(Sandbox.PRESIGNED_URL_EXPIRY_SECONDS)
+    );
+
+    const signed = await client.sign(new Request(url), {
+      aws: { signQuery: true }
+    });
+
+    return signed.url;
+  }
+
+  /**
    * Generate a presigned PUT URL for uploading an object to R2.
    * The container can curl PUT to this URL directly without credentials.
    */
@@ -4302,68 +4356,359 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   /**
-   * Mount a backup archive from R2 via s3fs so squashfuse can read it lazily.
+   * Generate a presigned PUT URL for a single part in a multipart upload.
    */
-  private async mountBackupR2(
-    mountPath: string,
-    prefix: string,
+  private async generatePresignedPartUrl(
+    r2Key: string,
+    uploadId: string,
+    partNumber: number
+  ): Promise<string> {
+    const { client, accountId, bucketName } = this.requirePresignedUrlSupport();
+
+    const encodedBucket = encodeURIComponent(bucketName);
+    const encodedKey = r2Key
+      .split('/')
+      .map((seg) => encodeURIComponent(seg))
+      .join('/');
+    const url = new URL(
+      `https://${accountId}.r2.cloudflarestorage.com/${encodedBucket}/${encodedKey}`
+    );
+    url.searchParams.set(
+      'X-Amz-Expires',
+      String(Sandbox.PRESIGNED_URL_EXPIRY_SECONDS)
+    );
+    url.searchParams.set('partNumber', String(partNumber));
+    url.searchParams.set('uploadId', uploadId);
+
+    const signed = await client.sign(new Request(url, { method: 'PUT' }), {
+      aws: { signQuery: true }
+    });
+
+    return signed.url;
+  }
+
+  /**
+   * Upload a backup archive to R2 using parallel multipart upload.
+   * Uses the S3-compatible API exclusively for create/complete/abort so that
+   * the uploadId is in the same namespace as the presigned part PUT URLs.
+   */
+  private async uploadBackupMultipart(
+    archivePath: string,
+    r2Key: string,
+    sizeBytes: number,
+    backupId: string,
+    dir: string,
     backupSession: string
   ): Promise<void> {
-    const { accountId, bucketName } = this.requirePresignedUrlSupport();
-    const endpoint = `https://${accountId}.r2.cloudflarestorage.com`;
-    const normalizedPrefix = prefix.startsWith('/') ? prefix : `/${prefix}`;
-    const options: RemoteMountBucketOptions = {
-      endpoint,
-      provider: 'r2',
-      readOnly: true,
-      prefix: normalizedPrefix,
-      s3fsOptions: ['use_path_request_style']
-    };
-    const passwordFilePath = this.generatePasswordFilePath();
-    const s3fsSource = buildS3fsSource(bucketName, normalizedPrefix);
-    const envObj = this.env as Record<string, unknown>;
-    const envCredentials = {
-      AWS_ACCESS_KEY_ID: getEnvString(envObj, 'AWS_ACCESS_KEY_ID'),
-      AWS_SECRET_ACCESS_KEY: getEnvString(envObj, 'AWS_SECRET_ACCESS_KEY'),
-      R2_ACCESS_KEY_ID: this.r2AccessKeyId || undefined,
-      R2_SECRET_ACCESS_KEY: this.r2SecretAccessKey || undefined
-    };
-    const credentials = detectCredentials(options, {
-      ...envCredentials,
-      ...this.envVars
-    });
-    const mountInfo: FuseMountInfo = {
-      mountType: 'fuse',
-      bucket: s3fsSource,
-      mountPath,
-      endpoint,
-      provider: 'r2',
-      passwordFilePath,
-      mounted: false
-    };
+    const targetParts = calculatePartCount(
+      sizeBytes,
+      BACKUP_MULTIPART_TARGET_PARTS
+    );
+    const numParts = Math.min(
+      targetParts,
+      Math.floor(sizeBytes / BACKUP_MULTIPART_MIN_PART_SIZE)
+    );
 
-    this.activeMounts.set(mountPath, mountInfo);
-
-    try {
-      await this.createPasswordFile(passwordFilePath, bucketName, credentials);
-      await this.execWithSession(
-        `mkdir -p ${shellEscape(mountPath)}`,
-        backupSession,
-        { origin: 'internal' }
-      );
-      await this.executeS3FSMount(
-        s3fsSource,
-        mountPath,
-        options,
-        'r2',
-        passwordFilePath,
+    if (numParts <= 1) {
+      return this.uploadBackupPresigned(
+        archivePath,
+        r2Key,
+        sizeBytes,
+        backupId,
+        dir,
         backupSession
       );
-      mountInfo.mounted = true;
+    }
+
+    const { client, accountId, bucketName } = this.requirePresignedUrlSupport();
+    const encodedBucket = encodeURIComponent(bucketName);
+    const encodedKey = r2Key
+      .split('/')
+      .map((seg) => encodeURIComponent(seg))
+      .join('/');
+    const objectUrl = `https://${accountId}.r2.cloudflarestorage.com/${encodedBucket}/${encodedKey}`;
+
+    const createResp = await client.fetch(`${objectUrl}?uploads`, {
+      method: 'POST'
+    });
+    if (!createResp.ok) {
+      throw new BackupCreateError({
+        message: `Failed to initiate multipart upload: HTTP ${createResp.status}`,
+        code: ErrorCode.BACKUP_CREATE_FAILED,
+        httpStatus: 500,
+        context: { dir, backupId },
+        timestamp: new Date().toISOString()
+      });
+    }
+
+    const createXml = await createResp.text();
+    const uploadIdMatch = createXml.match(/<UploadId>([^<]+)<\/UploadId>/);
+    const uploadId = uploadIdMatch?.[1];
+    if (!uploadId) {
+      throw new BackupCreateError({
+        message: 'Multipart upload response did not contain an UploadId',
+        code: ErrorCode.BACKUP_CREATE_FAILED,
+        httpStatus: 500,
+        context: { dir, backupId },
+        timestamp: new Date().toISOString()
+      });
+    }
+
+    const abortMultipart = async () => {
+      await client
+        .fetch(`${objectUrl}?uploadId=${encodeURIComponent(uploadId)}`, {
+          method: 'DELETE'
+        })
+        .catch(() => {});
+    };
+
+    try {
+      const partSize = Math.ceil(sizeBytes / numParts);
+      const parts = await Promise.all(
+        Array.from({ length: numParts }, (_, i) => ({
+          partNumber: i + 1,
+          url: '',
+          offset: i * partSize,
+          size: i === numParts - 1 ? sizeBytes - i * partSize : partSize
+        })).map(async (part) => ({
+          ...part,
+          url: await this.generatePresignedPartUrl(
+            r2Key,
+            uploadId,
+            part.partNumber
+          )
+        }))
+      );
+
+      let uploadResult: Awaited<
+        ReturnType<typeof this.client.backup.uploadParts>
+      >;
+      try {
+        uploadResult = await this.client.backup.uploadParts({
+          archivePath,
+          parts
+        });
+      } catch (err) {
+        if (
+          err instanceof SandboxError &&
+          err.errorResponse.httpStatus === 404
+        ) {
+          await abortMultipart();
+          return this.uploadBackupPresigned(
+            archivePath,
+            r2Key,
+            sizeBytes,
+            backupId,
+            dir,
+            backupSession
+          );
+        }
+        throw err;
+      }
+
+      if (!uploadResult.success || uploadResult.parts.length !== numParts) {
+        throw new BackupCreateError({
+          message: `Multipart upload returned ${uploadResult.parts.length} of ${numParts} parts`,
+          code: ErrorCode.BACKUP_CREATE_FAILED,
+          httpStatus: 500,
+          context: { dir, backupId },
+          timestamp: new Date().toISOString()
+        });
+      }
+
+      const completeXml = [
+        '<CompleteMultipartUpload>',
+        ...uploadResult.parts.map(
+          (p: { partNumber: number; etag: string }) =>
+            `<Part><PartNumber>${p.partNumber}</PartNumber><ETag>${p.etag}</ETag></Part>`
+        ),
+        '</CompleteMultipartUpload>'
+      ].join('');
+
+      const completeResp = await client.fetch(
+        `${objectUrl}?uploadId=${encodeURIComponent(uploadId)}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/xml' },
+          body: completeXml
+        }
+      );
+
+      if (!completeResp.ok) {
+        const body = await completeResp.text().catch(() => '');
+        throw new BackupCreateError({
+          message: `Multipart upload completion failed: HTTP ${completeResp.status} ${body}`,
+          code: ErrorCode.BACKUP_CREATE_FAILED,
+          httpStatus: 500,
+          context: { dir, backupId },
+          timestamp: new Date().toISOString()
+        });
+      }
     } catch (error) {
-      await this.deletePasswordFile(passwordFilePath);
-      this.activeMounts.delete(mountPath);
+      await abortMultipart();
       throw error;
+    }
+  }
+
+  /**
+   * Download a backup archive from R2 via presigned GET URL.
+   * For archives >= BACKUP_DOWNLOAD_PARALLEL_MIN_SIZE, uses BACKUP_DOWNLOAD_PARALLEL_PARTS
+   * concurrent curl processes (each downloading a byte-range) to maximise both
+   * network and disk-write throughput. Parts are assembled with cat then
+   * atomically moved to the final path.
+   */
+  private async downloadBackupParallel(
+    archivePath: string,
+    r2Key: string,
+    expectedSize: number,
+    backupId: string,
+    dir: string,
+    backupSession: string
+  ): Promise<void> {
+    const presignedUrl = await this.generatePresignedGetUrl(r2Key);
+    await this.execWithSession(
+      `mkdir -p ${BACKUP_CONTAINER_DIR}`,
+      backupSession,
+      { origin: 'internal' }
+    );
+
+    const tmpPath = `${archivePath}.tmp`;
+
+    if (expectedSize < BACKUP_DOWNLOAD_PARALLEL_MIN_SIZE) {
+      const curlCmd = [
+        'curl -sSf',
+        '--connect-timeout 10',
+        '--max-time 1800',
+        '--retry 2',
+        '--retry-max-time 60',
+        `-o ${shellEscape(tmpPath)}`,
+        shellEscape(presignedUrl)
+      ].join(' ');
+
+      const result = await this.execWithSession(curlCmd, backupSession, {
+        timeout: 1810_000,
+        origin: 'internal'
+      });
+
+      if (result.exitCode !== 0) {
+        await this.execWithSession(
+          `rm -f ${shellEscape(tmpPath)}`,
+          backupSession,
+          { origin: 'internal' }
+        ).catch(() => {});
+        throw new BackupRestoreError({
+          message: `Presigned URL download failed (exit code ${result.exitCode}): ${result.stderr}`,
+          code: ErrorCode.BACKUP_RESTORE_FAILED,
+          httpStatus: 500,
+          context: { dir, backupId },
+          timestamp: new Date().toISOString()
+        });
+      }
+    } else {
+      const numParts = calculatePartCount(
+        expectedSize,
+        BACKUP_DOWNLOAD_PARALLEL_PARTS
+      );
+      const partSize = Math.floor(expectedSize / numParts);
+      const ranges = Array.from({ length: numParts }, (_, i) => {
+        const start = i * partSize;
+        const end = i < numParts - 1 ? start + partSize - 1 : expectedSize - 1;
+        return { start, range: `${start}-${end}` };
+      });
+
+      const curlCmds = ranges.map(({ start, range }) =>
+        [
+          'curl -sSf',
+          '--connect-timeout 10',
+          '--max-time 1800',
+          `-H ${shellEscape(`Range: bytes=${range}`)}`,
+          shellEscape(presignedUrl),
+          '|',
+          'dd',
+          `of=${shellEscape(tmpPath)}`,
+          'oflag=seek_bytes',
+          `seek=${start}`,
+          'conv=notrunc',
+          '2>/dev/null'
+        ].join(' ')
+      );
+
+      const startLines = curlCmds.map((cmd, i) => `${cmd} & J${i}=$!`);
+      const waitLines = Array.from(
+        { length: numParts },
+        (_, i) => `wait $J${i}; E${i}=$?`
+      );
+      const exitVars = Array.from({ length: numParts }, (_, i) => `$E${i}`);
+
+      const script = [
+        `rm -f ${shellEscape(tmpPath)}`,
+        `truncate -s ${expectedSize} ${shellEscape(tmpPath)}`,
+        ...startLines,
+        ...waitLines,
+        `FAILED=$(( ${exitVars.join(' + ')} ))`,
+        `if [ "$FAILED" -ne 0 ]; then rm -f ${shellEscape(tmpPath)}; exit 1; fi`
+      ].join('; ');
+
+      const result = await this.execWithSession(script, backupSession, {
+        timeout: 1810_000,
+        origin: 'internal'
+      });
+
+      if (result.exitCode !== 0) {
+        await this.execWithSession(
+          `rm -f ${shellEscape(tmpPath)}`,
+          backupSession,
+          { origin: 'internal' }
+        ).catch(() => {});
+        throw new BackupRestoreError({
+          message: `Parallel download failed (exit code ${result.exitCode}): ${result.stderr}`,
+          code: ErrorCode.BACKUP_RESTORE_FAILED,
+          httpStatus: 500,
+          context: { dir, backupId },
+          timestamp: new Date().toISOString()
+        });
+      }
+    }
+
+    const sizeCheck = await this.execWithSession(
+      `stat -c %s ${shellEscape(tmpPath)}`,
+      backupSession,
+      { origin: 'internal' }
+    );
+    const actualSize = parseInt(sizeCheck.stdout.trim(), 10);
+    if (actualSize !== expectedSize) {
+      await this.execWithSession(
+        `rm -f ${shellEscape(tmpPath)}`,
+        backupSession,
+        { origin: 'internal' }
+      ).catch(() => {});
+      throw new BackupRestoreError({
+        message: `Downloaded archive size mismatch: expected ${expectedSize}, got ${actualSize}`,
+        code: ErrorCode.BACKUP_RESTORE_FAILED,
+        httpStatus: 500,
+        context: { dir, backupId },
+        timestamp: new Date().toISOString()
+      });
+    }
+
+    const mvResult = await this.execWithSession(
+      `mv ${shellEscape(tmpPath)} ${shellEscape(archivePath)}`,
+      backupSession,
+      { origin: 'internal' }
+    );
+    if (mvResult.exitCode !== 0) {
+      await this.execWithSession(
+        `rm -f ${shellEscape(tmpPath)}`,
+        backupSession,
+        { origin: 'internal' }
+      ).catch(() => {});
+      throw new BackupRestoreError({
+        message: `Failed to finalize downloaded archive: ${mvResult.stderr}`,
+        code: ErrorCode.BACKUP_RESTORE_FAILED,
+        httpStatus: 500,
+        context: { dir, backupId },
+        timestamp: new Date().toISOString()
+      });
     }
   }
 
@@ -4418,7 +4763,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       name,
       ttl = BACKUP_DEFAULT_TTL_SECONDS,
       gitignore = false,
-      excludes = []
+      excludes = [],
+      compression = BACKUP_DEFAULT_COMPRESSION,
+      compressThreads = BACKUP_DEFAULT_COMPRESS_THREADS,
+      multipart = true
     } = options;
 
     const backupStartTime = Date.now();
@@ -4497,7 +4845,12 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         dir,
         archivePath,
         backupSession,
-        { gitignore, excludes: normalizedExcludes }
+        {
+          gitignore,
+          excludes: normalizedExcludes,
+          compression,
+          compressThreads
+        }
       );
 
       if (!createResult.success) {
@@ -4514,15 +4867,26 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       const r2Key = `${BACKUP_STORAGE_PREFIX}/${backupId}/${BACKUP_ARCHIVE_OBJECT_NAME}`;
       const metaKey = `${BACKUP_STORAGE_PREFIX}/${backupId}/${BACKUP_METADATA_OBJECT_NAME}`;
 
-      // Step 2: Upload archive to R2 via presigned URL (isolated backup session)
-      await this.uploadBackupPresigned(
-        archivePath,
-        r2Key,
-        createResult.sizeBytes,
-        backupId,
-        dir,
-        backupSession
-      );
+      // Step 2: Upload archive to R2
+      if (multipart && createResult.sizeBytes >= BACKUP_MULTIPART_MIN_SIZE) {
+        await this.uploadBackupMultipart(
+          archivePath,
+          r2Key,
+          createResult.sizeBytes,
+          backupId,
+          dir,
+          backupSession
+        );
+      } else {
+        await this.uploadBackupPresigned(
+          archivePath,
+          r2Key,
+          createResult.sizeBytes,
+          backupId,
+          dir,
+          backupSession
+        );
+      }
 
       // Step 3: Write metadata alongside the archive
       const metadata = {
@@ -4903,7 +5267,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         });
       }
 
-      // Step 2: Check archive exists via HEAD (no body stream)
+      // Step 2: Check archive exists and get its size via HEAD (no body stream)
       const r2Key = `${BACKUP_STORAGE_PREFIX}/${id}/${BACKUP_ARCHIVE_OBJECT_NAME}`;
       const archiveHead = await bucket.head(r2Key);
       if (!archiveHead) {
@@ -4919,13 +5283,15 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       }
 
       backupSession = await this.ensureBackupSession();
-      const r2MountPath = `${BACKUP_CONTAINER_DIR}/r2mount/${id}`;
-      const archivePath = `${r2MountPath}/data.sqsh`;
+      const archivePath = `${BACKUP_CONTAINER_DIR}/${id}.sqsh`;
 
-      // Step 3: Tear down existing restore mounts before replacing the backing
-      // R2 mount. squashfuse reads the archive lazily through the s3fs mount,
-      // so the overlay and lower mounts must come down before the bucket mount.
-      const mountGlob = `/var/backups/mounts/r2mount/${id}/data`;
+      // Step 3: Tear down existing FUSE mounts before overwriting the archive.
+      // squashfuse holds the .sqsh file open; writing a new archive to the same
+      // path while the old mount is active corrupts the backing store.
+      // Unmount the overlay on dir, then iterate over all mount bases for this
+      // backup (both suffixed UUID_* and legacy unsuffixed UUID) and unmount
+      // their squashfuse lower dirs.
+      const mountGlob = `${BACKUP_CONTAINER_DIR}/mounts/${id}`;
       await this.execWithSession(
         `/usr/bin/fusermount3 -uz ${shellEscape(dir)} 2>/dev/null || true`,
         backupSession,
@@ -4936,21 +5302,30 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         backupSession,
         { origin: 'internal' }
       ).catch(() => {});
-      await this.execWithSession(
-        `/usr/bin/fusermount3 -u ${shellEscape(r2MountPath)} 2>/dev/null; /usr/bin/fusermount3 -uz ${shellEscape(r2MountPath)} 2>/dev/null; true`,
+
+      // Step 4: Write archive to the container (skip if already present and
+      // same size — avoids overwriting a file that a lazily-unmounted
+      // squashfuse may still hold open).
+      const sizeCheck = await this.execWithSession(
+        `stat -c %s ${shellEscape(archivePath)} 2>/dev/null || echo 0`,
         backupSession,
         { origin: 'internal' }
-      ).catch(() => {});
+      ).catch(() => ({ stdout: '0' }));
+      const existingSize = Number.parseInt(
+        (sizeCheck.stdout ?? '0').trim(),
+        10
+      );
 
-      const previousBackupMount = this.activeMounts.get(r2MountPath);
-      if (previousBackupMount?.mountType === 'fuse') {
-        previousBackupMount.mounted = false;
-        this.activeMounts.delete(r2MountPath);
-        await this.deletePasswordFile(previousBackupMount.passwordFilePath);
+      if (existingSize !== archiveHead.size) {
+        await this.downloadBackupParallel(
+          archivePath,
+          r2Key,
+          archiveHead.size,
+          id,
+          dir,
+          backupSession
+        );
       }
-
-      // Step 4: Mount the backup archive from R2 and restore directly from it.
-      await this.mountBackupR2(r2MountPath, `backups/${id}/`, backupSession);
 
       const restoreResult = await this.client.backup.restoreArchive(
         dir,
@@ -4977,6 +5352,14 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       };
     } catch (error) {
       caughtError = error instanceof Error ? error : new Error(String(error));
+      if (id && backupSession) {
+        const cleanupPath = `${BACKUP_CONTAINER_DIR}/${id}.sqsh`;
+        await this.execWithSession(
+          `rm -f ${shellEscape(cleanupPath)}`,
+          backupSession,
+          { origin: 'internal' }
+        ).catch(() => {});
+      }
       throw error;
     } finally {
       if (backupSession) {

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -4190,6 +4190,70 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     return normalizedExcludes;
   }
 
+  private resolveBackupCompression(compression: unknown): {
+    format: 'gzip' | 'lz4' | 'zstd';
+    threads: number;
+  } {
+    if (compression !== undefined) {
+      if (typeof compression !== 'object' || compression === null) {
+        throw new InvalidBackupConfigError({
+          message: 'BackupOptions.compression must be an object',
+          code: ErrorCode.INVALID_BACKUP_CONFIG,
+          httpStatus: 400,
+          context: { reason: 'compression must be an object' },
+          timestamp: new Date().toISOString()
+        });
+      }
+    }
+
+    const compressionOptions = compression as
+      | { format?: unknown; threads?: unknown }
+      | undefined;
+    const format = compressionOptions?.format ?? BACKUP_DEFAULT_COMPRESSION;
+    const threads =
+      compressionOptions?.threads ?? BACKUP_DEFAULT_COMPRESS_THREADS;
+    const allowedCompressions = ['gzip', 'lz4', 'zstd'];
+
+    if (
+      typeof format !== 'string' ||
+      !allowedCompressions.includes(
+        format as (typeof allowedCompressions)[number]
+      )
+    ) {
+      throw new InvalidBackupConfigError({
+        message:
+          'BackupOptions.compression.format must be one of: gzip, lz4, zstd',
+        code: ErrorCode.INVALID_BACKUP_CONFIG,
+        httpStatus: 400,
+        context: {
+          reason: 'compression.format must be one of: gzip, lz4, zstd'
+        },
+        timestamp: new Date().toISOString()
+      });
+    }
+
+    if (
+      typeof threads !== 'number' ||
+      !Number.isInteger(threads) ||
+      threads < 1
+    ) {
+      throw new InvalidBackupConfigError({
+        message: 'BackupOptions.compression.threads must be a positive integer',
+        code: ErrorCode.INVALID_BACKUP_CONFIG,
+        httpStatus: 400,
+        context: {
+          reason: 'compression.threads must be a positive integer'
+        },
+        timestamp: new Date().toISOString()
+      });
+    }
+
+    return {
+      format: format as 'gzip' | 'lz4' | 'zstd',
+      threads
+    };
+  }
+
   private static readonly PRESIGNED_URL_EXPIRY_SECONDS = 3600;
 
   /**
@@ -4784,8 +4848,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       ttl = BACKUP_DEFAULT_TTL_SECONDS,
       gitignore = false,
       excludes = [],
-      compression = BACKUP_DEFAULT_COMPRESSION,
-      compressThreads = BACKUP_DEFAULT_COMPRESS_THREADS,
+      compression,
       multipart = true
     } = options;
 
@@ -4855,34 +4918,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         });
       }
 
-      const allowedCompressions = ['gzip', 'lz4', 'zstd'];
-      if (!allowedCompressions.includes(compression)) {
-        throw new InvalidBackupConfigError({
-          message: 'BackupOptions.compression must be one of: gzip, lz4, zstd',
-          code: ErrorCode.INVALID_BACKUP_CONFIG,
-          httpStatus: 400,
-          context: {
-            reason: 'compression must be one of: gzip, lz4, zstd'
-          },
-          timestamp: new Date().toISOString()
-        });
-      }
-
-      if (
-        typeof compressThreads !== 'number' ||
-        !Number.isInteger(compressThreads) ||
-        compressThreads < 1
-      ) {
-        throw new InvalidBackupConfigError({
-          message: 'BackupOptions.compressThreads must be a positive integer',
-          code: ErrorCode.INVALID_BACKUP_CONFIG,
-          httpStatus: 400,
-          context: {
-            reason: 'compressThreads must be a positive integer'
-          },
-          timestamp: new Date().toISOString()
-        });
-      }
+      const resolvedCompression = this.resolveBackupCompression(compression);
 
       const normalizedExcludes = this.normalizeBackupExcludes(excludes);
 
@@ -4897,8 +4933,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         {
           gitignore,
           excludes: normalizedExcludes,
-          compression,
-          compressThreads
+          compression: resolvedCompression
         }
       );
 
@@ -5005,8 +5040,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       ttl = BACKUP_DEFAULT_TTL_SECONDS,
       gitignore = false,
       excludes = [],
-      compression = BACKUP_DEFAULT_COMPRESSION,
-      compressThreads = BACKUP_DEFAULT_COMPRESS_THREADS
+      compression
     } = options;
 
     const backupStartTime = Date.now();
@@ -5087,34 +5121,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         });
       }
 
-      const allowedCompressions = ['gzip', 'lz4', 'zstd'];
-      if (!allowedCompressions.includes(compression)) {
-        throw new InvalidBackupConfigError({
-          message: 'BackupOptions.compression must be one of: gzip, lz4, zstd',
-          code: ErrorCode.INVALID_BACKUP_CONFIG,
-          httpStatus: 400,
-          context: {
-            reason: 'compression must be one of: gzip, lz4, zstd'
-          },
-          timestamp: new Date().toISOString()
-        });
-      }
-
-      if (
-        typeof compressThreads !== 'number' ||
-        !Number.isInteger(compressThreads) ||
-        compressThreads < 1
-      ) {
-        throw new InvalidBackupConfigError({
-          message: 'BackupOptions.compressThreads must be a positive integer',
-          code: ErrorCode.INVALID_BACKUP_CONFIG,
-          httpStatus: 400,
-          context: {
-            reason: 'compressThreads must be a positive integer'
-          },
-          timestamp: new Date().toISOString()
-        });
-      }
+      const resolvedCompression = this.resolveBackupCompression(compression);
 
       const normalizedExcludes = this.normalizeBackupExcludes(excludes);
 
@@ -5130,8 +5137,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         {
           gitignore,
           excludes: normalizedExcludes,
-          compression,
-          compressThreads
+          compression: resolvedCompression
         }
       );
 

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -4544,6 +4544,17 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           timestamp: new Date().toISOString()
         });
       }
+
+      const head = await this.requireBackupBucket().head(r2Key);
+      if (!head || head.size !== sizeBytes) {
+        throw new BackupCreateError({
+          message: `Multipart upload verification failed: expected ${sizeBytes} bytes, got ${head?.size ?? 0}`,
+          code: ErrorCode.BACKUP_CREATE_FAILED,
+          httpStatus: 500,
+          context: { dir, backupId },
+          timestamp: new Date().toISOString()
+        });
+      }
     } catch (error) {
       await abortMultipart();
       throw error;
@@ -4955,7 +4966,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       name,
       ttl = BACKUP_DEFAULT_TTL_SECONDS,
       gitignore = false,
-      excludes = []
+      excludes = [],
+      compression = BACKUP_DEFAULT_COMPRESSION,
+      compressThreads = BACKUP_DEFAULT_COMPRESS_THREADS
     } = options;
 
     const backupStartTime = Date.now();
@@ -5047,7 +5060,12 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         dir,
         archivePath,
         backupSession,
-        { gitignore, excludes: normalizedExcludes }
+        {
+          gitignore,
+          excludes: normalizedExcludes,
+          compression,
+          compressThreads
+        }
       );
 
       if (!createResult.success) {

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -4486,7 +4486,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       try {
         uploadResult = await this.client.backup.uploadParts({
           archivePath,
-          parts
+          parts,
+          sessionId: backupSession
         });
       } catch (err) {
         if (

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -4849,6 +4849,35 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         });
       }
 
+      const allowedCompressions = ['gzip', 'lz4', 'zstd'];
+      if (!allowedCompressions.includes(compression)) {
+        throw new InvalidBackupConfigError({
+          message: 'BackupOptions.compression must be one of: gzip, lz4, zstd',
+          code: ErrorCode.INVALID_BACKUP_CONFIG,
+          httpStatus: 400,
+          context: {
+            reason: 'compression must be one of: gzip, lz4, zstd'
+          },
+          timestamp: new Date().toISOString()
+        });
+      }
+
+      if (
+        typeof compressThreads !== 'number' ||
+        !Number.isInteger(compressThreads) ||
+        compressThreads < 1
+      ) {
+        throw new InvalidBackupConfigError({
+          message: 'BackupOptions.compressThreads must be a positive integer',
+          code: ErrorCode.INVALID_BACKUP_CONFIG,
+          httpStatus: 400,
+          context: {
+            reason: 'compressThreads must be a positive integer'
+          },
+          timestamp: new Date().toISOString()
+        });
+      }
+
       const normalizedExcludes = this.normalizeBackupExcludes(excludes);
 
       backupSession = await this.ensureBackupSession();
@@ -5048,6 +5077,35 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           code: ErrorCode.INVALID_BACKUP_CONFIG,
           httpStatus: 400,
           context: { reason: 'excludes must be an array of strings' },
+          timestamp: new Date().toISOString()
+        });
+      }
+
+      const allowedCompressions = ['gzip', 'lz4', 'zstd'];
+      if (!allowedCompressions.includes(compression)) {
+        throw new InvalidBackupConfigError({
+          message: 'BackupOptions.compression must be one of: gzip, lz4, zstd',
+          code: ErrorCode.INVALID_BACKUP_CONFIG,
+          httpStatus: 400,
+          context: {
+            reason: 'compression must be one of: gzip, lz4, zstd'
+          },
+          timestamp: new Date().toISOString()
+        });
+      }
+
+      if (
+        typeof compressThreads !== 'number' ||
+        !Number.isInteger(compressThreads) ||
+        compressThreads < 1
+      ) {
+        throw new InvalidBackupConfigError({
+          message: 'BackupOptions.compressThreads must be a positive integer',
+          code: ErrorCode.INVALID_BACKUP_CONFIG,
+          httpStatus: 400,
+          context: {
+            reason: 'compressThreads must be a positive integer'
+          },
           timestamp: new Date().toISOString()
         });
       }

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -163,7 +163,11 @@ const BACKUP_DOWNLOAD_MAX_PARTS = 64;
  * Calculate the optimal number of parts for multipart upload/download
  * based on archive size. Larger archives benefit from more parallelism.
  */
-function calculatePartCount(sizeBytes: number, defaultParts: number): number {
+function calculatePartCount(
+  sizeBytes: number,
+  defaultParts: number,
+  maxParts: number
+): number {
   if (sizeBytes < 100 * 1024 * 1024) {
     // < 100 MiB: use default parts
     return defaultParts;
@@ -173,7 +177,7 @@ function calculatePartCount(sizeBytes: number, defaultParts: number): number {
     return Math.min(32, defaultParts * 2);
   }
   // >= 1 GiB: use max parts (64)
-  return BACKUP_MULTIPART_MAX_PARTS;
+  return maxParts;
 }
 
 function getNamespaceConfigurationCache(
@@ -4402,7 +4406,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   ): Promise<void> {
     const targetParts = calculatePartCount(
       sizeBytes,
-      BACKUP_MULTIPART_TARGET_PARTS
+      BACKUP_MULTIPART_TARGET_PARTS,
+      BACKUP_MULTIPART_MAX_PARTS
     );
     const numParts = Math.min(
       targetParts,
@@ -4566,8 +4571,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    * Download a backup archive from R2 via presigned GET URL.
    * For archives >= BACKUP_DOWNLOAD_PARALLEL_MIN_SIZE, uses BACKUP_DOWNLOAD_PARALLEL_PARTS
    * concurrent curl processes (each downloading a byte-range) to maximise both
-   * network and disk-write throughput. Parts are assembled with cat then
-   * atomically moved to the final path.
+   * network and disk-write throughput. Parts are written into a pre-sized file
+   * with dd using byte offsets, then atomically moved to the final path.
    */
   private async downloadBackupParallel(
     archivePath: string,
@@ -4619,7 +4624,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     } else {
       const numParts = calculatePartCount(
         expectedSize,
-        BACKUP_DOWNLOAD_PARALLEL_PARTS
+        BACKUP_DOWNLOAD_PARALLEL_PARTS,
+        BACKUP_DOWNLOAD_MAX_PARTS
       );
       const partSize = Math.floor(expectedSize / numParts);
       const ranges = Array.from({ length: numParts }, (_, i) => {

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -4644,7 +4644,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         ].join(' ')
       );
 
-      const startLines = curlCmds.map((cmd, i) => `${cmd} & J${i}=$!`);
+      const startLines = curlCmds.map(
+        (cmd, i) => `(set -o pipefail; ${cmd}) & J${i}=$!`
+      );
       const waitLines = Array.from(
         { length: numParts },
         (_, i) => `wait $J${i}; E${i}=$?`

--- a/packages/sandbox/tests/local-backup.test.ts
+++ b/packages/sandbox/tests/local-backup.test.ts
@@ -213,7 +213,14 @@ describe('Local Backup & Restore', () => {
         '/workspace/myapp',
         expect.stringContaining('/var/backups/'),
         expect.any(String), // backup session ID
-        { gitignore: false, excludes: [] }
+        {
+          gitignore: false,
+          excludes: [],
+          compression: {
+            format: 'lz4',
+            threads: 8
+          }
+        }
       );
 
       // Verify archive was uploaded to R2 via binding
@@ -359,7 +366,11 @@ describe('Local Backup & Restore', () => {
         expect.any(String),
         {
           gitignore: false,
-          excludes: ['node_modules/.cache', '.next/cache', 'dist']
+          excludes: ['node_modules/.cache', '.next/cache', 'dist'],
+          compression: {
+            format: 'lz4',
+            threads: 8
+          }
         }
       );
     });

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1912,7 +1912,12 @@ describe('Sandbox - Automatic Session Management', () => {
         '/app/project',
         expect.stringMatching(/^\/var\/backups\/.+\.sqsh$/),
         expect.stringMatching(/^__sandbox_backup_/),
-        { gitignore: false, excludes: [] }
+        {
+          gitignore: false,
+          excludes: [],
+          compression: 'lz4',
+          compressThreads: 8
+        }
       );
       expect(bucket.put).toHaveBeenCalled();
     });
@@ -1957,7 +1962,9 @@ describe('Sandbox - Automatic Session Management', () => {
         expect.stringMatching(/^__sandbox_backup_/),
         {
           gitignore: false,
-          excludes: ['node_modules/.cache', '.next/cache', 'dist']
+          excludes: ['node_modules/.cache', '.next/cache', 'dist'],
+          compression: 'lz4',
+          compressThreads: 8
         }
       );
     });
@@ -1988,8 +1995,8 @@ describe('Sandbox - Automatic Session Management', () => {
       const restoreArchiveSpy = vi
         .spyOn(backupSandbox.client.backup, 'restoreArchive')
         .mockResolvedValue({ success: true, dir: '/app/project' });
-      const mountBackupR2Spy = vi
-        .spyOn(backupSandbox as any, 'mountBackupR2')
+      const downloadBackupParallelSpy = vi
+        .spyOn(backupSandbox as any, 'downloadBackupParallel')
         .mockResolvedValue(undefined);
       vi.spyOn(backupSandbox as any, 'execWithSession').mockResolvedValue({
         stdout: '0',
@@ -2009,22 +2016,55 @@ describe('Sandbox - Automatic Session Management', () => {
       });
       expect(restoreArchiveSpy).toHaveBeenCalledWith(
         '/app/project',
-        `/var/backups/r2mount/${backupId}/data.sqsh`,
+        `/var/backups/${backupId}.sqsh`,
         expect.stringMatching(/^__sandbox_backup_/)
       );
-      expect(mountBackupR2Spy).toHaveBeenCalledWith(
-        `/var/backups/r2mount/${backupId}`,
-        `backups/${backupId}/`,
+      expect(downloadBackupParallelSpy).toHaveBeenCalledWith(
+        `/var/backups/${backupId}.sqsh`,
+        `backups/${backupId}/data.sqsh`,
+        42,
+        backupId,
+        '/app/project',
         expect.stringMatching(/^__sandbox_backup_/)
       );
-      expect(
-        (backupSandbox as any).execWithSession.mock.calls.some(
-          ([command]: [string]) =>
-            command.includes(
-              `/usr/bin/fusermount3 -uz '/var/backups/r2mount/${backupId}'`
-            )
-        )
-      ).toBe(true);
+    });
+
+    it('should write parallel restore ranges directly into the temp archive', async () => {
+      const { backupSandbox } = await createBackupSandbox();
+      const expectedSize = 16 * 1024 * 1024;
+      const execWithSessionSpy = vi
+        .spyOn(backupSandbox as any, 'execWithSession')
+        .mockResolvedValueOnce({ stdout: '', stderr: '', exitCode: 0 })
+        .mockResolvedValueOnce({ stdout: '', stderr: '', exitCode: 0 })
+        .mockResolvedValueOnce({
+          stdout: String(expectedSize),
+          stderr: '',
+          exitCode: 0
+        })
+        .mockResolvedValueOnce({ stdout: '', stderr: '', exitCode: 0 });
+      vi.spyOn(
+        backupSandbox as any,
+        'generatePresignedGetUrl'
+      ).mockResolvedValue('https://example.com/archive');
+
+      await (backupSandbox as any).downloadBackupParallel(
+        '/var/backups/test.sqsh',
+        'backups/test/data.sqsh',
+        expectedSize,
+        'test-backup-id',
+        '/app/project',
+        'backup-session'
+      );
+
+      const downloadCommand = execWithSessionSpy.mock.calls[1][0] as string;
+      expect(downloadCommand).toContain(
+        "truncate -s 16777216 '/var/backups/test.sqsh.tmp'"
+      );
+      expect(downloadCommand).toContain("of='/var/backups/test.sqsh.tmp'");
+      expect(downloadCommand).toContain('oflag=seek_bytes');
+      expect(downloadCommand).toContain('conv=notrunc');
+      expect(downloadCommand).not.toContain('cat ');
+      expect(downloadCommand).not.toContain('.part0.tmp');
     });
 
     it('should reject unsupported backup roots before calling the container', async () => {

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -2063,6 +2063,7 @@ describe('Sandbox - Automatic Session Management', () => {
       expect(downloadCommand).toContain("of='/var/backups/test.sqsh.tmp'");
       expect(downloadCommand).toContain('oflag=seek_bytes');
       expect(downloadCommand).toContain('conv=notrunc');
+      expect(downloadCommand).toContain('(set -o pipefail; curl -sSf');
       expect(downloadCommand).not.toContain('cat ');
       expect(downloadCommand).not.toContain('.part0.tmp');
     });

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1915,8 +1915,10 @@ describe('Sandbox - Automatic Session Management', () => {
         {
           gitignore: false,
           excludes: [],
-          compression: 'lz4',
-          compressThreads: 8
+          compression: {
+            format: 'lz4',
+            threads: 8
+          }
         }
       );
       expect(bucket.put).toHaveBeenCalled();
@@ -1963,8 +1965,10 @@ describe('Sandbox - Automatic Session Management', () => {
         {
           gitignore: false,
           excludes: ['node_modules/.cache', '.next/cache', 'dist'],
-          compression: 'lz4',
-          compressThreads: 8
+          compression: {
+            format: 'lz4',
+            threads: 8
+          }
         }
       );
     });
@@ -1979,10 +1983,12 @@ describe('Sandbox - Automatic Session Management', () => {
       await expect(
         backupSandbox.createBackup({
           dir: '/app/project',
-          compression: 'brotli' as unknown as 'gzip'
+          compression: {
+            format: 'brotli' as unknown as 'gzip'
+          }
         })
       ).rejects.toThrow(
-        /BackupOptions\.compression must be one of: gzip, lz4, zstd/
+        /BackupOptions\.compression\.format must be one of: gzip, lz4, zstd/
       );
 
       expect(createArchiveSpy).not.toHaveBeenCalled();
@@ -1998,10 +2004,12 @@ describe('Sandbox - Automatic Session Management', () => {
       await expect(
         backupSandbox.createBackup({
           dir: '/app/project',
-          compressThreads: 0
+          compression: {
+            threads: 0
+          }
         })
       ).rejects.toThrow(
-        /BackupOptions\.compressThreads must be a positive integer/
+        /BackupOptions\.compression\.threads must be a positive integer/
       );
 
       expect(createArchiveSpy).not.toHaveBeenCalled();

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1969,6 +1969,44 @@ describe('Sandbox - Automatic Session Management', () => {
       );
     });
 
+    it('should reject unsupported backup compression before calling the container', async () => {
+      const { backupSandbox } = await createBackupSandbox();
+      const createArchiveSpy = vi.spyOn(
+        backupSandbox.client.backup,
+        'createArchive'
+      );
+
+      await expect(
+        backupSandbox.createBackup({
+          dir: '/app/project',
+          compression: 'brotli' as unknown as 'gzip'
+        })
+      ).rejects.toThrow(
+        /BackupOptions\.compression must be one of: gzip, lz4, zstd/
+      );
+
+      expect(createArchiveSpy).not.toHaveBeenCalled();
+    });
+
+    it('should reject invalid backup compression thread count before calling the container', async () => {
+      const { backupSandbox } = await createBackupSandbox();
+      const createArchiveSpy = vi.spyOn(
+        backupSandbox.client.backup,
+        'createArchive'
+      );
+
+      await expect(
+        backupSandbox.createBackup({
+          dir: '/app/project',
+          compressThreads: 0
+        })
+      ).rejects.toThrow(
+        /BackupOptions\.compressThreads must be a positive integer/
+      );
+
+      expect(createArchiveSpy).not.toHaveBeenCalled();
+    });
+
     it('should allow restoring a backup into /app', async () => {
       const { backupSandbox, bucket } = await createBackupSandbox();
       const backupId = crypto.randomUUID();

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -133,6 +133,7 @@ export { parseSSEFrames } from './sse.js';
 // Export all types from types.ts
 export type {
   // Backup types
+  BackupCompressionOptions,
   BackupOptions,
   BaseExecOptions,
   // Bucket mounting types

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -105,6 +105,10 @@ export type {
   SessionCreateRequest,
   SessionDeleteRequest,
   StartProcessRequest,
+  UploadedPart,
+  UploadPart,
+  UploadPartsRequest,
+  UploadPartsResponse,
   WriteFileRequest
 } from './request-types.js';
 // RPC interface types (shared between SDK and container)

--- a/packages/shared/src/request-types.ts
+++ b/packages/shared/src/request-types.ts
@@ -159,7 +159,53 @@ export interface CreateBackupRequest {
   gitignore?: boolean;
   /** Glob patterns to exclude from the backup */
   excludes?: string[];
+  /** Compression algorithm for mksquashfs (default: lz4) */
+  compression?: 'gzip' | 'lz4' | 'zstd';
+  /** Number of parallel compression threads (default: 8) */
+  compressThreads?: number;
   sessionId?: string;
+}
+
+/**
+ * A single part to upload in a multipart upload.
+ * The container reads the byte range from the local archive and PUTs it
+ * to the presigned URL.
+ */
+export interface UploadPart {
+  partNumber: number;
+  /** Presigned PUT URL for this part */
+  url: string;
+  /** Byte offset within the archive file */
+  offset: number;
+  /** Number of bytes in this part */
+  size: number;
+}
+
+/**
+ * Request to upload parts of a backup archive directly from the container to R2.
+ * Used for parallel multipart upload of large archives.
+ */
+export interface UploadPartsRequest {
+  /** Path to the archive file in the container */
+  archivePath: string;
+  /** Parts to upload in parallel */
+  parts: UploadPart[];
+}
+
+/**
+ * Result for a single uploaded part (ETag returned by R2).
+ */
+export interface UploadedPart {
+  partNumber: number;
+  etag: string;
+}
+
+/**
+ * Response after the container has uploaded all parts.
+ */
+export interface UploadPartsResponse {
+  success: boolean;
+  parts: UploadedPart[];
 }
 
 /**

--- a/packages/shared/src/request-types.ts
+++ b/packages/shared/src/request-types.ts
@@ -190,6 +190,7 @@ export interface UploadPartsRequest {
   archivePath: string;
   /** Parts to upload in parallel */
   parts: UploadPart[];
+  sessionId?: string;
 }
 
 /**

--- a/packages/shared/src/request-types.ts
+++ b/packages/shared/src/request-types.ts
@@ -1,3 +1,5 @@
+import type { BackupCompressionOptions } from './types.js';
+
 /**
  * Request types for API calls to the container
  * Single source of truth for the contract between SDK clients and container handlers
@@ -159,10 +161,7 @@ export interface CreateBackupRequest {
   gitignore?: boolean;
   /** Glob patterns to exclude from the backup */
   excludes?: string[];
-  /** Compression algorithm for mksquashfs (default: lz4) */
-  compression?: 'gzip' | 'lz4' | 'zstd';
-  /** Number of parallel compression threads (default: 8) */
-  compressThreads?: number;
+  compression?: BackupCompressionOptions;
   sessionId?: string;
 }
 

--- a/packages/shared/src/rpc-types.ts
+++ b/packages/shared/src/rpc-types.ts
@@ -26,7 +26,9 @@ import type {
 } from './interpreter-types.js';
 import type {
   CreateBackupResponse,
-  RestoreBackupResponse
+  RestoreBackupResponse,
+  UploadedPart,
+  UploadPartsResponse
 } from './request-types.js';
 import type {
   CheckChangesRequest,
@@ -232,14 +234,30 @@ export interface SandboxBackupAPI {
     dir: string,
     archivePath: string,
     sessionId: string,
-    options?: { excludes?: string[]; gitignore?: boolean }
+    options?: {
+      excludes?: string[];
+      gitignore?: boolean;
+      compression?: 'gzip' | 'lz4' | 'zstd';
+      compressThreads?: number;
+    }
   ): Promise<CreateBackupResponse>;
   restoreArchive(
     dir: string,
     archivePath: string,
     sessionId: string
   ): Promise<RestoreBackupResponse>;
+  uploadParts(request: {
+    archivePath: string;
+    parts: Array<{
+      partNumber: number;
+      url: string;
+      offset: number;
+      size: number;
+    }>;
+  }): Promise<UploadPartsResponse>;
 }
+
+export type { UploadedPart, UploadPartsResponse };
 
 export interface SandboxDesktopAPI {
   start(options?: {

--- a/packages/shared/src/rpc-types.ts
+++ b/packages/shared/src/rpc-types.ts
@@ -31,6 +31,7 @@ import type {
   UploadPartsResponse
 } from './request-types.js';
 import type {
+  BackupCompressionOptions,
   CheckChangesRequest,
   CheckChangesResult,
   DeleteFileResult,
@@ -237,8 +238,7 @@ export interface SandboxBackupAPI {
     options?: {
       excludes?: string[];
       gitignore?: boolean;
-      compression?: 'gzip' | 'lz4' | 'zstd';
-      compressThreads?: number;
+      compression?: BackupCompressionOptions;
     }
   ): Promise<CreateBackupResponse>;
   restoreArchive(

--- a/packages/shared/src/rpc-types.ts
+++ b/packages/shared/src/rpc-types.ts
@@ -254,6 +254,7 @@ export interface SandboxBackupAPI {
       offset: number;
       size: number;
     }>;
+    sessionId?: string;
   }): Promise<UploadPartsResponse>;
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1094,6 +1094,11 @@ export interface ExecutionSession {
 /**
  * Options for creating a directory backup
  */
+export interface BackupCompressionOptions {
+  format?: 'gzip' | 'lz4' | 'zstd';
+  threads?: number;
+}
+
 export interface BackupOptions {
   /** Directory to back up. Must be absolute and under `/workspace`, `/home`, `/tmp`, `/var/tmp`, or `/app`. */
   dir: string;
@@ -1122,18 +1127,7 @@ export interface BackupOptions {
    * When true, the DO resolves BACKUP_BUCKET from its own env as an R2 binding.
    */
   localBucket?: boolean;
-  /**
-   * Compression algorithm for the squashfs archive.
-   * `lz4` is faster to compress/decompress at the cost of larger archives.
-   * `zstd` gives better compression ratios.
-   * Default: `lz4`.
-   */
-  compression?: 'gzip' | 'lz4' | 'zstd';
-  /**
-   * Number of parallel compression threads passed to mksquashfs `-processors`.
-   * Default: 8.
-   */
-  compressThreads?: number;
+  compression?: BackupCompressionOptions;
   /**
    * Use parallel multipart upload to R2 for large archives.
    * Significantly speeds up uploads for archives over 10 MiB.

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1122,6 +1122,24 @@ export interface BackupOptions {
    * When true, the DO resolves BACKUP_BUCKET from its own env as an R2 binding.
    */
   localBucket?: boolean;
+  /**
+   * Compression algorithm for the squashfs archive.
+   * `lz4` is faster to compress/decompress at the cost of larger archives.
+   * `zstd` gives better compression ratios.
+   * Default: `lz4`.
+   */
+  compression?: 'gzip' | 'lz4' | 'zstd';
+  /**
+   * Number of parallel compression threads passed to mksquashfs `-processors`.
+   * Default: 8.
+   */
+  compressThreads?: number;
+  /**
+   * Use parallel multipart upload to R2 for large archives.
+   * Significantly speeds up uploads for archives over 10 MiB.
+   * Default: true.
+   */
+  multipart?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR improves backup and restore performance for larger archives by:

- Switching the default squashfs compression to `lz4` with configurable compression threads.
- Adding multipart R2 uploads for large backup archives.
- Adding parallel ranged downloads during restore to reduce archive download time.
- Introducing backup options for `compression`, `compressThreads`, and `multipart`.

## Details

Large backups now upload through R2 multipart upload when enabled, while smaller backups continue using the existing single presigned PUT path. Restores now download larger archives in parallel ranges before mounting the squashfs archive in the container.

The new options allow callers to tune backup behavior:

- `compression`: choose `lz4`, `zstd`, or `gzip`
- `compressThreads`: configure mksquashfs processor count
- `multipart`: disable multipart upload when needed
