### PR TITLE
Add warn against mounting at /workspace

### DIFF
--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1192,6 +1192,17 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       validatePrefix(options.prefix);
     }
 
+    if (mountPath === '/workspace' || mountPath.startsWith('/workspace/')) {
+      this.logger.warn(
+        'Mounting a bucket at /workspace overlays the active workspace in production; prefer /data, /storage, or /mnt/* for bucket mounts.',
+        {
+          bucket,
+          mountPath,
+          localBucket: 'localBucket' in options && options.localBucket === true
+        }
+      );
+    }
+
     if ('localBucket' in options && options.localBucket) {
       await this.mountBucketLocal(bucket, mountPath, options);
       return;

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -2618,6 +2618,24 @@ describe('Sandbox - Automatic Session Management', () => {
       ).resolves.toBeUndefined();
     });
 
+    it('warns when mounting a bucket at /workspace', async () => {
+      mockMountScript({ exitCode: 0 });
+      const warnSpy = vi.spyOn((sandbox as any).logger, 'warn');
+
+      await expect(
+        sandbox.mountBucket('my-bucket', '/workspace', mountOptions)
+      ).resolves.toBeUndefined();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Mounting a bucket at /workspace overlays the active workspace in production; prefer /data, /storage, or /mnt/* for bucket mounts and use backup/restore for workspace persistence.',
+        {
+          bucket: 'my-bucket',
+          mountPath: '/workspace',
+          localBucket: false
+        }
+      );
+    });
+
     it('throws when the s3fs parent exits non-zero', async () => {
       mockMountScript({ exitCode: 2, stdout: 'fuse: bad mount point' });
 


### PR DESCRIPTION
# Summary

Adding a warning against mounting directly to `/workspace` to avoid confusion with overlaying templates or anything.