### PR TITLE
Retry 503 upgrades on the RPC control connection

### DIFF
--- a/.changeset/retry-rpc-503-upgrade.md
+++ b/.changeset/retry-rpc-503-upgrade.md
@@ -1,0 +1,7 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Ensure the RPC transport successfully connects once the container has started. This should
+reduce the likelihood of hitting an `RPCTransportError: WebSocket upgrade failed: 503 Service
+Unavailable` error when interacting with a sandbox before the container is ready.

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -12,9 +12,134 @@ The SDK uses proper HTTP status codes for container startup errors:
 
 ## Retry Logic
 
-- **Total budget**: 2 minutes
-- **Backoff**: 3s → 6s → 12s → 24s → 30s (capped)
-- **Only retries**: 503 Service Unavailable
+- **Total budget**: 2 minutes (configurable per Sandbox via `containerTimeouts`).
+- **Backoff**: 3s → 6s → 12s → 24s → 30s (capped at 30s).
+- **Only retries**: 503 Service Unavailable.
+
+### Retry surfaces
+
+Three independent code paths run the same retry algorithm. They all read the budget
+from the same source (`Sandbox.computeRetryTimeoutMs()`), so a single `setRetryTimeoutMs`
+call on the active client updates all of them.
+
+| Path                                     | Where                                                | What it retries                                    |
+| ---------------------------------------- | ---------------------------------------------------- | -------------------------------------------------- |
+| HTTP / route-based requests              | `BaseTransport.fetch()`                              | 503 from `containerFetch()` (port not ready, etc.) |
+| Route-based WebSocket upgrade            | `WebSocketTransport.fetchUpgradeWithRetry()`         | 503 on the WS upgrade fetch during cold start      |
+| RPC control-connection upgrade (capnweb) | `ContainerControlConnection.fetchUpgradeWithRetry()` | 503 on the WS upgrade fetch during cold start      |
+
+The two upgrade-retry paths exist because `containerFetch()` cannot be used for the
+WebSocket upgrade itself — calling it from the same DO during `onStart()` would re-enter
+`blockConcurrencyWhile` and deadlock. Instead, both paths call `stub.fetch()` directly and
+use 503 retries as the readiness signal:
+
+- **Container booting** — `containerFetch()` (which `stub.fetch()` ultimately routes
+  through for non-WS calls) handles this via `startAndWaitForPorts()` polling. The WS
+  upgrade path inherits the same wait because `Sandbox.fetch()` delegates to
+  `super.fetch()` for upgrade requests.
+- **No instance available** — only happens in production. `workerd` returns
+  `NoInstanceError` when the DO has no allocated container yet (cold start, eviction,
+  capacity pressure). `containerFetch()` translates this to 503; the SDK retries
+  until an instance is allocated. `wrangler dev` does not reproduce this case — see
+  `tests/container-connection.test.ts` for unit coverage.
+
+## Container Boot Lifecycle
+
+When a request triggers a cold start, the container goes through five distinct phases.
+Errors are surfaced as 503 (retried) for any phase that can self-heal, and 500 (immediate
+fail) for phases where retrying makes no difference.
+
+```text
+[1] Instance allocation     ──┐
+[2] Container start         ──┤  startAndWaitForPorts() owns 1–3
+[3] Port readiness          ──┘  driven by containerFetch() / Sandbox.fetch()
+[4] onStart hook            ──    runs inside blockConcurrencyWhile
+[5] Request proxying        ──    tcpPort.fetch() forwards the original request
+```
+
+### [1] Instance allocation
+
+**Budget:** `containerTimeouts.instanceGetTimeoutMS` (default 30 s).
+**What happens:** workerd's container scheduler tries to assign a VM to the DO. On a
+cold start or right after eviction there may not be one ready yet.
+
+| Failure                 | Surfaced as | SDK behavior                           |
+| ----------------------- | ----------- | -------------------------------------- |
+| `no container instance` | 503         | **Retry** (cold-start race)            |
+| `SURPASSED_*_LIMITS`    | 400         | Fail immediately (account-level limit) |
+
+Production-only: `wrangler dev` always has an instance ready, so phase 1 never returns
+503 locally.
+
+### [2] Container start
+
+**What happens:** `containerStart` boots the configured Docker image with the requested
+env, entrypoint, and outbound config.
+
+| Failure                          | Surfaced as | SDK behavior                                             |
+| -------------------------------- | ----------- | -------------------------------------------------------- |
+| `No such image available`        | 500         | Fail — misconfigured `wrangler.jsonc` or registry mirror |
+| `Container already exists`       | 500         | Fail — name collision in DO state                        |
+| `Container exited before health` | 500         | Fail — image entrypoint crashed before phase 3           |
+
+Image / config errors are not retryable; they will keep failing until the deployment is
+fixed.
+
+### [3] Port readiness
+
+**Budget:** `containerTimeouts.portReadyTimeoutMS` (default 90 s).
+**What happens:** `waitForPort()` polls TCP on the requested port (default 3000) every
+500 ms until it accepts a connection.
+
+| Failure                            | Surfaced as | SDK behavior                                                      |
+| ---------------------------------- | ----------- | ----------------------------------------------------------------- |
+| `the container is not listening`   | 503         | **Retry** — app still starting up                                 |
+| `failed to verify port`            | 503         | **Retry** — health check timeout                                  |
+| `container port not found`         | 503         | **Retry** — workerd hasn't picked up the Docker port mapping yet  |
+| `Monitor failed to find container` | 503         | **Retry** — monitor restarted between provisioning and port check |
+| Total wait > `portReadyTimeoutMS`  | 503         | **Retry** until the SDK's overall budget is exhausted             |
+
+Slow-booting images (large dependencies, JIT warm-up, restoring snapshots) most often
+trip up here. Increase `portReadyTimeoutMS` rather than `instanceGetTimeoutMS` for slow
+containers — they govern different phases.
+
+### [4] onStart hook
+
+**What happens:** Once the port is up, `@cloudflare/containers` calls
+`this.state.setHealthy()` and then `await this.onStart()` inside
+`blockConcurrencyWhile`. `Sandbox.onStart()` rehydrates exposed-port tokens, restores
+syncs, and primes session state.
+
+| Failure            | Surfaced as | SDK behavior                                                                    |
+| ------------------ | ----------- | ------------------------------------------------------------------------------- |
+| `onStart()` throws | bubble      | The DO gate stays held; later requests see the same exception until it succeeds |
+
+Anything `onStart` does that re-enters the DO via `stub.fetch()` will deadlock against
+its own `blockConcurrencyWhile`. The SDK avoids this by talking to the container over
+`stub.fetch()` directly (which routes via `containerFetch()` for non-WS calls and
+`super.fetch()` for the WS upgrade), never via the DO's own `fetch()` handler.
+
+### [5] Request proxying
+
+**What happens:** `tcpPort.fetch(containerUrl, request)` forwards the original request
+to the container. For WebSocket upgrades, the response carries a `webSocket` property
+that gets `accept()`ed and handed to capnweb / the route-based WS transport.
+
+| Failure                       | Surfaced as | SDK behavior                                                                                       |
+| ----------------------------- | ----------- | -------------------------------------------------------------------------------------------------- |
+| `network connection lost`     | 503         | **Retry** — socket dropped mid-request                                                             |
+| WebSocket close 1000 + reason | bubble      | Surfaced as `RPCTransportError(peer_closed)`; not retried (call may have already had side effects) |
+| Container-side handler error  | passthrough | The container returns a typed error, the SDK maps it to a `SandboxError` subclass                  |
+
+### Where the retries live, by phase
+
+| Phase              | Retried by                                                                                    |
+| ------------------ | --------------------------------------------------------------------------------------------- |
+| 1 Instance alloc   | All three retry surfaces (HTTP, route-based WS upgrade, RPC upgrade)                          |
+| 2 Container start  | None — 500 is permanent                                                                       |
+| 3 Port readiness   | HTTP via `BaseTransport.fetch()`; WS upgrades via `fetchUpgradeWithRetry()`                   |
+| 4 onStart          | None — the exception bubbles                                                                  |
+| 5 Request proxying | HTTP only (per-request retry); WS sessions reconnect on the next call after a transport error |
 
 ## Capacity Limit Errors (Production Only)
 

