### PR TITLE
Inject auth credentials in OpenCode example

### DIFF
--- a/examples/opencode/README.md
+++ b/examples/opencode/README.md
@@ -1,15 +1,18 @@
 # OpenCode + Sandbox SDK
 
 Run OpenCode inside Cloudflare Sandboxes! Just open the worker URL in your browser to get the full OpenCode web experience.
+This example uses Worker-side egress interception to inject Anthropic credentials, so the real API key never enters the sandbox container.
 
 ## Quick Start
 
-1. Copy `.dev.vars.example` to `.dev.vars` and add your Anthropic API key:
+1. Copy `.dev.vars.example` to `.dev.vars` and add your Anthropic API key for the Worker:
 
 ```bash
 cp .dev.vars.example .dev.vars
 # Edit .dev.vars with your ANTHROPIC_API_KEY
 ```
+
+The Worker reads `ANTHROPIC_API_KEY` from its environment and injects it into intercepted outbound requests. OpenCode inside the container only sees placeholder credentials.
 
 2. Install dependencies and run:
 
@@ -36,11 +39,27 @@ OpenCode handles everything:
 - Web UI (proxied from `desktop.dev.opencode.ai`)
 - WebSocket for terminal
 
+## Credential Flow
+
+Anthropic credentials stay in the Worker runtime:
+
+- The Worker stores the real `ANTHROPIC_API_KEY` in `.dev.vars` locally or as a Wrangler secret in production.
+- OpenCode inside the container is configured with a placeholder API key and a base URL under `https://api.anthropic.com/v1`.
+- `Sandbox.outboundByHost['api.anthropic.com']` intercepts outbound requests from the container, injects the real `x-api-key` header, and forwards the request upstream over HTTPS.
+- The real API key is never exposed to processes running inside the container.
+
+For production, store the key as a secret instead of committing it anywhere:
+
+```bash
+wrangler secret put ANTHROPIC_API_KEY
+```
+
 ## Key Benefits
 
 - **Web UI** - Full browser-based OpenCode experience
 - **Isolated execution** - Code runs in secure sandbox containers
 - **Persistent sessions** - Sessions survive across requests
+- **Credential isolation** - Provider credentials stay in the Worker and are injected through outbound egress handlers
 
 ## Advanced: Cloudflare AI Gateway
 

--- a/examples/opencode/src/index.ts
+++ b/examples/opencode/src/index.ts
@@ -5,7 +5,11 @@
  * 1. Web UI - Browse to / for the full OpenCode web experience
  * 2. Programmatic - POST to /api/test for SDK-based automation
  */
-import { getSandbox } from '@cloudflare/sandbox';
+import {
+  Sandbox as BaseSandbox,
+  ContainerProxy,
+  getSandbox
+} from '@cloudflare/sandbox';
 import {
   createOpencode,
   createOpencodeServer,
@@ -14,14 +18,55 @@ import {
 import type { Config, Part } from '@opencode-ai/sdk/v2';
 import type { OpencodeClient } from '@opencode-ai/sdk/v2/client';
 
-export { Sandbox } from '@cloudflare/sandbox';
+export { ContainerProxy };
 
-const getConfig = (env: Env): Config => ({
+export class Sandbox extends BaseSandbox<Env> {
+  interceptHttps = true;
+}
+
+const PROXY_INJECTED_API_KEY = 'proxy-injected';
+const ANTHROPIC_PROXY_BASE_URL = 'https://api.anthropic.com/v1';
+
+function getRequestBody(request: Request): ReadableStream | null | undefined {
+  if (request.method === 'GET' || request.method === 'HEAD') {
+    return undefined;
+  }
+
+  return request.body;
+}
+
+function buildTargetURL(request: Request, origin: string): string {
+  const url = new URL(request.url);
+  return `${origin}${url.pathname}${url.search}`;
+}
+
+Sandbox.outboundByHost = {
+  'api.anthropic.com': async (request: Request, env: Env) => {
+    if (!env.ANTHROPIC_API_KEY) {
+      return new Response('ANTHROPIC_API_KEY is not configured', {
+        status: 500
+      });
+    }
+
+    const headers = new Headers(request.headers);
+    headers.set('x-api-key', env.ANTHROPIC_API_KEY);
+    headers.delete('authorization');
+
+    return fetch(buildTargetURL(request, 'https://api.anthropic.com'), {
+      method: request.method,
+      headers,
+      body: getRequestBody(request)
+    });
+  }
+};
+
+const getConfig = (): Config => ({
   provider: {
     // Option A: Direct Anthropic provider (requires ANTHROPIC_API_KEY)
     anthropic: {
       options: {
-        apiKey: env.ANTHROPIC_API_KEY
+        apiKey: PROXY_INJECTED_API_KEY,
+        baseURL: ANTHROPIC_PROXY_BASE_URL
       }
     }
 
@@ -48,13 +93,13 @@ export default {
 
     // Programmatic SDK test endpoint
     if (request.method === 'POST' && url.pathname === '/api/test') {
-      return handleSdkTest(sandbox, env);
+      return handleSdkTest(sandbox);
     }
 
     // Everything else: Web UI proxy
     const server = await createOpencodeServer(sandbox, {
       directory: '/home/user/agents',
-      config: getConfig(env)
+      config: getConfig()
       // Optional: Pass custom environment variables (e.g., for tracing/telemetry)
       // env: { TRACEPARENT: '00-abc123-def456-01' },
     });
@@ -66,14 +111,13 @@ export default {
  * Test the programmatic SDK access
  */
 async function handleSdkTest(
-  sandbox: ReturnType<typeof getSandbox>,
-  env: Env
+  sandbox: ReturnType<typeof getSandbox>
 ): Promise<Response> {
   try {
     // Get typed SDK client
     const { client } = await createOpencode<OpencodeClient>(sandbox, {
       directory: '/home/user/agents',
-      config: getConfig(env)
+      config: getConfig()
     });
 
     // Create a session

--- a/examples/opencode/wrangler.jsonc
+++ b/examples/opencode/wrangler.jsonc
@@ -6,7 +6,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "opencode-sandbox",
   "main": "src/index.ts",
-  "compatibility_date": "2025-05-06",
+  "compatibility_date": "2026-04-22",
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
     "enabled": true


### PR DESCRIPTION
# Summary

Utilising the new HTTPS egress interception API to intercept outbound requests from OpenCode to inject authorization credentials, so no credentials ever are passed into the sandbox container.