### PR TITLE
feat: improve 5 lowest-scoring skill definitions

### DIFF
--- a/.agents/skills/architecture/SKILL.md
+++ b/.agents/skills/architecture/SKILL.md
@@ -1,28 +1,25 @@
 ---
 name: architecture
-description: Use when navigating the codebase for the first time, adding a new client method, adding a new container handler/service, or understanding how a request flows from Worker through the Sandbox DO into the container. Covers the three-layer architecture, client pattern, container runtime structure, and monorepo layout. (project)
+description: "Use when navigating the project structure, adding a new client method or container handler, tracing request flow from Worker through Sandbox DO into the container, or asking how the code is organized. Shows where to add REST endpoints, wire client SDK methods, register DO handlers, and trace HTTP requests through the Worker-to-container pipeline. (project)"
 ---
 
 # Architecture
 
 ## Three-Layer Architecture
 
-1. **`@cloudflare/sandbox` (`packages/sandbox/`)** — Public SDK published to npm
-   - `Sandbox` class: Durable Object that manages the container lifecycle
-   - Modular HTTP clients per capability (`CommandClient`, `FileClient`, `ProcessClient`, …)
+Only `@cloudflare/sandbox` is published to npm. The other two packages are internal.
+
+1. **`@cloudflare/sandbox` (`packages/sandbox/`)** — Public SDK
+   - `Sandbox` class: Durable Object managing container lifecycle
+   - Modular clients: `CommandClient`, `FileClient`, `ProcessClient`, `PortClient`, `GitClient`, etc.
    - `CodeInterpreter`: high-level API for Python/JS with structured outputs
-   - `proxyToSandbox()`: request handler for preview URL routing
+   - `proxyToSandbox()`: preview URL routing
 
-2. **`@repo/shared` (`packages/shared/`)** — Internal shared utilities
-   - Type definitions used by both SDK and container runtime
-   - Centralized error classes (`packages/shared/src/errors/`) and logging
-   - **Not published to npm**
+2. **`@repo/shared` (`packages/shared/`)** — Shared types, error classes (`src/errors/`), logging
 
-3. **`@repo/sandbox-container` (`packages/sandbox-container/`)** — Container runtime
-   - Bun-based HTTP server running inside the Docker container
-   - Dependency-injection container in `core/container.ts`
-   - Route handlers for command execution, file operations, process management
-   - **Not published to npm** (bundled into the Docker image)
+3. **`@repo/sandbox-container` (`packages/sandbox-container/`)** — Bun-based container runtime
+   - DI container in `core/container.ts`, route handlers, services, managers
+   - Bundled into the Docker image
 
 ## Request Flow
 
@@ -54,39 +51,23 @@ Errors flow back the same path: container → Sandbox DO → Worker, using the c
 
 ## Primary Control Path
 
-The primary Sandbox Durable Object to container control path is the container-control/control-plane path:
-
 - SDK side: `packages/sandbox/src/container-control/`
 - Container side: `packages/sandbox-container/src/control-plane/`
-- Current wire implementation: capnweb RPC over the `/rpc` WebSocket route
+- Wire: capnweb RPC over `/rpc` WebSocket (treat as implementation detail, not architectural boundary)
+- Contract: `SandboxAPI` interface in `@repo/shared`
 
-Control-channel/transport-layer capabilities belong in this path. Treat capnweb/RPC as the current implementation detail, not the architectural boundary.
-
-The shared `@repo/shared` `SandboxAPI` interface remains named `SandboxAPI` because it defines the current control API contract used by both sides.
+New control-plane capabilities go in this path.
 
 ## Route-Based Compatibility Path (`packages/sandbox/src/clients/`)
 
-`packages/sandbox/src/clients/` and `packages/sandbox/src/clients/transport/` implement the HTTP and custom WebSocket route-based compatibility API. Maintain these for compatibility, debugging, local development, fallback behavior, and bug fixes, but do not add new control-plane capabilities there by default.
+`packages/sandbox/src/clients/` and `clients/transport/` implement the HTTP/WebSocket compatibility API. Maintain for compatibility and debugging, but do not add new control-plane capabilities here.
 
