### PR TITLE
Fix local backup/restore when using RPC transport

### DIFF
--- a/.changeset/fix-local-backup-rpc-streaming.md
+++ b/.changeset/fix-local-backup-rpc-streaming.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Fixed `createBackup` and `restoreBackup` with `localBucket: true` failing on the `rpc` transport for archives larger than ~24 MiB.

--- a/examples/claude-code/src/index.ts
+++ b/examples/claude-code/src/index.ts
@@ -1,7 +1,6 @@
 import { Sandbox as BaseSandbox, getSandbox } from '@cloudflare/sandbox';
-import { escape } from 'querystring';
 
-export { ContainerProxy } from "@cloudflare/sandbox";
+export { ContainerProxy } from '@cloudflare/sandbox';
 
 export class Sandbox extends BaseSandbox<Env> {
   interceptHttps = true;
@@ -56,8 +55,11 @@ const EXTRA_SYSTEM =
 // outbound handler above and never enters the container.
 function placeholderAuthVars(env: Env): Record<string, string> {
   if (env.ANTHROPIC_API_KEY) return { ANTHROPIC_API_KEY: 'proxy-injected' };
-  if (env.CLAUDE_CODE_OAUTH_TOKEN) return { CLAUDE_CODE_OAUTH_TOKEN: 'proxy-injected' };
-  throw new Error('No Anthropic credential configured (set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN)');
+  if (env.CLAUDE_CODE_OAUTH_TOKEN)
+    return { CLAUDE_CODE_OAUTH_TOKEN: 'proxy-injected' };
+  throw new Error(
+    'No Anthropic credential configured (set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN)'
+  );
 }
 
 async function runTask(request: Request, env: Env): Promise<Response> {
@@ -66,14 +68,16 @@ async function runTask(request: Request, env: Env): Promise<Response> {
       repo?: string;
       task?: string;
     }>();
-    if (!repo || !task)
-      return new Response('invalid body', { status: 400 });
+    if (!repo || !task) return new Response('invalid body', { status: 400 });
 
     // get the repo name
     const name = repo.split('/').pop() ?? 'tmp';
 
     // derive a stable sandbox id from the repo name (sha-256, first 8 hex chars)
-    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(repo));
+    const digest = await crypto.subtle.digest(
+      'SHA-256',
+      new TextEncoder().encode(repo)
+    );
     const sandboxId = Array.from(new Uint8Array(digest))
       .map((b) => b.toString(16).padStart(2, '0'))
       .join('')
@@ -89,7 +93,11 @@ async function runTask(request: Request, env: Env): Promise<Response> {
     // Kick off CC with our query.
     const cmd = `claude --print --permission-mode bypassPermissions --append-system-prompt ${shellQuote(EXTRA_SYSTEM)} ${shellQuote(task)}`;
 
-    const logs = getOutput(await sandbox.exec(cmd, {env: {IS_SANDBOX: "1", ...placeholderAuthVars(env)}}));
+    const logs = getOutput(
+      await sandbox.exec(cmd, {
+        env: { IS_SANDBOX: '1', ...placeholderAuthVars(env) }
+      })
+    );
     const diff = getOutput(await sandbox.exec('git diff'));
 
     return Response.json({ logs, diff });
@@ -100,7 +108,8 @@ async function runTask(request: Request, env: Env): Promise<Response> {
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    if (request.method !== 'POST') return new Response('method not allowed', { status: 405 });
+    if (request.method !== 'POST')
+      return new Response('method not allowed', { status: 405 });
 
     const { pathname } = new URL(request.url);
     if (pathname !== '/') return new Response('not found');

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -66,7 +66,7 @@ import {
   SandboxError,
   SessionAlreadyExistsError
 } from './errors';
-import { collectFile } from './file-stream';
+import { collectFile, streamFile } from './file-stream';
 import { CodeInterpreter } from './interpreter';
 import { LocalMountSyncManager } from './local-mount-sync';
 import { proxyTerminal } from './pty';
@@ -5287,19 +5287,34 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       const r2Key = `${BACKUP_STORAGE_PREFIX}/${backupId}/${BACKUP_ARCHIVE_OBJECT_NAME}`;
       const metaKey = `${BACKUP_STORAGE_PREFIX}/${backupId}/${BACKUP_METADATA_OBJECT_NAME}`;
 
-      // Step 2: Read archive from container via file streaming, upload to R2 via binding
+      // Step 2: Read archive from container and stream it into R2 via binding.
+      // readFileStream returns SSE-framed base64 chunks, so we pipe it through
+      // streamFile (which decodes SSE frames + base64 on the fly) into a
+      // FixedLengthStream backed by the known archive size. This avoids
+      // buffering the whole archive in Worker memory.
       const archiveStream = await this.client.files.readFileStream(
         archivePath,
         backupSession
       );
-      const { content } = await collectFile(archiveStream);
-      const archiveData =
-        content instanceof Uint8Array
-          ? content
-          : new TextEncoder().encode(content);
-      await bucket.put(r2Key, archiveData);
+      const sseDecoded = new ReadableStream<Uint8Array>({
+        async start(controller) {
+          try {
+            for await (const chunk of streamFile(archiveStream)) {
+              if (chunk instanceof Uint8Array) {
+                controller.enqueue(chunk);
+              }
+            }
+            controller.close();
+          } catch (err) {
+            controller.error(err);
+          }
+        }
+      });
+      const fixedStream = new FixedLengthStream(createResult.sizeBytes);
+      sseDecoded.pipeTo(fixedStream.writable).catch(() => {});
+      await bucket.put(r2Key, fixedStream.readable);
 
-      // Verify upload
+      // Verify upload — size comes from createArchive result, not the stream.
       const head = await bucket.head(r2Key);
       if (!head || head.size !== createResult.sizeBytes) {
         throw new BackupCreateError({
@@ -5720,42 +5735,57 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       backupSession = await this.ensureBackupSession();
       const archivePath = `${BACKUP_CONTAINER_DIR}/${id}.sqsh`;
 
-      const archiveBuffer = await archiveObject.arrayBuffer();
-      const base64Content = Buffer.from(archiveBuffer).toString('base64');
-
       // Ensure backup directory exists
       await this.execWithSession(
         `mkdir -p ${BACKUP_CONTAINER_DIR}`,
         backupSession,
-        {
-          origin: 'internal'
+        { origin: 'internal' }
+      );
+
+      // Write the archive into the container.
+      // On the rpc transport, stream R2ObjectBody.body directly via
+      // writeFileStream to avoid base64-encoding the whole archive in Worker
+      // memory and hitting workerd's 32 MiB RPC payload cap.
+      // On http/websocket transports, fall back to the base64 writeFile path
+      // (those transports send via HTTP POST to the container, no RPC cap).
+      if (this.transport === 'rpc') {
+        const body = archiveObject.body;
+        if (!body) {
+          throw new BackupRestoreError({
+            message: `R2 archive object has no body stream for backup ${id}`,
+            code: ErrorCode.BACKUP_RESTORE_FAILED,
+            httpStatus: 500,
+            context: { dir, backupId: id },
+            timestamp: new Date().toISOString()
+          });
         }
-      );
-
-      const writeResult = await this.client.files.writeFile(
-        archivePath,
-        base64Content,
-        backupSession,
-        { encoding: 'base64' }
-      );
-
-      if (!writeResult.success) {
-        const writeErrorMessage =
-          'error' in writeResult &&
-          typeof writeResult.error === 'object' &&
-          writeResult.error !== null &&
-          'message' in writeResult.error &&
-          typeof writeResult.error.message === 'string'
-            ? writeResult.error.message
-            : `File write returned success: false for '${archivePath}'`;
-
-        throw new BackupRestoreError({
-          message: `Failed to write backup archive to ${archivePath}: ${writeErrorMessage}`,
-          code: ErrorCode.BACKUP_RESTORE_FAILED,
-          httpStatus: 500,
-          context: { dir, backupId: id },
-          timestamp: new Date().toISOString()
-        });
+        await this.client.writeFileStream(archivePath, body, backupSession);
+      } else {
+        const archiveBuffer = await archiveObject.arrayBuffer();
+        const base64Content = Buffer.from(archiveBuffer).toString('base64');
+        const writeResult = await this.client.files.writeFile(
+          archivePath,
+          base64Content,
+          backupSession,
+          { encoding: 'base64' }
+        );
+        if (!writeResult.success) {
+          const writeErrorMessage =
+            'error' in writeResult &&
+            typeof writeResult.error === 'object' &&
+            writeResult.error !== null &&
+            'message' in writeResult.error &&
+            typeof writeResult.error.message === 'string'
+              ? writeResult.error.message
+              : `File write returned success: false for '${archivePath}'`;
+          throw new BackupRestoreError({
+            message: `Failed to write backup archive to ${archivePath}: ${writeErrorMessage}`,
+            code: ErrorCode.BACKUP_RESTORE_FAILED,
+            httpStatus: 500,
+            context: { dir, backupId: id },
+            timestamp: new Date().toISOString()
+          });
+        }
       }
 
       // Step 3: Extract archive using unsquashfs (no FUSE needed)

--- a/tests/e2e/backup-workflow.test.ts
+++ b/tests/e2e/backup-workflow.test.ts
@@ -1118,3 +1118,137 @@ describe('Backup Workflow E2E', () => {
     }, 90000);
   });
 });
+
+describe('Large localBucket backup (>32 MiB RPC payload)', () => {
+  const isRPCTransport = process.env.TEST_TRANSPORT === 'rpc';
+
+  let sandbox: TestSandbox | null = null;
+  let workerUrl: string;
+  let headers: Record<string, string>;
+  let backupBucketAvailable = false;
+
+  beforeAll(async () => {
+    sandbox = await createTestSandbox();
+    workerUrl = sandbox.workerUrl;
+    headers = sandbox.headers(createUniqueSession());
+
+    // Probe for BACKUP_BUCKET — Miniflare R2 is always available locally
+    const probe = await fetch(`${workerUrl}/api/backup/create`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ dir: '/nonexistent-probe-dir' })
+    });
+    const probeText = await probe.text();
+    if (
+      !probeText.includes('BACKUP_BUCKET') &&
+      !probeText.includes('not configured')
+    ) {
+      backupBucketAvailable = true;
+    }
+  }, 120000);
+
+  afterAll(async () => {
+    await cleanupTestSandbox(sandbox);
+    sandbox = null;
+  }, 120000);
+
+  test('should round-trip a 40 MiB localBucket backup without 1011 WebSocket error', async () => {
+    if (!backupBucketAvailable) return;
+
+    const TEST_DIR = `/workspace/large-backup-test-${crypto.randomUUID().slice(0, 8)}`;
+
+    // 40 MiB of incompressible random data — squashfs won't compress it,
+    // so the archive stays large and crosses the 32 MiB RPC payload cap.
+    const seedResult = (await (
+      await fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          command: [
+            `mkdir -p ${TEST_DIR}`,
+            `dd if=/dev/urandom of=${TEST_DIR}/blob.bin bs=1M count=40 status=none`,
+            `sha256sum ${TEST_DIR}/blob.bin`
+          ].join(' && ')
+        })
+      })
+    ).json()) as ExecuteResponse;
+    expect(seedResult.exitCode).toBe(0);
+    const originalSha = seedResult.stdout?.trim().split(/\s+/)[0];
+    expect(originalSha).toMatch(/^[0-9a-f]{64}$/);
+
+    // Create backup with localBucket: true
+    const backupResponse = await fetch(`${workerUrl}/api/backup/create`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        dir: TEST_DIR,
+        name: 'large-local-backup',
+        ttl: 3600,
+        localBucket: true
+      })
+    });
+    if (!backupResponse.ok) {
+      throw new Error(`createBackup failed: ${await backupResponse.text()}`);
+    }
+    const backup = (await backupResponse.json()) as BackupResponse;
+    expect(backup.id).toBeDefined();
+
+    // Mutate so the restore is observable, then verify the mutation actually
+    // took effect — if this failed silently the final SHA check could pass
+    // even without a real restore.
+    const mutateResult = (await (
+      await fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          command: [
+            `echo gone > ${TEST_DIR}/blob.bin`,
+            `sha256sum ${TEST_DIR}/blob.bin`
+          ].join(' && ')
+        })
+      })
+    ).json()) as ExecuteResponse;
+    expect(mutateResult.exitCode).toBe(0);
+    const mutatedSha = mutateResult.stdout?.trim().split(/\s+/)[0];
+    expect(mutatedSha).toMatch(/^[0-9a-f]{64}$/);
+    expect(mutatedSha).not.toBe(originalSha);
+
+    // Restore — this blows up with 1011 on rpc transport before the fix
+    const restoreResponse = await fetch(`${workerUrl}/api/backup/restore`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ id: backup.id, dir: TEST_DIR, localBucket: true })
+    });
+    if (!restoreResponse.ok) {
+      const msg = await restoreResponse.text();
+      throw new Error(
+        `restoreBackup failed on ${isRPCTransport ? 'rpc' : (process.env.TEST_TRANSPORT ?? 'http')} transport: ${msg}`
+      );
+    }
+    const restoreResult = (await restoreResponse.json()) as RestoreResponse;
+    expect(restoreResult.success).toBe(true);
+
+    // Verify byte-for-byte equality via sha256
+    const verifyResult = (await (
+      await fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          command: [
+            `sha256sum ${TEST_DIR}/blob.bin`,
+            `wc -c ${TEST_DIR}/blob.bin`
+          ].join(' && ')
+        })
+      })
+    ).json()) as ExecuteResponse;
+    expect(verifyResult.exitCode).toBe(0);
+    const restoredSha = verifyResult.stdout
+      ?.trim()
+      .split('\n')[0]
+      .split(/\s+/)[0];
+    expect(restoredSha).toBe(originalSha);
+    expect(verifyResult.stdout).toContain('41943040');
+
+    await cleanupDir(workerUrl, headers, TEST_DIR);
+  }, 120000);
+});

