### PR TITLE
Add RPC only readFile({ encoding: 'none' }) to return ReadableStream

### DIFF
--- a/.changeset/readfile-none-encoding.md
+++ b/.changeset/readfile-none-encoding.md
@@ -1,0 +1,13 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+`readFile` now accepts `encoding: 'none'` on the `rpc` transport, returning a result whose `content` is a `ReadableStream<Uint8Array>` of raw binary data with no base64 encoding or buffering. Mirrors the existing `writeFile` support for `ReadableStream` input.
+
+```ts
+// Stream a binary file without buffering or base64 overhead (rpc transport only)
+const { content, size, mimeType } = await sandbox.readFile(
+  '/workspace/image.png',
+  { encoding: 'none' }
+);
+```

--- a/packages/sandbox-container/src/control-plane/api.ts
+++ b/packages/sandbox-container/src/control-plane/api.ts
@@ -18,6 +18,7 @@ import type {
   DesktopStatusResult,
   DesktopStopResult,
   ExecutionError,
+  FileEncoding,
   FileInfo,
   ListFilesOptions,
   Logger,
@@ -293,8 +294,50 @@ class FilesRPCAPI extends RpcTarget {
   async readFile(
     path: string,
     sessionId: string,
-    options?: { encoding?: string }
+    options: { encoding: 'none' }
+  ): Promise<{
+    success: true;
+    content: ReadableStream<Uint8Array>;
+    path: string;
+    size: number;
+    mimeType: string;
+    timestamp: string;
+  }>;
+  async readFile(
+    path: string,
+    sessionId: string,
+    options?: { encoding?: Exclude<FileEncoding, 'none'> }
+  ): Promise<{
+    success: true;
+    content: string;
+    path: string;
+    encoding: 'utf-8' | 'base64';
+    isBinary: boolean | undefined;
+    size: number;
+    mimeType: string;
+    timestamp: string;
+  }>;
+  async readFile(
+    path: string,
+    sessionId: string,
+    options?: { encoding?: FileEncoding }
   ) {
+    if (options?.encoding === 'none') {
+      const result = await this.#svc.readFileBinaryStream(path, sessionId);
+      const { content, size, mimeType } = extractData<{
+        content: ReadableStream<Uint8Array>;
+        size: number;
+        mimeType: string;
+      }>(result);
+      return {
+        success: true,
+        content,
+        path,
+        size,
+        mimeType,
+        timestamp: new Date().toISOString()
+      };
+    }
     const result = await this.#svc.readFile(path, options, sessionId);
     const content = extractData<string>(result);
     const metadata = (

--- a/packages/sandbox-container/src/services/file-service.ts
+++ b/packages/sandbox-container/src/services/file-service.ts
@@ -1686,6 +1686,97 @@ export class FileService implements FileSystemOperations {
    * Resolve a complete path in the context of the session's current working directory.  If the
    * provided path is relative, we append the session's current working directory to it.
    */
+  /**
+   * Stream raw binary file contents without SSE framing or base64 encoding.
+   * Intended for the RPC transport where the stream passes directly to the
+   * caller over the capnp binary channel — no encoding overhead.
+   *
+   * Validates the path, resolves relative paths via the session's cwd, then
+   * returns Bun's native file stream alongside the file size and MIME type.
+   *
+   * Returns a `ServiceResult` so callers receive typed `ErrorCode` values
+   * (e.g. `FILE_NOT_FOUND`, `VALIDATION_FAILED`) rather than plain throws.
+   */
+  async readFileBinaryStream(
+    path: string,
+    sessionId = 'default'
+  ): Promise<
+    ServiceResult<{
+      content: ReadableStream<Uint8Array>;
+      size: number;
+      mimeType: string;
+    }>
+  > {
+    // Validate path for security.
+    const validation = this.security.validatePath(path);
+    if (!validation.isValid) {
+      return {
+        success: false,
+        error: {
+          message: `Invalid path format for '${path}': ${validation.errors.join(', ')}`,
+          code: ErrorCode.VALIDATION_FAILED,
+          details: {
+            validationErrors: validation.errors.map((e) => ({
+              field: 'path',
+              message: e,
+              code: 'INVALID_PATH'
+            }))
+          } satisfies ValidationFailedContext
+        }
+      };
+    }
+
+    // Resolve relative paths via the session's working directory.
+    let resolvedPath = path;
+    if (!path.startsWith('/')) {
+      const result = await this.sessionManager.withSession(
+        sessionId,
+        async (exec) => this.resolvePathInSession(path, exec)
+      );
+      if (!result.success) {
+        return {
+          success: false,
+          error: {
+            message: `Failed to resolve path '${path}'`,
+            code: ErrorCode.FILESYSTEM_ERROR,
+            details: {
+              path,
+              operation: Operation.FILE_READ,
+              stderr: 'withSession failed'
+            } satisfies FileSystemContext
+          }
+        };
+      }
+      resolvedPath = result.data as string;
+    }
+
+    // Check existence and return the stream.
+    const file = Bun.file(resolvedPath);
+    const exists = await file.exists();
+    if (!exists) {
+      return {
+        success: false,
+        error: {
+          message: `File not found: ${resolvedPath}`,
+          code: ErrorCode.FILE_NOT_FOUND,
+          details: {
+            path: resolvedPath,
+            operation: Operation.FILE_READ
+          } satisfies FileNotFoundContext
+        }
+      };
+    }
+
+    return {
+      success: true,
+      data: {
+        content: file.stream(),
+        size: file.size,
+        mimeType: file.type || 'application/octet-stream'
+      }
+    };
+  }
+
   private async resolvePathInSession(
     path: string,
     exec: (

--- a/packages/sandbox-container/tests/services/file-service.test.ts
+++ b/packages/sandbox-container/tests/services/file-service.test.ts
@@ -8,6 +8,7 @@ import {
   vi
 } from 'bun:test';
 import type { Logger } from '@repo/shared';
+import { ErrorCode } from '@repo/shared/errors';
 import type { ServiceResult } from '@sandbox-container/core/types';
 import {
   FileService,
@@ -1312,6 +1313,114 @@ describe('FileService', () => {
       // Should have error event
       expect(sseEvents[0].type).toBe('error');
       expect(sseEvents[0].error).toContain('File not found');
+    });
+  });
+
+  describe('readFileBinaryStream', () => {
+    it('returns a raw binary ReadableStream with metadata for an existing file', async () => {
+      const fileBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // PNG magic bytes
+      mockBunFile({
+        exists: true,
+        size: fileBytes.byteLength,
+        type: 'image/png',
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue(fileBytes);
+            controller.close();
+          }
+        })
+      });
+
+      const result = await fileService.readFileBinaryStream(
+        '/tmp/image.png',
+        'session-1'
+      );
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      const { content, size, mimeType } = result.data;
+
+      expect(size).toBe(fileBytes.byteLength);
+      expect(mimeType).toBe('image/png');
+
+      const reader = content.getReader();
+      const chunks: Uint8Array[] = [];
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+      const assembled = new Uint8Array(
+        chunks.reduce((acc, c) => acc + c.byteLength, 0)
+      );
+      let offset = 0;
+      for (const c of chunks) {
+        assembled.set(c, offset);
+        offset += c.byteLength;
+      }
+
+      expect(assembled).toEqual(fileBytes);
+    });
+
+    it('returns FILE_NOT_FOUND when the file does not exist', async () => {
+      mockBunFile({ exists: false });
+
+      const result = await fileService.readFileBinaryStream(
+        '/tmp/nonexistent.bin',
+        'session-1'
+      );
+
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error.code).toBe(ErrorCode.FILE_NOT_FOUND);
+      expect(result.error.message).toContain('nonexistent.bin');
+    });
+
+    it('returns VALIDATION_FAILED for invalid paths', async () => {
+      mocked(mockSecurityService.validatePath).mockReturnValue({
+        isValid: false,
+        errors: ['Path traversal detected']
+      });
+
+      const result = await fileService.readFileBinaryStream(
+        '/tmp/../etc/passwd',
+        'session-1'
+      );
+
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error.code).toBe(ErrorCode.VALIDATION_FAILED);
+      expect(result.error.message).toContain('Path traversal detected');
+    });
+
+    it('resolves relative paths via session working directory', async () => {
+      const fileBytes = new Uint8Array([1, 2, 3, 4]);
+      mockBunFile({
+        exists: true,
+        size: fileBytes.byteLength,
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue(fileBytes);
+            controller.close();
+          }
+        })
+      });
+
+      // pwd returns /workspace, so 'blob.bin' resolves to '/workspace/blob.bin'
+      mocked(mockSessionManager.executeInSession).mockResolvedValue({
+        success: true,
+        data: { exitCode: 0, stdout: '/workspace', stderr: '' } as RawExecResult
+      });
+
+      const result = await fileService.readFileBinaryStream(
+        'blob.bin',
+        'session-1'
+      );
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.content).toBeInstanceOf(ReadableStream);
+      // Bun.file should have been called with the resolved absolute path
+      expect(bunFileSpy).toHaveBeenCalledWith('/workspace/blob.bin');
     });
   });
 });