-The route-based client pattern is:
-
-- **`BaseHttpClient`** — abstract route-based HTTP/WebSocket client with shared request/response handling
-- **`SandboxClient`** — compatibility aggregator that exposes all specialized route-based clients
-- **Specialized clients** — one per domain:
-  - `CommandClient` — exec / execStream
-  - `FileClient` — read, write, list, delete
-  - `ProcessClient` — start, stop, list, signal
-  - `PortClient` — expose / preview URLs
-  - `GitClient` — clone, checkout, status
-  - `UtilityClient` — ping, metadata
-  - `InterpreterClient` — code interpreter sessions
-
-When maintaining route-based compatibility, add or extend specialized clients under `packages/sandbox/src/clients/`. DO-to-container control capabilities belong in `packages/sandbox/src/container-control/` and `packages/sandbox-container/src/control-plane/`.
+Pattern: `BaseHttpClient` (abstract) -> specialized clients (`CommandClient`, `FileClient`, `ProcessClient`, `PortClient`, `GitClient`, `UtilityClient`, `InterpreterClient`) -> aggregated by `SandboxClient`.
 
 ## Container Runtime (`packages/sandbox-container/src/`)
 
-- **DI container** (`core/container.ts`) — manages service lifecycle and wiring
-- **Router** — simple HTTP router with middleware
+- **DI container** (`core/container.ts`) — wires services and manages their lifecycle
+- **Router** — HTTP router with middleware
 - **Control plane** (`control-plane/`) — primary container-side API called by the Sandbox DO
 - **Handlers** (`handlers/`) — route-based compatibility handlers, thin layer that parses requests
 - **Services** (`services/`) — business logic (`CommandService`, `FileService`, `ProcessService`, …)
@@ -97,15 +78,13 @@ Entry point: `packages/sandbox-container/src/index.ts` starts a Bun HTTP server 
 When adding a new container control operation:
 
 1. Add/extend a service in `services/` for the business logic.
-2. Add the control-plane method in `packages/sandbox-container/src/control-plane/`.
-3. Mirror the call in `packages/sandbox/src/container-control/`.
-4. Add unit tests on both sides; add an E2E test if it touches real shell/filesystem behavior.
+2. Add the control-plane method in `packages/sandbox-container/src/control-plane/`. Run `npm test -w @repo/sandbox-container` to verify.
+3. Mirror the call in `packages/sandbox/src/container-control/`. Run `npm run check` to confirm the RPC contract matches both sides.
+4. Add unit tests on both sides; add an E2E test if it touches real shell/filesystem behavior. Run `npm test` then `npm run test:e2e` if applicable.
 
 Only add a route handler in `handlers/` and a route-based SDK client in `packages/sandbox/src/clients/` when maintaining HTTP/WebSocket compatibility.
 
 ## Monorepo Structure