--- a/tests/e2e/backup-workflow.test.ts
+++ b/tests/e2e/backup-workflow.test.ts
@@ -1152,103 +1152,111 @@ describe('Large localBucket backup (>32 MiB RPC payload)', () => {
     sandbox = null;
   }, 120000);
 
-  test('should round-trip a 40 MiB localBucket backup without 1011 WebSocket error', async () => {
-    if (!backupBucketAvailable) return;
+  test.skipIf(process.env.TEST_TRANSPORT === 'websocket')(
+    'should round-trip a 40 MiB localBucket backup without 1011 WebSocket error',
+    async () => {
+      if (!backupBucketAvailable) return;
 
-    const TEST_DIR = `/workspace/large-backup-test-${crypto.randomUUID().slice(0, 8)}`;
+      const TEST_DIR = `/workspace/large-backup-test-${crypto.randomUUID().slice(0, 8)}`;
 
-    // 40 MiB of incompressible random data — squashfs won't compress it,
-    // so the archive stays large and crosses the 32 MiB RPC payload cap.
-    const seedResult = (await (
-      await fetch(`${workerUrl}/api/execute`, {
+      // 40 MiB of incompressible random data — squashfs won't compress it,
+      // so the archive stays large and crosses the 32 MiB RPC payload cap.
+      const seedResult = (await (
+        await fetch(`${workerUrl}/api/execute`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            command: [
+              `mkdir -p ${TEST_DIR}`,
+              `dd if=/dev/urandom of=${TEST_DIR}/blob.bin bs=1M count=40 status=none`,
+              `sha256sum ${TEST_DIR}/blob.bin`
+            ].join(' && ')
+          })
+        })
+      ).json()) as ExecuteResponse;
+      expect(seedResult.exitCode).toBe(0);
+      const originalSha = seedResult.stdout?.trim().split(/\s+/)[0];
+      expect(originalSha).toMatch(/^[0-9a-f]{64}$/);
+
+      // Create backup with localBucket: true
+      const backupResponse = await fetch(`${workerUrl}/api/backup/create`, {
         method: 'POST',
         headers,
         body: JSON.stringify({
-          command: [
-            `mkdir -p ${TEST_DIR}`,
-            `dd if=/dev/urandom of=${TEST_DIR}/blob.bin bs=1M count=40 status=none`,
-            `sha256sum ${TEST_DIR}/blob.bin`
-          ].join(' && ')
+          dir: TEST_DIR,
+          name: 'large-local-backup',
+          ttl: 3600,
+          localBucket: true
         })
-      })
-    ).json()) as ExecuteResponse;
-    expect(seedResult.exitCode).toBe(0);
-    const originalSha = seedResult.stdout?.trim().split(/\s+/)[0];
-    expect(originalSha).toMatch(/^[0-9a-f]{64}$/);
+      });
+      if (!backupResponse.ok) {
+        throw new Error(`createBackup failed: ${await backupResponse.text()}`);
+      }
+      const backup = (await backupResponse.json()) as BackupResponse;
+      expect(backup.id).toBeDefined();
 
-    // Create backup with localBucket: true
-    const backupResponse = await fetch(`${workerUrl}/api/backup/create`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        dir: TEST_DIR,
-        name: 'large-local-backup',
-        ttl: 3600,
-        localBucket: true
-      })
-    });
-    if (!backupResponse.ok) {
-      throw new Error(`createBackup failed: ${await backupResponse.text()}`);
-    }
-    const backup = (await backupResponse.json()) as BackupResponse;
-    expect(backup.id).toBeDefined();
+      // Mutate so the restore is observable, then verify the mutation actually
+      // took effect — if this failed silently the final SHA check could pass
+      // even without a real restore.
+      const mutateResult = (await (
+        await fetch(`${workerUrl}/api/execute`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            command: [
+              `echo gone > ${TEST_DIR}/blob.bin`,
+              `sha256sum ${TEST_DIR}/blob.bin`
+            ].join(' && ')
+          })
+        })
+      ).json()) as ExecuteResponse;
+      expect(mutateResult.exitCode).toBe(0);
+      const mutatedSha = mutateResult.stdout?.trim().split(/\s+/)[0];
+      expect(mutatedSha).toMatch(/^[0-9a-f]{64}$/);
+      expect(mutatedSha).not.toBe(originalSha);
 