--- a/packages/sandbox/src/clients/file-client.ts
+++ b/packages/sandbox/src/clients/file-client.ts
@@ -1,11 +1,13 @@
 import type {
   DeleteFileResult,
+  FileEncoding,
   FileExistsResult,
   ListFilesOptions,
   ListFilesResult,
   MkdirResult,
   MoveFileResult,
   ReadFileResult,
+  ReadFileStreamResult,
   RenameFileResult,
   WriteFileResult
 } from '@repo/shared';
@@ -97,16 +99,36 @@ export class FileClient extends BaseHttpClient {
   }
 
   /**
-   * Read content from a file
+   * Read content from a file.
+   *
    * @param path - File path to read from
    * @param sessionId - The session ID for this operation
    * @param options - Optional settings (encoding)
+   *
+   * When `encoding` is `'none'`, returns a `ReadFileStreamResult` whose
+   * `content` is a raw `ReadableStream<Uint8Array>`. This variant only works
+   * on the `rpc` transport; HTTP and WebSocket transports throw at runtime.
    */
   async readFile(
     path: string,
     sessionId: string,
-    options?: { encoding?: string }
-  ): Promise<ReadFileResult> {
+    options: { encoding: 'none' }
+  ): Promise<ReadFileStreamResult>;
+  async readFile(
+    path: string,
+    sessionId: string,
+    options?: { encoding?: Exclude<FileEncoding, 'none'> }
+  ): Promise<ReadFileResult>;
+  async readFile(
+    path: string,
+    sessionId: string,
+    options?: { encoding?: FileEncoding }
+  ): Promise<ReadFileResult | ReadFileStreamResult> {
+    if (options?.encoding === 'none') {
+      throw new Error(
+        "readFile with encoding: 'none' requires the rpc transport. Set SANDBOX_TRANSPORT=rpc."
+      );
+    }
     const data = {
       path,
       sessionId,
@@ -223,5 +245,24 @@ export class FileClient extends BaseHttpClient {
     const response = await this.post<FileExistsResult>('/api/exists', data);
 
     return response;
+  }
+
+  /**
+   * Write a file via a raw binary stream over the RPC transport.
+   * Throws on HTTP and WebSocket transports — use writeFile() with a string instead.
+   */
+  writeFileStream(
+    _path: string,
+    _content: ReadableStream<Uint8Array>,
+    _sessionId: string
+  ): Promise<{
+    success: boolean;
+    path: string;
+    bytesWritten: number;
+    timestamp: string;
+  }> {
+    throw new Error(
+      'writeFileStream requires the rpc transport. Set SANDBOX_TRANSPORT=rpc.'
+    );
   }
 }

--- a/packages/sandbox/src/clients/sandbox-client.ts
+++ b/packages/sandbox/src/clients/sandbox-client.ts
@@ -115,28 +115,6 @@ export class SandboxClient {
   }
 
   /**
-   * Stream a file directly to the container over a binary RPC channel.
-   *
-   * Requires the container-control path (`transport: 'rpc'`). Calling this
-   * method with the HTTP or WebSocket route transports throws an error because
-   * those transports do not support binary streaming.
-   */
-  writeFileStream(
-    _path: string,
-    _content: ReadableStream<Uint8Array>,
-    _sessionId: string
-  ): Promise<{
-    success: boolean;
-    path: string;
-    bytesWritten: number;
-    timestamp: string;
-  }> {
-    throw new Error(
-      'writeFileStream requires the RPC transport. Enable it with transport: "rpc" in sandbox options.'
-    );
-  }
-
-  /**
    * Connect WebSocket transport (no-op in HTTP mode)
    * Called automatically on first request, but can be called explicitly
    * to establish connection upfront.

--- a/packages/sandbox/src/container-control/client.ts
+++ b/packages/sandbox/src/container-control/client.ts
@@ -563,7 +563,10 @@ export class ContainerControlClient {
     return wrapStub(this.getConnection().rpc().commands, this.renewActivity);
   }
   get files(): SandboxFilesAPI {
-    return wrapStub(this.getConnection().rpc().files, this.renewActivity);
+    return wrapStub(
+      this.getConnection().rpc().files,
+      this.renewActivity
+    ) as unknown as SandboxFilesAPI;
   }
   get processes(): SandboxProcessesAPI {
     return wrapStub(this.getConnection().rpc().processes, this.renewActivity);
@@ -614,19 +617,6 @@ export class ContainerControlClient {
 
   disconnect(): void {
     this.destroyConnection();
-  }
-
-  async writeFileStream(
-    path: string,
-    stream: ReadableStream<Uint8Array>,
-    sessionId: string
-  ): Promise<{
-    success: boolean;
-    path: string;
-    bytesWritten: number;
-    timestamp: string;
-  }> {
-    return this.files.writeFileStream(path, stream, sessionId);
   }
 }
 

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -13,6 +13,7 @@ import type {
   ExecResult,
   ExecutionResult,
   ExecutionSession,
+  FileEncoding,
   ISandbox,
   LocalMountBucketOptions,
   LogEvent,
@@ -22,6 +23,8 @@ import type {
   ProcessOptions,
   ProcessStatus,
   PtyOptions,
+  ReadFileResult,
+  ReadFileStreamResult,
   RemoteMountBucketOptions,
   RestoreBackupResult,
   RunCodeOptions,
@@ -3441,7 +3444,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     const session = options.sessionId ?? (await this.ensureDefaultSession());
 
     if (content instanceof ReadableStream) {
-      return this.client.writeFileStream(path, content, session);
+      return this.client.files.writeFileStream(path, content, session);
     }
 
     return this.client.files.writeFile(path, content, session, {
@@ -3468,11 +3471,32 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     return this.client.files.moveFile(sourcePath, destinationPath, session);
   }
 
+  /**
+   * Read a file from the sandbox.
+   *
+   * @param encoding - How to encode the returned content:
+   *   - `undefined` (default): auto-detect from MIME type (text → UTF-8 string, binary → base64 string)
+   *   - `'utf-8'` / `'utf8'`: always return as UTF-8 string
+   *   - `'base64'`: always return as base64-encoded string
+   *   - `'none'`: return a result whose `content` is a raw binary `ReadableStream<Uint8Array>`
+   *              with no encoding overhead. **Requires `SANDBOX_TRANSPORT=rpc`.** Throws on HTTP/WebSocket transports.
+   */
   async readFile(
     path: string,
-    options: { encoding?: string; sessionId?: string } = {}
-  ) {
+    options: { encoding: 'none'; sessionId?: string }
+  ): Promise<ReadFileStreamResult>;
+  async readFile(
+    path: string,
+    options?: { encoding?: Exclude<FileEncoding, 'none'>; sessionId?: string }
+  ): Promise<ReadFileResult>;
+  async readFile(
+    path: string,
+    options: { encoding?: FileEncoding; sessionId?: string } = {}
+  ): Promise<ReadFileResult | ReadFileStreamResult> {
     const session = options.sessionId ?? (await this.ensureDefaultSession());
+    if (options.encoding === 'none') {
+      return this.client.files.readFile(path, session, { encoding: 'none' });
+    }
     return this.client.files.readFile(path, session, {
       encoding: options.encoding
     });
@@ -4103,8 +4127,16 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       // File operations - pass sessionId via options or parameter
       writeFile: (path, content, options) =>
         this.writeFile(path, content, { ...options, sessionId }),
-      readFile: (path, options) =>
-        this.readFile(path, { ...options, sessionId }),
+      readFile: ((
+        path: string,
+        options?: { encoding?: FileEncoding; sessionId?: string }
+      ) => {
+        const encoding = options?.encoding;
+        if (encoding === 'none') {
+          return this.readFile(path, { encoding: 'none', sessionId });
+        }
+        return this.readFile(path, { encoding, sessionId });
+      }) as ExecutionSession['readFile'],
       readFileStream: (path) => this.readFileStream(path, { sessionId }),
       watch: (path, options) => this.watch(path, { ...options, sessionId }),
       checkChanges: (path, options) =>
@@ -5759,7 +5791,11 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
             timestamp: new Date().toISOString()
           });
         }
