### PR TITLE
Refactor e2e code intepreter tests

### DIFF
--- a/tests/e2e/code-interpreter-workflow.test.ts
+++ b/tests/e2e/code-interpreter-workflow.test.ts
@@ -23,7 +23,6 @@ import {
   createUniqueSession,
   type TestSandbox
 } from './helpers/global-sandbox';
-import { createTestHeaders } from './helpers/test-fixtures';
 import type { ErrorResponse } from './test-worker/types';
 
 describe('Code Interpreter Workflow (E2E)', () => {
@@ -441,7 +440,7 @@ for i in range(3):
   // Test 6: Error Handling
   // ============================================================================
 
-  test('error handling: invalid language, non-existent context, Python unavailable', async () => {
+  test('error handling: invalid language and non-existent context', async () => {
     // Invalid language
     const invalidLangResponse = await fetch(
       `${workerUrl}/api/code/context/create`,
@@ -475,12 +474,6 @@ for i in range(3):
     );
 
     // Delete non-existent context
-    await fetch(`${workerUrl}/api/execute`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({ command: 'true' }),
-      signal: AbortSignal.timeout(10000)
-    });
     const deleteFakeResponse = await fetch(
       `${workerUrl}/api/code/context/fake-id-99999`,
       { method: 'DELETE', headers, signal: AbortSignal.timeout(10000) }
@@ -489,15 +482,24 @@ for i in range(3):
     await expect(deleteFakeResponse.json()).resolves.toEqual(
       expect.objectContaining({ error: expect.anything() })
     );
+  }, 60000);
+});
 
-    // Python unavailable on base image
-    // Use base image headers (without python type) for this specific test
-    const baseImageHeaders = createTestHeaders(sandbox!.sandboxId);
+describe('Code Interpreter Workflow (E2E) - base image', () => {
+  test('error handling: Python unavailable on base image', async ({
+    onTestFinished
+  }) => {
+    // Uses its own base-image sandbox so the cold-start cost is paid in
+    // createTestSandbox() (which runs an init command) rather than inside
+    // the timed assertion below.
+    const sandbox = await createTestSandbox();
+    onTestFinished(() => cleanupTestSandbox(sandbox).catch(() => {}));
+
     const pythonUnavailableResponse = await fetch(
-      `${workerUrl}/api/code/context/create`,
+      `${sandbox.workerUrl}/api/code/context/create`,
       {
         method: 'POST',
-        headers: baseImageHeaders,
+        headers: sandbox.headers(createUniqueSession()),
         body: JSON.stringify({ language: 'python' }),
         signal: AbortSignal.timeout(10000)
       }

--- a/tests/e2e/test-worker/wrangler.template.jsonc
+++ b/tests/e2e/test-worker/wrangler.template.jsonc
@@ -22,7 +22,8 @@
       "class_name": "Sandbox",
       "image": "{{IMAGE_SANDBOX}}",
       "name": "{{CONTAINER_NAME}}",
-      "instance_type": "standard-4"
+      "instance_type": "standard-4",
+      "max_instances": 50
     },
     {
       "class_name": "SandboxPython",


### PR DESCRIPTION
This PR updates the code interpreter test for the missing Python runtime into it's own block so we don't provision two sandboxes for a single test. This will hopefully reduce the chance of the test flaking.

It also increases the max instances of the default sandbox from 20 to 50.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->