-    // Mutate so the restore is observable, then verify the mutation actually
-    // took effect — if this failed silently the final SHA check could pass
-    // even without a real restore.
-    const mutateResult = (await (
-      await fetch(`${workerUrl}/api/execute`, {
+      // Restore — this blows up with 1011 on rpc transport before the fix
+      const restoreResponse = await fetch(`${workerUrl}/api/backup/restore`, {
         method: 'POST',
         headers,
         body: JSON.stringify({
-          command: [
-            `echo gone > ${TEST_DIR}/blob.bin`,
-            `sha256sum ${TEST_DIR}/blob.bin`
-          ].join(' && ')
+          id: backup.id,
+          dir: TEST_DIR,
+          localBucket: true
         })
-      })
-    ).json()) as ExecuteResponse;
-    expect(mutateResult.exitCode).toBe(0);
-    const mutatedSha = mutateResult.stdout?.trim().split(/\s+/)[0];
-    expect(mutatedSha).toMatch(/^[0-9a-f]{64}$/);
-    expect(mutatedSha).not.toBe(originalSha);
+      });
+      if (!restoreResponse.ok) {
+        const msg = await restoreResponse.text();
+        throw new Error(
+          `restoreBackup failed on ${isRPCTransport ? 'rpc' : (process.env.TEST_TRANSPORT ?? 'http')} transport: ${msg}`
+        );
+      }
+      const restoreResult = (await restoreResponse.json()) as RestoreResponse;
+      expect(restoreResult.success).toBe(true);
 