--- a/packages/sandbox/src/container-control/client.ts
+++ b/packages/sandbox/src/container-control/client.ts
@@ -393,7 +393,8 @@ export class ContainerControlClient {
     this.connOptions = {
       stub: options.stub,
       port: options.port,
-      logger: options.logger
+      logger: options.logger,
+      retryTimeoutMs: options.retryTimeoutMs
     };
     this.idleDisconnectMs =
       options.idleDisconnectMs ?? DEFAULT_IDLE_DISCONNECT_MS;
@@ -589,8 +590,14 @@ export class ContainerControlClient {
     return wrapStub(this.getConnection().rpc().interpreter, this.renewActivity);
   }
 
-  setRetryTimeoutMs(_ms: number): void {
-    // RPC transport does not use HTTP retry budgets
+  /**
+   * Update the 503 upgrade-retry budget. Applies to the current connection
+   * (if any) and is remembered for any future connections created after the
+   * client is torn down and reconnected.
+   */
+  setRetryTimeoutMs(ms: number): void {
+    this.connOptions.retryTimeoutMs = ms;
+    this.conn?.setRetryTimeoutMs(ms);
   }
 
   getTransportMode(): SandboxTransport {

--- a/packages/sandbox/src/container-control/connection.ts
+++ b/packages/sandbox/src/container-control/connection.ts
@@ -28,6 +28,9 @@ import { RpcSession, type RpcStub, type RpcTransport } from 'capnweb';
 // ---------------------------------------------------------------------------
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
+const DEFAULT_RETRY_TIMEOUT_MS = 120_000; // 2 minute total budget for 503 retries
+const MIN_TIME_FOR_RETRY_MS = 15_000; // Need at least 15s remaining to attempt a retry
+const MAX_RETRY_BACKOFF_MS = 30_000; // Cap exponential backoff at 30s
 
 /** Stub that can issue a WebSocket-upgrade fetch through the DO's Container base class. */
 export interface ContainerFetchStub {
@@ -38,6 +41,12 @@ export interface ContainerControlConnectionOptions {
   stub: ContainerFetchStub;
   port?: number;
   logger?: Logger;
+  /**
+   * Total retry budget (ms) for 503 upgrade responses while the container
+   * is starting. Defaults to 120 000 (2 minutes), matching the route-based
+   * `WebSocketTransport`. Set to 0 to disable retries.
+   */
+  retryTimeoutMs?: number;
 }
 
 /**
@@ -57,11 +66,13 @@ export class ContainerControlConnection {
   private readonly containerStub: ContainerFetchStub;
   private readonly port: number;
   private readonly logger: Logger;
+  private retryTimeoutMs: number;
 
   constructor(options: ContainerControlConnectionOptions) {
     this.containerStub = options.stub;
     this.port = options.port ?? 3000;
     this.logger = options.logger ?? createNoOpLogger();
+    this.retryTimeoutMs = options.retryTimeoutMs ?? DEFAULT_RETRY_TIMEOUT_MS;
 
     this.transport = new DeferredTransport();
     this.session = new RpcSession<SandboxAPI>(this.transport);
@@ -128,29 +139,22 @@ export class ContainerControlConnection {
     this.connectPromise = null;
   }
 
+  /**
+   * Update the 503 retry budget without recreating the connection. Takes
+   * effect on the next `connect()`; an in-flight connect uses the value
+   * captured at start. Mirrors `WebSocketTransport.setRetryTimeoutMs`.
+   */
+  setRetryTimeoutMs(ms: number): void {
+    this.retryTimeoutMs = ms;
+  }
+
   // -----------------------------------------------------------------------
   // Internal
   // -----------------------------------------------------------------------
 
   private async doConnect(): Promise<void> {
-    const controller = new AbortController();
-    const timeout = setTimeout(
-      () => controller.abort(),
-      DEFAULT_CONNECT_TIMEOUT_MS
-    );
-
     try {
-      const url = `http://localhost:${this.port}/rpc`;
-      const request = new Request(url, {
-        headers: {
-          Upgrade: 'websocket',
-          Connection: 'Upgrade'
-        },
-        signal: controller.signal
-      });
-
-      const response = await this.containerStub.fetch(request);
-      clearTimeout(timeout);
+      const response = await this.fetchUpgradeWithRetry();
 
       if (response.status !== 101) {
         throw new Error(
@@ -187,7 +191,6 @@ export class ContainerControlConnection {
         port: this.port
       });
     } catch (error) {
-      clearTimeout(timeout);
       this.connected = false;
       this.transport.abort(error);
       this.logger.error(
@@ -196,6 +199,79 @@ export class ContainerControlConnection {
       );
       throw error;
     }
+  }
+
+  /**
+   * Issue WebSocket upgrade fetches, retrying transient 503 responses with
+   * exponential backoff (3s → 6s → 12s → … capped at 30s) until either
+   * the upgrade succeeds, a non-503 status is returned, or the retry budget
+   * runs out. Mirrors `WebSocketTransport.fetchUpgradeWithRetry` so both
+   * transports behave the same way during container startup.
+   */
+  private async fetchUpgradeWithRetry(): Promise<Response> {
+    const retryTimeoutMs = this.retryTimeoutMs;
+    const startTime = Date.now();
+    let attempt = 0;
+
+    while (true) {
+      const response = await this.fetchUpgradeAttempt();
+
+      if (response.status !== 503) {
+        return response;
+      }
+
+      const elapsed = Date.now() - startTime;
+      const remaining = retryTimeoutMs - elapsed;
+
+      if (remaining <= MIN_TIME_FOR_RETRY_MS) {
+        return response;
+      }
+
+      const delay = Math.min(3000 * 2 ** attempt, MAX_RETRY_BACKOFF_MS);
+
+      this.logger.info(
+        'ContainerControlConnection upgrade returned 503, retrying',
+        {
+          attempt: attempt + 1,
+          delayMs: delay,
+          remainingSec: Math.floor(remaining / 1000)
+        }
+      );
+
+      await this.sleep(delay);
+      attempt++;
+    }
+  }
+
+  /**
+   * Single WebSocket-upgrade fetch attempt. Owns its own AbortController so
+   * each retry gets a fresh per-attempt connect timeout independent of the
+   * total retry budget.
+   */
+  private async fetchUpgradeAttempt(): Promise<Response> {
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(),
+      DEFAULT_CONNECT_TIMEOUT_MS
+    );
+
+    try {
+      const url = `http://localhost:${this.port}/rpc`;
+      const request = new Request(url, {
+        headers: {
+          Upgrade: 'websocket',
+          Connection: 'Upgrade'
+        },
+        signal: controller.signal
+      });
+      return await this.containerStub.fetch(request);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 }
 

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -720,6 +720,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         stub: this,
         port: 3000,
         logger: this.logger,
+        retryTimeoutMs: this.computeRetryTimeoutMs(),
         // Mirrors containerFetch()'s request lifecycle for the RPC transport.
         //
         // The HTTP transport bumps inflightRequests at the top of each

--- a/packages/sandbox/tests/container-connection.test.ts
+++ b/packages/sandbox/tests/container-connection.test.ts
@@ -285,4 +285,232 @@ describe('ContainerControlConnection', () => {
       await expect(recv).rejects.toThrow('WebSocket connection failed.');
     });
   });
+
+  describe('503 upgrade retry', () => {
+    /**
+     * Build a fake successful upgrade Response. Mirrors what
+     * Cloudflare's Container base class returns from `stub.fetch()`:
+     * a Response with `status === 101` and a non-standard `webSocket`
+     * property carrying the WebSocket instance.
+     */
+    function makeUpgradeResponse(): Response {
+      const target = new EventTarget();
+      const ws = Object.assign(target, {
+        send: () => {},
+        close: () => {},
+        accept: () => {}
+      }) as unknown as WebSocket;
+      // The workerd test runtime rejects new Response(null, { status: 101 }),
+      // so synthesize a Response-shaped object exposing only the fields
+      // ContainerControlConnection actually reads (status, statusText,
+      // and the non-standard `webSocket` accessor).
+      return {
+        status: 101,
+        statusText: 'Switching Protocols',
+        webSocket: ws
+      } as unknown as Response;
+    }
+
+    function make503(): Response {
+      return new Response('Container is starting.', {
+        status: 503,
+        statusText: 'Service Unavailable'
+      });
+    }
+
+    it('retries 503 upgrade responses until success', async () => {
+      vi.useFakeTimers();
+      try {
+        const fetchMock = vi
+          .fn<(req: Request) => Promise<Response>>()
+          .mockResolvedValueOnce(make503())
+          .mockResolvedValueOnce(make503())
+          .mockResolvedValueOnce(makeUpgradeResponse());
+
+        const conn = new ContainerControlConnection({
+          stub: { fetch: fetchMock },
+          retryTimeoutMs: 60_000
+        });
+
+        const connectPromise = conn.connect();
+        // First attempt fires synchronously.
+        await vi.advanceTimersByTimeAsync(0);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        // Backoff is 3s for attempt 1, 6s for attempt 2.
+        await vi.advanceTimersByTimeAsync(3_000);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+
+        await vi.advanceTimersByTimeAsync(6_000);
+        await connectPromise;
+
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(conn.isConnected()).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('gives up on 503 once the retry budget is exhausted', async () => {
+      vi.useFakeTimers();
+      try {
+        const fetchMock = vi
+          .fn<(req: Request) => Promise<Response>>()
+          .mockResolvedValue(make503());
+
+        const conn = new ContainerControlConnection({
+          stub: { fetch: fetchMock },
+          // 20s budget. Walk-through with MIN_TIME_FOR_RETRY_MS = 15s and
+          // 3s/6s/12s exponential backoff:
+          //   attempt 1 at t=0   (remaining 20s, retry after 3s)
+          //   attempt 2 at t=3s  (remaining 17s, retry after 6s)
+          //   attempt 3 at t=9s  (remaining 11s < 15s, give up)
+          retryTimeoutMs: 20_000
+        });
+
+        const connectPromise = conn.connect();
+        const assertion = expect(connectPromise).rejects.toThrow(
+          'WebSocket upgrade failed: 503'
+        );
+
+        // Run all timers — connect() must settle even with fake timers.
+        await vi.advanceTimersByTimeAsync(60_000);
+        await assertion;
+
+        expect(conn.isConnected()).toBe(false);
+        // Three attempts before remaining < MIN_TIME_FOR_RETRY_MS.
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not retry non-503 upgrade failures', async () => {
+      const fetchMock = vi
+        .fn<(req: Request) => Promise<Response>>()
+        .mockResolvedValue(new Response('Not Found', { status: 404 }));
+
+      const conn = new ContainerControlConnection({
+        stub: { fetch: fetchMock },
+        retryTimeoutMs: 120_000
+      });
+
+      await expect(conn.connect()).rejects.toThrow(
+        'WebSocket upgrade failed: 404'
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables retries when retryTimeoutMs is set to 0', async () => {
+      const fetchMock = vi
+        .fn<(req: Request) => Promise<Response>>()
+        .mockResolvedValue(
+          new Response('Container is starting.', {
+            status: 503,
+            statusText: 'Service Unavailable'
+          })
+        );
+
+      const conn = new ContainerControlConnection({
+        stub: { fetch: fetchMock },
+        retryTimeoutMs: 0
+      });
+
+      await expect(conn.connect()).rejects.toThrow(
+        'WebSocket upgrade failed: 503'
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses a default retry budget when retryTimeoutMs is omitted', async () => {
+      vi.useFakeTimers();
+      try {
+        const fetchMock = vi
+          .fn<(req: Request) => Promise<Response>>()
+          .mockResolvedValueOnce(make503())
+          .mockResolvedValueOnce(makeUpgradeResponse());
+
+        const conn = new ContainerControlConnection({
+          stub: { fetch: fetchMock }
+        });
+
+        const connectPromise = conn.connect();
+        await vi.advanceTimersByTimeAsync(0);
+        await vi.advanceTimersByTimeAsync(3_000);
+        await connectPromise;
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(conn.isConnected()).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('respects setRetryTimeoutMs() updates made before connect()', async () => {
+      vi.useFakeTimers();
+      try {
+        const fetchMock = vi
+          .fn<(req: Request) => Promise<Response>>()
+          .mockResolvedValue(make503());
+
+        const conn = new ContainerControlConnection({
+          stub: { fetch: fetchMock },
+          // Start with a very large budget — would normally allow many retries.
+          retryTimeoutMs: 600_000
+        });
+
+        // Lower the budget so the very first elapsed-time check gives up.
+        conn.setRetryTimeoutMs(1_000);
+
+        const connectPromise = conn.connect();
+        const assertion = expect(connectPromise).rejects.toThrow(
+          'WebSocket upgrade failed: 503'
+        );
+
+        await vi.advanceTimersByTimeAsync(60_000);
+        await assertion;
+
+        // Budget too small to satisfy MIN_TIME_FOR_RETRY_MS — no retries.
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('passes a fresh, non-aborted Request to each retry attempt', async () => {
+      vi.useFakeTimers();
+      try {
+        const seenRequests: Request[] = [];
+        const fetchMock = vi
+          .fn<(req: Request) => Promise<Response>>()
+          .mockImplementationOnce(async (req) => {
+            seenRequests.push(req);
+            return make503();
+          })
+          .mockImplementationOnce(async (req) => {
+            seenRequests.push(req);
+            if (req.signal.aborted) {
+              throw new Error('retry reused an aborted signal');
+            }
+            return makeUpgradeResponse();
+          });
+
+        const conn = new ContainerControlConnection({
+          stub: { fetch: fetchMock },
+          retryTimeoutMs: 60_000
+        });
+
+        const connectPromise = conn.connect();
+        await vi.advanceTimersByTimeAsync(0);
+        await vi.advanceTimersByTimeAsync(3_000);
+        await connectPromise;
+
+        expect(seenRequests).toHaveLength(2);
+        expect(seenRequests[0]).not.toBe(seenRequests[1]);
+        expect(seenRequests[1].signal.aborted).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
 });

--- a/packages/sandbox/tests/rpc-client-retry.test.ts
+++ b/packages/sandbox/tests/rpc-client-retry.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Verifies that `ContainerControlClient` plumbs the 503 retry budget
+ * through to the underlying `ContainerControlConnection`. The actual retry
+ * loop is exercised in `container-connection.test.ts`; here we only assert
+ * the wiring.
+ */
+
+interface CapturedOptions {
+  retryTimeoutMs?: number;
+}
+
+const captured: {
+  options: CapturedOptions[];
+  setRetryTimeoutCalls: number[];
+} = {
+  options: [],
+  setRetryTimeoutCalls: []
+};
+
+vi.mock('../src/container-control/connection', () => ({
+  ContainerControlConnection: class {
+    constructor(options: CapturedOptions) {
+      captured.options.push(options);
+    }
+    setRetryTimeoutMs(ms: number) {
+      captured.setRetryTimeoutCalls.push(ms);
+    }
+    isConnected() {
+      return false;
+    }
+    getStats() {
+      return { imports: 1, exports: 1 };
+    }
+    disconnect() {}
+    rpc() {
+      return new Proxy({}, { get: () => ({}) });
+    }
+    async connect() {}
+  }
+}));
+
+import { ContainerControlClient } from '../src/container-control/client';
+
+describe('ContainerControlClient retry timeout wiring', () => {
+  beforeEach(() => {
+    captured.options.length = 0;
+    captured.setRetryTimeoutCalls.length = 0;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('passes retryTimeoutMs through to ContainerControlConnection', () => {
+    const client = new ContainerControlClient({
+      stub: { fetch: vi.fn() },
+      retryTimeoutMs: 75_000
+    });
+
+    // Force connection construction by touching a sub-client.
+    void client.commands;
+
+    expect(captured.options).toHaveLength(1);
+    expect(captured.options[0].retryTimeoutMs).toBe(75_000);
+  });
+
+  it('omits retryTimeoutMs when not configured (lets the connection apply its default)', () => {
+    const client = new ContainerControlClient({
+      stub: { fetch: vi.fn() }
+    });
+
+    void client.commands;
+
+    expect(captured.options).toHaveLength(1);
+    expect(captured.options[0].retryTimeoutMs).toBeUndefined();
+  });
+
+  it('forwards setRetryTimeoutMs() to the active connection', () => {
+    const client = new ContainerControlClient({
+      stub: { fetch: vi.fn() },
+      retryTimeoutMs: 60_000
+    });
+
+    void client.commands;
+
+    client.setRetryTimeoutMs(45_000);
+
+    expect(captured.setRetryTimeoutCalls).toEqual([45_000]);
+  });
+
+  it('caches setRetryTimeoutMs() calls made before any connection is created', () => {
+    const client = new ContainerControlClient({
+      stub: { fetch: vi.fn() }
+    });
+
+    // No connection exists yet. The setter should still take effect once the
+    // connection is created — either by stashing the value and applying it on
+    // construction, or by applying it immediately if a connection is present.
+    client.setRetryTimeoutMs(15_000);
+
+    void client.commands;
+
+    expect(captured.options).toHaveLength(1);
+    expect(captured.options[0].retryTimeoutMs).toBe(15_000);
+  });
+});


### PR DESCRIPTION
The capnweb control connection threw on the first 503 from the container, surfacing as RPCTransportError(upgrade_failed) before the runtime had finished provisioning the instance. Apply the same
exponential-backoff retry budget the route-based WebSocketTransport already uses so RPC calls survive cold starts.