-        await this.client.writeFileStream(archivePath, body, backupSession);
+        await this.client.files.writeFileStream(
+          archivePath,
+          body,
+          backupSession
+        );
       } else {
         const archiveBuffer = await archiveObject.arrayBuffer();
         const base64Content = Buffer.from(archiveBuffer).toString('base64');

--- a/packages/sandbox/tests/file-client.test.ts
+++ b/packages/sandbox/tests/file-client.test.ts
@@ -828,4 +828,22 @@ database:
       expect(fullOptionsClient).toBeDefined();
     });
   });
+
+  describe('writeFileStream', () => {
+    it('throws on http transport with a clear message', () => {
+      expect(() =>
+        client.writeFileStream('/tmp/foo', new ReadableStream(), 'session-1')
+      ).toThrow('writeFileStream requires the rpc transport');
+    });
+  });
+
+  describe("readFile with encoding: 'none'", () => {
+    it('throws on http transport with a clear message', async () => {
+      await expect(
+        client.readFile('/tmp/foo', 'session-1', { encoding: 'none' })
+      ).rejects.toThrow(
+        "readFile with encoding: 'none' requires the rpc transport"
+      );
+    });
+  });
 });

--- a/packages/sandbox/tests/local-backup.test.ts
+++ b/packages/sandbox/tests/local-backup.test.ts
@@ -43,18 +43,39 @@ vi.mock('@cloudflare/containers', () => {
 function createMockR2Bucket() {
   const store = new Map<string, { data: ArrayBuffer; size: number }>();
   return {
-    put: vi.fn(async (key: string, data: string | ArrayBuffer | Uint8Array) => {
-      let bytes: Uint8Array;
-      if (typeof data === 'string') {
-        bytes = new TextEncoder().encode(data);
-      } else if (data instanceof Uint8Array) {
-        bytes = new Uint8Array(data);
-      } else {
-        bytes = new Uint8Array(data);
+    put: vi.fn(
+      async (
+        key: string,
+        data: string | ArrayBuffer | Uint8Array | ReadableStream<Uint8Array>
+      ) => {
+        let bytes: Uint8Array;
+        if (typeof data === 'string') {
+          bytes = new TextEncoder().encode(data);
+        } else if (data instanceof ReadableStream) {
+          // Collect stream chunks — mirrors what Miniflare/R2 does at the boundary
+          const reader = data.getReader();
+          const chunks: Uint8Array[] = [];
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (value) chunks.push(value);
+          }
+          const totalLength = chunks.reduce((n, c) => n + c.byteLength, 0);
+          bytes = new Uint8Array(totalLength);
+          let offset = 0;
+          for (const c of chunks) {
+            bytes.set(c, offset);
+            offset += c.byteLength;
+          }
+        } else if (data instanceof Uint8Array) {
+          bytes = new Uint8Array(data);
+        } else {
+          bytes = new Uint8Array(data);
+        }
+        const buffer = bytes.buffer as ArrayBuffer;
+        store.set(key, { data: buffer, size: bytes.byteLength });
       }
-      const buffer = bytes.buffer as ArrayBuffer;
-      store.set(key, { data: buffer, size: bytes.byteLength });
-    }),
+    ),
     get: vi.fn(async (key: string) => {
       const entry = store.get(key);
       if (!entry) return null;
@@ -226,7 +247,7 @@ describe('Local Backup & Restore', () => {
       // Verify archive was uploaded to R2 via binding
       expect(mockBucket.put).toHaveBeenCalledWith(
         expect.stringMatching(/^backups\/.*\/data\.sqsh$/),
-        expect.any(Uint8Array)
+        expect.any(ReadableStream)
       );
 
       // Verify metadata was written

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -155,6 +155,7 @@ export type {
   ExecutionSession,
   // File streaming types
   FileChunk,
+  FileEncoding,
   FileExistsResult,
   FileInfo,
   FileMetadata,
@@ -195,6 +196,7 @@ export type {
   ProcessStartResult,
   ProcessStatus,
   ReadFileResult,
+  ReadFileStreamResult,
   RemoteMountBucketOptions,
   RenameFileResult,
   RestoreBackupResult,

--- a/packages/shared/src/rpc-types.ts
+++ b/packages/shared/src/rpc-types.ts
@@ -35,6 +35,7 @@ import type {
   CheckChangesRequest,
   CheckChangesResult,
   DeleteFileResult,
+  FileEncoding,
   FileExistsResult,
   GitCheckoutResult,
   ListFilesOptions,
@@ -52,6 +53,7 @@ import type {
   ProcessLogsResult,
   ProcessStartResult,
   ReadFileResult,
+  ReadFileStreamResult,
   RenameFileResult,
   WatchRequest,
   WriteFileResult
@@ -102,7 +104,12 @@ export interface SandboxFilesAPI {
   readFile(
     path: string,
     sessionId: string,
-    options?: { encoding?: string }
+    options: { encoding: 'none' }
+  ): Promise<ReadFileStreamResult>;
+  readFile(
+    path: string,
+    sessionId: string,
+    options?: { encoding?: Exclude<FileEncoding, 'none'> }
   ): Promise<ReadFileResult>;
   readFileStream(
     path: string,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -576,6 +576,16 @@ export interface WriteFileResult {
   exitCode?: number;
 }
 
+/**
+ * Valid `encoding` values accepted by `readFile` / `writeFile` options.
+ *
+ * - `'utf-8'` / `'utf8'` — treat content as text.
+ * - `'base64'` — treat content as base64-encoded binary.
+ * - `'none'` — RPC-only streaming variant of `readFile`, returns a
+ *   `ReadableStream<Uint8Array>` of raw bytes (see `ReadFileStreamResult`).
+ */
+export type FileEncoding = 'utf-8' | 'utf8' | 'base64' | 'none';
+
 export interface ReadFileResult {
   success: boolean;
   path: string;
@@ -602,6 +612,22 @@ export interface ReadFileResult {
    * File size in bytes
    */
   size?: number;
+}
+
+/**
+ * Result of `readFile()` with `encoding: 'none'` on the RPC transport.
+ *
+ * `content` is a raw binary `ReadableStream<Uint8Array>` delivered directly
+ * over the capnp channel — no base64 encoding, no SSE framing, no buffering.
+ * Only supported on the `rpc` transport; HTTP/WebSocket transports throw.
+ */
+export interface ReadFileStreamResult {
+  success: true;
+  path: string;
+  content: ReadableStream<Uint8Array>;
+  size: number;
+  mimeType: string;
+  timestamp: string;
 }
 
 export interface DeleteFileResult {
@@ -1027,7 +1053,11 @@ export interface ExecutionSession {
   ): Promise<WriteFileResult>;
   readFile(
     path: string,
-    options?: { encoding?: string }
+    options: { encoding: 'none' }
+  ): Promise<ReadFileStreamResult>;
+  readFile(
+    path: string,
+    options?: { encoding?: Exclude<FileEncoding, 'none'> }
   ): Promise<ReadFileResult>;
   readFileStream(path: string): Promise<ReadableStream<Uint8Array>>;
   watch(
@@ -1311,7 +1341,11 @@ export interface ISandbox {
   ): Promise<WriteFileResult>;
   readFile(
     path: string,
-    options?: { encoding?: string }
+    options: { encoding: 'none' }
+  ): Promise<ReadFileStreamResult>;
+  readFile(
+    path: string,
+    options?: { encoding?: Exclude<FileEncoding, 'none'> }
   ): Promise<ReadFileResult>;
   readFileStream(path: string): Promise<ReadableStream<Uint8Array>>;
   watch(

--- a/tests/e2e/file-operations-workflow.test.ts
+++ b/tests/e2e/file-operations-workflow.test.ts
@@ -414,3 +414,64 @@ describe.skipIf(!isRPCTransport)('File Streaming Write (rpc)', () => {
     expect(Number.parseInt(result.stdout.trim(), 10)).toBe(256 * 1024);
   });
 });
+
+describe.skipIf(!isRPCTransport)('File Binary Read (rpc)', () => {
+  let sandbox: TestSandbox | null = null;
+  let workerUrl: string;
+  let headers: Record<string, string>;
+
+  beforeAll(async () => {
+    sandbox = await createTestSandbox();
+    workerUrl = sandbox.workerUrl;
+    headers = sandbox.headers(createUniqueSession());
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanupTestSandbox(sandbox);
+    sandbox = null;
+  }, 60000);
+
+  test('readFile({ encoding: "none" }) returns raw bytes matching sha256 of original', async () => {
+    const testPath = sandbox!.uniquePath('binary-read-test.bin');
+
+    // Write 10 MiB of incompressible random data entirely inside the container
+    const seedResult = (await (
+      await fetch(`${workerUrl}/api/execute`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          command: [
+            `mkdir -p $(dirname ${testPath})`,
+            `dd if=/dev/urandom of=${testPath} bs=1M count=10 status=none`,
+            `sha256sum ${testPath}`
+          ].join(' && ')
+        })
+      })
+    ).json()) as { stdout: string; exitCode: number };
+    expect(seedResult.exitCode).toBe(0);
+    const [originalSha] = seedResult.stdout.trim().split(/\s+/);
+    expect(originalSha).toMatch(/^[0-9a-f]{64}$/);
+
+    // Read back via encoding: 'none' — raw binary, no base64
+    const readResponse = await fetch(`${workerUrl}/api/file/read-binary`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ path: testPath })
+    });
+    expect(readResponse.status).toBe(200);
+    expect(readResponse.headers.get('content-type')).toBe(
+      'application/octet-stream'
+    );
+
+    // Collect and sha256 the response bytes in JS
+    const bytes = new Uint8Array(await readResponse.arrayBuffer());
+    expect(bytes.byteLength).toBe(10 * 1024 * 1024);
+
+    // Use crypto.subtle to sha256 the collected bytes
+    const hashBuffer = await crypto.subtle.digest('SHA-256', bytes);
+    const restoredSha = Array.from(new Uint8Array(hashBuffer))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+    expect(restoredSha).toBe(originalSha);
+  }, 60000);
+});

--- a/tests/e2e/test-worker/index.ts
+++ b/tests/e2e/test-worker/index.ts
@@ -696,6 +696,18 @@ console.log('Terminal server on port ' + port);
         });
       }
 
+      // File read-binary: readFile({ encoding: 'none' }) — rpc transport only.
+      // Returns raw binary response so the test can sha256 the collected bytes.
+      if (
+        url.pathname === '/api/file/read-binary' &&
+        request.method === 'POST'
+      ) {
+        const result = await executor.readFile(body.path, { encoding: 'none' });
+        return new Response(result.content, {
+          headers: { 'Content-Type': result.mimeType }
+        });
+      }
+
       // File mkdir
       if (url.pathname === '/api/file/mkdir' && request.method === 'POST') {
         await executor.mkdir(body.path, { recursive: body.recursive });


### PR DESCRIPTION
Adds encoding: 'none' to `readFile()` which returns a `ReadableStream<Uint8Array>`
of raw binary data on the rpc transport — no base64 encoding or buffering. Mirrors the existing `writeFile()` support for `ReadableStream` input.

```ts
const { content, size, mimeType } = await sandbox.readFile(
  '/workspace/image.png',
  { encoding: 'none' }
);

return new Response(content, {
  headers: { "Content-Type": mimeType }
});
```

This removes the need for parsing SSE streams, `streamFile`, `collectFile` etc.

Also moves `writeFileStream` from a top-level method on `SandboxClient` / `ContainerControlClient` onto `FileClient` (client.files), where all other file operations live. No change to the public sandbox.writeFile(path, stream) API.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->