-    // Restore — this blows up with 1011 on rpc transport before the fix
-    const restoreResponse = await fetch(`${workerUrl}/api/backup/restore`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({ id: backup.id, dir: TEST_DIR, localBucket: true })
-    });
-    if (!restoreResponse.ok) {
-      const msg = await restoreResponse.text();
-      throw new Error(
-        `restoreBackup failed on ${isRPCTransport ? 'rpc' : (process.env.TEST_TRANSPORT ?? 'http')} transport: ${msg}`
-      );
-    }
-    const restoreResult = (await restoreResponse.json()) as RestoreResponse;
-    expect(restoreResult.success).toBe(true);
-
-    // Verify byte-for-byte equality via sha256
-    const verifyResult = (await (
-      await fetch(`${workerUrl}/api/execute`, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({
-          command: [
-            `sha256sum ${TEST_DIR}/blob.bin`,
-            `wc -c ${TEST_DIR}/blob.bin`
-          ].join(' && ')
+      // Verify byte-for-byte equality via sha256
+      const verifyResult = (await (
+        await fetch(`${workerUrl}/api/execute`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            command: [
+              `sha256sum ${TEST_DIR}/blob.bin`,
+              `wc -c ${TEST_DIR}/blob.bin`
+            ].join(' && ')
+          })
         })
-      })
-    ).json()) as ExecuteResponse;
-    expect(verifyResult.exitCode).toBe(0);
-    const restoredSha = verifyResult.stdout
-      ?.trim()
-      .split('\n')[0]
-      .split(/\s+/)[0];
-    expect(restoredSha).toBe(originalSha);
-    expect(verifyResult.stdout).toContain('41943040');
+      ).json()) as ExecuteResponse;
+      expect(verifyResult.exitCode).toBe(0);
+      const restoredSha = verifyResult.stdout
+        ?.trim()
+        .split('\n')[0]
+        .split(/\s+/)[0];
+      expect(restoredSha).toBe(originalSha);
+      expect(verifyResult.stdout).toContain('41943040');
 
-    await cleanupDir(workerUrl, headers, TEST_DIR);
-  }, 120000);
+      await cleanupDir(workerUrl, headers, TEST_DIR);
+    },
+    180000
+  );
 });


### PR DESCRIPTION
This change fixes restore flow on the RPC transport to stream the archive to the sandbox using the streaming write file flow. This avoids the 32 MiB limit on RPC payloads.

For backup we now always stream the data to R2 regardless of transport type avoiding buffering the archive into memory.