-
-Uses npm workspaces + [Turbo](https://turbo.build/):
 
 - `packages/sandbox` — main SDK package (published)
 - `packages/shared` — shared types and utilities (internal)
@@ -113,25 +92,11 @@ Uses npm workspaces + [Turbo](https://turbo.build/):
 - `examples/` — working example projects
 - `tooling/` — shared TypeScript configs
 
-`turbo.json` orchestrates dependency-aware builds.
+Uses npm workspaces + Turbo (`turbo.json` orchestrates dependency-aware builds).
 
 ## Cross-Cutting Patterns
 
-- **Sessions** — isolate execution contexts (cwd, env vars). Default session is auto-created; multiple sessions per sandbox are supported.
-- **Ports** — expose internal services via preview URLs with token auth. Auto-cleaned on sandbox sleep. Production preview URLs require a custom domain with wildcard DNS (`*.yourdomain.com`); `.workers.dev` does not support the required subdomain patterns.
+- **Sessions** — isolate execution contexts (cwd, env vars). Default auto-created; multiple per sandbox supported. See `session-execution` skill for implementation details.
+- **Ports** — expose internal services via preview URLs with token auth. Auto-cleaned on sandbox sleep. Production requires wildcard DNS (`*.yourdomain.com`); `.workers.dev` does not support the required subdomain patterns.
 - **Container isolation** — handled at the Cloudflare platform level (VMs), not by SDK code.
-
-## Container Base Image
-
-The container runtime uses Ubuntu 22.04 with:
-
-- Python 3.11 (matplotlib, numpy, pandas, ipython)
-- Node.js 20 LTS
-- Bun 1.x (powers the container HTTP server)
-- Git, curl, wget, jq, and other common utilities
-
-When modifying `packages/sandbox/Dockerfile`:
-
-- Keep images lean — every MB affects cold start
-- Pin versions for reproducibility
-- Clean up package manager caches to reduce image size
+- **Container image** — see `packages/sandbox/Dockerfile`. Pin versions, clean caches to minimize cold start.

--- a/.agents/skills/coding-standards/SKILL.md
+++ b/.agents/skills/coding-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coding-standards
-description: Use when writing or reviewing TypeScript in this repo. Covers the no-`any` rule and where to put new types, the uppercase-acronym style guide, and the rules for code comments (no historical context). (project)
+description: "Use when writing or reviewing TypeScript in this repo. Enforces the no-any typing rule, guides type file placement, applies uppercase-acronym naming conventions (API not Api, URL not Url), and strips historical context from code comments. (project)"
 ---
 
 # Coding Standards
@@ -77,4 +77,12 @@ When adding or modifying SDK methods:
 
 - Use clear, descriptive names that indicate what the method does
 - Validate inputs before passing to container APIs
-- Provide helpful error messages with context (use the custom error classes in `packages/shared/src/errors/`)
+- Throw custom error classes from `packages/shared/src/errors/` with context:
+
+```typescript
+// ✅ Good: specific error class with context
+throw new SandboxError(ErrorCode.INVALID_PATH, `Path must be under /workspace: ${path}`);
+
+// ❌ Bad: generic error, no context
+throw new Error('invalid path');
+```

--- a/.agents/skills/examples/SKILL.md
+++ b/.agents/skills/examples/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: examples
-description: Use when working in the examples/ directory, running an example with wrangler dev, adding a new example, or answering questions about EXPOSE directives and the local Docker dev loop. (project)
+description: "Use when running examples with wrangler dev, scaffolding new example projects, debugging the local Docker dev loop, or understanding EXPOSE directives. Guides setup, execution, and troubleshooting of working sample apps in the examples/ directory. (project)"
 ---
 
 # Examples
@@ -45,9 +45,21 @@ Including `EXPOSE` is still recommended in example Dockerfiles because it docume
 ## Adding a New Example
 
 1. Copy `examples/minimal/` as a starting point.
-2. Update `package.json` `name` and any wrangler config (`wrangler.jsonc`) — class names, DO bindings, container image tag.
-3. Add a `README.md` with an `# H1` title (the README scanner uses it) and a short description of what the example demonstrates.
-4. Make sure the example builds and `npm run dev` works from a clean checkout.
+2. Update `package.json` `name` and `wrangler.jsonc` — key fields to change:
+   ```jsonc
+   {
+     "name": "your-example",
+     "main": "src/index.ts",
+     "durable_objects": {
+       "bindings": [{ "name": "SANDBOX", "class_name": "YourSandbox" }]
+     },
+     "containers": {
+       "image": "your-example:latest"  // must match Dockerfile output tag
+     }
+   }
+   ```
+3. Add a `README.md` with an `# H1` title (the README scanner uses it) and a short description.
+4. Run `npm run dev` from the example directory. Verify the dev server starts and responds. If the Docker build fails, check that the image tag in `wrangler.jsonc` matches the Dockerfile output.
 5. If the example demonstrates a new SDK capability, link to it from `packages/sandbox/README.md`.
 
 ## Local Development Tips

--- a/.agents/skills/examples/SKILL.md
+++ b/.agents/skills/examples/SKILL.md
@@ -53,9 +53,14 @@ Including `EXPOSE` is still recommended in example Dockerfiles because it docume
      "durable_objects": {
        "bindings": [{ "name": "SANDBOX", "class_name": "YourSandbox" }]
      },
-     "containers": {
-       "image": "your-example:latest"  // must match Dockerfile output tag
-     }
+     "containers": [
+       {
+         "class_name": "YourSandbox",
+         "image": "./Dockerfile",
+         "instance_type": "lite",
+         "max_instances": 1
+       }
+     ]
    }
    ```
 3. Add a `README.md` with an `# H1` title (the README scanner uses it) and a short description.

--- a/.agents/skills/sandbox-bridge/SKILL.md
+++ b/.agents/skills/sandbox-bridge/SKILL.md
@@ -1,100 +1,60 @@
 ---
 name: sandbox-bridge
-description: Use when you need to exercise a real, running Sandbox deployment via HTTP — for example to validate SDK changes against a live container, reproduce a user-reported issue, or experiment with the API (including FUSE bucket mounts) without spinning up `wrangler dev`. Documents the Sandbox bridge worker reachable via `SANDBOX_WORKER_URL` + `SANDBOX_API_KEY` when the host injects them.
+description: "Use when validating SDK changes against a live container, reproducing user-reported issues, or experimenting with the Sandbox API (including FUSE bucket mounts) without wrangler dev. Drives a real sandbox via curl using SANDBOX_WORKER_URL and SANDBOX_API_KEY."
 ---
 
 # Sandbox Bridge
 
-A hosted Cloudflare Sandbox deployment _may_ be available to agents working in this repo, depending on whether the host injects credentials for it. It exposes the full `@cloudflare/sandbox` SDK over a small HTTP API ("the bridge") so you can drive a real sandbox container from `curl`, scripts, or tests without deploying your own worker.
+A hosted Sandbox deployment may be available when the host injects `SANDBOX_WORKER_URL` and `SANDBOX_API_KEY` into the shell. It exposes the full `@cloudflare/sandbox` SDK over HTTP so you can drive a real container from `curl` or scripts.
 
-The source for the bridge lives in the repo:
-
-- `bridge/worker/` — the deployed worker entrypoint (thin wrapper).
-- `packages/sandbox/src/bridge/` — the actual bridge implementation: routes, auth, pool management.
-
-If the API behaves unexpectedly, read those before guessing.
+Source: `bridge/worker/` (worker entrypoint), `packages/sandbox/src/bridge/` (implementation: routes, auth, pool management). Read these if the API behaves unexpectedly.
 
 ## Credentials
 
-When the host provides them, two environment variables are set in your shell:
+| Variable             | Purpose                                  |
+| -------------------- | ---------------------------------------- |
+| `SANDBOX_WORKER_URL` | Base URL of the bridge worker (https).   |
+| `SANDBOX_API_KEY`    | Bearer token for `Authorization` header. |
 
-| Variable             | Purpose                                       |
-| -------------------- | --------------------------------------------- |
-| `SANDBOX_WORKER_URL` | Base URL of the bridge worker (https).        |
-| `SANDBOX_API_KEY`    | Bearer token for `Authorization` header.      |
-
-If either is unset, the bridge isn't available for this session — fall back to `wrangler dev` against an example, or ask the user to enable it.
-
-All requests require `Authorization: Bearer $SANDBOX_API_KEY`. Missing/invalid tokens return `401 unauthorized`. **Always pass the token via the header — never via a query string — to keep it out of access logs and shell history.**
-
-## OpenAPI Spec
-
-The full, authoritative spec is served by the bridge itself:
-
-```bash
-curl -sf -H "Authorization: Bearer $SANDBOX_API_KEY" \
-  "$SANDBOX_WORKER_URL/v1/openapi.json" | jq '.paths | keys'
-```
+If either is unset, fall back to `wrangler dev` (see the `examples` skill). Always pass the token via the header, never a query string. Missing/invalid tokens return `401`.
 
 ## Typical Flow
-
-The bridge is stateless from the client's point of view: each sandbox is identified by an opaque ID returned from `POST /v1/sandbox`. Use that ID for every subsequent `/v1/sandbox/{id}/*` call, then `DELETE` it when done.
 
 ### 1. Create a sandbox
 
 ```bash
-SID=$(curl -s -X POST "$SANDBOX_WORKER_URL/v1/sandbox" \
+SID=$(curl -sf -X POST "$SANDBOX_WORKER_URL/v1/sandbox" \
   -H "Authorization: Bearer $SANDBOX_API_KEY" | jq -r .id)
-echo "$SID"   # e.g. nmghbg45psadoawxuazxrfr23e
+# Verify creation succeeded before continuing
+[ -n "$SID" ] && echo "Created: $SID" || echo "FAILED"
 ```
 
 ### 2. Exec a command (SSE stream)
 
-`POST /v1/sandbox/{id}/exec` streams output as Server-Sent Events. The body takes an `argv` array — already shell-split — so wrap shell snippets in `["sh","-lc", "..."]`.
+`POST /v1/sandbox/{id}/exec` streams SSE. Body takes `argv` (already shell-split), optional `timeout_ms` and `cwd` (must resolve under `/workspace`).
 
 ```bash
 curl -sN -X POST "$SANDBOX_WORKER_URL/v1/sandbox/$SID/exec" \
   -H "Authorization: Bearer $SANDBOX_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"argv":["sh","-lc","echo hello; uname -a"]}'
+  -d '{"argv":["sh","-lc","echo hello"]}'
 ```
 
-Events emitted:
-
-| Event    | `data` payload                          | Notes                              |
-| -------- | --------------------------------------- | ---------------------------------- |
-| `stdout` | base64-encoded chunk of stdout          | May fire many times.               |
-| `stderr` | base64-encoded chunk of stderr          | May fire many times.               |
-| `exit`   | `{"exit_code": N}` (JSON)               | Terminal — stream closes after.    |
-| `error`  | `{"error":"...","code":"..."}` (JSON)   | Terminal — replaces `exit`.        |
-
-Decode stdout/stderr with `base64 -d`. Optional request fields: `timeout_ms` (per-call timeout) and `cwd` (must resolve under `/workspace`).
-
-A small helper to print decoded stdout:
-
-```bash
-curl -sN -X POST "$SANDBOX_WORKER_URL/v1/sandbox/$SID/exec" \
-  -H "Authorization: Bearer $SANDBOX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"argv":["sh","-lc","ls /workspace"]}' \
-| awk '/^event: /{ev=$2} /^data: /{sub(/^data: /,""); if(ev=="stdout") print | "base64 -d"; else if(ev=="exit"||ev=="error") print "[" ev "] " $0}'
-```
+SSE events: `stdout`/`stderr` (base64-encoded), `exit` (`{"exit_code": N}`, terminal), `error` (terminal, replaces `exit`). Decode with `base64 -d`.
 
 ### 3. Read / write files
 
-Files live under `/workspace` inside the sandbox. The path in the URL is given **without** the leading slash and must resolve within `/workspace`.
+Paths are relative to root, must resolve within `/workspace`.
 
 ```bash
 # Write
-echo 'print("hi")' | curl -s -X PUT \
+echo 'print("hi")' | curl -sf -X PUT \
   "$SANDBOX_WORKER_URL/v1/sandbox/$SID/file/workspace/main.py" \
   -H "Authorization: Bearer $SANDBOX_API_KEY" \
-  -H "Content-Type: application/octet-stream" \
-  --data-binary @-
+  -H "Content-Type: application/octet-stream" --data-binary @-
 
 # Read
-curl -s -X GET \
-  "$SANDBOX_WORKER_URL/v1/sandbox/$SID/file/workspace/main.py" \
+curl -sf "$SANDBOX_WORKER_URL/v1/sandbox/$SID/file/workspace/main.py" \
   -H "Authorization: Bearer $SANDBOX_API_KEY"
 ```
 
@@ -103,86 +63,42 @@ curl -s -X GET \
 Always clean up. Destroying an unknown ID is a no-op (`204`).
 
 ```bash
-curl -s -X DELETE "$SANDBOX_WORKER_URL/v1/sandbox/$SID" \
+curl -sf -X DELETE "$SANDBOX_WORKER_URL/v1/sandbox/$SID" \
   -H "Authorization: Bearer $SANDBOX_API_KEY" -w "%{http_code}\n"
 ```
 
 ## Sessions
 
-Every sandbox has a **default session** that backs exec/file/PTY calls when no `Session-Id` header is set. Sessions isolate two things across commands:
-
-- **Working directory** — `cd` in one exec persists for subsequent execs in the same session.
-- **Environment variables** — `export FOO=bar` likewise persists, and `env` passed at session creation seeds the session.
-
-Use named sessions when you need parallel execution contexts in the same sandbox (e.g. a long-running build in one and quick probes in another) without them clobbering each other's `cwd`/env.
-
-### Create a session
+The default session backs all calls when no `Session-Id` header is set. Sessions isolate `cwd` and env vars across commands. Use named sessions for parallel execution contexts.
 
 ```bash
-SESS=$(curl -s -X POST "$SANDBOX_WORKER_URL/v1/sandbox/$SID/session" \
+# Create
+SESS=$(curl -sf -X POST "$SANDBOX_WORKER_URL/v1/sandbox/$SID/session" \
   -H "Authorization: Bearer $SANDBOX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"cwd":"/workspace","env":{"NODE_ENV":"test"}}' | jq -r .id)
-```
 
-The body is optional. You can also pass `id` to choose your own (must match `^[a-zA-Z0-9._-]{1,128}$`); otherwise one is generated for you.
-
-### Use a session
-
-Pass the ID via the `Session-Id` header on `exec`, file read/write, or `pty`:
-
-```bash
-curl -sN -X POST "$SANDBOX_WORKER_URL/v1/sandbox/$SID/exec" \
-  -H "Authorization: Bearer $SANDBOX_API_KEY" \
-  -H "Session-Id: $SESS" \
-  -H "Content-Type: application/json" \
-  -d '{"argv":["sh","-lc","cd src && pwd && echo $NODE_ENV"]}'
-
-# A second exec in the same session inherits cwd=/workspace/src and NODE_ENV=test:
+# Use — pass Session-Id header on exec, file, or pty calls
 curl -sN -X POST "$SANDBOX_WORKER_URL/v1/sandbox/$SID/exec" \
   -H "Authorization: Bearer $SANDBOX_API_KEY" \
   -H "Session-Id: $SESS" \
   -H "Content-Type: application/json" \
   -d '{"argv":["sh","-lc","pwd"]}'
-```
 
-Invalid session IDs return `400 invalid_request`. Unknown but well-formed IDs are created on first use by some routes — prefer explicit `POST /session` so you control `cwd`/`env`.
-
-### Delete a session
-
-```bash
-curl -s -X DELETE "$SANDBOX_WORKER_URL/v1/sandbox/$SID/session/$SESS" \
+# Delete (default session cannot be deleted)
+curl -sf -X DELETE "$SANDBOX_WORKER_URL/v1/sandbox/$SID/session/$SESS" \
   -H "Authorization: Bearer $SANDBOX_API_KEY"
 ```
 
-The default session cannot be deleted (`502 session_error`). Sessions also disappear when the parent sandbox is destroyed.
-
 ## Other Endpoints
 
-These exist on the bridge — consult `/v1/openapi.json` for full schemas before using them:
-
-| Path                              | Purpose                                           |
-| --------------------------------- | ------------------------------------------------- |
-| `/health`                         | Liveness probe.                                   |
-| `/v1/pool/{prime,stats,shutdown-prewarmed}` | Pre-warm pool management.               |
-| `/v1/sandbox/{id}/pty`            | Interactive PTY stream.                           |
-| `/v1/sandbox/{id}/running`        | List running processes.                           |
-| `/v1/sandbox/{id}/{mount,unmount}` | Mount / unmount S3-compatible buckets via FUSE.  |
-| `/v1/sandbox/{id}/{hydrate,persist}` | Workspace persistence ops.                     |
+Consult `$SANDBOX_WORKER_URL/v1/openapi.json` for full schemas. Key routes: `/health`, `/v1/pool/{prime,stats}`, `/v1/sandbox/{id}/pty`, `/v1/sandbox/{id}/running`, `/v1/sandbox/{id}/{mount,unmount}` (FUSE), `/v1/sandbox/{id}/{hydrate,persist}`.
 
 ## Error Codes
 
-Errors return JSON `{ "error": "...", "code": "..." }` with one of:
-`unauthorized`, `invalid_request`, `exec_error`, `exec_transport_error`,
-`workspace_read_not_found`, `workspace_archive_read_error`,
-`workspace_archive_write_error`, `capacity_exceeded`, `pool_error`,
-`mount_error`, `unmount_error`, `session_error`.
+JSON `{ "error": "...", "code": "..." }` with codes: `unauthorized`, `invalid_request`, `exec_error`, `exec_transport_error`, `workspace_read_not_found`, `workspace_archive_read_error`, `workspace_archive_write_error`, `capacity_exceeded`, `pool_error`, `mount_error`, `unmount_error`, `session_error`. Inside an SSE stream, errors arrive as `event: error`.
 
-Once an `exec` SSE stream is open, transport errors arrive as `event: error` instead of an HTTP error.
+## Bridge vs. `wrangler dev`
 
-## When to Use This vs. `wrangler dev`
-
-- **Bridge** — fastest path to "does this command behave correctly inside a real sandbox container?". No local Docker, no build step. Also the only option for features that depend on host-level capabilities the local dev loop doesn't replicate, notably **FUSE-based bucket mounts** (`/v1/sandbox/{id}/mount`) — `wrangler dev` cannot mount s3fs-FUSE filesystems.
-- **`wrangler dev`** (see the `examples` skill) — required when iterating on the container image, the worker code, or anything that isn't already deployed to the bridge.
-
-The bridge runs whatever version of `@cloudflare/sandbox` is currently deployed to it; it is **not** automatically updated from your working tree. If you need to test unreleased SDK changes that don't require FUSE, use `wrangler dev` against a local example instead.
+- **Bridge** — fastest path to test real container behavior. Required for FUSE bucket mounts. Runs the currently deployed SDK version, not your working tree.
+- **`wrangler dev`** — required when iterating on the container image, worker code, or unreleased SDK changes.

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing
-description: Use when writing or running tests for this project. Covers unit vs E2E test decisions, test file locations, mock patterns, and project-specific testing conventions. (project)
+description: "Use when writing, running, or debugging tests. Creates unit and E2E tests, selects the correct test suite, places test files in project-standard locations, and applies mock patterns (mock container, createNoOpLogger). (project)"
 ---
 
 # Testing in Sandbox SDK
@@ -121,8 +121,8 @@ describe('ComponentName', () => {
 
 After making any meaningful code change:
 
-1. `npm run check` - catch type errors first
-2. `npm test` - verify unit tests pass
-3. `npm run test:e2e` - if touching core functionality
+1. `npm run check` — catch type errors first. If this fails, fix type errors before proceeding.
+2. `npm test` — verify unit tests pass. If a test hangs (known vitest-pool-workers issue), the results are still valid; check pass/fail output above the hang.
+3. `npm run test:e2e` — if touching core functionality. If E2E tests fail with connection errors, verify Docker is running and the container image is built (`npm run docker:rebuild` from repo root).
 
-**Build trust**: The monorepo build system handles dependencies automatically. E2E tests always run against latest built code - no manual rebuild needed.
+The monorepo build system handles dependencies automatically. E2E tests always run against latest built code.


### PR DESCRIPTION
Hey @ghostwriternr 👋

I ran your skills through `tessl skill review` at work and found targeted improvements in your skills. Here's the before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| sandbox-bridge | 80% | 96% | +16% |
| testing | 82% | 97% | +15% |
| architecture | 82% | 90% | +8% |
| coding-standards | 83% | 90% | +7% |
| examples | 82% | 87% | +5% |

These were easy changes to bring the skill's structure and activation in line with what performs well against Anthropic's best practices.

<details>
<summary>What changed in sandbox-bridge</summary>

Quoted the description and tightened it with active verbs. Trimmed verbose intro paragraph, consolidated the Sessions section (removed duplicate curl examples), condensed "Other Endpoints" and "Error Codes" into compact paragraphs. Added a validation checkpoint after sandbox creation. 189 to 105 lines.

</details>

<details>
<summary>What changed in testing</summary>

Quoted the description with concrete action verbs ("Creates unit and E2E tests, selects the correct test suite, places test files..."). Named specific mock patterns in the description. Added error recovery guidance to each step of the development workflow.

</details>

<details>
<summary>What changed in architecture</summary>

Replaced "Covers" with active verbs ("Shows where to add REST endpoints, wire client SDK methods, register DO handlers"). Consolidated the "not published to npm" annotations, condensed Three-Layer Architecture descriptions, trimmed Route-Based Compatibility Path from verbose list to compact pattern summary. Added validation commands to the "adding a new control operation" workflow.

</details>

<details>
<summary>What changed in coding-standards and examples</summary>

coding-standards: Replaced topic language with action verbs ("Enforces the no-any typing rule..."), added inline examples (API not Api, URL not Url), expanded API Design section with concrete TypeScript good vs bad error handling patterns.

examples: Rewrote description with concrete actions, added a concrete wrangler.jsonc configuration snippet, improved validation guidance and Docker failure troubleshooting.

</details>

In addition, I stress-tested your [`architecture` skill against a few real-world scenarios](https://tessl.io/registry/skills/github/cloudflare/sandbox-sdk/architecture/evals), and it held up really well. This means that your skill meaningfully improves agent steering and contributes to stronger output quality. Kudos for that!

Honest disclosure, I work at @tesslio where we build tooling around skills like these. Not a pitch, just saw room for improvement and wanted to contribute.

If you want to self-improve your skills, or define your own scenarios to pressure test, just ask your agent (Claude Code, Codex, etc.) to evaluate and optimize your skill with Tessl. Ping me [@rohan-tessl](https://github.com/rohan-tessl), if you hit any snags.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->