### PR TITLE
Implement no credential R2 binding mount support

### DIFF
--- a/.changeset/r2-egress-mount.md
+++ b/.changeset/r2-egress-mount.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Add credential-less R2 bucket mounting via egress interception

--- a/bridge/worker/README.md
+++ b/bridge/worker/README.md
@@ -261,13 +261,23 @@ curl -X POST http://localhost:8787/v1/sandbox/mfrggzdfmy2tqnrz/mount \
   -d '{"bucket": "my-bucket", "mountPath": "/mnt/data", "options": {"endpoint": "https://ACCT.r2.cloudflarestorage.com"}}'
 ```
 
+To mount a Worker R2 binding without credentials, omit `options.endpoint`. The `bucket`
+value must match the R2 binding name on the Worker:
+
+```sh
+curl -X POST http://localhost:8787/v1/sandbox/mfrggzdfmy2tqnrz/mount \
+  -H "Authorization: Bearer $SANDBOX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"bucket": "MY_BUCKET", "mountPath": "/mnt/data", "options": {"prefix": "/uploads/"}}'
+```
+
 **Request body:**
 
 | Field                                 | Type    | Required | Description                                    |
 | ------------------------------------- | ------- | -------- | ---------------------------------------------- |
 | `bucket`                              | string  | yes      | Bucket name                                    |
 | `mountPath`                           | string  | yes      | Absolute path in the container to mount at     |
-| `options.endpoint`                    | string  | yes      | S3-compatible endpoint URL                     |
+| `options.endpoint`                    | string  | no       | S3-compatible endpoint URL                     |
 | `options.readOnly`                    | boolean | no       | Mount as read-only (default: false)            |
 | `options.prefix`                      | string  | no       | Subdirectory prefix within the bucket          |
 | `options.credentials.accessKeyId`     | string  | no       | Explicit access key (auto-detected if omitted) |

--- a/bridge/worker/README.md
+++ b/bridge/worker/README.md
@@ -271,14 +271,11 @@ curl -X POST http://localhost:8787/v1/sandbox/mfrggzdfmy2tqnrz/mount \
   -d '{"binding": "MY_BUCKET", "mountPath": "/mnt/data", "options": {"prefix": "/uploads/"}}'
 ```
 
-For compatibility, `bucket` is also accepted as the binding name when `binding`
-is omitted and `options.endpoint` is not provided.
-
 **Request body:**
 
 | Field                                 | Type    | Required | Description                                                                     |
 | ------------------------------------- | ------- | -------- | ------------------------------------------------------------------------------- |
-| `bucket`                              | string  | no       | Remote bucket name, or legacy R2 binding name when `binding` is omitted         |
+| `bucket`                              | string  | no       | Remote bucket name for endpoint-based S3-compatible mounts                      |
 | `binding`                             | string  | no       | Worker R2 binding name for credential-less R2 binding mounts                    |
 | `mountPath`                           | string  | yes      | Absolute path in the container to mount at                                      |
 | `options.endpoint`                    | string  | no       | S3-compatible endpoint URL for remote mounts; mutually exclusive with `binding` |

--- a/bridge/worker/README.md
+++ b/bridge/worker/README.md
@@ -261,27 +261,31 @@ curl -X POST http://localhost:8787/v1/sandbox/mfrggzdfmy2tqnrz/mount \
   -d '{"bucket": "my-bucket", "mountPath": "/mnt/data", "options": {"endpoint": "https://ACCT.r2.cloudflarestorage.com"}}'
 ```
 
-To mount a Worker R2 binding without credentials, omit `options.endpoint`. The `bucket`
-value must match the R2 binding name on the Worker:
+To mount a Worker R2 binding without credentials, provide the top-level `binding`
+field and omit `options.endpoint`:
 
 ```sh
 curl -X POST http://localhost:8787/v1/sandbox/mfrggzdfmy2tqnrz/mount \
   -H "Authorization: Bearer $SANDBOX_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"bucket": "MY_BUCKET", "mountPath": "/mnt/data", "options": {"prefix": "/uploads/"}}'
+  -d '{"binding": "MY_BUCKET", "mountPath": "/mnt/data", "options": {"prefix": "/uploads/"}}'
 ```
+
+For compatibility, `bucket` is also accepted as the binding name when `binding`
+is omitted and `options.endpoint` is not provided.
 
 **Request body:**
 
-| Field                                 | Type    | Required | Description                                    |
-| ------------------------------------- | ------- | -------- | ---------------------------------------------- |
-| `bucket`                              | string  | yes      | Bucket name                                    |
-| `mountPath`                           | string  | yes      | Absolute path in the container to mount at     |
-| `options.endpoint`                    | string  | no       | S3-compatible endpoint URL                     |
-| `options.readOnly`                    | boolean | no       | Mount as read-only (default: false)            |
-| `options.prefix`                      | string  | no       | Subdirectory prefix within the bucket          |
-| `options.credentials.accessKeyId`     | string  | no       | Explicit access key (auto-detected if omitted) |
-| `options.credentials.secretAccessKey` | string  | no       | Explicit secret key (auto-detected if omitted) |
+| Field                                 | Type    | Required | Description                                                                     |
+| ------------------------------------- | ------- | -------- | ------------------------------------------------------------------------------- |
+| `bucket`                              | string  | no       | Remote bucket name, or legacy R2 binding name when `binding` is omitted         |
+| `binding`                             | string  | no       | Worker R2 binding name for credential-less R2 binding mounts                    |
+| `mountPath`                           | string  | yes      | Absolute path in the container to mount at                                      |
+| `options.endpoint`                    | string  | no       | S3-compatible endpoint URL for remote mounts; mutually exclusive with `binding` |
+| `options.readOnly`                    | boolean | no       | Mount as read-only (default: false)                                             |
+| `options.prefix`                      | string  | no       | Subdirectory prefix within the bucket                                           |
+| `options.credentials.accessKeyId`     | string  | no       | Explicit access key (auto-detected if omitted)                                  |
+| `options.credentials.secretAccessKey` | string  | no       | Explicit secret key (auto-detected if omitted)                                  |
 
 Credentials are optional — the SDK auto-detects from Worker secrets (`R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY` or `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`).
 

--- a/bridge/worker/src/__tests__/mount.test.ts
+++ b/bridge/worker/src/__tests__/mount.test.ts
@@ -122,6 +122,31 @@ describe('POST /v1/sandbox/:id/mount', () => {
     });
   });
 
+  it('mounts a Worker R2 binding from explicit binding', async () => {
+    const res = await mountRequest({
+      binding: 'MY_BUCKET',
+      mountPath: '/mnt/data',
+      options: { readOnly: true, prefix: '/uploads/' }
+    });
+    expect(res.status).toBe(200);
+
+    expect(mockSandbox.mountBucket).toHaveBeenCalledWith('MY_BUCKET', '/mnt/data', {
+      readOnly: true,
+      prefix: '/uploads/'
+    });
+  });
+
+  it('rejects binding with endpoint', async () => {
+    const res = await mountRequest({
+      binding: 'MY_BUCKET',
+      mountPath: '/mnt/data',
+      options: { endpoint: 'https://acct.r2.cloudflarestorage.com' }
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('either binding or options.endpoint');
+  });
+
   it('passes s3fsOptions for R2 binding mounts', async () => {
     const res = await mountRequest({
       bucket: 'MY_BUCKET',
@@ -152,10 +177,10 @@ describe('POST /v1/sandbox/:id/mount', () => {
     });
   });
 
-  it('rejects missing bucket', async () => {
+  it('rejects missing bucket and binding', async () => {
     const res = await mountRequest({
       mountPath: '/mnt/data',
-      options: { endpoint: 'https://acct.r2.cloudflarestorage.com' }
+      options: {}
     });
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };

--- a/bridge/worker/src/__tests__/mount.test.ts
+++ b/bridge/worker/src/__tests__/mount.test.ts
@@ -71,9 +71,9 @@ describe('POST /v1/sandbox/:id/mount', () => {
       options: { endpoint: 'https://s3.us-west-2.amazonaws.com' }
     });
 
-    const call = mockSandbox.mountBucket.mock.calls[0];
-    expect(call[2]).toEqual({ endpoint: 'https://s3.us-west-2.amazonaws.com' });
-    expect(call[2]).not.toHaveProperty('credentials');
+    expect(mockSandbox.mountBucket).toHaveBeenCalledWith('my-bucket', '/mnt/data', {
+      endpoint: 'https://s3.us-west-2.amazonaws.com'
+    });
   });
 
   it('passes prefix option', async () => {
@@ -105,6 +105,33 @@ describe('POST /v1/sandbox/:id/mount', () => {
     expect(mockSandbox.mountBucket).toHaveBeenCalledWith('my-bucket', '/mnt/data', {
       endpoint: 'https://acct.r2.cloudflarestorage.com',
       readOnly: true
+    });
+  });
+
+  it('mounts a Worker R2 binding when endpoint is omitted', async () => {
+    const res = await mountRequest({
+      bucket: 'MY_BUCKET',
+      mountPath: '/mnt/data',
+      options: { readOnly: true, prefix: '/uploads/' }
+    });
+    expect(res.status).toBe(200);
+
+    expect(mockSandbox.mountBucket).toHaveBeenCalledWith('MY_BUCKET', '/mnt/data', {
+      readOnly: true,
+      prefix: '/uploads/'
+    });
+  });
+
+  it('passes s3fsOptions for R2 binding mounts', async () => {
+    const res = await mountRequest({
+      bucket: 'MY_BUCKET',
+      mountPath: '/mnt/data',
+      options: { s3fsOptions: ['nomultipart', 'nomixupload'] }
+    });
+    expect(res.status).toBe(200);
+
+    expect(mockSandbox.mountBucket).toHaveBeenCalledWith('MY_BUCKET', '/mnt/data', {
+      s3fsOptions: ['nomultipart', 'nomixupload']
     });
   });
 
@@ -149,11 +176,11 @@ describe('POST /v1/sandbox/:id/mount', () => {
     expect(body.error).toContain('options');
   });
 
-  it('rejects missing endpoint', async () => {
+  it('rejects non-string endpoint values', async () => {
     const res = await mountRequest({
       bucket: 'my-bucket',
       mountPath: '/mnt/data',
-      options: {}
+      options: { endpoint: 123 }
     });
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };

--- a/bridge/worker/src/__tests__/mount.test.ts
+++ b/bridge/worker/src/__tests__/mount.test.ts
@@ -108,9 +108,9 @@ describe('POST /v1/sandbox/:id/mount', () => {
     });
   });
 
-  it('mounts a Worker R2 binding when endpoint is omitted', async () => {
+  it('mounts a Worker R2 binding when binding is provided', async () => {
     const res = await mountRequest({
-      bucket: 'MY_BUCKET',
+      binding: 'MY_BUCKET',
       mountPath: '/mnt/data',
       options: { readOnly: true, prefix: '/uploads/' }
     });
@@ -149,7 +149,7 @@ describe('POST /v1/sandbox/:id/mount', () => {
 
   it('passes s3fsOptions for R2 binding mounts', async () => {
     const res = await mountRequest({
-      bucket: 'MY_BUCKET',
+      binding: 'MY_BUCKET',
       mountPath: '/mnt/data',
       options: { s3fsOptions: ['nomultipart', 'nomixupload'] }
     });
@@ -184,7 +184,7 @@ describe('POST /v1/sandbox/:id/mount', () => {
     });
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toContain('bucket');
+    expect(body.error).toContain('binding');
   });
 
   it('rejects missing mountPath', async () => {

--- a/bridge/worker/src/__tests__/mount.test.ts
+++ b/bridge/worker/src/__tests__/mount.test.ts
@@ -135,6 +135,23 @@ describe('POST /v1/sandbox/:id/mount', () => {
     });
   });
 
+  it('passes s3fsOptions for remote mounts', async () => {
+    const res = await mountRequest({
+      bucket: 'my-bucket',
+      mountPath: '/mnt/data',
+      options: {
+        endpoint: 'https://acct.r2.cloudflarestorage.com',
+        s3fsOptions: ['nomultipart']
+      }
+    });
+    expect(res.status).toBe(200);
+
+    expect(mockSandbox.mountBucket).toHaveBeenCalledWith('my-bucket', '/mnt/data', {
+      endpoint: 'https://acct.r2.cloudflarestorage.com',
+      s3fsOptions: ['nomultipart']
+    });
+  });
+
   it('rejects missing bucket', async () => {
     const res = await mountRequest({
       mountPath: '/mnt/data',
@@ -176,6 +193,17 @@ describe('POST /v1/sandbox/:id/mount', () => {
     expect(body.error).toContain('options');
   });
 
+  it('rejects array options', async () => {
+    const res = await mountRequest({
+      bucket: 'my-bucket',
+      mountPath: '/mnt/data',
+      options: [] as unknown as Record<string, unknown>
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('options');
+  });
+
   it('rejects non-string endpoint values', async () => {
     const res = await mountRequest({
       bucket: 'my-bucket',
@@ -185,6 +213,76 @@ describe('POST /v1/sandbox/:id/mount', () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain('endpoint');
+  });
+
+  it('rejects non-array s3fsOptions values', async () => {
+    const res = await mountRequest({
+      bucket: 'my-bucket',
+      mountPath: '/mnt/data',
+      options: {
+        endpoint: 'https://acct.r2.cloudflarestorage.com',
+        s3fsOptions: 'nomultipart'
+      }
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('s3fsOptions');
+  });
+
+  it('rejects non-string s3fsOptions entries', async () => {
+    const res = await mountRequest({
+      bucket: 'my-bucket',
+      mountPath: '/mnt/data',
+      options: {
+        endpoint: 'https://acct.r2.cloudflarestorage.com',
+        s3fsOptions: ['nomultipart', 123]
+      }
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('s3fsOptions');
+  });
+
+  it('rejects non-boolean readOnly values', async () => {
+    const res = await mountRequest({
+      bucket: 'my-bucket',
+      mountPath: '/mnt/data',
+      options: {
+        endpoint: 'https://acct.r2.cloudflarestorage.com',
+        readOnly: 'true'
+      }
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('readOnly');
+  });
+
+  it('rejects non-string prefix values', async () => {
+    const res = await mountRequest({
+      bucket: 'my-bucket',
+      mountPath: '/mnt/data',
+      options: {
+        endpoint: 'https://acct.r2.cloudflarestorage.com',
+        prefix: 123
+      }
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('prefix');
+  });
+
+  it('rejects malformed credentials', async () => {
+    const res = await mountRequest({
+      bucket: 'my-bucket',
+      mountPath: '/mnt/data',
+      options: {
+        endpoint: 'https://acct.r2.cloudflarestorage.com',
+        credentials: { accessKeyId: 'AKID' }
+      }
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('credentials');
   });
 
   it('rejects invalid JSON body', async () => {

--- a/packages/sandbox/src/bridge/openapi.ts
+++ b/packages/sandbox/src/bridge/openapi.ts
@@ -98,11 +98,11 @@ export const OPENAPI_SCHEMA = {
       },
       MountBucketRequestOptions: {
         type: 'object',
-        required: ['endpoint'],
         properties: {
           endpoint: {
             type: 'string',
-            description: 'S3-compatible endpoint URL.',
+            description:
+              'S3-compatible endpoint URL. Omit to mount a Worker R2 binding with the same name as `bucket`.',
             example: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com'
           },
           readOnly: {
@@ -120,6 +120,13 @@ export const OPENAPI_SCHEMA = {
             $ref: '#/components/schemas/MountBucketCredentials',
             description:
               'Explicit credentials. When omitted, the SDK auto-detects from Worker secrets (R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY or AWS equivalents).'
+          },
+          s3fsOptions: {
+            type: 'array',
+            items: { type: 'string' },
+            description:
+              'Advanced: Override or extend s3fs mount options. Only applies to R2 binding mounts (when endpoint is omitted).',
+            example: ['nomultipart']
           }
         }
       },

--- a/packages/sandbox/src/bridge/openapi.ts
+++ b/packages/sandbox/src/bridge/openapi.ts
@@ -125,7 +125,7 @@ export const OPENAPI_SCHEMA = {
             type: 'array',
             items: { type: 'string' },
             description:
-              'Advanced: Override or extend s3fs mount options. Only applies to R2 binding mounts (when endpoint is omitted).',
+              'Advanced: Override or extend s3fs mount options for both remote mounts and R2 binding mounts.',
             example: ['nomultipart']
           }
         }

--- a/packages/sandbox/src/bridge/openapi.ts
+++ b/packages/sandbox/src/bridge/openapi.ts
@@ -102,7 +102,7 @@ export const OPENAPI_SCHEMA = {
           endpoint: {
             type: 'string',
             description:
-              'S3-compatible endpoint URL. Omit to mount a Worker R2 binding with the same name as `bucket`.',
+              'S3-compatible endpoint URL for remote mounts. Mutually exclusive with top-level `binding`.',
             example: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com'
           },
           readOnly: {
@@ -132,12 +132,19 @@ export const OPENAPI_SCHEMA = {
       },
       MountBucketRequest: {
         type: 'object',
-        required: ['bucket', 'mountPath', 'options'],
+        required: ['mountPath', 'options'],
         properties: {
           bucket: {
             type: 'string',
-            description: 'Bucket name.',
+            description:
+              'Remote bucket name. For compatibility, also used as the R2 binding name when `binding` is omitted.',
             example: 'my-r2-bucket'
+          },
+          binding: {
+            type: 'string',
+            description:
+              'Worker R2 binding name for credential-less R2 binding mounts. Mutually exclusive with `options.endpoint`.',
+            example: 'MY_BUCKET'
           },
           mountPath: {
             type: 'string',

--- a/packages/sandbox/src/bridge/openapi.ts
+++ b/packages/sandbox/src/bridge/openapi.ts
@@ -113,8 +113,8 @@ export const OPENAPI_SCHEMA = {
           prefix: {
             type: 'string',
             description:
-              'Optional prefix/subdirectory within the bucket to mount. Must start and end with `/`.',
-            example: '/uploads/images/'
+              'Optional prefix/subdirectory within the bucket to mount. Must start with `/`. Trailing slashes are stripped automatically.',
+            example: '/uploads/images'
           },
           credentials: {
             $ref: '#/components/schemas/MountBucketCredentials',

--- a/packages/sandbox/src/bridge/openapi.ts
+++ b/packages/sandbox/src/bridge/openapi.ts
@@ -137,7 +137,7 @@ export const OPENAPI_SCHEMA = {
           bucket: {
             type: 'string',
             description:
-              'Remote bucket name. For compatibility, also used as the R2 binding name when `binding` is omitted.',
+              'Remote bucket name for endpoint-based S3-compatible mounts.',
             example: 'my-r2-bucket'
           },
           binding: {

--- a/packages/sandbox/src/bridge/routes.ts
+++ b/packages/sandbox/src/bridge/routes.ts
@@ -6,7 +6,14 @@
  * factory and reused for all requests.
  */
 
-import type { ExecutionSession, ISandbox, PtyOptions } from '@repo/shared';
+import type {
+  ExecutionSession,
+  ISandbox,
+  MountBucketOptions,
+  PtyOptions,
+  R2BindingMountBucketOptions,
+  RemoteMountBucketOptions
+} from '@repo/shared';
 import { Hono, type MiddlewareHandler } from 'hono';
 import type { Sandbox } from '../sandbox';
 import { getSandbox as _getSandbox } from '../sandbox';
@@ -682,9 +689,12 @@ export function createBridgeApp(
     if (!body.options || typeof body.options !== 'object') {
       return errorJson('options must be an object', 'invalid_request', 400);
     }
-    if (!body.options.endpoint || typeof body.options.endpoint !== 'string') {
+    if (
+      body.options.endpoint !== undefined &&
+      typeof body.options.endpoint !== 'string'
+    ) {
       return errorJson(
-        'options.endpoint must be a non-empty string',
+        'options.endpoint must be a string when provided',
         'invalid_request',
         400
       );
@@ -692,26 +702,36 @@ export function createBridgeApp(
 
     const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
 
-    const sdkOptions: {
-      endpoint: string;
-      readOnly?: boolean;
-      prefix?: string;
-      credentials?: { accessKeyId: string; secretAccessKey: string };
-    } = {
-      endpoint: body.options.endpoint
-    };
-
-    if (body.options.readOnly !== undefined) {
-      sdkOptions.readOnly = body.options.readOnly;
-    }
-    if (body.options.prefix !== undefined) {
-      sdkOptions.prefix = body.options.prefix;
-    }
-    if (body.options.credentials) {
-      sdkOptions.credentials = {
-        accessKeyId: body.options.credentials.accessKeyId,
-        secretAccessKey: body.options.credentials.secretAccessKey
+    let sdkOptions: MountBucketOptions;
+    if (body.options.endpoint) {
+      const remoteOptions: RemoteMountBucketOptions = {
+        endpoint: body.options.endpoint
       };
+      if (body.options.readOnly !== undefined) {
+        remoteOptions.readOnly = body.options.readOnly;
+      }
+      if (body.options.prefix !== undefined) {
+        remoteOptions.prefix = body.options.prefix;
+      }
+      if (body.options.credentials) {
+        remoteOptions.credentials = {
+          accessKeyId: body.options.credentials.accessKeyId,
+          secretAccessKey: body.options.credentials.secretAccessKey
+        };
+      }
+      sdkOptions = remoteOptions;
+    } else {
+      const r2BindingOptions: R2BindingMountBucketOptions = {};
+      if (body.options.readOnly !== undefined) {
+        r2BindingOptions.readOnly = body.options.readOnly;
+      }
+      if (body.options.prefix !== undefined) {
+        r2BindingOptions.prefix = body.options.prefix;
+      }
+      if (body.options.s3fsOptions !== undefined) {
+        r2BindingOptions.s3fsOptions = body.options.s3fsOptions;
+      }
+      sdkOptions = r2BindingOptions;
     }
 
     try {

--- a/packages/sandbox/src/bridge/routes.ts
+++ b/packages/sandbox/src/bridge/routes.ts
@@ -33,6 +33,7 @@ import type {
   BridgeEnv,
   ExecRequest,
   MountBucketRequest,
+  MountBucketRequestOptions,
   RunningResponse,
   UnmountBucketRequest,
   WriteResponse
@@ -64,6 +65,115 @@ function getSandbox<T extends Sandbox<any>>(
   containerUUID: string
 ): BridgeSandbox {
   return _getSandbox(ns, containerUUID) as unknown as BridgeSandbox;
+}
+
+function hasEndpoint(
+  options: MountBucketRequestOptions
+): options is MountBucketRequestOptions & { endpoint: string } {
+  return 'endpoint' in options && typeof options.endpoint === 'string';
+}
+
+function hasCredentials(
+  options: MountBucketRequestOptions
+): options is MountBucketRequestOptions & {
+  credentials: { accessKeyId: string; secretAccessKey: string };
+} {
+  return 'credentials' in options && options.credentials !== undefined;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === 'string')
+  );
+}
+
+function validateMountOptions(
+  options: MountBucketRequestOptions
+): Response | null {
+  if ('endpoint' in options && !hasEndpoint(options)) {
+    return errorJson(
+      'options.endpoint must be a string when provided',
+      'invalid_request',
+      400
+    );
+  }
+  if (
+    options.s3fsOptions !== undefined &&
+    !isStringArray(options.s3fsOptions)
+  ) {
+    return errorJson(
+      'options.s3fsOptions must be an array of strings when provided',
+      'invalid_request',
+      400
+    );
+  }
+  if (options.readOnly !== undefined && typeof options.readOnly !== 'boolean') {
+    return errorJson(
+      'options.readOnly must be a boolean when provided',
+      'invalid_request',
+      400
+    );
+  }
+  if (options.prefix !== undefined && typeof options.prefix !== 'string') {
+    return errorJson(
+      'options.prefix must be a string when provided',
+      'invalid_request',
+      400
+    );
+  }
+  if (
+    'credentials' in options &&
+    options.credentials !== undefined &&
+    (typeof options.credentials !== 'object' ||
+      options.credentials === null ||
+      typeof options.credentials.accessKeyId !== 'string' ||
+      typeof options.credentials.secretAccessKey !== 'string')
+  ) {
+    return errorJson(
+      'options.credentials must include string accessKeyId and secretAccessKey',
+      'invalid_request',
+      400
+    );
+  }
+  return null;
+}
+
+function toSDKMountOptions(
+  options: MountBucketRequestOptions
+): MountBucketOptions {
+  if (hasEndpoint(options)) {
+    const remoteOptions: RemoteMountBucketOptions = {
+      endpoint: options.endpoint
+    };
+    if (options.readOnly !== undefined) {
+      remoteOptions.readOnly = options.readOnly;
+    }
+    if (options.prefix !== undefined) {
+      remoteOptions.prefix = options.prefix;
+    }
+    if (hasCredentials(options)) {
+      remoteOptions.credentials = {
+        accessKeyId: options.credentials.accessKeyId,
+        secretAccessKey: options.credentials.secretAccessKey
+      };
+    }
+    if (options.s3fsOptions !== undefined) {
+      remoteOptions.s3fsOptions = options.s3fsOptions;
+    }
+    return remoteOptions;
+  }
+
+  const r2BindingOptions: R2BindingMountBucketOptions = {};
+  if (options.readOnly !== undefined) {
+    r2BindingOptions.readOnly = options.readOnly;
+  }
+  if (options.prefix !== undefined) {
+    r2BindingOptions.prefix = options.prefix;
+  }
+  if (options.s3fsOptions !== undefined) {
+    r2BindingOptions.s3fsOptions = options.s3fsOptions;
+  }
+  return r2BindingOptions;
 }
 
 // ---------------------------------------------------------------------------
@@ -686,53 +796,18 @@ export function createBridgeApp(
         400
       );
     }
-    if (!body.options || typeof body.options !== 'object') {
+    if (
+      !body.options ||
+      typeof body.options !== 'object' ||
+      Array.isArray(body.options)
+    ) {
       return errorJson('options must be an object', 'invalid_request', 400);
     }
-    if (
-      body.options.endpoint !== undefined &&
-      typeof body.options.endpoint !== 'string'
-    ) {
-      return errorJson(
-        'options.endpoint must be a string when provided',
-        'invalid_request',
-        400
-      );
-    }
+    const optionsError = validateMountOptions(body.options);
+    if (optionsError) return optionsError;
 
     const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
-
-    let sdkOptions: MountBucketOptions;
-    if (body.options.endpoint) {
-      const remoteOptions: RemoteMountBucketOptions = {
-        endpoint: body.options.endpoint
-      };
-      if (body.options.readOnly !== undefined) {
-        remoteOptions.readOnly = body.options.readOnly;
-      }
-      if (body.options.prefix !== undefined) {
-        remoteOptions.prefix = body.options.prefix;
-      }
-      if (body.options.credentials) {
-        remoteOptions.credentials = {
-          accessKeyId: body.options.credentials.accessKeyId,
-          secretAccessKey: body.options.credentials.secretAccessKey
-        };
-      }
-      sdkOptions = remoteOptions;
-    } else {
-      const r2BindingOptions: R2BindingMountBucketOptions = {};
-      if (body.options.readOnly !== undefined) {
-        r2BindingOptions.readOnly = body.options.readOnly;
-      }
-      if (body.options.prefix !== undefined) {
-        r2BindingOptions.prefix = body.options.prefix;
-      }
-      if (body.options.s3fsOptions !== undefined) {
-        r2BindingOptions.s3fsOptions = body.options.s3fsOptions;
-      }
-      sdkOptions = r2BindingOptions;
-    }
+    const sdkOptions = toSDKMountOptions(body.options);
 
     try {
       await sandbox.mountBucket(body.bucket, body.mountPath, sdkOptions);

--- a/packages/sandbox/src/bridge/routes.ts
+++ b/packages/sandbox/src/bridge/routes.ts
@@ -73,6 +73,10 @@ function hasEndpoint(
   return 'endpoint' in options && typeof options.endpoint === 'string';
 }
 
+function hasEndpointProperty(options: MountBucketRequestOptions): boolean {
+  return 'endpoint' in options && options.endpoint !== undefined;
+}
+
 function hasCredentials(
   options: MountBucketRequestOptions
 ): options is MountBucketRequestOptions & {
@@ -88,11 +92,33 @@ function isStringArray(value: unknown): value is string[] {
 }
 
 function validateMountOptions(
-  options: MountBucketRequestOptions
+  options: MountBucketRequestOptions,
+  binding?: string
 ): Response | null {
   if ('endpoint' in options && !hasEndpoint(options)) {
     return errorJson(
       'options.endpoint must be a string when provided',
+      'invalid_request',
+      400
+    );
+  }
+  if (binding !== undefined && typeof binding !== 'string') {
+    return errorJson(
+      'binding must be a string when provided',
+      'invalid_request',
+      400
+    );
+  }
+  if (binding === '') {
+    return errorJson(
+      'binding must be a non-empty string when provided',
+      'invalid_request',
+      400
+    );
+  }
+  if (binding !== undefined && hasEndpointProperty(options)) {
+    return errorJson(
+      'Provide either binding or options.endpoint, not both',
       'invalid_request',
       400
     );
@@ -136,6 +162,16 @@ function validateMountOptions(
     );
   }
   return null;
+}
+
+function resolveMountBucketName(body: MountBucketRequest): string | Response {
+  if (body.binding !== undefined) return body.binding;
+  if (body.bucket && typeof body.bucket === 'string') return body.bucket;
+  return errorJson(
+    'bucket must be a non-empty string when binding is omitted',
+    'invalid_request',
+    400
+  );
 }
 
 function toSDKMountOptions(
@@ -775,7 +811,10 @@ export function createBridgeApp(
       return errorJson('Invalid JSON body', 'invalid_request', 400);
     }
 
-    if (!body.bucket || typeof body.bucket !== 'string') {
+    if (
+      body.bucket !== undefined &&
+      (typeof body.bucket !== 'string' || body.bucket === '')
+    ) {
       return errorJson(
         'bucket must be a non-empty string',
         'invalid_request',
@@ -803,14 +842,16 @@ export function createBridgeApp(
     ) {
       return errorJson('options must be an object', 'invalid_request', 400);
     }
-    const optionsError = validateMountOptions(body.options);
+    const optionsError = validateMountOptions(body.options, body.binding);
     if (optionsError) return optionsError;
+    const bucketName = resolveMountBucketName(body);
+    if (bucketName instanceof Response) return bucketName;
 
     const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
     const sdkOptions = toSDKMountOptions(body.options);
 
     try {
-      await sandbox.mountBucket(body.bucket, body.mountPath, sdkOptions);
+      await sandbox.mountBucket(bucketName, body.mountPath, sdkOptions);
       return c.json({ ok: true });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/packages/sandbox/src/bridge/routes.ts
+++ b/packages/sandbox/src/bridge/routes.ts
@@ -165,10 +165,17 @@ function validateMountOptions(
 }
 
 function resolveMountBucketName(body: MountBucketRequest): string | Response {
+  if (hasEndpoint(body.options)) {
+    if (body.bucket && typeof body.bucket === 'string') return body.bucket;
+    return errorJson(
+      'bucket must be a non-empty string for remote mounts',
+      'invalid_request',
+      400
+    );
+  }
   if (body.binding !== undefined) return body.binding;
-  if (body.bucket && typeof body.bucket === 'string') return body.bucket;
   return errorJson(
-    'bucket must be a non-empty string when binding is omitted',
+    'binding must be a non-empty string for R2 binding mounts',
     'invalid_request',
     400
   );

--- a/packages/sandbox/src/bridge/types.ts
+++ b/packages/sandbox/src/bridge/types.ts
@@ -5,6 +5,12 @@
  * (e.g. the Python `CloudflareSandboxClient`) and the bridge worker.
  */
 
+import type {
+  BucketCredentials,
+  MountBucketOptions,
+  R2BindingMountBucketOptions,
+  RemoteMountBucketOptions
+} from '@repo/shared';
 import type { Sandbox } from '../sandbox';
 
 // ---------------------------------------------------------------------------
@@ -106,25 +112,20 @@ export interface ErrorResponse {
   code: string;
 }
 
-/** Credentials for mounting an S3-compatible bucket. */
-export interface MountBucketCredentials {
-  accessKeyId: string;
-  secretAccessKey: string;
-}
+/** JSON mount options accepted by the bridge; mirrors the SDK mount option variants. */
+export type MountBucketRequestOptions =
+  | Pick<
+      RemoteMountBucketOptions,
+      'endpoint' | 'readOnly' | 'prefix' | 'credentials' | 's3fsOptions'
+    >
+  | Pick<R2BindingMountBucketOptions, 'readOnly' | 'prefix' | 's3fsOptions'>;
 
-/** Options nested inside a MountBucketRequest. */
-export interface MountBucketRequestOptions {
-  /** S3-compatible endpoint URL. Omit to mount a Worker R2 binding with the same name as `bucket`. */
-  endpoint?: string;
-  /** Mount filesystem as read-only (default: false). */
-  readOnly?: boolean;
-  /** Optional prefix/subdirectory within the bucket to mount. */
-  prefix?: string;
-  /** Explicit credentials. Omit to use auto-detected Worker secrets. */
-  credentials?: MountBucketCredentials;
-  /** Advanced: Override or extend s3fs options (R2 binding mounts only). */
-  s3fsOptions?: string[];
-}
+export type {
+  BucketCredentials as MountBucketCredentials,
+  MountBucketOptions,
+  R2BindingMountBucketOptions,
+  RemoteMountBucketOptions
+};
 
 /** Sent by the client for /mount requests. */
 export interface MountBucketRequest {
@@ -132,7 +133,7 @@ export interface MountBucketRequest {
   bucket: string;
   /** Absolute path in the container to mount at. */
   mountPath: string;
-  /** Mount configuration. */
+  /** Mount configuration. Omit `endpoint` to mount a Worker R2 binding named by `bucket`. */
   options: MountBucketRequestOptions;
 }
 

--- a/packages/sandbox/src/bridge/types.ts
+++ b/packages/sandbox/src/bridge/types.ts
@@ -129,11 +129,13 @@ export type {
 
 /** Sent by the client for /mount requests. */
 export interface MountBucketRequest {
-  /** Bucket name. */
-  bucket: string;
+  /** Remote bucket name, or legacy R2 binding name when `binding` is omitted. */
+  bucket?: string;
+  /** Worker R2 binding name for credential-less R2 binding mounts. */
+  binding?: string;
   /** Absolute path in the container to mount at. */
   mountPath: string;
-  /** Mount configuration. Omit `endpoint` to mount a Worker R2 binding named by `bucket`. */
+  /** Mount configuration. Provide `endpoint` for remote mounts or `binding` for R2 binding mounts. */
   options: MountBucketRequestOptions;
 }
 

--- a/packages/sandbox/src/bridge/types.ts
+++ b/packages/sandbox/src/bridge/types.ts
@@ -114,14 +114,16 @@ export interface MountBucketCredentials {
 
 /** Options nested inside a MountBucketRequest. */
 export interface MountBucketRequestOptions {
-  /** S3-compatible endpoint URL (required). */
-  endpoint: string;
+  /** S3-compatible endpoint URL. Omit to mount a Worker R2 binding with the same name as `bucket`. */
+  endpoint?: string;
   /** Mount filesystem as read-only (default: false). */
   readOnly?: boolean;
   /** Optional prefix/subdirectory within the bucket to mount. */
   prefix?: string;
   /** Explicit credentials. Omit to use auto-detected Worker secrets. */
   credentials?: MountBucketCredentials;
+  /** Advanced: Override or extend s3fs options (R2 binding mounts only). */
+  s3fsOptions?: string[];
 }
 
 /** Sent by the client for /mount requests. */

--- a/packages/sandbox/src/bridge/types.ts
+++ b/packages/sandbox/src/bridge/types.ts
@@ -129,7 +129,7 @@ export type {
 
 /** Sent by the client for /mount requests. */
 export interface MountBucketRequest {
-  /** Remote bucket name, or legacy R2 binding name when `binding` is omitted. */
+  /** Remote bucket name for endpoint-based S3-compatible mounts. */
   bucket?: string;
   /** Worker R2 binding name for credential-less R2 binding mounts. */
   binding?: string;

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1398,6 +1398,16 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
               'Mount the same binding only once, or use the same prefix for additional mounts.'
           );
         }
+        if (
+          mountInfo.mountType === 'r2-egress' &&
+          mountInfo.bucket === bucket &&
+          mountInfo.readOnly !== (options.readOnly ?? false)
+        ) {
+          throw new InvalidMountConfigError(
+            `R2 binding "${bucket}" is already mounted at ${existingMountPath} with a different readOnly setting. ` +
+              'Mount the same binding only once, or use the same readOnly value for additional mounts.'
+          );
+        }
       }
 
       const passwordFilePath = this.generatePasswordFilePath();

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -98,9 +98,8 @@ import {
   S3FSMountError
 } from './storage-mount/errors';
 import {
-  r2EgressHandler,
-  registerBucketAccess,
-  revokeBucketAccess
+  type R2EgressParams,
+  r2EgressHandler
 } from './storage-mount/r2-egress-handler';
 import type {
   FuseMountInfo,
@@ -1298,6 +1297,16 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
   }
 
+  private getR2EgressParams(): R2EgressParams {
+    const buckets: Record<string, string | undefined> = {};
+    for (const [, m] of this.activeMounts) {
+      if (m.mountType === 'r2-egress') {
+        buckets[m.bucket] = m.prefix;
+      }
+    }
+    return { buckets };
+  }
+
   /**
    * Credential-less R2 mount: egress interception routes s3fs requests to the
    * R2 binding. No S3 credentials are needed in the container or Worker env.
@@ -1316,29 +1325,37 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       validateBucketBindingName(bucket, mountPath);
       this.validateMountPath(mountPath);
 
-      registerBucketAccess(this.ctx.id.toString(), bucket);
-
-      // Register the r2.internal egress handler for this DO instance so the
-      // Cloudflare Containers runtime routes s3fs requests to r2EgressHandler.
-      await this.setOutboundByHost('r2.internal', 'r2Mount');
+      const passwordFilePath = this.generatePasswordFilePath();
+      await this.createPasswordFile(passwordFilePath, bucket, {
+        accessKeyId: 'x',
+        secretAccessKey: 'x'
+      });
 
       const mountInfo: R2EgressMountInfo = {
         mountType: 'r2-egress',
         bucket,
         mountPath,
-        mounted: false
+        passwordFilePath,
+        mounted: false,
+        prefix
       };
       this.activeMounts.set(mountPath, mountInfo);
 
       await this.execInternal(`mkdir -p ${shellEscape(mountPath)}`);
 
-      const s3fsSource = buildS3fsSource(bucket, prefix);
+      await this.setOutboundByHost<R2EgressParams>(
+        'r2.internal',
+        'r2EgressMount',
+        this.getR2EgressParams()
+      );
+
+      const s3fsSource = bucket;
       const s3fsArgMap = new Map<string, string>();
+      s3fsArgMap.set('passwd_file', `passwd_file=${passwordFilePath}`);
       for (const arg of resolveS3fsOptions('r2', options.s3fsOptions)) {
         const [key] = arg.split('=');
         s3fsArgMap.set(key, arg);
       }
-      s3fsArgMap.set('nosignrequest', 'nosignrequest');
       s3fsArgMap.set('use_path_request_style', 'use_path_request_style');
       s3fsArgMap.set('url', 'url=http://r2.internal');
 
@@ -1347,25 +1364,42 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
       const optionsStr = shellEscape(s3fsArgs.join(','));
       const mountCmd = `s3fs ${shellEscape(s3fsSource)} ${shellEscape(mountPath)} -o ${optionsStr}`;
+      this.logger.debug('r2-egress: running s3fs', { mountCmd });
       const result = await this.execInternal(mountCmd);
+      this.logger.debug('r2-egress: s3fs exited', {
+        exitCode: result.exitCode,
+        stdout: result.stdout,
+        stderr: result.stderr
+      });
       if (result.exitCode !== 0) {
         throw new S3FSMountError(
           `S3FS mount failed: ${result.stderr || result.stdout || 'Unknown error'}`
         );
       }
 
+      const mountpointCheck = await this.execInternal(
+        `mountpoint -q ${shellEscape(mountPath)} && echo 'FUSE_MOUNTED' || echo 'NOT_FUSE_MOUNTED'`
+      );
+      this.logger.debug('r2-egress: mountpoint check', {
+        stdout: mountpointCheck.stdout.trim(),
+        exitCode: mountpointCheck.exitCode
+      });
+
       mountInfo.mounted = true;
       mountOutcome = 'success';
     } catch (error) {
       mountError = error instanceof Error ? error : new Error(String(error));
-      revokeBucketAccess(this.ctx.id.toString(), bucket);
       this.activeMounts.delete(mountPath);
-
-      // Remove the egress handler if no r2-egress mounts remain.
-      if (!this.hasActiveR2EgressMounts()) {
+      const remainingParams = this.getR2EgressParams();
+      if (Object.keys(remainingParams.buckets).length === 0) {
         await this.removeOutboundByHost('r2.internal').catch(() => {});
+      } else {
+        await this.setOutboundByHost<R2EgressParams>(
+          'r2.internal',
+          'r2EgressMount',
+          remainingParams
+        ).catch(() => {});
       }
-
       throw error;
     } finally {
       logCanonicalEvent(this.logger, {
@@ -1379,13 +1413,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         error: mountError
       });
     }
-  }
-
-  private hasActiveR2EgressMounts(): boolean {
-    for (const m of this.activeMounts.values()) {
-      if (m.mountType === 'r2-egress') return true;
-    }
-    return false;
   }
 
   /**
@@ -1550,9 +1577,19 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
             `fusermount -u failed (exit ${result.exitCode}): ${stderr}`
           );
         }
-        revokeBucketAccess(this.ctx.id.toString(), mountInfo.bucket);
+        await this.deletePasswordFile(mountInfo.passwordFilePath);
         mountInfo.mounted = false;
         this.activeMounts.delete(mountPath);
+        const remainingR2Params = this.getR2EgressParams();
+        if (Object.keys(remainingR2Params.buckets).length === 0) {
+          await this.removeOutboundByHost('r2.internal');
+        } else {
+          await this.setOutboundByHost<R2EgressParams>(
+            'r2.internal',
+            'r2EgressMount',
+            remainingR2Params
+          );
+        }
 
         try {
           await this.execInternal(
@@ -1560,10 +1597,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           );
         } catch {
           // Best-effort directory removal
-        }
-
-        if (!this.hasActiveR2EgressMounts()) {
-          await this.removeOutboundByHost('r2.internal').catch(() => {});
         }
       } else {
         // FUSE unmount
@@ -1903,7 +1936,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
               );
             }
           }
-          revokeBucketAccess(this.ctx.id.toString(), mountInfo.bucket);
+          await this.deletePasswordFile(mountInfo.passwordFilePath);
         } else {
           if (mountInfo.mounted) {
             try {
@@ -1927,14 +1960,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           // Always cleanup password file for FUSE mounts
           await this.deletePasswordFile(mountInfo.passwordFilePath);
         }
-      }
-
-      // Remove the egress handler if any R2 egress mounts were active.
-      // hasActiveR2EgressMounts() still returns true here because
-      // activeMounts is cleared below — we just want to know if we need
-      // to deregister the outbound handler.
-      if (this.hasActiveR2EgressMounts()) {
-        await this.removeOutboundByHost('r2.internal').catch(() => {});
       }
 
       // portTokens is cleared while still inside destroy()'s try block:
@@ -2155,13 +2180,17 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     // Disconnect the active client so open sockets do not hold the DO alive.
     this.client.disconnect();
 
-    // Stop local sync managers and revoke R2 egress access before clearing the map.
+    // Stop local sync managers before clearing the map.
+    let hadR2EgressMount = false;
     for (const [, m] of this.activeMounts) {
       if (m.mountType === 'local-sync') {
         await m.syncManager.stop().catch(() => {});
       } else if (m.mountType === 'r2-egress') {
-        revokeBucketAccess(this.ctx.id.toString(), m.bucket);
+        hadR2EgressMount = true;
       }
+    }
+    if (hadR2EgressMount) {
+      await this.removeOutboundByHost('r2.internal').catch(() => {});
     }
 
     this.activeMounts.clear();
@@ -6046,3 +6075,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
   }
 }
+
+Sandbox.outboundByHost = { 'r2.internal': r2EgressHandler };
+Sandbox.outboundHandlers = { r2EgressMount: r2EgressHandler };

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -519,10 +519,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   defaultPort = 3000; // Default port for the container's Bun server
   sleepAfter: string | number = '10m'; // Sleep the sandbox if no requests are made in this timeframe
 
-  static outboundHandlers = {
-    r2Mount: r2EgressHandler
-  };
-
   client: SandboxClient | ContainerControlClient;
 
   private codeInterpreter: CodeInterpreter;

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -105,7 +105,7 @@ import type {
   FuseMountInfo,
   LocalSyncMountInfo,
   MountInfo,
-  R2EgressMountInfo
+  R2BindingMountInfo
 } from './storage-mount/types';
 import { SDK_VERSION } from './version';
 
@@ -139,6 +139,48 @@ type CachedSandboxConfiguration = {
   transport?: SandboxTransport;
 };
 
+type R2EgressContainerState = DurableObjectState<{}> & {
+  exports?: {
+    ContainerProxy?: (options: {
+      props: {
+        enableInternet?: boolean;
+        containerId: string;
+        className: string;
+        outboundByHostOverrides: Record<
+          string,
+          {
+            method: string;
+            params: R2EgressParams;
+          }
+        >;
+      };
+    }) => Fetcher;
+  };
+  container?: {
+    interceptOutboundHttp(host: string, fetcher: Fetcher): Promise<void>;
+  };
+};
+
+const R2_EGRESS_PROXY_TARGET_CLASS_NAME =
+  'CloudflareSandboxR2EgressProxyTarget';
+
+class R2EgressProxyTarget extends Container {}
+
+Object.defineProperty(R2EgressProxyTarget, 'name', {
+  value: R2_EGRESS_PROXY_TARGET_CLASS_NAME
+});
+
+R2EgressProxyTarget.outboundHandlers = { r2EgressMount: r2EgressHandler };
+
+function isFetcher(value: unknown): value is Fetcher {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'fetch' in value &&
+    typeof value.fetch === 'function'
+  );
+}
+
 type ConfigurableSandboxStub = {
   configure?: (configuration: SandboxConfiguration) => Promise<void>;
   setSandboxName?: (name: string, normalizeId?: boolean) => Promise<void>;
@@ -157,7 +199,8 @@ const sandboxConfigurationCache = new WeakMap<
 
 const R2_DEFAULT_S3FS_OPTIONS: readonly string[] = [
   'stat_cache_expire=60',
-  'enable_noobj_cache'
+  'enable_noobj_cache',
+  'multipart_size=5'
 ];
 
 const BACKUP_DEFAULT_TTL_SECONDS = 259200;
@@ -1358,12 +1401,14 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       }
 
       const passwordFilePath = this.generatePasswordFilePath();
+      // s3fs requires a passwd file before it will issue requests; the R2
+      // egress handler resolves the Worker binding and ignores S3 signatures.
       await this.createPasswordFile(passwordFilePath, bucket, {
         accessKeyId: 'x',
         secretAccessKey: 'x'
       });
 
-      const mountInfo: R2EgressMountInfo = {
+      const mountInfo: R2BindingMountInfo = {
         mountType: 'r2-egress',
         bucket,
         mountPath,
@@ -1374,13 +1419,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       };
       this.activeMounts.set(mountPath, mountInfo);
 
-      await this.execInternal(`mkdir -p ${shellEscape(mountPath)}`);
+      await this.configureR2EgressOutbound();
 
-      await this.setOutboundByHost<R2EgressParams>(
-        'r2.internal',
-        'r2EgressMount',
-        this.getR2EgressParams()
-      );
+      await this.execInternal(`mkdir -p ${shellEscape(mountPath)}`);
 
       const s3fsSource = bucket;
       const s3fsArgMap = new Map<string, string>();
@@ -1440,15 +1481,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         );
       }
       const remainingParams = this.getR2EgressParams();
-      if (Object.keys(remainingParams.buckets).length === 0) {
-        await this.removeOutboundByHost('r2.internal').catch(() => {});
-      } else {
-        await this.setOutboundByHost<R2EgressParams>(
-          'r2.internal',
-          'r2EgressMount',
-          remainingParams
-        ).catch(() => {});
-      }
+      await this.configureR2EgressOutbound(remainingParams).catch(() => {});
       throw error;
     } finally {
       logCanonicalEvent(this.logger, {
@@ -1616,37 +1649,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         await mountInfo.syncManager.stop();
         mountInfo.mounted = false;
         this.activeMounts.delete(mountPath);
-      } else if (mountInfo.mountType === 'r2-egress') {
-        const result = await this.execInternal(
-          `fusermount -u ${shellEscape(mountPath)}`
-        );
-        if (result.exitCode !== 0) {
-          const stderr = result.stderr || 'unknown error';
-          throw new BucketUnmountError(
-            `fusermount -u failed (exit ${result.exitCode}): ${stderr}`
-          );
-        }
-        await this.deletePasswordFile(mountInfo.passwordFilePath);
-        mountInfo.mounted = false;
-        this.activeMounts.delete(mountPath);
-        const remainingR2Params = this.getR2EgressParams();
-        if (Object.keys(remainingR2Params.buckets).length === 0) {
-          await this.removeOutboundByHost('r2.internal');
-        } else {
-          await this.setOutboundByHost<R2EgressParams>(
-            'r2.internal',
-            'r2EgressMount',
-            remainingR2Params
-          );
-        }
-
-        try {
-          await this.execInternal(
-            `mountpoint -q ${shellEscape(mountPath)} || rmdir ${shellEscape(mountPath)}`
-          );
-        } catch {
-          // Best-effort directory removal
-        }
       } else {
         // FUSE unmount
         try {
@@ -1663,6 +1665,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
           // Only remove from tracking if unmount succeeded
           this.activeMounts.delete(mountPath);
+
+          if (mountInfo.mountType === 'r2-egress') {
+            await this.teardownR2EgressMount();
+          }
 
           // Remove the now-empty mount directory
           try {
@@ -2239,7 +2245,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       }
     }
     if (hadR2EgressMount) {
-      await this.removeOutboundByHost('r2.internal').catch(() => {});
+      await this.configureR2EgressOutbound({ buckets: {} }).catch(() => {});
     }
 
     this.activeMounts.clear();
@@ -6123,7 +6129,46 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       });
     }
   }
-}
 
-Sandbox.outboundByHost = { 'r2.internal': r2EgressHandler };
-Sandbox.outboundHandlers = { r2EgressMount: r2EgressHandler };
+  private async configureR2EgressOutbound(
+    params: R2EgressParams = this.getR2EgressParams()
+  ): Promise<void> {
+    const ctx = this.ctx as R2EgressContainerState;
+    if (!ctx.container?.interceptOutboundHttp) {
+      throw new InvalidMountConfigError(
+        'R2 binding mounts require container outbound interception support'
+      );
+    }
+    if (!ctx.exports?.ContainerProxy) {
+      throw new InvalidMountConfigError(
+        'R2 binding mounts require exporting ContainerProxy from the Worker entrypoint'
+      );
+    }
+
+    const fetcher = ctx.exports.ContainerProxy({
+      props: {
+        enableInternet: this.enableInternet,
+        containerId: this.ctx.id.toString(),
+        className: R2_EGRESS_PROXY_TARGET_CLASS_NAME,
+        outboundByHostOverrides: {
+          'r2.internal': {
+            method: 'r2EgressMount',
+            params
+          }
+        }
+      }
+    });
+    if (!isFetcher(fetcher)) {
+      throw new InvalidMountConfigError(
+        'R2 binding mounts require ContainerProxy to return a valid Fetcher'
+      );
+    }
+
+    await ctx.container.interceptOutboundHttp('r2.internal', fetcher);
+  }
+
+  private async teardownR2EgressMount(): Promise<void> {
+    const remainingR2Params = this.getR2EgressParams();
+    await this.configureR2EgressOutbound(remainingR2Params);
+  }
+}

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -155,6 +155,11 @@ const sandboxConfigurationCache = new WeakMap<
   Map<string, CachedSandboxConfiguration>
 >();
 
+const R2_DEFAULT_S3FS_OPTIONS: readonly string[] = [
+  'stat_cache_expire=60',
+  'enable_noobj_cache'
+];
+
 const BACKUP_DEFAULT_TTL_SECONDS = 259200;
 const BACKUP_MAX_NAME_LENGTH = 256;
 const BACKUP_CONTAINER_DIR = '/var/backups';
@@ -1294,13 +1299,30 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   private getR2EgressParams(): R2EgressParams {
-    const buckets: Record<string, string | undefined> = {};
+    const buckets: R2EgressParams['buckets'] = {};
     for (const [, m] of this.activeMounts) {
       if (m.mountType === 'r2-egress') {
-        buckets[m.bucket] = m.prefix;
+        buckets[m.bucket] = {
+          prefix: m.prefix,
+          readOnly: m.readOnly
+        };
       }
     }
     return { buckets };
+  }
+
+  private validateR2EgressS3fsOptions(options?: string[]): void {
+    if (!options) return;
+
+    const protectedOptions = new Set(['passwd_file', 'url']);
+    for (const option of options) {
+      const [key] = option.split('=');
+      if (protectedOptions.has(key)) {
+        throw new InvalidMountConfigError(
+          `s3fs option "${key}" cannot be overridden for R2 binding mounts`
+        );
+      }
+    }
   }
 
   /**
@@ -1320,6 +1342,20 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     try {
       validateBucketBindingName(bucket, mountPath);
       this.validateMountPath(mountPath);
+      this.validateR2EgressS3fsOptions(options.s3fsOptions);
+
+      for (const [existingMountPath, mountInfo] of this.activeMounts) {
+        if (
+          mountInfo.mountType === 'r2-egress' &&
+          mountInfo.bucket === bucket &&
+          mountInfo.prefix !== prefix
+        ) {
+          throw new InvalidMountConfigError(
+            `R2 binding "${bucket}" is already mounted at ${existingMountPath} with a different prefix. ` +
+              'Mount the same binding only once, or use the same prefix for additional mounts.'
+          );
+        }
+      }
 
       const passwordFilePath = this.generatePasswordFilePath();
       await this.createPasswordFile(passwordFilePath, bucket, {
@@ -1333,7 +1369,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         mountPath,
         passwordFilePath,
         mounted: false,
-        prefix
+        prefix,
+        readOnly: options.readOnly ?? false
       };
       this.activeMounts.set(mountPath, mountInfo);
 
@@ -1348,6 +1385,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       const s3fsSource = bucket;
       const s3fsArgMap = new Map<string, string>();
       s3fsArgMap.set('passwd_file', `passwd_file=${passwordFilePath}`);
+      for (const arg of R2_DEFAULT_S3FS_OPTIONS) {
+        const [key] = arg.split('=');
+        s3fsArgMap.set(key, arg);
+      }
       for (const arg of resolveS3fsOptions('r2', options.s3fsOptions)) {
         const [key] = arg.split('=');
         s3fsArgMap.set(key, arg);
@@ -1381,11 +1422,23 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         exitCode: mountpointCheck.exitCode
       });
 
+      if (mountpointCheck.stdout.trim() !== 'FUSE_MOUNTED') {
+        throw new S3FSMountError(
+          `s3fs exited 0 but mount was not established at ${mountPath}`
+        );
+      }
+
       mountInfo.mounted = true;
       mountOutcome = 'success';
     } catch (error) {
       mountError = error instanceof Error ? error : new Error(String(error));
+      const failedMount = this.activeMounts.get(mountPath);
       this.activeMounts.delete(mountPath);
+      if (failedMount?.mountType === 'r2-egress') {
+        await this.deletePasswordFile(failedMount.passwordFilePath).catch(
+          () => {}
+        );
+      }
       const remainingParams = this.getR2EgressParams();
       if (Object.keys(remainingParams.buckets).length === 0) {
         await this.removeOutboundByHost('r2.internal').catch(() => {});

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1196,7 +1196,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
 
     const remoteOptions = options as RemoteMountBucketOptions;
-    if (!remoteOptions.endpoint) {
+    if (remoteOptions.endpoint === undefined) {
       const envObj = this.env as Record<string, unknown>;
       const binding = envObj[bucket];
       if (isR2Bucket(binding)) {
@@ -1335,7 +1335,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     options: R2BindingMountBucketOptions
   ): Promise<void> {
     const mountStartTime = Date.now();
-    const prefix = options.prefix || undefined;
+    const prefix = options.prefix;
     let mountOutcome: 'success' | 'error' = 'error';
     let mountError: Error | undefined;
 
@@ -1473,7 +1473,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     options: RemoteMountBucketOptions
   ): Promise<void> {
     const mountStartTime = Date.now();
-    const prefix = options.prefix || undefined;
+    const prefix = options.prefix;
     let mountOutcome: 'success' | 'error' = 'error';
     let mountError: Error | undefined;
     let passwordFilePath: string | undefined;

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -197,11 +197,11 @@ const sandboxConfigurationCache = new WeakMap<
   Map<string, CachedSandboxConfiguration>
 >();
 
-const R2_DEFAULT_S3FS_OPTIONS: readonly string[] = [
-  'stat_cache_expire=60',
-  'enable_noobj_cache',
-  'multipart_size=5'
-];
+const R2_DEFAULT_S3FS_OPTIONS: Readonly<Record<string, string | boolean>> = {
+  stat_cache_expire: '60',
+  enable_noobj_cache: true,
+  multipart_size: '5'
+};
 
 const BACKUP_DEFAULT_TTL_SECONDS = 259200;
 const BACKUP_MAX_NAME_LENGTH = 256;
@@ -1419,28 +1419,21 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       };
       this.activeMounts.set(mountPath, mountInfo);
 
-      await this.configureR2EgressOutbound();
+      await this.configureR2EgressOutbound(this.getR2EgressParams());
 
       await this.execInternal(`mkdir -p ${shellEscape(mountPath)}`);
 
       const s3fsSource = bucket;
-      const s3fsArgMap = new Map<string, string>();
-      s3fsArgMap.set('passwd_file', `passwd_file=${passwordFilePath}`);
-      for (const arg of R2_DEFAULT_S3FS_OPTIONS) {
-        const [key] = arg.split('=');
-        s3fsArgMap.set(key, arg);
-      }
-      for (const arg of resolveS3fsOptions('r2', options.s3fsOptions)) {
-        const [key] = arg.split('=');
-        s3fsArgMap.set(key, arg);
-      }
-      s3fsArgMap.set('use_path_request_style', 'use_path_request_style');
-      s3fsArgMap.set('url', 'url=http://r2.internal');
+      const s3fsOptions: Record<string, string | boolean> = {
+        passwd_file: passwordFilePath,
+        ...R2_DEFAULT_S3FS_OPTIONS,
+        ...parseS3fsOptions(resolveS3fsOptions('r2', options.s3fsOptions)),
+        use_path_request_style: true,
+        url: 'http://r2.internal',
+        ...(options.readOnly ? { ro: true } : {})
+      };
 
-      if (options.readOnly) s3fsArgMap.set('ro', 'ro');
-      const s3fsArgs = Array.from(s3fsArgMap.values());
-
-      const optionsStr = shellEscape(s3fsArgs.join(','));
+      const optionsStr = shellEscape(serializeS3fsOptions(s3fsOptions));
       const mountCmd = `s3fs ${shellEscape(s3fsSource)} ${shellEscape(mountPath)} -o ${optionsStr}`;
       this.logger.debug('r2-egress: running s3fs', { mountCmd });
       const result = await this.execInternal(mountCmd);
@@ -1667,7 +1660,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           this.activeMounts.delete(mountPath);
 
           if (mountInfo.mountType === 'r2-egress') {
-            await this.teardownR2EgressMount();
+            await this.configureR2EgressOutbound(this.getR2EgressParams());
           }
 
           // Remove the now-empty mount directory
@@ -1886,6 +1879,26 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     );
   }
 
+  private async unmountTrackedFuseMount(
+    mountPath: string,
+    mountInfo: FuseMountInfo | R2BindingMountInfo
+  ): Promise<void> {
+    if (!mountInfo.mounted) return;
+
+    this.logger.debug(
+      `Unmounting bucket ${mountInfo.bucket} from ${mountPath}`
+    );
+    const result = await this.execInternal(
+      `fusermount -u ${shellEscape(mountPath)}`
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `fusermount -u failed (exit ${result.exitCode}): ${result.stderr || 'unknown error'}`
+      );
+    }
+    mountInfo.mounted = false;
+  }
+
   /**
    * In-flight `destroy()` promise. While set, concurrent callers coalesce
    * onto the same teardown instead of triggering a second one. Cleared when
@@ -1967,49 +1980,16 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
               `Failed to stop local sync for ${mountPath}: ${errorMsg}`
             );
           }
-        } else if (mountInfo.mountType === 'r2-egress') {
-          if (mountInfo.mounted) {
-            try {
-              this.logger.debug(
-                `Unmounting R2 egress bucket ${mountInfo.bucket} from ${mountPath}`
-              );
-              const result = await this.execInternal(
-                `fusermount -u ${shellEscape(mountPath)}`
-              );
-              if (result.exitCode !== 0) {
-                throw new Error(
-                  `fusermount -u failed (exit ${result.exitCode}): ${result.stderr || 'unknown error'}`
-                );
-              }
-              mountInfo.mounted = false;
-            } catch (error) {
-              mountFailures++;
-              const errorMsg =
-                error instanceof Error ? error.message : String(error);
-              this.logger.warn(
-                `Failed to unmount R2 egress bucket ${mountInfo.bucket} from ${mountPath}: ${errorMsg}`
-              );
-            }
-          }
-          await this.deletePasswordFile(mountInfo.passwordFilePath);
         } else {
-          if (mountInfo.mounted) {
-            try {
-              this.logger.debug(
-                `Unmounting bucket ${mountInfo.bucket} from ${mountPath}`
-              );
-              await this.execInternal(
-                `fusermount -u ${shellEscape(mountPath)}`
-              );
-              mountInfo.mounted = false;
-            } catch (error) {
-              mountFailures++;
-              const errorMsg =
-                error instanceof Error ? error.message : String(error);
-              this.logger.warn(
-                `Failed to unmount bucket ${mountInfo.bucket} from ${mountPath}: ${errorMsg}`
-              );
-            }
+          try {
+            await this.unmountTrackedFuseMount(mountPath, mountInfo);
+          } catch (error) {
+            mountFailures++;
+            const errorMsg =
+              error instanceof Error ? error.message : String(error);
+            this.logger.warn(
+              `Failed to unmount bucket ${mountInfo.bucket} from ${mountPath}: ${errorMsg}`
+            );
           }
 
           // Always cleanup password file for FUSE mounts
@@ -6131,7 +6111,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   private async configureR2EgressOutbound(
-    params: R2EgressParams = this.getR2EgressParams()
+    params: R2EgressParams
   ): Promise<void> {
     const ctx = this.ctx as R2EgressContainerState;
     if (!ctx.container?.interceptOutboundHttp) {
@@ -6165,10 +6145,5 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
 
     await ctx.container.interceptOutboundHttp('r2.internal', fetcher);
-  }
-
-  private async teardownR2EgressMount(): Promise<void> {
-    const remainingR2Params = this.getR2EgressParams();
-    await this.configureR2EgressOutbound(remainingR2Params);
   }
 }

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -23,6 +23,7 @@ import type {
   ProcessOptions,
   ProcessStatus,
   PtyOptions,
+  R2BindingMountBucketOptions,
   ReadFileResult,
   ReadFileStreamResult,
   RemoteMountBucketOptions,
@@ -84,7 +85,10 @@ import {
   buildS3fsSource,
   detectCredentials,
   detectProviderFromUrl,
+  isR2Bucket,
+  MissingCredentialsError,
   resolveS3fsOptions,
+  validateBucketBindingName,
   validateBucketName,
   validatePrefix
 } from './storage-mount';
@@ -93,10 +97,16 @@ import {
   InvalidMountConfigError,
   S3FSMountError
 } from './storage-mount/errors';
+import {
+  r2EgressHandler,
+  registerBucketAccess,
+  revokeBucketAccess
+} from './storage-mount/r2-egress-handler';
 import type {
   FuseMountInfo,
   LocalSyncMountInfo,
-  MountInfo
+  MountInfo,
+  R2EgressMountInfo
 } from './storage-mount/types';
 import { SDK_VERSION } from './version';
 
@@ -506,28 +516,13 @@ export function connect(stub: {
   };
 }
 
-/**
- * Type guard for R2Bucket binding.
- * Checks for the minimal R2Bucket interface methods we use.
- */
-function isR2Bucket(value: unknown): value is R2Bucket {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'put' in value &&
-    typeof (value as Record<string, unknown>).put === 'function' &&
-    'get' in value &&
-    typeof (value as Record<string, unknown>).get === 'function' &&
-    'head' in value &&
-    typeof (value as Record<string, unknown>).head === 'function' &&
-    'delete' in value &&
-    typeof (value as Record<string, unknown>).delete === 'function'
-  );
-}
-
 export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   defaultPort = 3000; // Default port for the container's Bun server
   sleepAfter: string | number = '10m'; // Sleep the sandbox if no requests are made in this timeframe
+
+  static outboundHandlers = {
+    r2Mount: r2EgressHandler
+  };
 
   client: SandboxClient | ContainerControlClient;
 
@@ -1200,11 +1195,25 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       return;
     }
 
-    await this.mountBucketFuse(
-      bucket,
-      mountPath,
-      options as RemoteMountBucketOptions
-    );
+    const remoteOptions = options as RemoteMountBucketOptions;
+    if (!remoteOptions.endpoint) {
+      const envObj = this.env as Record<string, unknown>;
+      const binding = envObj[bucket];
+      if (isR2Bucket(binding)) {
+        await this.mountBucketR2Egress(
+          bucket,
+          mountPath,
+          options as R2BindingMountBucketOptions
+        );
+        return;
+      }
+      throw new InvalidMountConfigError(
+        `R2 binding "${bucket}" not found in Worker env. ` +
+          'Ensure the binding name matches the bucket binding configured in wrangler.jsonc.'
+      );
+    }
+
+    await this.mountBucketFuse(bucket, mountPath, remoteOptions);
   }
 
   /**
@@ -1287,6 +1296,96 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         error: mountError
       });
     }
+  }
+
+  /**
+   * Credential-less R2 mount: egress interception routes s3fs requests to the
+   * R2 binding. No S3 credentials are needed in the container or Worker env.
+   */
+  private async mountBucketR2Egress(
+    bucket: string,
+    mountPath: string,
+    options: R2BindingMountBucketOptions
+  ): Promise<void> {
+    const mountStartTime = Date.now();
+    const prefix = options.prefix || undefined;
+    let mountOutcome: 'success' | 'error' = 'error';
+    let mountError: Error | undefined;
+
+    try {
+      validateBucketBindingName(bucket, mountPath);
+      this.validateMountPath(mountPath);
+
+      registerBucketAccess(this.ctx.id.toString(), bucket);
+
+      // Register the r2.internal egress handler for this DO instance so the
+      // Cloudflare Containers runtime routes s3fs requests to r2EgressHandler.
+      await this.setOutboundByHost('r2.internal', 'r2Mount');
+
+      const mountInfo: R2EgressMountInfo = {
+        mountType: 'r2-egress',
+        bucket,
+        mountPath,
+        mounted: false
+      };
+      this.activeMounts.set(mountPath, mountInfo);
+
+      await this.execInternal(`mkdir -p ${shellEscape(mountPath)}`);
+
+      const s3fsSource = buildS3fsSource(bucket, prefix);
+      const s3fsArgMap = new Map<string, string>();
+      for (const arg of resolveS3fsOptions('r2', options.s3fsOptions)) {
+        const [key] = arg.split('=');
+        s3fsArgMap.set(key, arg);
+      }
+      s3fsArgMap.set('nosignrequest', 'nosignrequest');
+      s3fsArgMap.set('use_path_request_style', 'use_path_request_style');
+      s3fsArgMap.set('url', 'url=http://r2.internal');
+
+      if (options.readOnly) s3fsArgMap.set('ro', 'ro');
+      const s3fsArgs = Array.from(s3fsArgMap.values());
+
+      const optionsStr = shellEscape(s3fsArgs.join(','));
+      const mountCmd = `s3fs ${shellEscape(s3fsSource)} ${shellEscape(mountPath)} -o ${optionsStr}`;
+      const result = await this.execInternal(mountCmd);
+      if (result.exitCode !== 0) {
+        throw new S3FSMountError(
+          `S3FS mount failed: ${result.stderr || result.stdout || 'Unknown error'}`
+        );
+      }
+
+      mountInfo.mounted = true;
+      mountOutcome = 'success';
+    } catch (error) {
+      mountError = error instanceof Error ? error : new Error(String(error));
+      revokeBucketAccess(this.ctx.id.toString(), bucket);
+      this.activeMounts.delete(mountPath);
+
+      // Remove the egress handler if no r2-egress mounts remain.
+      if (!this.hasActiveR2EgressMounts()) {
+        await this.removeOutboundByHost('r2.internal').catch(() => {});
+      }
+
+      throw error;
+    } finally {
+      logCanonicalEvent(this.logger, {
+        event: 'bucket.mount',
+        outcome: mountOutcome,
+        durationMs: Date.now() - mountStartTime,
+        bucket,
+        mountPath,
+        provider: 'r2',
+        prefix,
+        error: mountError
+      });
+    }
+  }
+
+  private hasActiveR2EgressMounts(): boolean {
+    for (const m of this.activeMounts.values()) {
+      if (m.mountType === 'r2-egress') return true;
+    }
+    return false;
   }
 
   /**
@@ -1441,6 +1540,31 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         await mountInfo.syncManager.stop();
         mountInfo.mounted = false;
         this.activeMounts.delete(mountPath);
+      } else if (mountInfo.mountType === 'r2-egress') {
+        const result = await this.execInternal(
+          `fusermount -u ${shellEscape(mountPath)}`
+        );
+        if (result.exitCode !== 0) {
+          const stderr = result.stderr || 'unknown error';
+          throw new BucketUnmountError(
+            `fusermount -u failed (exit ${result.exitCode}): ${stderr}`
+          );
+        }
+        revokeBucketAccess(this.ctx.id.toString(), mountInfo.bucket);
+        mountInfo.mounted = false;
+        this.activeMounts.delete(mountPath);
+
+        try {
+          await this.execInternal(
+            `mountpoint -q ${shellEscape(mountPath)} || rmdir ${shellEscape(mountPath)}`
+          );
+        } catch {
+          // Best-effort directory removal
+        }
+
+        if (!this.hasActiveR2EgressMounts()) {
+          await this.removeOutboundByHost('r2.internal').catch(() => {});
+        }
       } else {
         // FUSE unmount
         try {
@@ -1499,7 +1623,26 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   /**
-   * Validate mount options
+   * Shared validation for mount path (absolute, not already in use).
+   */
+  private validateMountPath(mountPath: string): void {
+    if (!mountPath.startsWith('/')) {
+      throw new InvalidMountConfigError(
+        `Mount path must be absolute (start with /): "${mountPath}"`
+      );
+    }
+
+    if (this.activeMounts.has(mountPath)) {
+      const existingMount = this.activeMounts.get(mountPath);
+      throw new InvalidMountConfigError(
+        `Mount path "${mountPath}" is already in use by bucket "${existingMount?.bucket}". ` +
+          `Unmount the existing bucket first or use a different mount path.`
+      );
+    }
+  }
+
+  /**
+   * Validate mount options for remote (FUSE) mounts
    */
   private validateMountOptions(
     bucket: string,
@@ -1516,22 +1659,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
 
     validateBucketName(bucket, mountPath);
-
-    // Validate mount path is absolute
-    if (!mountPath.startsWith('/')) {
-      throw new InvalidMountConfigError(
-        `Mount path must be absolute (start with /): "${mountPath}"`
-      );
-    }
-
-    // Check for duplicate mount path
-    if (this.activeMounts.has(mountPath)) {
-      const existingMount = this.activeMounts.get(mountPath);
-      throw new InvalidMountConfigError(
-        `Mount path "${mountPath}" is already in use by bucket "${existingMount?.bucket}". ` +
-          `Unmount the existing bucket first or use a different mount path.`
-      );
-    }
+    this.validateMountPath(mountPath);
 
     // Prefix validation is handled centrally in mountBucket()
   }
@@ -1751,6 +1879,31 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
               `Failed to stop local sync for ${mountPath}: ${errorMsg}`
             );
           }
+        } else if (mountInfo.mountType === 'r2-egress') {
+          if (mountInfo.mounted) {
+            try {
+              this.logger.debug(
+                `Unmounting R2 egress bucket ${mountInfo.bucket} from ${mountPath}`
+              );
+              const result = await this.execInternal(
+                `fusermount -u ${shellEscape(mountPath)}`
+              );
+              if (result.exitCode !== 0) {
+                throw new Error(
+                  `fusermount -u failed (exit ${result.exitCode}): ${result.stderr || 'unknown error'}`
+                );
+              }
+              mountInfo.mounted = false;
+            } catch (error) {
+              mountFailures++;
+              const errorMsg =
+                error instanceof Error ? error.message : String(error);
+              this.logger.warn(
+                `Failed to unmount R2 egress bucket ${mountInfo.bucket} from ${mountPath}: ${errorMsg}`
+              );
+            }
+          }
+          revokeBucketAccess(this.ctx.id.toString(), mountInfo.bucket);
         } else {
           if (mountInfo.mounted) {
             try {
@@ -1774,6 +1927,14 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           // Always cleanup password file for FUSE mounts
           await this.deletePasswordFile(mountInfo.passwordFilePath);
         }
+      }
+
+      // Remove the egress handler if any R2 egress mounts were active.
+      // hasActiveR2EgressMounts() still returns true here because
+      // activeMounts is cleared below — we just want to know if we need
+      // to deregister the outbound handler.
+      if (this.hasActiveR2EgressMounts()) {
+        await this.removeOutboundByHost('r2.internal').catch(() => {});
       }
 
       // portTokens is cleared while still inside destroy()'s try block:
@@ -1994,10 +2155,13 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     // Disconnect the active client so open sockets do not hold the DO alive.
     this.client.disconnect();
 
-    // Stop local sync managers before clearing the map.
+    // Stop local sync managers and revoke R2 egress access before clearing the map.
     for (const [, m] of this.activeMounts) {
-      if (m.mountType === 'local-sync')
+      if (m.mountType === 'local-sync') {
         await m.syncManager.stop().catch(() => {});
+      } else if (m.mountType === 'r2-egress') {
+        revokeBucketAccess(this.ctx.id.toString(), m.bucket);
+      }
     }
 
     this.activeMounts.clear();

--- a/packages/sandbox/src/storage-mount/index.ts
+++ b/packages/sandbox/src/storage-mount/index.ts
@@ -19,6 +19,7 @@ export type {
   FuseMountInfo,
   LocalSyncMountInfo,
   MountInfo,
+  R2BindingMountInfo,
   R2EgressMountInfo
 } from './types';
 export {

--- a/packages/sandbox/src/storage-mount/index.ts
+++ b/packages/sandbox/src/storage-mount/index.ts
@@ -15,9 +15,16 @@ export {
   getProviderFlags,
   resolveS3fsOptions
 } from './provider-detection';
-export type { FuseMountInfo, LocalSyncMountInfo, MountInfo } from './types';
+export type {
+  FuseMountInfo,
+  LocalSyncMountInfo,
+  MountInfo,
+  R2EgressMountInfo
+} from './types';
 export {
   buildS3fsSource,
+  isR2Bucket,
+  validateBucketBindingName,
   validateBucketName,
   validatePrefix
 } from './validation';

--- a/packages/sandbox/src/storage-mount/r2-egress-handler.ts
+++ b/packages/sandbox/src/storage-mount/r2-egress-handler.ts
@@ -1,0 +1,623 @@
+/**
+ * Egress handler that translates S3 API requests from s3fs into R2 binding calls.
+ *
+ * When s3fs inside the container makes requests to http://r2.internal/<bucket>/...,
+ * the Cloudflare egress interception layer routes them here. The bucket name is read
+ * from the first path segment, resolved to a Worker R2 binding, and the request is
+ * executed via the R2 binding API — no S3 credentials ever touch the container.
+ *
+ * S3 path-style layout: /bucketName/objectKey
+ * Query params drive operation selection (list-type=2, uploads, uploadId, location).
+ */
+
+import type {
+  OutboundHandler,
+  OutboundHandlerContext
+} from '@cloudflare/containers';
+import { isR2Bucket } from './validation';
+
+// ---------------------------------------------------------------------------
+// Per-instance bucket allowlist
+//
+// Maps containerId → Set of bucket binding names that this sandbox instance
+// is explicitly permitted to access. Populated by mountBucketR2Egress() and
+// cleaned up on unmount/destroy. Requests for buckets not in this set are
+// rejected with 403 to prevent a sandbox from reaching R2 bindings it was
+// never told to mount.
+// ---------------------------------------------------------------------------
+
+const allowedBuckets = new Map<string, Set<string>>();
+
+export function registerBucketAccess(
+  containerId: string,
+  bucketName: string
+): void {
+  const existing = allowedBuckets.get(containerId);
+  if (existing) {
+    existing.add(bucketName);
+  } else {
+    allowedBuckets.set(containerId, new Set([bucketName]));
+  }
+}
+
+export function revokeBucketAccess(
+  containerId: string,
+  bucketName: string
+): void {
+  const buckets = allowedBuckets.get(containerId);
+  if (!buckets) return;
+  buckets.delete(bucketName);
+  if (buckets.size === 0) allowedBuckets.delete(containerId);
+}
+
+// ---------------------------------------------------------------------------
+// XML helpers
+// ---------------------------------------------------------------------------
+
+const XML_NS = 'xmlns="http://s3.amazonaws.com/doc/2006-03-01/"';
+const XML_DECL = '<?xml version="1.0" encoding="UTF-8"?>\n';
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function xmlResponse(body: string, status = 200): Response {
+  return new Response(XML_DECL + body, {
+    status,
+    headers: { 'Content-Type': 'application/xml' }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Path / query parsing
+// ---------------------------------------------------------------------------
+
+interface ParsedPath {
+  bucket: string;
+  key: string;
+}
+
+function parsePath(pathname: string): ParsedPath | null {
+  const stripped = pathname.startsWith('/') ? pathname.slice(1) : pathname;
+  if (!stripped) return null;
+  const slash = stripped.indexOf('/');
+  if (slash === -1) return { bucket: stripped, key: '' };
+  return { bucket: stripped.slice(0, slash), key: stripped.slice(slash + 1) };
+}
+
+// ---------------------------------------------------------------------------
+// R2 binding resolution
+// ---------------------------------------------------------------------------
+
+function resolveR2Bucket(env: unknown, name: string): R2Bucket | null {
+  if (typeof env !== 'object' || env === null) return null;
+  const val = (env as Record<string, unknown>)[name];
+  return isR2Bucket(val) ? val : null;
+}
+
+// ---------------------------------------------------------------------------
+// Range header parsing
+// ---------------------------------------------------------------------------
+
+function parseRange(header: string | null): R2Range | undefined {
+  if (!header) return undefined;
+  const m = header.match(/^bytes=(\d*)-(\d*)$/);
+  if (!m) return undefined;
+  const start = m[1] ? parseInt(m[1], 10) : undefined;
+  const end = m[2] ? parseInt(m[2], 10) : undefined;
+
+  if (start === undefined && end !== undefined) {
+    return { suffix: end };
+  }
+  if (start !== undefined && end !== undefined) {
+    return { offset: start, length: end - start + 1 };
+  }
+  if (start !== undefined) {
+    return { offset: start };
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// S3 XML response builders
+// ---------------------------------------------------------------------------
+
+function buildListObjectsV2Xml(
+  bucketName: string,
+  prefix: string,
+  delimiter: string,
+  maxKeys: number,
+  result: R2Objects
+): string {
+  const contents = result.objects
+    .map(
+      (obj) =>
+        `<Contents>` +
+        `<Key>${escapeXml(obj.key)}</Key>` +
+        `<LastModified>${obj.uploaded.toISOString()}</LastModified>` +
+        `<ETag>${escapeXml(obj.httpEtag)}</ETag>` +
+        `<Size>${obj.size}</Size>` +
+        `<StorageClass>STANDARD</StorageClass>` +
+        `</Contents>`
+    )
+    .join('');
+
+  const commonPrefixes = result.delimitedPrefixes
+    .map(
+      (p) => `<CommonPrefixes><Prefix>${escapeXml(p)}</Prefix></CommonPrefixes>`
+    )
+    .join('');
+
+  const nextToken =
+    result.truncated && result.cursor
+      ? `<NextContinuationToken>${escapeXml(result.cursor)}</NextContinuationToken>`
+      : '';
+
+  const keyCount = result.objects.length + result.delimitedPrefixes.length;
+
+  return (
+    `<ListBucketResult ${XML_NS}>` +
+    `<Name>${escapeXml(bucketName)}</Name>` +
+    `<Prefix>${escapeXml(prefix)}</Prefix>` +
+    `<KeyCount>${keyCount}</KeyCount>` +
+    `<MaxKeys>${maxKeys}</MaxKeys>` +
+    (delimiter ? `<Delimiter>${escapeXml(delimiter)}</Delimiter>` : '') +
+    `<IsTruncated>${result.truncated}</IsTruncated>` +
+    nextToken +
+    contents +
+    commonPrefixes +
+    `</ListBucketResult>`
+  );
+}
+
+function buildLocationXml(): string {
+  return `<LocationConstraint ${XML_NS}/>`;
+}
+
+function buildInitiateMultipartUploadXml(
+  bucketName: string,
+  key: string,
+  uploadId: string
+): string {
+  return (
+    `<InitiateMultipartUploadResult ${XML_NS}>` +
+    `<Bucket>${escapeXml(bucketName)}</Bucket>` +
+    `<Key>${escapeXml(key)}</Key>` +
+    `<UploadId>${escapeXml(uploadId)}</UploadId>` +
+    `</InitiateMultipartUploadResult>`
+  );
+}
+
+function buildCompleteMultipartUploadXml(
+  bucketName: string,
+  key: string,
+  etag: string
+): string {
+  return (
+    `<CompleteMultipartUploadResult ${XML_NS}>` +
+    `<Location>http://r2.internal/${escapeXml(bucketName)}/${escapeXml(key)}</Location>` +
+    `<Bucket>${escapeXml(bucketName)}</Bucket>` +
+    `<Key>${escapeXml(key)}</Key>` +
+    `<ETag>${escapeXml(etag)}</ETag>` +
+    `</CompleteMultipartUploadResult>`
+  );
+}
+
+function buildCopyObjectXml(etag: string, uploaded: Date): string {
+  return (
+    `<CopyObjectResult ${XML_NS}>` +
+    `<LastModified>${uploaded.toISOString()}</LastModified>` +
+    `<ETag>${escapeXml(etag)}</ETag>` +
+    `</CopyObjectResult>`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CompleteMultipartUpload XML body parser
+// ---------------------------------------------------------------------------
+
+interface UploadedPart {
+  partNumber: number;
+  etag: string;
+}
+
+function parseCompleteMultipartUploadBody(body: string): UploadedPart[] {
+  const parts: UploadedPart[] = [];
+  const partSegments = body.match(/<Part>[\s\S]*?<\/Part>/g) ?? [];
+  for (const segment of partSegments) {
+    const numMatch = /<PartNumber>(\d+)<\/PartNumber>/.exec(segment);
+    const etagMatch = /<ETag>("?[^<]+"?)<\/ETag>/.exec(segment);
+    if (numMatch && etagMatch) {
+      parts.push({
+        partNumber: parseInt(numMatch[1], 10),
+        etag: etagMatch[1].replace(/^"|"$/g, '')
+      });
+    }
+  }
+  return parts;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP metadata helpers
+// ---------------------------------------------------------------------------
+
+function buildResponseHeaders(obj: R2Object): Headers {
+  const headers = new Headers();
+  headers.set('ETag', obj.httpEtag);
+  headers.set('Content-Length', String(obj.size));
+  headers.set('Last-Modified', obj.uploaded.toUTCString());
+  headers.set('Accept-Ranges', 'bytes');
+  if (obj.httpMetadata?.contentType) {
+    headers.set('Content-Type', obj.httpMetadata.contentType);
+  }
+  if (obj.httpMetadata?.contentDisposition) {
+    headers.set('Content-Disposition', obj.httpMetadata.contentDisposition);
+  }
+  if (obj.httpMetadata?.contentEncoding) {
+    headers.set('Content-Encoding', obj.httpMetadata.contentEncoding);
+  }
+  if (obj.httpMetadata?.contentLanguage) {
+    headers.set('Content-Language', obj.httpMetadata.contentLanguage);
+  }
+  if (obj.httpMetadata?.cacheControl) {
+    headers.set('Cache-Control', obj.httpMetadata.cacheControl);
+  }
+  return headers;
+}
+
+function buildContentRange(range: R2Range, totalSize: number): string {
+  if ('suffix' in range) {
+    const start = Math.max(0, totalSize - range.suffix);
+    return `bytes ${start}-${totalSize - 1}/${totalSize}`;
+  }
+  const start = range.offset ?? 0;
+  const end =
+    range.length !== undefined ? start + range.length - 1 : totalSize - 1;
+  return `bytes ${start}-${end}/${totalSize}`;
+}
+
+function extractHttpMetadata(request: Request): R2HTTPMetadata {
+  const meta: R2HTTPMetadata = {};
+  const ct = request.headers.get('Content-Type');
+  if (ct) meta.contentType = ct;
+  const cd = request.headers.get('Content-Disposition');
+  if (cd) meta.contentDisposition = cd;
+  const ce = request.headers.get('Content-Encoding');
+  if (ce) meta.contentEncoding = ce;
+  const cl = request.headers.get('Content-Language');
+  if (cl) meta.contentLanguage = cl;
+  const cc = request.headers.get('Cache-Control');
+  if (cc) meta.cacheControl = cc;
+  return meta;
+}
+
+function parseCopySource(header: string): ParsedPath | null {
+  const sourcePath = header.split('?')[0] ?? '';
+  if (!sourcePath) return null;
+  const decoded = decodeURIComponent(sourcePath);
+  return parsePath(decoded.startsWith('/') ? decoded : `/${decoded}`);
+}
+
+function normalizeStorageClass(
+  storageClass: string | undefined
+): 'Standard' | 'InfrequentAccess' | undefined {
+  if (storageClass === 'Standard' || storageClass === 'InfrequentAccess') {
+    return storageClass;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Operation handlers
+// ---------------------------------------------------------------------------
+
+async function handleListObjects(
+  r2: R2Bucket,
+  bucketName: string,
+  url: URL
+): Promise<Response> {
+  const prefix = url.searchParams.get('prefix') ?? '';
+  const delimiter = url.searchParams.get('delimiter') ?? '';
+  const maxKeys = Math.min(
+    parseInt(url.searchParams.get('max-keys') ?? '1000', 10),
+    1000
+  );
+  const continuationToken =
+    url.searchParams.get('continuation-token') ?? undefined;
+
+  const listOpts: R2ListOptions = {
+    prefix: prefix || undefined,
+    delimiter: delimiter || undefined,
+    limit: maxKeys,
+    cursor: continuationToken
+  };
+
+  const result = await r2.list(listOpts);
+  return xmlResponse(
+    buildListObjectsV2Xml(bucketName, prefix, delimiter, maxKeys, result)
+  );
+}
+
+async function handleHeadObject(r2: R2Bucket, key: string): Promise<Response> {
+  const obj = await r2.head(key);
+  if (!obj) {
+    return new Response(null, { status: 404 });
+  }
+  return new Response(null, {
+    status: 200,
+    headers: buildResponseHeaders(obj)
+  });
+}
+
+async function handleGetObject(
+  r2: R2Bucket,
+  key: string,
+  request: Request
+): Promise<Response> {
+  const range = parseRange(request.headers.get('Range'));
+
+  if (!range) {
+    const obj = await r2.get(key);
+    if (!obj) {
+      return new Response(null, { status: 404 });
+    }
+    return new Response(obj.body, {
+      status: 200,
+      headers: buildResponseHeaders(obj)
+    });
+  }
+
+  const [headObj, rangeObj] = await Promise.all([
+    r2.head(key),
+    r2.get(key, { range })
+  ]);
+  if (!headObj || !rangeObj) {
+    return new Response(null, { status: 404 });
+  }
+
+  const headers = buildResponseHeaders(rangeObj);
+  headers.set('Content-Range', buildContentRange(range, headObj.size));
+  headers.set('Content-Length', String(rangeObj.size));
+
+  return new Response(rangeObj.body, { status: 206, headers });
+}
+
+async function handlePutObject(
+  r2: R2Bucket,
+  bucketName: string,
+  key: string,
+  request: Request,
+  env: Cloudflare.Env,
+  permitted: Set<string>
+): Promise<Response> {
+  const copySourceHeader = request.headers.get('x-amz-copy-source');
+  if (copySourceHeader) {
+    const copySource = parseCopySource(copySourceHeader);
+    if (!copySource || !copySource.key) {
+      return new Response('Bad Request: invalid x-amz-copy-source', {
+        status: 400
+      });
+    }
+
+    if (!permitted.has(copySource.bucket)) {
+      return new Response(
+        `Access to R2 bucket "${copySource.bucket}" is not permitted. ` +
+          'Call mountBucket() with this bucket before accessing it.',
+        { status: 403 }
+      );
+    }
+
+    const sourceBucket =
+      copySource.bucket === bucketName
+        ? r2
+        : resolveR2Bucket(env, copySource.bucket);
+    if (!sourceBucket) {
+      return new Response(
+        `R2 binding "${copySource.bucket}" not found in Worker env. ` +
+          'Ensure the binding name matches the bucket name passed to mountBucket().',
+        { status: 500 }
+      );
+    }
+
+    const sourceObject = await sourceBucket.get(copySource.key);
+    if (!sourceObject) {
+      return new Response(null, { status: 404 });
+    }
+
+    const metadataDirective = request.headers.get('x-amz-metadata-directive');
+    const httpMetadata =
+      metadataDirective?.toUpperCase() === 'REPLACE'
+        ? extractHttpMetadata(request)
+        : sourceObject.httpMetadata;
+    const result = await r2.put(key, sourceObject.body, {
+      httpMetadata,
+      customMetadata: sourceObject.customMetadata,
+      storageClass: normalizeStorageClass(sourceObject.storageClass)
+    });
+    return xmlResponse(buildCopyObjectXml(result.httpEtag, result.uploaded));
+  }
+
+  const httpMetadata = extractHttpMetadata(request);
+  const result = await r2.put(key, request.body, { httpMetadata });
+  const headers = new Headers();
+  headers.set('ETag', result.httpEtag);
+  return new Response(null, { status: 200, headers });
+}
+
+async function handleDeleteObject(
+  r2: R2Bucket,
+  key: string
+): Promise<Response> {
+  await r2.delete(key);
+  return new Response(null, { status: 204 });
+}
+
+async function handleCreateMultipartUpload(
+  r2: R2Bucket,
+  bucketName: string,
+  key: string,
+  request: Request
+): Promise<Response> {
+  const httpMetadata = extractHttpMetadata(request);
+  const upload = await r2.createMultipartUpload(key, { httpMetadata });
+  return xmlResponse(
+    buildInitiateMultipartUploadXml(bucketName, key, upload.uploadId)
+  );
+}
+
+async function handleUploadPart(
+  r2: R2Bucket,
+  key: string,
+  url: URL,
+  request: Request
+): Promise<Response> {
+  const uploadId = url.searchParams.get('uploadId') ?? '';
+  const partNumber = parseInt(url.searchParams.get('partNumber') ?? '0', 10);
+  if (!uploadId || !partNumber) {
+    return new Response('Bad Request: missing uploadId or partNumber', {
+      status: 400
+    });
+  }
+  const upload = r2.resumeMultipartUpload(key, uploadId);
+  const part = await upload.uploadPart(
+    partNumber,
+    request.body as ReadableStream
+  );
+  const headers = new Headers();
+  headers.set('ETag', `"${part.etag}"`);
+  return new Response(null, { status: 200, headers });
+}
+
+async function handleCompleteMultipartUpload(
+  r2: R2Bucket,
+  bucketName: string,
+  key: string,
+  url: URL,
+  request: Request
+): Promise<Response> {
+  const uploadId = url.searchParams.get('uploadId') ?? '';
+  if (!uploadId) {
+    return new Response('Bad Request: missing uploadId', { status: 400 });
+  }
+  const bodyText = await request.text();
+  const parsedParts = parseCompleteMultipartUploadBody(bodyText);
+  const r2Parts: R2UploadedPart[] = parsedParts.map((p) => ({
+    partNumber: p.partNumber,
+    etag: p.etag
+  }));
+  const upload = r2.resumeMultipartUpload(key, uploadId);
+  const result = await upload.complete(r2Parts);
+  return xmlResponse(
+    buildCompleteMultipartUploadXml(bucketName, key, result.httpEtag)
+  );
+}
+
+async function handleAbortMultipartUpload(
+  r2: R2Bucket,
+  key: string,
+  url: URL
+): Promise<Response> {
+  const uploadId = url.searchParams.get('uploadId') ?? '';
+  if (!uploadId) {
+    return new Response('Bad Request: missing uploadId', { status: 400 });
+  }
+  const upload = r2.resumeMultipartUpload(key, uploadId);
+  await upload.abort();
+  return new Response(null, { status: 204 });
+}
+
+// ---------------------------------------------------------------------------
+// Main handler
+// ---------------------------------------------------------------------------
+
+export const r2EgressHandler: OutboundHandler = async (
+  request: Request,
+  env: Cloudflare.Env,
+  ctx: OutboundHandlerContext
+): Promise<Response> => {
+  const url = new URL(request.url);
+  const parsed = parsePath(url.pathname);
+
+  if (!parsed) {
+    return new Response('Bad Request: empty path', { status: 400 });
+  }
+
+  const { bucket: bucketName, key } = parsed;
+
+  const permitted = allowedBuckets.get(ctx.containerId);
+  if (!permitted?.has(bucketName)) {
+    return new Response(
+      `Access to R2 bucket "${bucketName}" is not permitted. ` +
+        'Call mountBucket() with this bucket before accessing it.',
+      { status: 403 }
+    );
+  }
+
+  const r2 = resolveR2Bucket(env, bucketName);
+  if (!r2) {
+    return new Response(
+      `R2 binding "${bucketName}" not found in Worker env. ` +
+        'Ensure the binding name matches the bucket name passed to mountBucket().',
+      { status: 500 }
+    );
+  }
+
+  const { method } = request;
+
+  // Bucket-level operations (no key)
+  if (!key) {
+    if (method === 'GET' && url.searchParams.has('location')) {
+      return xmlResponse(buildLocationXml());
+    }
+    if (method === 'GET' && url.searchParams.get('list-type') === '2') {
+      return handleListObjects(r2, bucketName, url);
+    }
+    // Legacy ListObjects (v1) — s3fs may use this for some operations
+    if (method === 'GET') {
+      return handleListObjects(r2, bucketName, url);
+    }
+    return new Response('Method Not Allowed', { status: 405 });
+  }
+
+  // Multipart upload: POST /bucket/key?uploads — initiate
+  if (method === 'POST' && url.searchParams.has('uploads')) {
+    return handleCreateMultipartUpload(r2, bucketName, key, request);
+  }
+
+  // Multipart upload: POST /bucket/key?uploadId=X — complete
+  if (method === 'POST' && url.searchParams.has('uploadId')) {
+    return handleCompleteMultipartUpload(r2, bucketName, key, url, request);
+  }
+
+  // Multipart upload: PUT /bucket/key?partNumber=N&uploadId=X — upload part
+  if (
+    method === 'PUT' &&
+    url.searchParams.has('partNumber') &&
+    url.searchParams.has('uploadId')
+  ) {
+    return handleUploadPart(r2, key, url, request);
+  }
+
+  // Multipart upload: DELETE /bucket/key?uploadId=X — abort
+  if (method === 'DELETE' && url.searchParams.has('uploadId')) {
+    return handleAbortMultipartUpload(r2, key, url);
+  }
+
+  // Standard object operations
+  switch (method) {
+    case 'HEAD':
+      return handleHeadObject(r2, key);
+    case 'GET':
+      return handleGetObject(r2, key, request);
+    case 'PUT':
+      return handlePutObject(r2, bucketName, key, request, env, permitted);
+    case 'DELETE':
+      return handleDeleteObject(r2, key);
+    default:
+      return new Response('Method Not Allowed', { status: 405 });
+  }
+};

--- a/packages/sandbox/src/storage-mount/r2-egress-handler.ts
+++ b/packages/sandbox/src/storage-mount/r2-egress-handler.ts
@@ -19,10 +19,8 @@ import { isR2Bucket } from './validation';
 // ---------------------------------------------------------------------------
 // Per-mount bucket params
 //
-// Passed through setOutboundByHost params so they are serialized into
-// ContainerProxy props and transmitted with every intercepted request.
-// This avoids relying on module-level state which is not shared across
-// Cloudflare Worker isolates.
+// Serialized into ContainerProxy props and transmitted with every intercepted
+// request so each Worker isolate receives the active mount configuration.
 // ---------------------------------------------------------------------------
 
 export type R2EgressParams = {
@@ -35,8 +33,9 @@ export type R2EgressParams = {
 
 const XML_NS = 'xmlns="http://s3.amazonaws.com/doc/2006-03-01/"';
 const XML_DECL = '<?xml version="1.0" encoding="UTF-8"?>\n';
+const R2_MULTIPART_PART_SIZE = 5 * 1024 * 1024;
 
-function escapeXml(s: string): string {
+function escapeXML(s: string): string {
   return s
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
@@ -142,36 +141,30 @@ function buildListObjectsV2Xml(
   const contents = result.objects
     .map(
       (obj) =>
-        `<Contents>` +
-        `<Key>${escapeXml(obj.key)}</Key>` +
-        `<LastModified>${obj.uploaded.toISOString()}</LastModified>` +
-        `<ETag>${escapeXml(obj.httpEtag)}</ETag>` +
-        `<Size>${obj.size}</Size>` +
-        `<StorageClass>STANDARD</StorageClass>` +
-        `</Contents>`
+        `<Contents><Key>${escapeXML(obj.key)}</Key><LastModified>${obj.uploaded.toISOString()}</LastModified><ETag>${escapeXML(obj.httpEtag)}</ETag><Size>${obj.size}</Size><StorageClass>STANDARD</StorageClass></Contents>`
     )
     .join('');
 
   const commonPrefixes = result.delimitedPrefixes
     .map(
-      (p) => `<CommonPrefixes><Prefix>${escapeXml(p)}</Prefix></CommonPrefixes>`
+      (p) => `<CommonPrefixes><Prefix>${escapeXML(p)}</Prefix></CommonPrefixes>`
     )
     .join('');
 
   const nextToken =
     result.truncated && result.cursor
-      ? `<NextContinuationToken>${escapeXml(result.cursor)}</NextContinuationToken>`
+      ? `<NextContinuationToken>${escapeXML(result.cursor)}</NextContinuationToken>`
       : '';
 
   const keyCount = result.objects.length + result.delimitedPrefixes.length;
 
   return (
     `<ListBucketResult ${XML_NS}>` +
-    `<Name>${escapeXml(bucketName)}</Name>` +
-    `<Prefix>${escapeXml(prefix)}</Prefix>` +
+    `<Name>${escapeXML(bucketName)}</Name>` +
+    `<Prefix>${escapeXML(prefix)}</Prefix>` +
     `<KeyCount>${keyCount}</KeyCount>` +
     `<MaxKeys>${maxKeys}</MaxKeys>` +
-    (delimiter ? `<Delimiter>${escapeXml(delimiter)}</Delimiter>` : '') +
+    (delimiter ? `<Delimiter>${escapeXML(delimiter)}</Delimiter>` : '') +
     `<IsTruncated>${result.truncated}</IsTruncated>` +
     nextToken +
     contents +
@@ -191,9 +184,9 @@ function buildInitiateMultipartUploadXml(
 ): string {
   return (
     `<InitiateMultipartUploadResult ${XML_NS}>` +
-    `<Bucket>${escapeXml(bucketName)}</Bucket>` +
-    `<Key>${escapeXml(key)}</Key>` +
-    `<UploadId>${escapeXml(uploadId)}</UploadId>` +
+    `<Bucket>${escapeXML(bucketName)}</Bucket>` +
+    `<Key>${escapeXML(key)}</Key>` +
+    `<UploadId>${escapeXML(uploadId)}</UploadId>` +
     `</InitiateMultipartUploadResult>`
   );
 }
@@ -205,10 +198,10 @@ function buildCompleteMultipartUploadXml(
 ): string {
   return (
     `<CompleteMultipartUploadResult ${XML_NS}>` +
-    `<Location>http://r2.internal/${escapeXml(bucketName)}/${escapeXml(key)}</Location>` +
-    `<Bucket>${escapeXml(bucketName)}</Bucket>` +
-    `<Key>${escapeXml(key)}</Key>` +
-    `<ETag>${escapeXml(etag)}</ETag>` +
+    `<Location>http://r2.internal/${escapeXML(bucketName)}/${escapeXML(key)}</Location>` +
+    `<Bucket>${escapeXML(bucketName)}</Bucket>` +
+    `<Key>${escapeXML(key)}</Key>` +
+    `<ETag>${escapeXML(etag)}</ETag>` +
     `</CompleteMultipartUploadResult>`
   );
 }
@@ -217,7 +210,7 @@ function buildCopyObjectXml(etag: string, uploaded: Date): string {
   return (
     `<CopyObjectResult ${XML_NS}>` +
     `<LastModified>${uploaded.toISOString()}</LastModified>` +
-    `<ETag>${escapeXml(etag)}</ETag>` +
+    `<ETag>${escapeXML(etag)}</ETag>` +
     `</CopyObjectResult>`
   );
 }
@@ -354,6 +347,82 @@ function normalizeStorageClass(
   return undefined;
 }
 
+async function readRequestBody(
+  request: Request
+): Promise<Uint8Array | Response> {
+  if (!request.body) {
+    return new Response('Bad Request: missing request body', { status: 400 });
+  }
+  // R2 writes require a known-length body; intercepted s3fs request streams do
+  // not carry that length through the outbound proxy.
+  return new Uint8Array(await request.arrayBuffer());
+}
+
+function mergeChunks(chunks: Uint8Array[], totalLength: number): Uint8Array {
+  const merged = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return merged;
+}
+
+async function putRequestBody(
+  r2: R2Bucket,
+  key: string,
+  request: Request,
+  options: R2MultipartOptions
+): Promise<R2Object | Response> {
+  if (!request.body) {
+    return new Response('Bad Request: missing request body', { status: 400 });
+  }
+
+  const upload = await r2.createMultipartUpload(key, options);
+  const reader = request.body.getReader();
+  const uploadedParts: R2UploadedPart[] = [];
+  let partNumber = 1;
+  let chunks: Uint8Array[] = [];
+  let bufferedBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      bufferedBytes += value.length;
+
+      while (bufferedBytes >= R2_MULTIPART_PART_SIZE) {
+        const partBuffer = mergeChunks(chunks, bufferedBytes);
+        const part = partBuffer.slice(0, R2_MULTIPART_PART_SIZE);
+        const remainder = partBuffer.slice(R2_MULTIPART_PART_SIZE);
+        uploadedParts.push(await upload.uploadPart(partNumber, part));
+        partNumber++;
+        chunks = remainder.length > 0 ? [remainder] : [];
+        bufferedBytes = remainder.length;
+      }
+    }
+
+    if (uploadedParts.length === 0 && bufferedBytes === 0) {
+      // Empty body — R2 multipart does not support 0-byte parts; abort and use
+      // a direct put instead.
+      await upload.abort();
+      return r2.put(key, new Uint8Array(0), options);
+    }
+
+    if (bufferedBytes > 0) {
+      uploadedParts.push(
+        await upload.uploadPart(partNumber, mergeChunks(chunks, bufferedBytes))
+      );
+    }
+
+    return upload.complete(uploadedParts);
+  } catch (error) {
+    await upload.abort();
+    throw error;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Operation handlers
 // ---------------------------------------------------------------------------
@@ -438,13 +507,13 @@ async function handleGetObject(
     if (!obj) {
       return new Response(null, { status: 404 });
     }
-    const body = await obj.arrayBuffer();
-    return new Response(body, {
+    return new Response(obj.body, {
       status: 200,
       headers: buildResponseHeaders(obj)
     });
   }
 
+  // R2 range bodies do not include the full object size needed for Content-Range.
   const [headObj, rangeObj] = await Promise.all([
     r2.head(key),
     r2.get(key, { range })
@@ -453,7 +522,6 @@ async function handleGetObject(
     return new Response(null, { status: 404 });
   }
 
-  const rangeBody = await rangeObj.arrayBuffer();
   const headers = buildResponseHeaders(rangeObj);
   headers.set('Content-Range', buildContentRange(range, headObj.size));
   headers.set(
@@ -461,7 +529,7 @@ async function handleGetObject(
     String(getRangeContentLength(range, headObj.size))
   );
 
-  return new Response(rangeBody, { status: 206, headers });
+  return new Response(rangeObj.body, { status: 206, headers });
 }
 
 async function handlePutObject(
@@ -516,8 +584,7 @@ async function handlePutObject(
       metadataDirective?.toUpperCase() === 'REPLACE'
         ? extractHttpMetadata(request)
         : sourceObject.httpMetadata;
-    const sourceBody = await sourceObject.arrayBuffer();
-    const result = await r2.put(key, sourceBody, {
+    const result = await r2.put(key, sourceObject.body, {
       httpMetadata,
       customMetadata: sourceObject.customMetadata,
       storageClass: normalizeStorageClass(sourceObject.storageClass)
@@ -526,8 +593,8 @@ async function handlePutObject(
   }
 
   const httpMetadata = extractHttpMetadata(request);
-  const body = await request.arrayBuffer();
-  const result = await r2.put(key, body, { httpMetadata });
+  const result = await putRequestBody(r2, key, request, { httpMetadata });
+  if (result instanceof Response) return result;
   const headers = new Headers();
   headers.set('ETag', result.httpEtag);
   return new Response(null, { status: 200, headers });
@@ -568,7 +635,8 @@ async function handleUploadPart(
     });
   }
   const upload = r2.resumeMultipartUpload(key, uploadId);
-  const body = await request.arrayBuffer();
+  const body = await readRequestBody(request);
+  if (body instanceof Response) return body;
   const part = await upload.uploadPart(partNumber, body);
   const headers = new Headers();
   headers.set('ETag', `"${part.etag}"`);

--- a/packages/sandbox/src/storage-mount/r2-egress-handler.ts
+++ b/packages/sandbox/src/storage-mount/r2-egress-handler.ts
@@ -17,38 +17,17 @@ import type {
 import { isR2Bucket } from './validation';
 
 // ---------------------------------------------------------------------------
-// Per-instance bucket allowlist
+// Per-mount bucket params
 //
-// Maps containerId → Set of bucket binding names that this sandbox instance
-// is explicitly permitted to access. Populated by mountBucketR2Egress() and
-// cleaned up on unmount/destroy. Requests for buckets not in this set are
-// rejected with 403 to prevent a sandbox from reaching R2 bindings it was
-// never told to mount.
+// Passed through setOutboundByHost params so they are serialized into
+// ContainerProxy props and transmitted with every intercepted request.
+// This avoids relying on module-level state which is not shared across
+// Cloudflare Worker isolates.
 // ---------------------------------------------------------------------------
 
-const allowedBuckets = new Map<string, Set<string>>();
-
-export function registerBucketAccess(
-  containerId: string,
-  bucketName: string
-): void {
-  const existing = allowedBuckets.get(containerId);
-  if (existing) {
-    existing.add(bucketName);
-  } else {
-    allowedBuckets.set(containerId, new Set([bucketName]));
-  }
-}
-
-export function revokeBucketAccess(
-  containerId: string,
-  bucketName: string
-): void {
-  const buckets = allowedBuckets.get(containerId);
-  if (!buckets) return;
-  buckets.delete(bucketName);
-  if (buckets.size === 0) allowedBuckets.delete(containerId);
-}
+export type R2EgressParams = {
+  buckets: Record<string, string | undefined>;
+};
 
 // ---------------------------------------------------------------------------
 // XML helpers
@@ -81,12 +60,19 @@ interface ParsedPath {
   key: string;
 }
 
+function normalizeObjectKey(value: string): string {
+  return value.replace(/^\/+/, '');
+}
+
 function parsePath(pathname: string): ParsedPath | null {
   const stripped = pathname.startsWith('/') ? pathname.slice(1) : pathname;
   if (!stripped) return null;
   const slash = stripped.indexOf('/');
   if (slash === -1) return { bucket: stripped, key: '' };
-  return { bucket: stripped.slice(0, slash), key: stripped.slice(slash + 1) };
+  return {
+    bucket: stripped.slice(0, slash),
+    key: normalizeObjectKey(stripped.slice(slash + 1))
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -126,12 +112,26 @@ function parseRange(header: string | null): R2Range | undefined {
 // S3 XML response builders
 // ---------------------------------------------------------------------------
 
+interface ListDisplayObject {
+  key: string;
+  uploaded: Date;
+  httpEtag: string;
+  size: number;
+}
+
+interface ListDisplayResult {
+  objects: ListDisplayObject[];
+  delimitedPrefixes: string[];
+  truncated: boolean;
+  cursor?: string;
+}
+
 function buildListObjectsV2Xml(
   bucketName: string,
   prefix: string,
   delimiter: string,
   maxKeys: number,
-  result: R2Objects
+  result: ListDisplayResult
 ): string {
   const contents = result.objects
     .map(
@@ -299,7 +299,13 @@ function parseCopySource(header: string): ParsedPath | null {
   const sourcePath = header.split('?')[0] ?? '';
   if (!sourcePath) return null;
   const decoded = decodeURIComponent(sourcePath);
-  return parsePath(decoded.startsWith('/') ? decoded : `/${decoded}`);
+  const parsed = parsePath(decoded.startsWith('/') ? decoded : `/${decoded}`);
+  return parsed
+    ? {
+        bucket: parsed.bucket,
+        key: normalizeObjectKey(parsed.key)
+      }
+    : null;
 }
 
 function normalizeStorageClass(
@@ -318,9 +324,10 @@ function normalizeStorageClass(
 async function handleListObjects(
   r2: R2Bucket,
   bucketName: string,
-  url: URL
+  url: URL,
+  mountPrefix?: string
 ): Promise<Response> {
-  const prefix = url.searchParams.get('prefix') ?? '';
+  const queryPrefix = normalizeObjectKey(url.searchParams.get('prefix') ?? '');
   const delimiter = url.searchParams.get('delimiter') ?? '';
   const maxKeys = Math.min(
     parseInt(url.searchParams.get('max-keys') ?? '1000', 10),
@@ -329,24 +336,60 @@ async function handleListObjects(
   const continuationToken =
     url.searchParams.get('continuation-token') ?? undefined;
 
+  const r2Prefix = mountPrefix ? `${mountPrefix}/${queryPrefix}` : queryPrefix;
+
   const listOpts: R2ListOptions = {
-    prefix: prefix || undefined,
+    prefix: r2Prefix || undefined,
     delimiter: delimiter || undefined,
     limit: maxKeys,
     cursor: continuationToken
   };
 
   const result = await r2.list(listOpts);
+  console.log('[r2-egress] LIST result', {
+    r2Prefix,
+    count: result.objects.length,
+    objects: result.objects.map((o) => ({ key: o.key, size: o.size }))
+  });
+
+  const stripKey = mountPrefix
+    ? (k: string): string =>
+        k.startsWith(`${mountPrefix}/`) ? k.slice(mountPrefix.length + 1) : k
+    : (k: string): string => k;
+
+  const displayResult: ListDisplayResult = {
+    objects: result.objects.map((obj) => ({
+      key: stripKey(obj.key),
+      uploaded: obj.uploaded,
+      httpEtag: obj.httpEtag,
+      size: obj.size
+    })),
+    delimitedPrefixes: result.delimitedPrefixes.map(stripKey),
+    truncated: result.truncated,
+    cursor: result.truncated ? result.cursor : undefined
+  };
+
   return xmlResponse(
-    buildListObjectsV2Xml(bucketName, prefix, delimiter, maxKeys, result)
+    buildListObjectsV2Xml(
+      bucketName,
+      queryPrefix,
+      delimiter,
+      maxKeys,
+      displayResult
+    )
   );
 }
 
 async function handleHeadObject(r2: R2Bucket, key: string): Promise<Response> {
   const obj = await r2.head(key);
   if (!obj) {
+    console.log('[r2-egress] HEAD 404', { key });
     return new Response(null, { status: 404 });
   }
+  console.log('[r2-egress] HEAD 200', { key, size: obj.size });
+  // NOTE: The outbound proxy rewrites Content-Length to 0 for bodiless
+  // responses. s3fs stat cache must be pre-populated from LIST (readdir)
+  // so that getattr never falls through to HEAD for file size information.
   return new Response(null, {
     status: 200,
     headers: buildResponseHeaders(obj)
@@ -363,9 +406,12 @@ async function handleGetObject(
   if (!range) {
     const obj = await r2.get(key);
     if (!obj) {
+      console.log('[r2-egress] GET 404', { key });
       return new Response(null, { status: 404 });
     }
-    return new Response(obj.body, {
+    const body = await obj.arrayBuffer();
+    console.log('[r2-egress] GET 200', { key, bytes: body.byteLength });
+    return new Response(body, {
       status: 200,
       headers: buildResponseHeaders(obj)
     });
@@ -379,11 +425,12 @@ async function handleGetObject(
     return new Response(null, { status: 404 });
   }
 
+  const rangeBody = await rangeObj.arrayBuffer();
   const headers = buildResponseHeaders(rangeObj);
   headers.set('Content-Range', buildContentRange(range, headObj.size));
-  headers.set('Content-Length', String(rangeObj.size));
+  headers.set('Content-Length', String(rangeBody.byteLength));
 
-  return new Response(rangeObj.body, { status: 206, headers });
+  return new Response(rangeBody, { status: 206, headers });
 }
 
 async function handlePutObject(
@@ -392,7 +439,8 @@ async function handlePutObject(
   key: string,
   request: Request,
   env: Cloudflare.Env,
-  permitted: Set<string>
+  permitted: Set<string>,
+  mountPrefix?: string
 ): Promise<Response> {
   const copySourceHeader = request.headers.get('x-amz-copy-source');
   if (copySourceHeader) {
@@ -423,7 +471,11 @@ async function handlePutObject(
       );
     }
 
-    const sourceObject = await sourceBucket.get(copySource.key);
+    const sourceKey =
+      mountPrefix && copySource.bucket === bucketName
+        ? `${mountPrefix}/${copySource.key}`
+        : copySource.key;
+    const sourceObject = await sourceBucket.get(sourceKey);
     if (!sourceObject) {
       return new Response(null, { status: 404 });
     }
@@ -433,7 +485,8 @@ async function handlePutObject(
       metadataDirective?.toUpperCase() === 'REPLACE'
         ? extractHttpMetadata(request)
         : sourceObject.httpMetadata;
-    const result = await r2.put(key, sourceObject.body, {
+    const sourceBody = await sourceObject.arrayBuffer();
+    const result = await r2.put(key, sourceBody, {
       httpMetadata,
       customMetadata: sourceObject.customMetadata,
       storageClass: normalizeStorageClass(sourceObject.storageClass)
@@ -442,7 +495,8 @@ async function handlePutObject(
   }
 
   const httpMetadata = extractHttpMetadata(request);
-  const result = await r2.put(key, request.body, { httpMetadata });
+  const body = await request.arrayBuffer();
+  const result = await r2.put(key, body, { httpMetadata });
   const headers = new Headers();
   headers.set('ETag', result.httpEtag);
   return new Response(null, { status: 200, headers });
@@ -534,13 +588,23 @@ async function handleAbortMultipartUpload(
 // Main handler
 // ---------------------------------------------------------------------------
 
-export const r2EgressHandler: OutboundHandler = async (
+export const r2EgressHandler: OutboundHandler<
+  Cloudflare.Env,
+  R2EgressParams
+> = async (
   request: Request,
   env: Cloudflare.Env,
-  ctx: OutboundHandlerContext
+  ctx: OutboundHandlerContext<R2EgressParams>
 ): Promise<Response> => {
   const url = new URL(request.url);
   const parsed = parsePath(url.pathname);
+
+  console.log('[r2-egress] incoming request', {
+    method: request.method,
+    url: request.url,
+    containerId: ctx.containerId,
+    paramBuckets: ctx.params ? Object.keys(ctx.params.buckets) : null
+  });
 
   if (!parsed) {
     return new Response('Bad Request: empty path', { status: 400 });
@@ -548,14 +612,28 @@ export const r2EgressHandler: OutboundHandler = async (
 
   const { bucket: bucketName, key } = parsed;
 
-  const permitted = allowedBuckets.get(ctx.containerId);
-  if (!permitted?.has(bucketName)) {
+  if (!ctx.params?.buckets || !(bucketName in ctx.params.buckets)) {
+    console.log('[r2-egress] 403: bucket not in params', {
+      bucketName,
+      containerId: ctx.containerId,
+      paramBuckets: ctx.params ? Object.keys(ctx.params.buckets) : null
+    });
     return new Response(
       `Access to R2 bucket "${bucketName}" is not permitted. ` +
         'Call mountBucket() with this bucket before accessing it.',
       { status: 403 }
     );
   }
+
+  const rawPrefix = ctx.params.buckets[bucketName];
+  const mountPrefix = rawPrefix ? normalizeObjectKey(rawPrefix) : undefined;
+
+  console.log('[r2-egress] resolved', {
+    bucketName,
+    key,
+    rawPrefix,
+    mountPrefix
+  });
 
   const r2 = resolveR2Bucket(env, bucketName);
   if (!r2) {
@@ -574,23 +652,26 @@ export const r2EgressHandler: OutboundHandler = async (
       return xmlResponse(buildLocationXml());
     }
     if (method === 'GET' && url.searchParams.get('list-type') === '2') {
-      return handleListObjects(r2, bucketName, url);
+      return handleListObjects(r2, bucketName, url, mountPrefix);
     }
     // Legacy ListObjects (v1) — s3fs may use this for some operations
     if (method === 'GET') {
-      return handleListObjects(r2, bucketName, url);
+      return handleListObjects(r2, bucketName, url, mountPrefix);
     }
     return new Response('Method Not Allowed', { status: 405 });
   }
 
+  const fullKey = mountPrefix ? `${mountPrefix}/${key}` : key;
+  const permitted = new Set(Object.keys(ctx.params.buckets));
+
   // Multipart upload: POST /bucket/key?uploads — initiate
   if (method === 'POST' && url.searchParams.has('uploads')) {
-    return handleCreateMultipartUpload(r2, bucketName, key, request);
+    return handleCreateMultipartUpload(r2, bucketName, fullKey, request);
   }
 
   // Multipart upload: POST /bucket/key?uploadId=X — complete
   if (method === 'POST' && url.searchParams.has('uploadId')) {
-    return handleCompleteMultipartUpload(r2, bucketName, key, url, request);
+    return handleCompleteMultipartUpload(r2, bucketName, fullKey, url, request);
   }
 
   // Multipart upload: PUT /bucket/key?partNumber=N&uploadId=X — upload part
@@ -599,24 +680,32 @@ export const r2EgressHandler: OutboundHandler = async (
     url.searchParams.has('partNumber') &&
     url.searchParams.has('uploadId')
   ) {
-    return handleUploadPart(r2, key, url, request);
+    return handleUploadPart(r2, fullKey, url, request);
   }
 
   // Multipart upload: DELETE /bucket/key?uploadId=X — abort
   if (method === 'DELETE' && url.searchParams.has('uploadId')) {
-    return handleAbortMultipartUpload(r2, key, url);
+    return handleAbortMultipartUpload(r2, fullKey, url);
   }
 
   // Standard object operations
   switch (method) {
     case 'HEAD':
-      return handleHeadObject(r2, key);
+      return handleHeadObject(r2, fullKey);
     case 'GET':
-      return handleGetObject(r2, key, request);
+      return handleGetObject(r2, fullKey, request);
     case 'PUT':
-      return handlePutObject(r2, bucketName, key, request, env, permitted);
+      return handlePutObject(
+        r2,
+        bucketName,
+        fullKey,
+        request,
+        env,
+        permitted,
+        mountPrefix
+      );
     case 'DELETE':
-      return handleDeleteObject(r2, key);
+      return handleDeleteObject(r2, fullKey);
     default:
       return new Response('Method Not Allowed', { status: 405 });
   }

--- a/packages/sandbox/src/storage-mount/r2-egress-handler.ts
+++ b/packages/sandbox/src/storage-mount/r2-egress-handler.ts
@@ -346,17 +346,6 @@ function normalizeStorageClass(
   return undefined;
 }
 
-async function readRequestBody(
-  request: Request
-): Promise<Uint8Array | Response> {
-  if (!request.body) {
-    return new Response('Bad Request: missing request body', { status: 400 });
-  }
-  // R2 writes require a known-length body; intercepted s3fs request streams do
-  // not carry that length through the outbound proxy.
-  return new Uint8Array(await request.arrayBuffer());
-}
-
 async function putRequestBody(
   r2: R2Bucket,
   key: string,
@@ -597,10 +586,26 @@ async function handleUploadPart(
       status: 400
     });
   }
+  if (!request.body) {
+    return new Response('Bad Request: missing request body', { status: 400 });
+  }
+  const contentLength = request.headers.get('Content-Length');
+  const partLength = contentLength ? Number.parseInt(contentLength, 10) : NaN;
+  if (!Number.isFinite(partLength) || partLength < 0) {
+    return new Response('Bad Request: missing or invalid Content-Length', {
+      status: 400
+    });
+  }
   const upload = r2.resumeMultipartUpload(key, uploadId);
-  const body = await readRequestBody(request);
-  if (body instanceof Response) return body;
-  const part = await upload.uploadPart(partNumber, body);
+  let part: R2UploadedPart;
+  if (partLength === 0) {
+    part = await upload.uploadPart(partNumber, new Uint8Array(0));
+  } else {
+    const { readable, writable } = new FixedLengthStream(partLength);
+    const pipe = request.body.pipeTo(writable);
+    part = await upload.uploadPart(partNumber, readable);
+    await pipe;
+  }
   const headers = new Headers();
   headers.set('ETag', `"${part.etag}"`);
   return new Response(null, { status: 200, headers });

--- a/packages/sandbox/src/storage-mount/r2-egress-handler.ts
+++ b/packages/sandbox/src/storage-mount/r2-egress-handler.ts
@@ -352,10 +352,6 @@ async function putRequestBody(
   request: Request,
   options: R2PutOptions
 ): Promise<R2Object | Response> {
-  if (!request.body) {
-    return new Response('Bad Request: missing request body', { status: 400 });
-  }
-
   const contentLength = request.headers.get('Content-Length');
   const length = contentLength ? Number.parseInt(contentLength, 10) : NaN;
   if (!Number.isFinite(length) || length < 0) {
@@ -366,6 +362,10 @@ async function putRequestBody(
 
   if (length === 0) {
     return r2.put(key, new Uint8Array(0), options);
+  }
+
+  if (!request.body) {
+    return new Response('Bad Request: missing request body', { status: 400 });
   }
 
   const { readable, writable } = new FixedLengthStream(length);

--- a/packages/sandbox/src/storage-mount/r2-egress-handler.ts
+++ b/packages/sandbox/src/storage-mount/r2-egress-handler.ts
@@ -26,7 +26,7 @@ import { isR2Bucket } from './validation';
 // ---------------------------------------------------------------------------
 
 export type R2EgressParams = {
-  buckets: Record<string, string | undefined>;
+  buckets: Record<string, { prefix?: string; readOnly?: boolean }>;
 };
 
 // ---------------------------------------------------------------------------
@@ -330,7 +330,7 @@ async function handleListObjects(
   const queryPrefix = normalizeObjectKey(url.searchParams.get('prefix') ?? '');
   const delimiter = url.searchParams.get('delimiter') ?? '';
   const maxKeys = Math.min(
-    parseInt(url.searchParams.get('max-keys') ?? '1000', 10),
+    parseInt(url.searchParams.get('max-keys') ?? '1000', 10) || 1000,
     1000
   );
   const continuationToken =
@@ -346,11 +346,6 @@ async function handleListObjects(
   };
 
   const result = await r2.list(listOpts);
-  console.log('[r2-egress] LIST result', {
-    r2Prefix,
-    count: result.objects.length,
-    objects: result.objects.map((o) => ({ key: o.key, size: o.size }))
-  });
 
   const stripKey = mountPrefix
     ? (k: string): string =>
@@ -383,10 +378,8 @@ async function handleListObjects(
 async function handleHeadObject(r2: R2Bucket, key: string): Promise<Response> {
   const obj = await r2.head(key);
   if (!obj) {
-    console.log('[r2-egress] HEAD 404', { key });
     return new Response(null, { status: 404 });
   }
-  console.log('[r2-egress] HEAD 200', { key, size: obj.size });
   // NOTE: The outbound proxy rewrites Content-Length to 0 for bodiless
   // responses. s3fs stat cache must be pre-populated from LIST (readdir)
   // so that getattr never falls through to HEAD for file size information.
@@ -406,11 +399,9 @@ async function handleGetObject(
   if (!range) {
     const obj = await r2.get(key);
     if (!obj) {
-      console.log('[r2-egress] GET 404', { key });
       return new Response(null, { status: 404 });
     }
     const body = await obj.arrayBuffer();
-    console.log('[r2-egress] GET 200', { key, bytes: body.byteLength });
     return new Response(body, {
       status: 200,
       headers: buildResponseHeaders(obj)
@@ -599,13 +590,6 @@ export const r2EgressHandler: OutboundHandler<
   const url = new URL(request.url);
   const parsed = parsePath(url.pathname);
 
-  console.log('[r2-egress] incoming request', {
-    method: request.method,
-    url: request.url,
-    containerId: ctx.containerId,
-    paramBuckets: ctx.params ? Object.keys(ctx.params.buckets) : null
-  });
-
   if (!parsed) {
     return new Response('Bad Request: empty path', { status: 400 });
   }
@@ -613,11 +597,6 @@ export const r2EgressHandler: OutboundHandler<
   const { bucket: bucketName, key } = parsed;
 
   if (!ctx.params?.buckets || !(bucketName in ctx.params.buckets)) {
-    console.log('[r2-egress] 403: bucket not in params', {
-      bucketName,
-      containerId: ctx.containerId,
-      paramBuckets: ctx.params ? Object.keys(ctx.params.buckets) : null
-    });
     return new Response(
       `Access to R2 bucket "${bucketName}" is not permitted. ` +
         'Call mountBucket() with this bucket before accessing it.',
@@ -625,15 +604,12 @@ export const r2EgressHandler: OutboundHandler<
     );
   }
 
-  const rawPrefix = ctx.params.buckets[bucketName];
-  const mountPrefix = rawPrefix ? normalizeObjectKey(rawPrefix) : undefined;
-
-  console.log('[r2-egress] resolved', {
-    bucketName,
-    key,
-    rawPrefix,
-    mountPrefix
-  });
+  const bucketParams = ctx.params.buckets[bucketName];
+  const rawPrefix = bucketParams.prefix;
+  const mountPrefix = rawPrefix
+    ? normalizeObjectKey(rawPrefix).replace(/\/+$/, '')
+    : undefined;
+  const readOnly = bucketParams.readOnly ?? false;
 
   const r2 = resolveR2Bucket(env, bucketName);
   if (!r2) {
@@ -663,6 +639,18 @@ export const r2EgressHandler: OutboundHandler<
 
   const fullKey = mountPrefix ? `${mountPrefix}/${key}` : key;
   const permitted = new Set(Object.keys(ctx.params.buckets));
+
+  if (
+    readOnly &&
+    (method === 'PUT' ||
+      method === 'DELETE' ||
+      (method === 'POST' &&
+        (url.searchParams.has('uploads') || url.searchParams.has('uploadId'))))
+  ) {
+    return new Response('Forbidden: bucket mount is read-only', {
+      status: 403
+    });
+  }
 
   // Multipart upload: POST /bucket/key?uploads — initiate
   if (method === 'POST' && url.searchParams.has('uploads')) {

--- a/packages/sandbox/src/storage-mount/r2-egress-handler.ts
+++ b/packages/sandbox/src/storage-mount/r2-egress-handler.ts
@@ -231,6 +231,17 @@ interface UploadedPart {
   etag: string;
 }
 
+function extractXmlTagContent(segment: string, tagName: string): string | null {
+  const openTag = `<${tagName}>`;
+  const closeTag = `</${tagName}>`;
+  const start = segment.indexOf(openTag);
+  if (start === -1) return null;
+  const contentStart = start + openTag.length;
+  const end = segment.indexOf(closeTag, contentStart);
+  if (end === -1) return null;
+  return segment.slice(contentStart, end);
+}
+
 function parseCompleteMultipartUploadBody(body: string): UploadedPart[] {
   const parts: UploadedPart[] = [];
   let pos = 0;
@@ -241,12 +252,13 @@ function parseCompleteMultipartUploadBody(body: string): UploadedPart[] {
     if (end === -1) break;
     const segment = body.slice(start, end + 7);
     pos = end + 7;
-    const numMatch = /<PartNumber>(\d+)<\/PartNumber>/.exec(segment);
-    const etagMatch = /<ETag>("?[^<]+"?)<\/ETag>/.exec(segment);
-    if (numMatch && etagMatch) {
+    const partNumberText = extractXmlTagContent(segment, 'PartNumber');
+    const etagText = extractXmlTagContent(segment, 'ETag');
+    const partNumber = partNumberText ? parseInt(partNumberText, 10) : NaN;
+    if (Number.isFinite(partNumber) && etagText) {
       parts.push({
-        partNumber: parseInt(numMatch[1], 10),
-        etag: etagMatch[1].replace(/^"|"$/g, '')
+        partNumber,
+        etag: etagText.replace(/^"|"$/g, '')
       });
     }
   }
@@ -290,6 +302,19 @@ function buildContentRange(range: R2Range, totalSize: number): string {
   const end =
     range.length !== undefined ? start + range.length - 1 : totalSize - 1;
   return `bytes ${start}-${end}/${totalSize}`;
+}
+
+function getRangeContentLength(range: R2Range, totalSize: number): number {
+  if ('suffix' in range) {
+    return Math.min(range.suffix, totalSize);
+  }
+  const start = range.offset ?? 0;
+  if (start >= totalSize) {
+    return 0;
+  }
+  const requestedLength =
+    range.length !== undefined ? range.length : totalSize - start;
+  return Math.min(requestedLength, totalSize - start);
 }
 
 function extractHttpMetadata(request: Request): R2HTTPMetadata {
@@ -431,7 +456,10 @@ async function handleGetObject(
   const rangeBody = await rangeObj.arrayBuffer();
   const headers = buildResponseHeaders(rangeObj);
   headers.set('Content-Range', buildContentRange(range, headObj.size));
-  headers.set('Content-Length', String(rangeBody.byteLength));
+  headers.set(
+    'Content-Length',
+    String(getRangeContentLength(range, headObj.size))
+  );
 
   return new Response(rangeBody, { status: 206, headers });
 }
@@ -540,10 +568,8 @@ async function handleUploadPart(
     });
   }
   const upload = r2.resumeMultipartUpload(key, uploadId);
-  const part = await upload.uploadPart(
-    partNumber,
-    request.body as ReadableStream
-  );
+  const body = await request.arrayBuffer();
+  const part = await upload.uploadPart(partNumber, body);
   const headers = new Headers();
   headers.set('ETag', `"${part.etag}"`);
   return new Response(null, { status: 200, headers });

--- a/packages/sandbox/src/storage-mount/r2-egress-handler.ts
+++ b/packages/sandbox/src/storage-mount/r2-egress-handler.ts
@@ -33,7 +33,6 @@ export type R2EgressParams = {
 
 const XML_NS = 'xmlns="http://s3.amazonaws.com/doc/2006-03-01/"';
 const XML_DECL = '<?xml version="1.0" encoding="UTF-8"?>\n';
-const R2_MULTIPART_PART_SIZE = 5 * 1024 * 1024;
 
 function escapeXML(s: string): string {
   return s
@@ -358,69 +357,33 @@ async function readRequestBody(
   return new Uint8Array(await request.arrayBuffer());
 }
 
-function mergeChunks(chunks: Uint8Array[], totalLength: number): Uint8Array {
-  const merged = new Uint8Array(totalLength);
-  let offset = 0;
-  for (const chunk of chunks) {
-    merged.set(chunk, offset);
-    offset += chunk.length;
-  }
-  return merged;
-}
-
 async function putRequestBody(
   r2: R2Bucket,
   key: string,
   request: Request,
-  options: R2MultipartOptions
+  options: R2PutOptions
 ): Promise<R2Object | Response> {
   if (!request.body) {
     return new Response('Bad Request: missing request body', { status: 400 });
   }
 
-  const upload = await r2.createMultipartUpload(key, options);
-  const reader = request.body.getReader();
-  const uploadedParts: R2UploadedPart[] = [];
-  let partNumber = 1;
-  let chunks: Uint8Array[] = [];
-  let bufferedBytes = 0;
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      chunks.push(value);
-      bufferedBytes += value.length;
-
-      while (bufferedBytes >= R2_MULTIPART_PART_SIZE) {
-        const partBuffer = mergeChunks(chunks, bufferedBytes);
-        const part = partBuffer.slice(0, R2_MULTIPART_PART_SIZE);
-        const remainder = partBuffer.slice(R2_MULTIPART_PART_SIZE);
-        uploadedParts.push(await upload.uploadPart(partNumber, part));
-        partNumber++;
-        chunks = remainder.length > 0 ? [remainder] : [];
-        bufferedBytes = remainder.length;
-      }
-    }
-
-    if (uploadedParts.length === 0 && bufferedBytes === 0) {
-      // Empty body — R2 multipart does not support 0-byte parts; abort and use
-      // a direct put instead.
-      await upload.abort();
-      return r2.put(key, new Uint8Array(0), options);
-    }
-
-    if (bufferedBytes > 0) {
-      uploadedParts.push(
-        await upload.uploadPart(partNumber, mergeChunks(chunks, bufferedBytes))
-      );
-    }
-
-    return upload.complete(uploadedParts);
-  } catch (error) {
-    await upload.abort();
-    throw error;
+  const contentLength = request.headers.get('Content-Length');
+  const length = contentLength ? Number.parseInt(contentLength, 10) : NaN;
+  if (!Number.isFinite(length) || length < 0) {
+    return new Response('Bad Request: missing or invalid Content-Length', {
+      status: 400
+    });
   }
+
+  if (length === 0) {
+    return r2.put(key, new Uint8Array(0), options);
+  }
+
+  const { readable, writable } = new FixedLengthStream(length);
+  const pipe = request.body.pipeTo(writable);
+  const result = await r2.put(key, readable, options);
+  await pipe;
+  return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/sandbox/src/storage-mount/r2-egress-handler.ts
+++ b/packages/sandbox/src/storage-mount/r2-egress-handler.ts
@@ -64,6 +64,12 @@ function normalizeObjectKey(value: string): string {
   return value.replace(/^\/+/, '');
 }
 
+function trimTrailingSlashes(s: string): string {
+  let end = s.length;
+  while (end > 0 && s[end - 1] === '/') end--;
+  return s.slice(0, end);
+}
+
 function parsePath(pathname: string): ParsedPath | null {
   const stripped = pathname.startsWith('/') ? pathname.slice(1) : pathname;
   if (!stripped) return null;
@@ -227,8 +233,14 @@ interface UploadedPart {
 
 function parseCompleteMultipartUploadBody(body: string): UploadedPart[] {
   const parts: UploadedPart[] = [];
-  const partSegments = body.match(/<Part>[\s\S]*?<\/Part>/g) ?? [];
-  for (const segment of partSegments) {
+  let pos = 0;
+  while (pos < body.length) {
+    const start = body.indexOf('<Part>', pos);
+    if (start === -1) break;
+    const end = body.indexOf('</Part>', start + 6);
+    if (end === -1) break;
+    const segment = body.slice(start, end + 7);
+    pos = end + 7;
     const numMatch = /<PartNumber>(\d+)<\/PartNumber>/.exec(segment);
     const etagMatch = /<ETag>("?[^<]+"?)<\/ETag>/.exec(segment);
     if (numMatch && etagMatch) {
@@ -607,7 +619,7 @@ export const r2EgressHandler: OutboundHandler<
   const bucketParams = ctx.params.buckets[bucketName];
   const rawPrefix = bucketParams.prefix;
   const mountPrefix = rawPrefix
-    ? normalizeObjectKey(rawPrefix).replace(/\/+$/, '')
+    ? trimTrailingSlashes(normalizeObjectKey(rawPrefix))
     : undefined;
   const readOnly = bucketParams.readOnly ?? false;
 

--- a/packages/sandbox/src/storage-mount/types.ts
+++ b/packages/sandbox/src/storage-mount/types.ts
@@ -32,5 +32,7 @@ export interface R2EgressMountInfo {
   mountType: 'r2-egress';
   bucket: string;
   mountPath: string;
+  passwordFilePath: string;
   mounted: boolean;
+  prefix?: string;
 }

--- a/packages/sandbox/src/storage-mount/types.ts
+++ b/packages/sandbox/src/storage-mount/types.ts
@@ -8,7 +8,7 @@ import type { LocalMountSyncManager } from '../local-mount-sync';
 /**
  * Internal tracking information for active mounts
  */
-export type MountInfo = FuseMountInfo | LocalSyncMountInfo | R2EgressMountInfo;
+export type MountInfo = FuseMountInfo | LocalSyncMountInfo | R2BindingMountInfo;
 
 export interface FuseMountInfo {
   mountType: 'fuse';
@@ -28,7 +28,7 @@ export interface LocalSyncMountInfo {
   mounted: boolean;
 }
 
-export interface R2EgressMountInfo {
+export interface R2BindingMountInfo {
   mountType: 'r2-egress';
   bucket: string;
   mountPath: string;
@@ -37,3 +37,5 @@ export interface R2EgressMountInfo {
   prefix?: string;
   readOnly: boolean;
 }
+
+export type R2EgressMountInfo = R2BindingMountInfo;

--- a/packages/sandbox/src/storage-mount/types.ts
+++ b/packages/sandbox/src/storage-mount/types.ts
@@ -35,4 +35,5 @@ export interface R2EgressMountInfo {
   passwordFilePath: string;
   mounted: boolean;
   prefix?: string;
+  readOnly: boolean;
 }

--- a/packages/sandbox/src/storage-mount/types.ts
+++ b/packages/sandbox/src/storage-mount/types.ts
@@ -8,7 +8,7 @@ import type { LocalMountSyncManager } from '../local-mount-sync';
 /**
  * Internal tracking information for active mounts
  */
-export type MountInfo = FuseMountInfo | LocalSyncMountInfo;
+export type MountInfo = FuseMountInfo | LocalSyncMountInfo | R2EgressMountInfo;
 
 export interface FuseMountInfo {
   mountType: 'fuse';
@@ -25,5 +25,12 @@ export interface LocalSyncMountInfo {
   bucket: string;
   mountPath: string;
   syncManager: LocalMountSyncManager;
+  mounted: boolean;
+}
+
+export interface R2EgressMountInfo {
+  mountType: 'r2-egress';
+  bucket: string;
+  mountPath: string;
   mounted: boolean;
 }

--- a/packages/sandbox/src/storage-mount/validation.ts
+++ b/packages/sandbox/src/storage-mount/validation.ts
@@ -59,6 +59,7 @@ export function validateBucketBindingName(
     );
   }
 
+  // Worker binding names follow JavaScript identifier syntax.
   const bindingNameRegex = /^[A-Za-z_][A-Za-z0-9_]*$/;
   if (!bindingNameRegex.test(bucketBinding)) {
     throw new InvalidMountConfigError(

--- a/packages/sandbox/src/storage-mount/validation.ts
+++ b/packages/sandbox/src/storage-mount/validation.ts
@@ -1,5 +1,26 @@
 import { InvalidMountConfigError } from './errors';
 
+/**
+ * Type guard for R2Bucket binding.
+ * Checks for the minimal R2Bucket interface methods we use.
+ */
+export function isR2Bucket(value: unknown): value is R2Bucket {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'put' in value &&
+    typeof (value as Record<string, unknown>).put === 'function' &&
+    'get' in value &&
+    typeof (value as Record<string, unknown>).get === 'function' &&
+    'head' in value &&
+    typeof (value as Record<string, unknown>).head === 'function' &&
+    'delete' in value &&
+    typeof (value as Record<string, unknown>).delete === 'function' &&
+    'list' in value &&
+    typeof (value as Record<string, unknown>).list === 'function'
+  );
+}
+
 export function validatePrefix(prefix: string): void {
   if (!prefix.startsWith('/')) {
     throw new InvalidMountConfigError(
@@ -22,6 +43,26 @@ export function validateBucketName(bucket: string, mountPath: string): void {
     throw new InvalidMountConfigError(
       `Invalid bucket name: "${bucket}". Bucket names must be 3-63 characters, ` +
         `lowercase alphanumeric, dots, or hyphens, and cannot start/end with dots or hyphens.`
+    );
+  }
+}
+
+export function validateBucketBindingName(
+  bucketBinding: string,
+  mountPath: string
+): void {
+  if (bucketBinding.includes(':')) {
+    const [bucketName, prefixPart] = bucketBinding.split(':');
+    throw new InvalidMountConfigError(
+      `Bucket name cannot contain ':'. To mount a prefix, use the 'prefix' option:\n` +
+        `  mountBucket('${bucketName}', '${mountPath}', { ...options, prefix: '${prefixPart}' })`
+    );
+  }
+
+  const bindingNameRegex = /^[A-Za-z_][A-Za-z0-9_]*$/;
+  if (!bindingNameRegex.test(bucketBinding)) {
+    throw new InvalidMountConfigError(
+      `Invalid R2 binding name: "${bucketBinding}". Binding names must start with a letter or underscore and contain only letters, numbers, or underscores.`
     );
   }
 }

--- a/packages/sandbox/tests/r2-egress-handler.test.ts
+++ b/packages/sandbox/tests/r2-egress-handler.test.ts
@@ -411,7 +411,10 @@ describe('r2EgressHandler', () => {
         new Request('http://r2.internal/MY_BUCKET/new-file.txt', {
           method: 'PUT',
           body: 'new content',
-          headers: { 'Content-Type': 'text/plain' }
+          headers: {
+            'Content-Length': '11',
+            'Content-Type': 'text/plain'
+          }
         }),
         makeEnv(r2),
         makeCtx()
@@ -419,11 +422,35 @@ describe('r2EgressHandler', () => {
       expect(res.status).toBe(200);
       expect(res.headers.get('ETag')).toBeTruthy();
       expect(store.has('new-file.txt')).toBe(true);
-      expect(r2.put).not.toHaveBeenCalled();
-      expect(r2.createMultipartUpload).toHaveBeenCalledWith('new-file.txt', {
-        httpMetadata: { contentType: 'text/plain' }
-      });
+      expect(r2.put).toHaveBeenCalledTimes(1);
+      expect(r2.put).toHaveBeenCalledWith(
+        'new-file.txt',
+        expect.any(ReadableStream),
+        { httpMetadata: { contentType: 'text/plain' } }
+      );
+      expect(r2.createMultipartUpload).not.toHaveBeenCalled();
       expect(store.get('new-file.txt')?.body).toBe('new content');
+    });
+
+    it('accepts zero-length PUT requests with no body stream', async () => {
+      const store = new Map<string, MockObject>();
+      const r2 = createMockR2Bucket(store);
+      const request = {
+        method: 'PUT',
+        url: 'http://r2.internal/MY_BUCKET/empty.txt',
+        headers: new Headers({
+          'Content-Length': '0',
+          'Content-Type': 'text/plain'
+        }),
+        body: null
+      } as unknown as Request;
+
+      const res = await r2EgressHandler(request, makeEnv(r2), makeCtx());
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('ETag')).toBeTruthy();
+      expect(store.get('empty.txt')?.body).toBe('');
+      expect(store.get('empty.txt')?.contentType).toBe('text/plain');
     });
 
     it('copies an object when x-amz-copy-source is present', async () => {

--- a/packages/sandbox/tests/r2-egress-handler.test.ts
+++ b/packages/sandbox/tests/r2-egress-handler.test.ts
@@ -1,0 +1,617 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  r2EgressHandler,
+  registerBucketAccess,
+  revokeBucketAccess
+} from '../src/storage-mount/r2-egress-handler';
+
+// ---------------------------------------------------------------------------
+// Mock R2 binding factory
+// ---------------------------------------------------------------------------
+
+interface MockObject {
+  body: string;
+  contentType?: string;
+  customMetadata?: Record<string, string>;
+  etag?: string;
+  storageClass?: 'Standard' | 'InfrequentAccess';
+}
+
+function makeR2Object(key: string, obj: MockObject): R2ObjectBody {
+  const etag = obj.etag ?? `"etag-${key}"`;
+  const size = obj.body.length;
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(obj.body));
+      controller.close();
+    }
+  });
+  return {
+    key,
+    size,
+    etag: etag.replace(/"/g, ''),
+    httpEtag: etag,
+    uploaded: new Date('2024-01-01T00:00:00Z'),
+    httpMetadata: obj.contentType ? { contentType: obj.contentType } : {},
+    customMetadata: obj.customMetadata ?? {},
+    storageClass: obj.storageClass ?? 'Standard',
+    body: stream,
+    bodyUsed: false,
+    text: () => Promise.resolve(obj.body),
+    arrayBuffer: () =>
+      Promise.resolve(encoder.encode(obj.body).buffer as ArrayBuffer),
+    json: () => Promise.resolve(JSON.parse(obj.body)),
+    blob: () => Promise.resolve(new Blob([obj.body]))
+  } as unknown as R2ObjectBody;
+}
+
+function makeR2Head(key: string, obj: MockObject): R2Object {
+  const etag = obj.etag ?? `"etag-${key}"`;
+  return {
+    key,
+    size: obj.body.length,
+    etag: etag.replace(/"/g, ''),
+    httpEtag: etag,
+    uploaded: new Date('2024-01-01T00:00:00Z'),
+    httpMetadata: obj.contentType ? { contentType: obj.contentType } : {},
+    customMetadata: obj.customMetadata ?? {},
+    storageClass: obj.storageClass ?? 'Standard'
+  } as unknown as R2Object;
+}
+
+function sliceBody(body: string, range: R2Range): string {
+  if ('suffix' in range) {
+    return body.slice(-range.suffix);
+  }
+  const offset = range.offset ?? 0;
+  return range.length !== undefined
+    ? body.slice(offset, offset + range.length)
+    : body.slice(offset);
+}
+
+function createMockR2Bucket(store: Map<string, MockObject>): R2Bucket {
+  const uploads = new Map<
+    string,
+    { key: string; parts: Map<number, string> }
+  >();
+
+  return {
+    get: vi.fn(async (key: string, opts?: { range?: R2Range }) => {
+      const obj = store.get(key);
+      if (!obj) return null;
+      if (opts?.range) {
+        return makeR2Object(key, {
+          ...obj,
+          body: sliceBody(obj.body, opts.range)
+        });
+      }
+      return makeR2Object(key, obj);
+    }),
+    put: vi.fn(async (key: string, value: unknown, options?: R2PutOptions) => {
+      let body = '';
+      if (typeof value === 'string') body = value;
+      else if (value instanceof ReadableStream) {
+        const reader = value.getReader();
+        const chunks: Uint8Array[] = [];
+        while (true) {
+          const { done, value: chunk } = await reader.read();
+          if (done) break;
+          if (chunk) chunks.push(chunk as Uint8Array);
+        }
+        body = new TextDecoder().decode(
+          chunks.reduce((acc, c) => {
+            const merged = new Uint8Array(acc.length + c.length);
+            merged.set(acc);
+            merged.set(c, acc.length);
+            return merged;
+          }, new Uint8Array(0))
+        );
+      }
+      const httpMetadata = options?.httpMetadata;
+      const contentType =
+        typeof httpMetadata === 'object' &&
+        httpMetadata &&
+        'contentType' in httpMetadata
+          ? httpMetadata.contentType
+          : undefined;
+      const stored: MockObject = {
+        body,
+        contentType,
+        customMetadata: options?.customMetadata,
+        storageClass:
+          options?.storageClass === 'Standard' ||
+          options?.storageClass === 'InfrequentAccess'
+            ? options.storageClass
+            : undefined
+      };
+      store.set(key, stored);
+      return makeR2Head(key, stored);
+    }),
+    head: vi.fn(async (key: string) => {
+      const obj = store.get(key);
+      return obj ? makeR2Head(key, obj) : null;
+    }),
+    delete: vi.fn(async (key: string) => {
+      store.delete(key);
+    }),
+    list: vi.fn(async (opts?: R2ListOptions) => {
+      const prefix = opts?.prefix ?? '';
+      const delimiter = opts?.delimiter ?? '';
+      const limit = opts?.limit ?? 1000;
+
+      const allKeys = [...store.keys()].filter((k) =>
+        prefix ? k.startsWith(prefix) : true
+      );
+
+      const prefixSet = new Set<string>();
+      const objects: R2Object[] = [];
+
+      for (const key of allKeys) {
+        if (delimiter) {
+          const rest = key.slice(prefix.length);
+          const delimIdx = rest.indexOf(delimiter);
+          if (delimIdx !== -1) {
+            prefixSet.add(prefix + rest.slice(0, delimIdx + 1));
+            continue;
+          }
+        }
+        objects.push(makeR2Head(key, store.get(key)!));
+        if (objects.length >= limit) break;
+      }
+
+      return {
+        objects,
+        truncated: false,
+        cursor: undefined,
+        delimitedPrefixes: [...prefixSet]
+      } as unknown as R2Objects;
+    }),
+    createMultipartUpload: vi.fn(async (key: string) => {
+      const uploadId = `upload-${key}-${Date.now()}`;
+      uploads.set(uploadId, { key, parts: new Map() });
+      return {
+        key,
+        uploadId,
+        uploadPart: vi.fn(async (partNumber: number, value: unknown) => {
+          let body = '';
+          if (typeof value === 'string') body = value;
+          uploads.get(uploadId)!.parts.set(partNumber, body);
+          return { partNumber, etag: `part-etag-${partNumber}` };
+        }),
+        complete: vi.fn(async () => {
+          const upload = uploads.get(uploadId)!;
+          const combined = [...upload.parts.entries()]
+            .sort((a, b) => a[0] - b[0])
+            .map(([, v]) => v)
+            .join('');
+          store.set(key, { body: combined });
+          return makeR2Head(key, { body: combined });
+        }),
+        abort: vi.fn(async () => {
+          uploads.delete(uploadId);
+        })
+      } as unknown as R2MultipartUpload;
+    }),
+    resumeMultipartUpload: vi.fn((key: string, uploadId: string) => {
+      return {
+        key,
+        uploadId,
+        uploadPart: vi.fn(async (partNumber: number) => ({
+          partNumber,
+          etag: `part-etag-${partNumber}`
+        })),
+        complete: vi.fn(async (parts: R2UploadedPart[]) => {
+          const joined = parts.map((p) => `part-${p.partNumber}`).join('');
+          store.set(key, { body: joined });
+          return makeR2Head(key, { body: joined });
+        }),
+        abort: vi.fn(async () => {
+          uploads.delete(uploadId);
+        })
+      } as unknown as R2MultipartUpload;
+    })
+  } as unknown as R2Bucket;
+}
+
+function makeEnv(bucket: R2Bucket, bindingName = 'MY_BUCKET'): Cloudflare.Env {
+  return { [bindingName]: bucket } as unknown as Cloudflare.Env;
+}
+
+function makeCtx() {
+  return { containerId: 'test-container', className: 'Sandbox' };
+}
+
+function req(method: string, path: string, body?: string): Request {
+  return new Request(`http://r2.internal${path}`, {
+    method,
+    body: body ?? null,
+    headers: body ? { 'Content-Type': 'application/octet-stream' } : {}
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('r2EgressHandler', () => {
+  // Register MY_BUCKET for the test container before each test so the
+  // allowlist check passes. Tests for the 403 path manage their own state.
+  beforeEach(() => {
+    registerBucketAccess('test-container', 'MY_BUCKET');
+  });
+  afterEach(() => {
+    revokeBucketAccess('test-container', 'MY_BUCKET');
+  });
+
+  describe('GetBucketLocation', () => {
+    it('returns LocationConstraint XML', async () => {
+      const r2 = createMockR2Bucket(new Map());
+      const res = await r2EgressHandler(
+        req('GET', '/MY_BUCKET?location'),
+        makeEnv(r2),
+        makeCtx()
+      );
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      expect(text).toContain('<LocationConstraint');
+    });
+  });
+
+  describe('ListObjectsV2', () => {
+    it('returns ListBucketResult XML with objects', async () => {
+      const store = new Map<string, MockObject>([
+        ['file1.txt', { body: 'hello' }],
+        ['file2.txt', { body: 'world' }]
+      ]);
+      const r2 = createMockR2Bucket(store);
+      const res = await r2EgressHandler(
+        req('GET', '/MY_BUCKET?list-type=2'),
+        makeEnv(r2),
+        makeCtx()
+      );
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      expect(text).toContain('<ListBucketResult');
+      expect(text).toContain('<Key>file1.txt</Key>');
+      expect(text).toContain('<Key>file2.txt</Key>');
+      expect(text).toContain('<IsTruncated>false</IsTruncated>');
+    });
+
+    it('returns CommonPrefixes when delimiter is provided', async () => {
+      const store = new Map<string, MockObject>([
+        ['folder/a.txt', { body: 'a' }],
+        ['folder/b.txt', { body: 'b' }],
+        ['root.txt', { body: 'r' }]
+      ]);
+      const r2 = createMockR2Bucket(store);
+      const res = await r2EgressHandler(
+        req('GET', '/MY_BUCKET?list-type=2&delimiter=/'),
+        makeEnv(r2),
+        makeCtx()
+      );
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      expect(text).toContain('<CommonPrefixes>');
+      expect(text).toContain('<Prefix>folder/</Prefix>');
+      expect(text).toContain('<Key>root.txt</Key>');
+    });
+  });
+
+  describe('HeadObject', () => {
+    it('returns 200 with metadata headers for existing key', async () => {
+      const store = new Map<string, MockObject>([
+        ['test.txt', { body: 'hello', contentType: 'text/plain' }]
+      ]);
+      const r2 = createMockR2Bucket(store);
+      const res = await r2EgressHandler(
+        req('HEAD', '/MY_BUCKET/test.txt'),
+        makeEnv(r2),
+        makeCtx()
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Content-Length')).toBe('5');
+      expect(res.headers.get('Content-Type')).toBe('text/plain');
+      expect(res.headers.get('ETag')).toBeTruthy();
+    });
+
+    it('returns 404 for missing key', async () => {
+      const r2 = createMockR2Bucket(new Map());
+      const res = await r2EgressHandler(
+        req('HEAD', '/MY_BUCKET/missing.txt'),
+        makeEnv(r2),
+        makeCtx()
+      );
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GetObject', () => {
+    it('returns object body with 200', async () => {
+      const store = new Map<string, MockObject>([
+        ['hello.txt', { body: 'Hello, World!' }]
+      ]);
+      const r2 = createMockR2Bucket(store);
+      const res = await r2EgressHandler(
+        req('GET', '/MY_BUCKET/hello.txt'),
+        makeEnv(r2),
+        makeCtx()
+      );
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      expect(text).toBe('Hello, World!');
+    });
+
+    it('returns 404 for missing key', async () => {
+      const r2 = createMockR2Bucket(new Map());
+      const res = await r2EgressHandler(
+        req('GET', '/MY_BUCKET/missing.txt'),
+        makeEnv(r2),
+        makeCtx()
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 206 with correct Content-Range for a fixed byte range', async () => {
+      const store = new Map<string, MockObject>([
+        ['large.bin', { body: '0123456789' }]
+      ]);
+      const r2 = createMockR2Bucket(store);
+      const res = await r2EgressHandler(
+        new Request('http://r2.internal/MY_BUCKET/large.bin', {
+          headers: { Range: 'bytes=2-5' }
+        }),
+        makeEnv(r2),
+        makeCtx()
+      );
+      expect(res.status).toBe(206);
+      expect(res.headers.get('Content-Range')).toBe('bytes 2-5/10');
+      expect(res.headers.get('Content-Length')).toBe('4');
+      expect(await res.text()).toBe('2345');
+    });
+
+    it('returns 206 with correct Content-Range for an open-ended range', async () => {
+      const store = new Map<string, MockObject>([
+        ['large.bin', { body: '0123456789' }]
+      ]);
+      const r2 = createMockR2Bucket(store);
+      const res = await r2EgressHandler(
+        new Request('http://r2.internal/MY_BUCKET/large.bin', {
+          headers: { Range: 'bytes=7-' }
+        }),
+        makeEnv(r2),
+        makeCtx()
+      );
+      expect(res.status).toBe(206);
+      expect(res.headers.get('Content-Range')).toBe('bytes 7-9/10');
+      expect(res.headers.get('Content-Length')).toBe('3');
+    });
+
+    it('advertises Accept-Ranges: bytes on non-range GET responses', async () => {
+      const store = new Map<string, MockObject>([
+        ['file.txt', { body: 'hello' }]
+      ]);
+      const r2 = createMockR2Bucket(store);
+      const res = await r2EgressHandler(
+        req('GET', '/MY_BUCKET/file.txt'),
+        makeEnv(r2),
+        makeCtx()
+      );
+      expect(res.headers.get('Accept-Ranges')).toBe('bytes');
+    });
+  });
+
+  describe('PutObject', () => {
+    it('stores object and returns 200 with ETag', async () => {
+      const store = new Map<string, MockObject>();
+      const r2 = createMockR2Bucket(store);
+      const res = await r2EgressHandler(
+        new Request('http://r2.internal/MY_BUCKET/new-file.txt', {
+          method: 'PUT',
+          body: 'new content',
+          headers: { 'Content-Type': 'text/plain' }
+        }),
+        makeEnv(r2),
+        makeCtx()
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get('ETag')).toBeTruthy();
+      expect(store.has('new-file.txt')).toBe(true);
+    });
+
+    it('copies an object when x-amz-copy-source is present', async () => {
+      const store = new Map<string, MockObject>([
+        [
+          'source.txt',
+          {
+            body: 'copy me',
+            contentType: 'text/plain',
+            customMetadata: { source: 'yes' }
+          }
+        ]
+      ]);
+      const r2 = createMockR2Bucket(store);
+      const res = await r2EgressHandler(
+        new Request('http://r2.internal/MY_BUCKET/copied.txt', {
+          method: 'PUT',
+          headers: { 'x-amz-copy-source': '/MY_BUCKET/source.txt' }
+        }),
+        makeEnv(r2),
+        makeCtx()
+      );
+
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      expect(text).toContain('<CopyObjectResult');
+      expect(store.get('copied.txt')).toEqual({
+        body: 'copy me',
+        contentType: 'text/plain',
+        customMetadata: { source: 'yes' },
+        storageClass: 'Standard'
+      });
+    });
+
+    it('replaces metadata on copy when requested', async () => {
+      const store = new Map<string, MockObject>([
+        ['source.txt', { body: 'copy me', contentType: 'text/plain' }]
+      ]);
+      const r2 = createMockR2Bucket(store);
+      const res = await r2EgressHandler(
+        new Request('http://r2.internal/MY_BUCKET/copied.txt', {
+          method: 'PUT',
+          headers: {
+            'x-amz-copy-source': '/MY_BUCKET/source.txt',
+            'x-amz-metadata-directive': 'REPLACE',
+            'Content-Type': 'application/json'
+          }
+        }),
+        makeEnv(r2),
+        makeCtx()
+      );
+
+      expect(res.status).toBe(200);
+      expect(store.get('copied.txt')?.contentType).toBe('application/json');
+    });
+  });
+
+  describe('DeleteObject', () => {
+    it('deletes object and returns 204', async () => {
+      const store = new Map<string, MockObject>([
+        ['to-delete.txt', { body: 'gone' }]
+      ]);
+      const r2 = createMockR2Bucket(store);
+      const res = await r2EgressHandler(
+        req('DELETE', '/MY_BUCKET/to-delete.txt'),
+        makeEnv(r2),
+        makeCtx()
+      );
+      expect(res.status).toBe(204);
+      expect(store.has('to-delete.txt')).toBe(false);
+    });
+  });
+
+  describe('Multipart upload', () => {
+    it('initiates multipart upload and returns XML with uploadId', async () => {
+      const r2 = createMockR2Bucket(new Map());
+      const res = await r2EgressHandler(
+        req('POST', '/MY_BUCKET/big-file.bin?uploads'),
+        makeEnv(r2),
+        makeCtx()
+      );
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      expect(text).toContain('<InitiateMultipartUploadResult');
+      expect(text).toContain('<Bucket>MY_BUCKET</Bucket>');
+      expect(text).toContain('<Key>big-file.bin</Key>');
+      expect(text).toContain('<UploadId>');
+    });
+
+    it('completes multipart upload and returns ETag', async () => {
+      const store = new Map<string, MockObject>();
+      const r2 = createMockR2Bucket(store);
+
+      // Initiate
+      const initRes = await r2EgressHandler(
+        req('POST', '/MY_BUCKET/big-file.bin?uploads'),
+        makeEnv(r2),
+        makeCtx()
+      );
+      const initText = await initRes.text();
+      const uploadIdMatch = /<UploadId>([^<]+)<\/UploadId>/.exec(initText);
+      const uploadId = uploadIdMatch![1];
+
+      // Complete
+      const completeBody = `<CompleteMultipartUpload>
+        <Part><PartNumber>1</PartNumber><ETag>"part-etag-1"</ETag></Part>
+        <Part><PartNumber>2</PartNumber><ETag>"part-etag-2"</ETag></Part>
+      </CompleteMultipartUpload>`;
+
+      const completeRes = await r2EgressHandler(
+        new Request(
+          `http://r2.internal/MY_BUCKET/big-file.bin?uploadId=${uploadId}`,
+          { method: 'POST', body: completeBody }
+        ),
+        makeEnv(r2),
+        makeCtx()
+      );
+      expect(completeRes.status).toBe(200);
+      const completeText = await completeRes.text();
+      expect(completeText).toContain('<CompleteMultipartUploadResult');
+      expect(completeText).toContain('<ETag>');
+    });
+
+    it('aborts multipart upload and returns 204', async () => {
+      const r2 = createMockR2Bucket(new Map());
+
+      const initRes = await r2EgressHandler(
+        req('POST', '/MY_BUCKET/abort-test.bin?uploads'),
+        makeEnv(r2),
+        makeCtx()
+      );
+      const initText = await initRes.text();
+      const uploadIdMatch = /<UploadId>([^<]+)<\/UploadId>/.exec(initText);
+      const uploadId = uploadIdMatch![1];
+
+      const abortRes = await r2EgressHandler(
+        req('DELETE', `/MY_BUCKET/abort-test.bin?uploadId=${uploadId}`),
+        makeEnv(r2),
+        makeCtx()
+      );
+      expect(abortRes.status).toBe(204);
+    });
+  });
+
+  describe('Bucket allowlist', () => {
+    it('returns 403 when bucket is not in the allowlist', async () => {
+      const r2 = createMockR2Bucket(new Map([['key.txt', { body: 'hi' }]]));
+      const res = await r2EgressHandler(
+        req('GET', '/OTHER_BUCKET/key.txt'),
+        makeEnv(r2, 'OTHER_BUCKET'),
+        makeCtx()
+      );
+      expect(res.status).toBe(403);
+      const text = await res.text();
+      expect(text).toContain('OTHER_BUCKET');
+    });
+
+    it('returns 403 for a different container even if bucket is registered', async () => {
+      registerBucketAccess('other-container', 'MY_BUCKET');
+      const r2 = createMockR2Bucket(new Map([['key.txt', { body: 'hi' }]]));
+      const res = await r2EgressHandler(
+        req('GET', '/MY_BUCKET/key.txt'),
+        makeEnv(r2),
+        { containerId: 'unrelated-container', className: 'Sandbox' }
+      );
+      revokeBucketAccess('other-container', 'MY_BUCKET');
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 500 when bucket is in allowlist but not in env', async () => {
+      const res = await r2EgressHandler(
+        req('GET', '/MY_BUCKET/some-key'),
+        {} as Cloudflare.Env,
+        makeCtx()
+      );
+      expect(res.status).toBe(500);
+      const text = await res.text();
+      expect(text).toContain('MY_BUCKET');
+    });
+  });
+
+  describe('XML escaping', () => {
+    it('escapes special characters in object keys', async () => {
+      const store = new Map<string, MockObject>([
+        ['path/with <special> & "chars"', { body: 'content' }]
+      ]);
+      const r2 = createMockR2Bucket(store);
+      const res = await r2EgressHandler(
+        req('GET', '/MY_BUCKET?list-type=2'),
+        makeEnv(r2),
+        makeCtx()
+      );
+      const text = await res.text();
+      expect(text).toContain('&lt;special&gt;');
+      expect(text).toContain('&amp;');
+    });
+  });
+});

--- a/packages/sandbox/tests/r2-egress-handler.test.ts
+++ b/packages/sandbox/tests/r2-egress-handler.test.ts
@@ -1,8 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
-  r2EgressHandler,
-  registerBucketAccess,
-  revokeBucketAccess
+  type R2EgressParams,
+  r2EgressHandler
 } from '../src/storage-mount/r2-egress-handler';
 
 // ---------------------------------------------------------------------------
@@ -91,6 +90,8 @@ function createMockR2Bucket(store: Map<string, MockObject>): R2Bucket {
     put: vi.fn(async (key: string, value: unknown, options?: R2PutOptions) => {
       let body = '';
       if (typeof value === 'string') body = value;
+      else if (value instanceof ArrayBuffer)
+        body = new TextDecoder().decode(value);
       else if (value instanceof ReadableStream) {
         const reader = value.getReader();
         const chunks: Uint8Array[] = [];
@@ -218,8 +219,10 @@ function makeEnv(bucket: R2Bucket, bindingName = 'MY_BUCKET'): Cloudflare.Env {
   return { [bindingName]: bucket } as unknown as Cloudflare.Env;
 }
 
-function makeCtx() {
-  return { containerId: 'test-container', className: 'Sandbox' };
+function makeCtx(
+  params: R2EgressParams = { buckets: { MY_BUCKET: undefined } }
+) {
+  return { containerId: 'test-container', className: 'Sandbox', params };
 }
 
 function req(method: string, path: string, body?: string): Request {
@@ -235,15 +238,6 @@ function req(method: string, path: string, body?: string): Request {
 // ---------------------------------------------------------------------------
 
 describe('r2EgressHandler', () => {
-  // Register MY_BUCKET for the test container before each test so the
-  // allowlist check passes. Tests for the 403 path manage their own state.
-  beforeEach(() => {
-    registerBucketAccess('test-container', 'MY_BUCKET');
-  });
-  afterEach(() => {
-    revokeBucketAccess('test-container', 'MY_BUCKET');
-  });
-
   describe('GetBucketLocation', () => {
     it('returns LocationConstraint XML', async () => {
       const r2 = createMockR2Bucket(new Map());
@@ -574,15 +568,17 @@ describe('r2EgressHandler', () => {
       expect(text).toContain('OTHER_BUCKET');
     });
 
-    it('returns 403 for a different container even if bucket is registered', async () => {
-      registerBucketAccess('other-container', 'MY_BUCKET');
+    it('returns 403 when bucket is not in params', async () => {
       const r2 = createMockR2Bucket(new Map([['key.txt', { body: 'hi' }]]));
       const res = await r2EgressHandler(
         req('GET', '/MY_BUCKET/key.txt'),
         makeEnv(r2),
-        { containerId: 'unrelated-container', className: 'Sandbox' }
+        {
+          containerId: 'test-container',
+          className: 'Sandbox',
+          params: { buckets: {} }
+        }
       );
-      revokeBucketAccess('other-container', 'MY_BUCKET');
       expect(res.status).toBe(403);
     });
 

--- a/packages/sandbox/tests/r2-egress-handler.test.ts
+++ b/packages/sandbox/tests/r2-egress-handler.test.ts
@@ -14,6 +14,7 @@ interface MockObject {
   customMetadata?: Record<string, string>;
   etag?: string;
   storageClass?: 'Standard' | 'InfrequentAccess';
+  failArrayBuffer?: boolean;
 }
 
 function makeR2Object(key: string, obj: MockObject): R2ObjectBody {
@@ -38,8 +39,12 @@ function makeR2Object(key: string, obj: MockObject): R2ObjectBody {
     body: stream,
     bodyUsed: false,
     text: () => Promise.resolve(obj.body),
-    arrayBuffer: () =>
-      Promise.resolve(encoder.encode(obj.body).buffer as ArrayBuffer),
+    arrayBuffer: () => {
+      if (obj.failArrayBuffer) {
+        throw new Error('arrayBuffer should not be called');
+      }
+      return Promise.resolve(encoder.encode(obj.body).buffer as ArrayBuffer);
+    },
     json: () => Promise.resolve(JSON.parse(obj.body)),
     blob: () => Promise.resolve(new Blob([obj.body]))
   } as unknown as R2ObjectBody;
@@ -69,6 +74,32 @@ function sliceBody(body: string, range: R2Range): string {
     : body.slice(offset);
 }
 
+async function readBodyValue(value: unknown): Promise<string> {
+  if (typeof value === 'string') return value;
+  if (value instanceof ArrayBuffer) return new TextDecoder().decode(value);
+  if (ArrayBuffer.isView(value)) {
+    return new TextDecoder().decode(value);
+  }
+  if (value instanceof ReadableStream) {
+    const reader = value.getReader();
+    const chunks: Uint8Array[] = [];
+    while (true) {
+      const { done, value: chunk } = await reader.read();
+      if (done) break;
+      if (chunk) chunks.push(chunk as Uint8Array);
+    }
+    return new TextDecoder().decode(
+      chunks.reduce((acc, c) => {
+        const merged = new Uint8Array(acc.length + c.length);
+        merged.set(acc);
+        merged.set(c, acc.length);
+        return merged;
+      }, new Uint8Array(0))
+    );
+  }
+  return '';
+}
+
 function createMockR2Bucket(store: Map<string, MockObject>): R2Bucket {
   const uploads = new Map<
     string,
@@ -88,27 +119,7 @@ function createMockR2Bucket(store: Map<string, MockObject>): R2Bucket {
       return makeR2Object(key, obj);
     }),
     put: vi.fn(async (key: string, value: unknown, options?: R2PutOptions) => {
-      let body = '';
-      if (typeof value === 'string') body = value;
-      else if (value instanceof ArrayBuffer)
-        body = new TextDecoder().decode(value);
-      else if (value instanceof ReadableStream) {
-        const reader = value.getReader();
-        const chunks: Uint8Array[] = [];
-        while (true) {
-          const { done, value: chunk } = await reader.read();
-          if (done) break;
-          if (chunk) chunks.push(chunk as Uint8Array);
-        }
-        body = new TextDecoder().decode(
-          chunks.reduce((acc, c) => {
-            const merged = new Uint8Array(acc.length + c.length);
-            merged.set(acc);
-            merged.set(c, acc.length);
-            return merged;
-          }, new Uint8Array(0))
-        );
-      }
+      const body = await readBodyValue(value);
       const httpMetadata = options?.httpMetadata;
       const contentType =
         typeof httpMetadata === 'object' &&
@@ -175,8 +186,7 @@ function createMockR2Bucket(store: Map<string, MockObject>): R2Bucket {
         key,
         uploadId,
         uploadPart: vi.fn(async (partNumber: number, value: unknown) => {
-          let body = '';
-          if (typeof value === 'string') body = value;
+          const body = await readBodyValue(value);
           uploads.get(uploadId)!.parts.set(partNumber, body);
           return { partNumber, etag: `part-etag-${partNumber}` };
         }),
@@ -321,7 +331,7 @@ describe('r2EgressHandler', () => {
   describe('GetObject', () => {
     it('returns object body with 200', async () => {
       const store = new Map<string, MockObject>([
-        ['hello.txt', { body: 'Hello, World!' }]
+        ['hello.txt', { body: 'Hello, World!', failArrayBuffer: true }]
       ]);
       const r2 = createMockR2Bucket(store);
       const res = await r2EgressHandler(
@@ -346,7 +356,7 @@ describe('r2EgressHandler', () => {
 
     it('returns 206 with correct Content-Range for a fixed byte range', async () => {
       const store = new Map<string, MockObject>([
-        ['large.bin', { body: '0123456789' }]
+        ['large.bin', { body: '0123456789', failArrayBuffer: true }]
       ]);
       const r2 = createMockR2Bucket(store);
       const res = await r2EgressHandler(
@@ -409,6 +419,11 @@ describe('r2EgressHandler', () => {
       expect(res.status).toBe(200);
       expect(res.headers.get('ETag')).toBeTruthy();
       expect(store.has('new-file.txt')).toBe(true);
+      expect(r2.put).not.toHaveBeenCalled();
+      expect(r2.createMultipartUpload).toHaveBeenCalledWith('new-file.txt', {
+        httpMetadata: { contentType: 'text/plain' }
+      });
+      expect(store.get('new-file.txt')?.body).toBe('new content');
     });
 
     it('copies an object when x-amz-copy-source is present', async () => {
@@ -418,7 +433,8 @@ describe('r2EgressHandler', () => {
           {
             body: 'copy me',
             contentType: 'text/plain',
-            customMetadata: { source: 'yes' }
+            customMetadata: { source: 'yes' },
+            failArrayBuffer: true
           }
         ]
       ]);

--- a/packages/sandbox/tests/r2-egress-handler.test.ts
+++ b/packages/sandbox/tests/r2-egress-handler.test.ts
@@ -219,9 +219,7 @@ function makeEnv(bucket: R2Bucket, bindingName = 'MY_BUCKET'): Cloudflare.Env {
   return { [bindingName]: bucket } as unknown as Cloudflare.Env;
 }
 
-function makeCtx(
-  params: R2EgressParams = { buckets: { MY_BUCKET: undefined } }
-) {
+function makeCtx(params: R2EgressParams = { buckets: { MY_BUCKET: {} } }) {
   return { containerId: 'test-container', className: 'Sandbox', params };
 }
 
@@ -552,6 +550,62 @@ describe('r2EgressHandler', () => {
         makeCtx()
       );
       expect(abortRes.status).toBe(204);
+    });
+  });
+
+  describe('read-only mounts', () => {
+    const readOnlyCtx = () =>
+      makeCtx({ buckets: { MY_BUCKET: { readOnly: true } } });
+
+    it('allows read operations', async () => {
+      const store = new Map<string, MockObject>([
+        ['readable.txt', { body: 'read me' }]
+      ]);
+      const r2 = createMockR2Bucket(store);
+
+      const res = await r2EgressHandler(
+        req('GET', '/MY_BUCKET/readable.txt'),
+        makeEnv(r2),
+        readOnlyCtx()
+      );
+
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe('read me');
+    });
+
+    it.each([
+      ['PUT', '/MY_BUCKET/new-file.txt'],
+      ['DELETE', '/MY_BUCKET/existing.txt'],
+      ['POST', '/MY_BUCKET/big-file.bin?uploads'],
+      ['POST', '/MY_BUCKET/big-file.bin?uploadId=upload-1'],
+      ['DELETE', '/MY_BUCKET/big-file.bin?uploadId=upload-1']
+    ])('rejects mutating operation %s %s', async (method, path) => {
+      const r2 = createMockR2Bucket(new Map());
+
+      const res = await r2EgressHandler(
+        req(method, path, method === 'POST' ? '<xml />' : undefined),
+        makeEnv(r2),
+        readOnlyCtx()
+      );
+
+      expect(res.status).toBe(403);
+      expect(await res.text()).toContain('read-only');
+    });
+
+    it('rejects copy object requests', async () => {
+      const r2 = createMockR2Bucket(new Map());
+
+      const res = await r2EgressHandler(
+        new Request('http://r2.internal/MY_BUCKET/copied.txt', {
+          method: 'PUT',
+          headers: { 'x-amz-copy-source': '/MY_BUCKET/source.txt' }
+        }),
+        makeEnv(r2),
+        readOnlyCtx()
+      );
+
+      expect(res.status).toBe(403);
+      expect(await res.text()).toContain('read-only');
     });
   });
 

--- a/packages/sandbox/tests/r2-egress-mount.test.ts
+++ b/packages/sandbox/tests/r2-egress-mount.test.ts
@@ -349,6 +349,19 @@ describe('Sandbox R2 egress mounts', () => {
     );
   });
 
+  it('treats an empty endpoint string as a remote mount configuration error', async () => {
+    const sandbox = new Sandbox(
+      createMockCtx() as unknown as ConstructorParameters<typeof Sandbox>[0],
+      { MY_BUCKET: createMockR2Bucket() }
+    );
+
+    await expect(
+      sandbox.mountBucket('MY_BUCKET', '/mnt/data', {
+        endpoint: ''
+      } as unknown as Parameters<Sandbox['mountBucket']>[2])
+    ).rejects.toThrow('Invalid endpoint URL');
+  });
+
   it('rejects a second mount of the same R2 binding with a different prefix', async () => {
     const sandbox = new Sandbox(
       createMockCtx() as unknown as ConstructorParameters<typeof Sandbox>[0],

--- a/packages/sandbox/tests/r2-egress-mount.test.ts
+++ b/packages/sandbox/tests/r2-egress-mount.test.ts
@@ -5,6 +5,10 @@ import {
   r2EgressHandler
 } from '../src/storage-mount/r2-egress-handler';
 
+type MockFetcher = {
+  fetch: ReturnType<typeof vi.fn>;
+};
+
 vi.mock('./interpreter', () => ({
   CodeInterpreter: vi.fn().mockImplementation(() => ({}))
 }));
@@ -74,7 +78,13 @@ vi.mock('@cloudflare/containers', () => {
   };
 });
 
-function createMockCtx() {
+function createMockCtx(options?: {
+  includeContainerProxy?: boolean;
+  containerProxyResult?: unknown;
+}) {
+  const containerProxyFetcher =
+    options?.containerProxyResult ?? ({ fetch: vi.fn() } satisfies MockFetcher);
+  const ContainerProxy = vi.fn().mockReturnValue(containerProxyFetcher);
   return {
     storage: {
       get: vi.fn().mockResolvedValue(null),
@@ -92,7 +102,12 @@ function createMockCtx() {
       toString: () => 'test-sandbox-id',
       equals: vi.fn(),
       name: 'test-sandbox'
-    }
+    },
+    container: {
+      interceptOutboundHttp: vi.fn().mockResolvedValue(undefined)
+    },
+    exports: options?.includeContainerProxy === false ? {} : { ContainerProxy },
+    containerProxyFetcher
   };
 }
 
@@ -149,29 +164,28 @@ function createExecResult(
 }
 
 describe('Sandbox R2 egress mounts', () => {
-  it('registers the credential-less R2 outbound handler under the runtime key', async () => {
-    const sandbox = new Sandbox(
+  it('does not register static R2 outbound interception on the base Sandbox class', () => {
+    class BaseSandbox extends Sandbox {}
+    new BaseSandbox(
       createMockCtx() as unknown as ConstructorParameters<typeof Sandbox>[0],
       { MY_BUCKET: createMockR2Bucket() }
     );
 
-    await expect(
+    expect(
       (
-        sandbox as unknown as {
-          setOutboundByHost: (
-            hostname: string,
-            method: string
-          ) => Promise<void>;
+        BaseSandbox as unknown as {
+          outboundByHost?: Record<string, unknown>;
         }
-      ).setOutboundByHost('r2.internal', 'r2EgressMount')
-    ).resolves.toBeUndefined();
+      ).outboundByHost
+    ).toBeUndefined();
 
     expect(
-      (Sandbox as unknown as { outboundHandlers?: Record<string, unknown> })
-        .outboundHandlers
-    ).toMatchObject({
-      r2EgressMount: r2EgressHandler
-    });
+      (
+        BaseSandbox as unknown as {
+          outboundHandlers?: Record<string, unknown>;
+        }
+      ).outboundHandlers
+    ).toBeUndefined();
   });
 
   describe('handler prefix translation', () => {
@@ -331,21 +345,122 @@ describe('Sandbox R2 egress mounts', () => {
       generatePasswordFilePath
     });
 
-    const setOutboundByHost = vi.fn().mockResolvedValue(undefined);
-    Object.assign(sandbox as object, { setOutboundByHost });
-
     await sandbox.mountBucket('MY_BUCKET', '/mnt/data', {
       prefix: '/uploads',
       readOnly: true,
       s3fsOptions: ['stat_cache_expire=1']
     } as any);
 
+    expect(mockCtx.exports.ContainerProxy).toHaveBeenCalledWith({
+      props: {
+        enableInternet: undefined,
+        containerId: 'test-sandbox-id',
+        className: 'CloudflareSandboxR2EgressProxyTarget',
+        outboundByHostOverrides: {
+          'r2.internal': {
+            method: 'r2EgressMount',
+            params: {
+              buckets: { MY_BUCKET: { prefix: '/uploads', readOnly: true } }
+            }
+          }
+        }
+      }
+    });
+    expect(mockCtx.container.interceptOutboundHttp).toHaveBeenCalledWith(
+      'r2.internal',
+      mockCtx.containerProxyFetcher
+    );
+    expect(
+      mockCtx.container.interceptOutboundHttp.mock.invocationCallOrder[0]
+    ).toBeLessThan(execInternal.mock.invocationCallOrder[0]);
     expect(execInternal).toHaveBeenNthCalledWith(1, "mkdir -p '/mnt/data'");
     expect(execInternal).toHaveBeenCalledTimes(3);
-    expect(setOutboundByHost).toHaveBeenCalledWith(
-      'r2.internal',
-      'r2EgressMount',
-      { buckets: { MY_BUCKET: { prefix: '/uploads', readOnly: true } } }
+  });
+
+  it('throws a clear error when ContainerProxy is not exported for R2 binding mounts', async () => {
+    const mockCtx = createMockCtx({ includeContainerProxy: false });
+    const sandbox = new Sandbox(
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+      { MY_BUCKET: createMockR2Bucket() }
+    );
+
+    Object.assign(sandbox as object, {
+      execInternal: vi.fn(),
+      createPasswordFile: vi.fn().mockResolvedValue(undefined),
+      deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-no-proxy')
+    });
+
+    await expect(
+      sandbox.mountBucket('MY_BUCKET', '/mnt/no-proxy', {} as any)
+    ).rejects.toThrow('exporting ContainerProxy');
+
+    expect(mockCtx.container.interceptOutboundHttp).not.toHaveBeenCalled();
+  });
+
+  it('throws a clear error when ContainerProxy does not return a fetcher', async () => {
+    const mockCtx = createMockCtx({ containerProxyResult: {} });
+    const sandbox = new Sandbox(
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+      { MY_BUCKET: createMockR2Bucket() }
+    );
+
+    Object.assign(sandbox as object, {
+      execInternal: vi.fn(),
+      createPasswordFile: vi.fn().mockResolvedValue(undefined),
+      deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-bad-proxy')
+    });
+
+    await expect(
+      sandbox.mountBucket('MY_BUCKET', '/mnt/bad-proxy', {} as any)
+    ).rejects.toThrow('valid Fetcher');
+
+    expect(mockCtx.container.interceptOutboundHttp).not.toHaveBeenCalled();
+  });
+
+  it('isolates R2 egress from user-defined outbound handlers on Sandbox subclasses', async () => {
+    class UserSandbox extends Sandbox {}
+    UserSandbox.outboundHandlers = {
+      userHandler: vi.fn()
+    };
+    UserSandbox.outboundByHost = {
+      'example.com': vi.fn()
+    };
+
+    const mockCtx = createMockCtx();
+    const sandbox = new UserSandbox(
+      mockCtx as unknown as ConstructorParameters<typeof UserSandbox>[0],
+      { MY_BUCKET: createMockR2Bucket() }
+    );
+
+    Object.assign(sandbox as object, {
+      execInternal: vi.fn(async (command: string) => {
+        if (command.startsWith('mkdir -p ')) return createExecResult(command);
+        if (command.includes('s3fs ')) return createExecResult(command);
+        if (command.startsWith('mountpoint')) {
+          return createExecResult(command, { stdout: 'FUSE_MOUNTED' });
+        }
+        throw new Error(`Unexpected command: ${command}`);
+      }),
+      createPasswordFile: vi.fn().mockResolvedValue(undefined),
+      deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-isolated')
+    });
+
+    await sandbox.mountBucket('MY_BUCKET', '/mnt/isolated', {} as any);
+
+    expect(mockCtx.exports.ContainerProxy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        props: expect.objectContaining({
+          className: 'CloudflareSandboxR2EgressProxyTarget',
+          outboundByHostOverrides: {
+            'r2.internal': expect.objectContaining({
+              method: 'r2EgressMount'
+            })
+          }
+        })
+      })
     );
   });
 
@@ -383,9 +498,7 @@ describe('Sandbox R2 egress mounts', () => {
       generatePasswordFilePath: vi
         .fn()
         .mockReturnValueOnce('/tmp/.s3fs-one')
-        .mockReturnValueOnce('/tmp/.s3fs-two'),
-      setOutboundByHost: vi.fn().mockResolvedValue(undefined),
-      removeOutboundByHost: vi.fn().mockResolvedValue(undefined)
+        .mockReturnValueOnce('/tmp/.s3fs-two')
     });
 
     await sandbox.mountBucket('MY_BUCKET', '/mnt/one', {
@@ -399,9 +512,59 @@ describe('Sandbox R2 egress mounts', () => {
     ).rejects.toThrow('already mounted');
   });
 
-  it('deletes the password file when R2 egress mount fails', async () => {
+  it('updates R2 egress interception to deny all buckets after final unmount', async () => {
+    const mockCtx = createMockCtx();
     const sandbox = new Sandbox(
-      createMockCtx() as unknown as ConstructorParameters<typeof Sandbox>[0],
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+      { MY_BUCKET: createMockR2Bucket() }
+    );
+
+    Object.assign(sandbox as object, {
+      execInternal: vi.fn(async (command: string) => {
+        if (command.startsWith('mkdir -p ')) return createExecResult(command);
+        if (command.includes('s3fs ')) return createExecResult(command);
+        if (command.startsWith('mountpoint -q') && command.includes('echo')) {
+          return createExecResult(command, { stdout: 'FUSE_MOUNTED' });
+        }
+        if (command.startsWith('fusermount -u ')) {
+          return createExecResult(command);
+        }
+        if (command.startsWith('mountpoint -q') && command.includes('rmdir')) {
+          return createExecResult(command);
+        }
+        throw new Error(`Unexpected command: ${command}`);
+      }),
+      createPasswordFile: vi.fn().mockResolvedValue(undefined),
+      deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-unmount')
+    });
+
+    await sandbox.mountBucket('MY_BUCKET', '/mnt/data', {} as any);
+    await sandbox.unmountBucket('/mnt/data');
+
+    expect(mockCtx.exports.ContainerProxy).toHaveBeenLastCalledWith({
+      props: {
+        enableInternet: undefined,
+        containerId: 'test-sandbox-id',
+        className: 'CloudflareSandboxR2EgressProxyTarget',
+        outboundByHostOverrides: {
+          'r2.internal': {
+            method: 'r2EgressMount',
+            params: { buckets: {} }
+          }
+        }
+      }
+    });
+    expect(mockCtx.container.interceptOutboundHttp).toHaveBeenLastCalledWith(
+      'r2.internal',
+      mockCtx.containerProxyFetcher
+    );
+  });
+
+  it('deletes the password file when R2 egress mount fails', async () => {
+    const mockCtx = createMockCtx();
+    const sandbox = new Sandbox(
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
       { MY_BUCKET: createMockR2Bucket() }
     );
 
@@ -420,9 +583,7 @@ describe('Sandbox R2 egress mounts', () => {
       execInternal,
       createPasswordFile: vi.fn().mockResolvedValue(undefined),
       deletePasswordFile,
-      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-failed'),
-      setOutboundByHost: vi.fn().mockResolvedValue(undefined),
-      removeOutboundByHost: vi.fn().mockResolvedValue(undefined)
+      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-failed')
     });
 
     await expect(
@@ -430,6 +591,19 @@ describe('Sandbox R2 egress mounts', () => {
     ).rejects.toThrow('S3FS mount failed');
 
     expect(deletePasswordFile).toHaveBeenCalledWith('/tmp/.s3fs-failed');
+    expect(mockCtx.exports.ContainerProxy).toHaveBeenLastCalledWith({
+      props: {
+        enableInternet: undefined,
+        containerId: 'test-sandbox-id',
+        className: 'CloudflareSandboxR2EgressProxyTarget',
+        outboundByHostOverrides: {
+          'r2.internal': {
+            method: 'r2EgressMount',
+            params: { buckets: {} }
+          }
+        }
+      }
+    });
   });
 
   it('throws when s3fs exits 0 but mountpoint check does not confirm mount', async () => {
@@ -450,11 +624,7 @@ describe('Sandbox R2 egress mounts', () => {
       }),
       createPasswordFile: vi.fn().mockResolvedValue(undefined),
       deletePasswordFile,
-      generatePasswordFilePath: vi
-        .fn()
-        .mockReturnValue('/tmp/.s3fs-check-fail'),
-      setOutboundByHost: vi.fn().mockResolvedValue(undefined),
-      removeOutboundByHost: vi.fn().mockResolvedValue(undefined)
+      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-check-fail')
     });
 
     await expect(
@@ -477,9 +647,7 @@ describe('Sandbox R2 egress mounts', () => {
         execInternal: vi.fn(),
         createPasswordFile,
         deletePasswordFile: vi.fn().mockResolvedValue(undefined),
-        generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-unused'),
-        setOutboundByHost: vi.fn().mockResolvedValue(undefined),
-        removeOutboundByHost: vi.fn().mockResolvedValue(undefined)
+        generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-unused')
       });
 
       await expect(

--- a/packages/sandbox/tests/r2-egress-mount.test.ts
+++ b/packages/sandbox/tests/r2-egress-mount.test.ts
@@ -464,7 +464,7 @@ describe('Sandbox R2 egress mounts', () => {
     );
   });
 
-  it('treats an empty endpoint string as a remote mount configuration error', async () => {
+  it('rejects invalid endpoint URLs for S3-compatible mounts', async () => {
     const sandbox = new Sandbox(
       createMockCtx() as unknown as ConstructorParameters<typeof Sandbox>[0],
       { MY_BUCKET: createMockR2Bucket() }
@@ -510,6 +510,43 @@ describe('Sandbox R2 egress mounts', () => {
         prefix: '/two'
       } as any)
     ).rejects.toThrow('already mounted');
+  });
+
+  it('rejects a second mount of the same R2 binding with a different readOnly setting', async () => {
+    const sandbox = new Sandbox(
+      createMockCtx() as unknown as ConstructorParameters<typeof Sandbox>[0],
+      { MY_BUCKET: createMockR2Bucket() }
+    );
+
+    const execInternal = vi.fn(async (command: string) => {
+      if (command.startsWith('mkdir -p ')) return createExecResult(command);
+      if (command.includes('s3fs ')) return createExecResult(command);
+      if (command.startsWith('mountpoint')) {
+        return createExecResult(command, { stdout: 'FUSE_MOUNTED' });
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    Object.assign(sandbox as object, {
+      execInternal,
+      createPasswordFile: vi.fn().mockResolvedValue(undefined),
+      deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi
+        .fn()
+        .mockReturnValueOnce('/tmp/.s3fs-one')
+        .mockReturnValueOnce('/tmp/.s3fs-two')
+    });
+
+    await sandbox.mountBucket('MY_BUCKET', '/mnt/one', {
+      prefix: '/shared',
+      readOnly: true
+    } as any);
+
+    await expect(
+      sandbox.mountBucket('MY_BUCKET', '/mnt/two', {
+        prefix: '/shared',
+        readOnly: false
+      } as any)
+    ).rejects.toThrow('different readOnly setting');
   });
 
   it('updates R2 egress interception to deny all buckets after final unmount', async () => {

--- a/packages/sandbox/tests/r2-egress-mount.test.ts
+++ b/packages/sandbox/tests/r2-egress-mount.test.ts
@@ -134,6 +134,20 @@ function createMockR2Bucket(): R2Bucket {
   } as unknown as R2Bucket;
 }
 
+function createExecResult(
+  command: string,
+  overrides?: Partial<{ stdout: string; stderr: string; exitCode: number }>
+) {
+  return {
+    success: (overrides?.exitCode ?? 0) === 0,
+    stdout: overrides?.stdout ?? '',
+    stderr: overrides?.stderr ?? '',
+    exitCode: overrides?.exitCode ?? 0,
+    command,
+    timestamp: new Date().toISOString()
+  };
+}
+
 describe('Sandbox R2 egress mounts', () => {
   it('registers the credential-less R2 outbound handler under the runtime key', async () => {
     const sandbox = new Sandbox(
@@ -164,7 +178,9 @@ describe('Sandbox R2 egress mounts', () => {
     it('prepends mount prefix to GET key', async () => {
       const bucket = createMockR2Bucket();
       const mockEnv = { MY_BUCKET: bucket } as unknown as Cloudflare.Env;
-      const params: R2EgressParams = { buckets: { MY_BUCKET: '/data/run1' } };
+      const params: R2EgressParams = {
+        buckets: { MY_BUCKET: { prefix: '/data/run1' } }
+      };
       await r2EgressHandler(
         new Request('http://r2.internal/MY_BUCKET/fixtures/sample.txt'),
         mockEnv,
@@ -194,7 +210,9 @@ describe('Sandbox R2 egress mounts', () => {
         truncated: false
       });
       const mockEnv = { MY_BUCKET: bucket } as unknown as Cloudflare.Env;
-      const params: R2EgressParams = { buckets: { MY_BUCKET: '/data/run1' } };
+      const params: R2EgressParams = {
+        buckets: { MY_BUCKET: { prefix: '/data/run1' } }
+      };
       const res = await r2EgressHandler(
         new Request(
           'http://r2.internal/MY_BUCKET/?list-type=2&prefix=fixtures%2F&delimiter=%2F'
@@ -214,13 +232,27 @@ describe('Sandbox R2 egress mounts', () => {
     it('does not modify keys when no prefix is registered', async () => {
       const bucket = createMockR2Bucket();
       const mockEnv = { MY_BUCKET: bucket } as unknown as Cloudflare.Env;
-      const params: R2EgressParams = { buckets: { MY_BUCKET: undefined } };
+      const params: R2EgressParams = { buckets: { MY_BUCKET: {} } };
       await r2EgressHandler(
         new Request('http://r2.internal/MY_BUCKET/sample.txt'),
         mockEnv,
         { containerId: 'ctr-3', className: 'Sandbox', params }
       );
       expect(bucket.get).toHaveBeenCalledWith('sample.txt');
+    });
+
+    it('strips trailing slash from prefix to avoid double-slash in key', async () => {
+      const bucket = createMockR2Bucket();
+      const mockEnv = { MY_BUCKET: bucket } as unknown as Cloudflare.Env;
+      const params: R2EgressParams = {
+        buckets: { MY_BUCKET: { prefix: '/data/run1/' } }
+      };
+      await r2EgressHandler(
+        new Request('http://r2.internal/MY_BUCKET/file.txt'),
+        mockEnv,
+        { containerId: 'ctr-4', className: 'Sandbox', params }
+      );
+      expect(bucket.get).toHaveBeenCalledWith('data/run1/file.txt');
     });
   });
 
@@ -254,7 +286,9 @@ describe('Sandbox R2 egress mounts', () => {
       }
 
       if (command.includes('s3fs ')) {
-        const params: R2EgressParams = { buckets: { MY_BUCKET: '/uploads' } };
+        const params: R2EgressParams = {
+          buckets: { MY_BUCKET: { prefix: '/uploads' } }
+        };
         const probe = await r2EgressHandler(
           new Request('http://r2.internal/MY_BUCKET?location', {
             method: 'GET'
@@ -311,7 +345,137 @@ describe('Sandbox R2 egress mounts', () => {
     expect(setOutboundByHost).toHaveBeenCalledWith(
       'r2.internal',
       'r2EgressMount',
-      { buckets: { MY_BUCKET: '/uploads' } }
+      { buckets: { MY_BUCKET: { prefix: '/uploads', readOnly: true } } }
     );
   });
+
+  it('rejects a second mount of the same R2 binding with a different prefix', async () => {
+    const sandbox = new Sandbox(
+      createMockCtx() as unknown as ConstructorParameters<typeof Sandbox>[0],
+      { MY_BUCKET: createMockR2Bucket() }
+    );
+
+    const execInternal = vi.fn(async (command: string) => {
+      if (command.startsWith('mkdir -p ')) return createExecResult(command);
+      if (command.includes('s3fs ')) return createExecResult(command);
+      if (command.startsWith('mountpoint')) {
+        return createExecResult(command, { stdout: 'FUSE_MOUNTED' });
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    Object.assign(sandbox as object, {
+      execInternal,
+      createPasswordFile: vi.fn().mockResolvedValue(undefined),
+      deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi
+        .fn()
+        .mockReturnValueOnce('/tmp/.s3fs-one')
+        .mockReturnValueOnce('/tmp/.s3fs-two'),
+      setOutboundByHost: vi.fn().mockResolvedValue(undefined),
+      removeOutboundByHost: vi.fn().mockResolvedValue(undefined)
+    });
+
+    await sandbox.mountBucket('MY_BUCKET', '/mnt/one', {
+      prefix: '/one'
+    } as any);
+
+    await expect(
+      sandbox.mountBucket('MY_BUCKET', '/mnt/two', {
+        prefix: '/two'
+      } as any)
+    ).rejects.toThrow('already mounted');
+  });
+
+  it('deletes the password file when R2 egress mount fails', async () => {
+    const sandbox = new Sandbox(
+      createMockCtx() as unknown as ConstructorParameters<typeof Sandbox>[0],
+      { MY_BUCKET: createMockR2Bucket() }
+    );
+
+    const execInternal = vi.fn(async (command: string) => {
+      if (command.startsWith('mkdir -p ')) return createExecResult(command);
+      if (command.includes('s3fs ')) {
+        return createExecResult(command, {
+          exitCode: 1,
+          stderr: 'mount failed'
+        });
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    const deletePasswordFile = vi.fn().mockResolvedValue(undefined);
+    Object.assign(sandbox as object, {
+      execInternal,
+      createPasswordFile: vi.fn().mockResolvedValue(undefined),
+      deletePasswordFile,
+      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-failed'),
+      setOutboundByHost: vi.fn().mockResolvedValue(undefined),
+      removeOutboundByHost: vi.fn().mockResolvedValue(undefined)
+    });
+
+    await expect(
+      sandbox.mountBucket('MY_BUCKET', '/mnt/fail', {} as any)
+    ).rejects.toThrow('S3FS mount failed');
+
+    expect(deletePasswordFile).toHaveBeenCalledWith('/tmp/.s3fs-failed');
+  });
+
+  it('throws when s3fs exits 0 but mountpoint check does not confirm mount', async () => {
+    const sandbox = new Sandbox(
+      createMockCtx() as unknown as ConstructorParameters<typeof Sandbox>[0],
+      { MY_BUCKET: createMockR2Bucket() }
+    );
+
+    const deletePasswordFile = vi.fn().mockResolvedValue(undefined);
+    Object.assign(sandbox as object, {
+      execInternal: vi.fn(async (command: string) => {
+        if (command.startsWith('mkdir -p ')) return createExecResult(command);
+        if (command.includes('s3fs ')) return createExecResult(command);
+        if (command.startsWith('mountpoint')) {
+          return createExecResult(command, { stdout: 'NOT_FUSE_MOUNTED' });
+        }
+        throw new Error(`Unexpected command: ${command}`);
+      }),
+      createPasswordFile: vi.fn().mockResolvedValue(undefined),
+      deletePasswordFile,
+      generatePasswordFilePath: vi
+        .fn()
+        .mockReturnValue('/tmp/.s3fs-check-fail'),
+      setOutboundByHost: vi.fn().mockResolvedValue(undefined),
+      removeOutboundByHost: vi.fn().mockResolvedValue(undefined)
+    });
+
+    await expect(
+      sandbox.mountBucket('MY_BUCKET', '/mnt/check-fail', {} as any)
+    ).rejects.toThrow('mount was not established');
+
+    expect(deletePasswordFile).toHaveBeenCalledWith('/tmp/.s3fs-check-fail');
+  });
+
+  it.each(['passwd_file=/tmp/creds', 'url=https://example.com'])(
+    'rejects protected s3fs option override: %s',
+    async (option) => {
+      const sandbox = new Sandbox(
+        createMockCtx() as unknown as ConstructorParameters<typeof Sandbox>[0],
+        { MY_BUCKET: createMockR2Bucket() }
+      );
+
+      const createPasswordFile = vi.fn().mockResolvedValue(undefined);
+      Object.assign(sandbox as object, {
+        execInternal: vi.fn(),
+        createPasswordFile,
+        deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+        generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-unused'),
+        setOutboundByHost: vi.fn().mockResolvedValue(undefined),
+        removeOutboundByHost: vi.fn().mockResolvedValue(undefined)
+      });
+
+      await expect(
+        sandbox.mountBucket('MY_BUCKET', '/mnt/data', {
+          s3fsOptions: [option]
+        } as any)
+      ).rejects.toThrow('cannot be overridden');
+
+      expect(createPasswordFile).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/packages/sandbox/tests/r2-egress-mount.test.ts
+++ b/packages/sandbox/tests/r2-egress-mount.test.ts
@@ -10,10 +10,33 @@ vi.mock('./interpreter', () => ({
 }));
 
 vi.mock('@cloudflare/containers', () => {
+  const outboundHandlersRegistry = new Map<string, Record<string, unknown>>();
+  const outboundByHostRegistry = new Map<string, Record<string, unknown>>();
+
   const MockContainer = class Container {
     ctx: unknown;
     env: unknown;
     sleepAfter: string | number = '10m';
+
+    static get outboundHandlers(): Record<string, unknown> | undefined {
+      return outboundHandlersRegistry.get(Container.name);
+    }
+
+    static set outboundHandlers(handlers: Record<string, unknown>) {
+      const existing = outboundHandlersRegistry.get(Container.name) ?? {};
+      outboundHandlersRegistry.set(Container.name, {
+        ...existing,
+        ...handlers
+      });
+    }
+
+    static get outboundByHost(): Record<string, unknown> | undefined {
+      return outboundByHostRegistry.get(Container.name);
+    }
+
+    static set outboundByHost(handlers: Record<string, unknown>) {
+      outboundByHostRegistry.set(Container.name, handlers);
+    }
 
     constructor(ctx: unknown, env: unknown) {
       this.ctx = ctx;
@@ -32,10 +55,14 @@ vi.mock('@cloudflare/containers', () => {
 
     renewActivityTimeout() {}
 
-    async setOutboundByHost(
-      _hostname: string,
-      _method: string
-    ): Promise<void> {}
+    async setOutboundByHost(_hostname: string, _method: string): Promise<void> {
+      const handlers = outboundHandlersRegistry.get(this.constructor.name);
+      if (!handlers || !(_method in handlers)) {
+        throw new Error(
+          `Outbound handler method '${_method}' not found in outboundHandlers for ${this.constructor.name}`
+        );
+      }
+    }
 
     async removeOutboundByHost(_hostname: string): Promise<void> {}
   };
@@ -85,7 +112,20 @@ function createMockR2Bucket(): R2Bucket {
     head: vi.fn(async () => null),
     delete: vi.fn(async () => undefined),
     list: vi.fn(async () => ({
-      objects: [],
+      objects: [
+        {
+          key: 'data/run1/fixtures/sample.txt',
+          uploaded: new Date('2024-01-01T00:00:00Z'),
+          httpEtag: '"abc"',
+          size: 10,
+          version: 'v1',
+          etag: 'abc',
+          checksums: {},
+          storageClass: 'Standard',
+          writeHttpMetadata: () => {},
+          customMetadata: {}
+        }
+      ],
       truncated: false,
       delimitedPrefixes: []
     })),
@@ -95,6 +135,31 @@ function createMockR2Bucket(): R2Bucket {
 }
 
 describe('Sandbox R2 egress mounts', () => {
+  it('registers the credential-less R2 outbound handler under the runtime key', async () => {
+    const sandbox = new Sandbox(
+      createMockCtx() as unknown as ConstructorParameters<typeof Sandbox>[0],
+      { MY_BUCKET: createMockR2Bucket() }
+    );
+
+    await expect(
+      (
+        sandbox as unknown as {
+          setOutboundByHost: (
+            hostname: string,
+            method: string
+          ) => Promise<void>;
+        }
+      ).setOutboundByHost('r2.internal', 'r2EgressMount')
+    ).resolves.toBeUndefined();
+
+    expect(
+      (Sandbox as unknown as { outboundHandlers?: Record<string, unknown> })
+        .outboundHandlers
+    ).toMatchObject({
+      r2EgressMount: r2EgressHandler
+    });
+  });
+
   describe('handler prefix translation', () => {
     it('prepends mount prefix to GET key', async () => {
       const bucket = createMockR2Bucket();

--- a/packages/sandbox/tests/r2-egress-mount.test.ts
+++ b/packages/sandbox/tests/r2-egress-mount.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Sandbox } from '../src/sandbox';
 import {
-  r2EgressHandler,
-  revokeBucketAccess
+  type R2EgressParams,
+  r2EgressHandler
 } from '../src/storage-mount/r2-egress-handler';
 
 vi.mock('./interpreter', () => ({
@@ -31,6 +31,13 @@ vi.mock('@cloudflare/containers', () => {
     }
 
     renewActivityTimeout() {}
+
+    async setOutboundByHost(
+      _hostname: string,
+      _method: string
+    ): Promise<void> {}
+
+    async removeOutboundByHost(_hostname: string): Promise<void> {}
   };
 
   return {
@@ -88,6 +95,70 @@ function createMockR2Bucket(): R2Bucket {
 }
 
 describe('Sandbox R2 egress mounts', () => {
+  describe('handler prefix translation', () => {
+    it('prepends mount prefix to GET key', async () => {
+      const bucket = createMockR2Bucket();
+      const mockEnv = { MY_BUCKET: bucket } as unknown as Cloudflare.Env;
+      const params: R2EgressParams = { buckets: { MY_BUCKET: '/data/run1' } };
+      await r2EgressHandler(
+        new Request('http://r2.internal/MY_BUCKET/fixtures/sample.txt'),
+        mockEnv,
+        { containerId: 'ctr-1', className: 'Sandbox', params }
+      );
+      expect(bucket.get).toHaveBeenCalledWith('data/run1/fixtures/sample.txt');
+    });
+
+    it('prepends mount prefix to list query-prefix and strips it from response keys', async () => {
+      const bucket = createMockR2Bucket();
+      (bucket.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        objects: [
+          {
+            key: 'data/run1/fixtures/sample.txt',
+            uploaded: new Date('2024-01-01T00:00:00Z'),
+            httpEtag: '"abc"',
+            size: 10,
+            version: 'v1',
+            etag: 'abc',
+            checksums: {},
+            storageClass: 'Standard',
+            writeHttpMetadata: () => {},
+            customMetadata: {}
+          }
+        ],
+        delimitedPrefixes: [],
+        truncated: false
+      });
+      const mockEnv = { MY_BUCKET: bucket } as unknown as Cloudflare.Env;
+      const params: R2EgressParams = { buckets: { MY_BUCKET: '/data/run1' } };
+      const res = await r2EgressHandler(
+        new Request(
+          'http://r2.internal/MY_BUCKET/?list-type=2&prefix=fixtures%2F&delimiter=%2F'
+        ),
+        mockEnv,
+        { containerId: 'ctr-2', className: 'Sandbox', params }
+      );
+      expect(bucket.list).toHaveBeenCalledWith(
+        expect.objectContaining({ prefix: 'data/run1/fixtures/' })
+      );
+      const xml = await res.text();
+      expect(xml).toContain('<Key>fixtures/sample.txt</Key>');
+      expect(xml).not.toContain('data/run1');
+      expect(xml).toContain('<Prefix>fixtures/</Prefix>');
+    });
+
+    it('does not modify keys when no prefix is registered', async () => {
+      const bucket = createMockR2Bucket();
+      const mockEnv = { MY_BUCKET: bucket } as unknown as Cloudflare.Env;
+      const params: R2EgressParams = { buckets: { MY_BUCKET: undefined } };
+      await r2EgressHandler(
+        new Request('http://r2.internal/MY_BUCKET/sample.txt'),
+        mockEnv,
+        { containerId: 'ctr-3', className: 'Sandbox', params }
+      );
+      expect(bucket.get).toHaveBeenCalledWith('sample.txt');
+    });
+  });
+
   it('registers bucket access before s3fs mount and applies required R2 options', async () => {
     const mockCtx = createMockCtx();
     const mockEnv = {
@@ -105,13 +176,11 @@ describe('Sandbox R2 egress mounts', () => {
         .filter((value): value is Promise<unknown> => value instanceof Promise)
     );
 
-    const setOutboundByHost = vi.fn().mockResolvedValue(undefined);
-    const removeOutboundByHost = vi.fn().mockResolvedValue(undefined);
     const execInternal = vi.fn().mockImplementation(async (command: string) => {
-      if (command.startsWith('mkdir -p ')) {
+      if (command.startsWith('mkdir -p ') || command.startsWith('mountpoint')) {
         return {
           success: true,
-          stdout: '',
+          stdout: 'FUSE_MOUNTED',
           stderr: '',
           exitCode: 0,
           command,
@@ -119,18 +188,20 @@ describe('Sandbox R2 egress mounts', () => {
         };
       }
 
-      if (command.startsWith('s3fs ')) {
+      if (command.includes('s3fs ')) {
+        const params: R2EgressParams = { buckets: { MY_BUCKET: '/uploads' } };
         const probe = await r2EgressHandler(
           new Request('http://r2.internal/MY_BUCKET?location', {
             method: 'GET'
           }),
           mockEnv as Cloudflare.Env,
-          { containerId: 'test-sandbox-id', className: 'Sandbox' }
+          { containerId: 'test-sandbox-id', className: 'Sandbox', params }
         );
         expect(probe.status).toBe(200);
-        expect(command).toContain('MY_BUCKET:/uploads');
+        expect(command).toContain("'MY_BUCKET'");
+        expect(command).not.toContain(':/uploads');
         expect(command).toContain('url=http://r2.internal');
-        expect(command).toContain('nosignrequest');
+        expect(command).toContain(`passwd_file=${FAKE_PASSWD}`);
         expect(command).toContain('use_path_request_style');
         expect(command).toContain('nomixupload');
         expect(command).toContain('stat_cache_expire=1');
@@ -149,25 +220,33 @@ describe('Sandbox R2 egress mounts', () => {
       throw new Error(`Unexpected command: ${command}`);
     });
 
+    const FAKE_PASSWD = '/tmp/.s3fs-test-passwd';
+    const createPasswordFile = vi.fn().mockResolvedValue(undefined);
+    const deletePasswordFile = vi.fn().mockResolvedValue(undefined);
+    const generatePasswordFilePath = vi.fn().mockReturnValue(FAKE_PASSWD);
+
     Object.assign(sandbox as object, {
-      setOutboundByHost,
-      removeOutboundByHost,
-      execInternal
+      execInternal,
+      createPasswordFile,
+      deletePasswordFile,
+      generatePasswordFilePath
     });
 
-    try {
-      await sandbox.mountBucket('MY_BUCKET', '/mnt/data', {
-        prefix: '/uploads',
-        readOnly: true,
-        s3fsOptions: ['stat_cache_expire=1']
-      } as any);
-    } finally {
-      revokeBucketAccess('test-sandbox-id', 'MY_BUCKET');
-    }
+    const setOutboundByHost = vi.fn().mockResolvedValue(undefined);
+    Object.assign(sandbox as object, { setOutboundByHost });
 
-    expect(setOutboundByHost).toHaveBeenCalledWith('r2.internal', 'r2Mount');
+    await sandbox.mountBucket('MY_BUCKET', '/mnt/data', {
+      prefix: '/uploads',
+      readOnly: true,
+      s3fsOptions: ['stat_cache_expire=1']
+    } as any);
+
     expect(execInternal).toHaveBeenNthCalledWith(1, "mkdir -p '/mnt/data'");
-    expect(execInternal).toHaveBeenCalledTimes(2);
-    expect(removeOutboundByHost).not.toHaveBeenCalled();
+    expect(execInternal).toHaveBeenCalledTimes(3);
+    expect(setOutboundByHost).toHaveBeenCalledWith(
+      'r2.internal',
+      'r2EgressMount',
+      { buckets: { MY_BUCKET: '/uploads' } }
+    );
   });
 });

--- a/packages/sandbox/tests/r2-egress-mount.test.ts
+++ b/packages/sandbox/tests/r2-egress-mount.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Sandbox } from '../src/sandbox';
+import {
+  r2EgressHandler,
+  revokeBucketAccess
+} from '../src/storage-mount/r2-egress-handler';
+
+vi.mock('./interpreter', () => ({
+  CodeInterpreter: vi.fn().mockImplementation(() => ({}))
+}));
+
+vi.mock('@cloudflare/containers', () => {
+  const MockContainer = class Container {
+    ctx: unknown;
+    env: unknown;
+    sleepAfter: string | number = '10m';
+
+    constructor(ctx: unknown, env: unknown) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+
+    async fetch(): Promise<Response> {
+      return new Response('Mock Container fetch');
+    }
+
+    async destroy(): Promise<void> {}
+
+    async getState() {
+      return { status: 'healthy' };
+    }
+
+    renewActivityTimeout() {}
+  };
+
+  return {
+    Container: MockContainer,
+    getContainer: vi.fn(),
+    switchPort: vi.fn()
+  };
+});
+
+function createMockCtx() {
+  return {
+    storage: {
+      get: vi.fn().mockResolvedValue(null),
+      put: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      list: vi.fn().mockResolvedValue(new Map())
+    },
+    blockConcurrencyWhile: vi
+      .fn()
+      .mockImplementation(
+        <T>(callback: () => Promise<T>): Promise<T> => callback()
+      ),
+    waitUntil: vi.fn(),
+    id: {
+      toString: () => 'test-sandbox-id',
+      equals: vi.fn(),
+      name: 'test-sandbox'
+    }
+  };
+}
+
+function createMockR2Bucket(): R2Bucket {
+  return {
+    get: vi.fn(async () => null),
+    put: vi.fn(async () => ({
+      key: 'ignored',
+      size: 0,
+      etag: 'etag',
+      httpEtag: '"etag"',
+      uploaded: new Date('2024-01-01T00:00:00Z'),
+      httpMetadata: {},
+      customMetadata: {},
+      storageClass: 'Standard'
+    })),
+    head: vi.fn(async () => null),
+    delete: vi.fn(async () => undefined),
+    list: vi.fn(async () => ({
+      objects: [],
+      truncated: false,
+      delimitedPrefixes: []
+    })),
+    createMultipartUpload: vi.fn(),
+    resumeMultipartUpload: vi.fn()
+  } as unknown as R2Bucket;
+}
+
+describe('Sandbox R2 egress mounts', () => {
+  it('registers bucket access before s3fs mount and applies required R2 options', async () => {
+    const mockCtx = createMockCtx();
+    const mockEnv = {
+      MY_BUCKET: createMockR2Bucket()
+    };
+
+    const sandbox = new Sandbox(
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+      mockEnv
+    );
+
+    await Promise.all(
+      (mockCtx.blockConcurrencyWhile as ReturnType<typeof vi.fn>).mock.results
+        .map((result) => result.value)
+        .filter((value): value is Promise<unknown> => value instanceof Promise)
+    );
+
+    const setOutboundByHost = vi.fn().mockResolvedValue(undefined);
+    const removeOutboundByHost = vi.fn().mockResolvedValue(undefined);
+    const execInternal = vi.fn().mockImplementation(async (command: string) => {
+      if (command.startsWith('mkdir -p ')) {
+        return {
+          success: true,
+          stdout: '',
+          stderr: '',
+          exitCode: 0,
+          command,
+          timestamp: new Date().toISOString()
+        };
+      }
+
+      if (command.startsWith('s3fs ')) {
+        const probe = await r2EgressHandler(
+          new Request('http://r2.internal/MY_BUCKET?location', {
+            method: 'GET'
+          }),
+          mockEnv as Cloudflare.Env,
+          { containerId: 'test-sandbox-id', className: 'Sandbox' }
+        );
+        expect(probe.status).toBe(200);
+        expect(command).toContain('MY_BUCKET:/uploads');
+        expect(command).toContain('url=http://r2.internal');
+        expect(command).toContain('nosignrequest');
+        expect(command).toContain('use_path_request_style');
+        expect(command).toContain('nomixupload');
+        expect(command).toContain('stat_cache_expire=1');
+        expect(command).toContain(',ro');
+
+        return {
+          success: true,
+          stdout: '',
+          stderr: '',
+          exitCode: 0,
+          command,
+          timestamp: new Date().toISOString()
+        };
+      }
+
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    Object.assign(sandbox as object, {
+      setOutboundByHost,
+      removeOutboundByHost,
+      execInternal
+    });
+
+    try {
+      await sandbox.mountBucket('MY_BUCKET', '/mnt/data', {
+        prefix: '/uploads',
+        readOnly: true,
+        s3fsOptions: ['stat_cache_expire=1']
+      } as any);
+    } finally {
+      revokeBucketAccess('test-sandbox-id', 'MY_BUCKET');
+    }
+
+    expect(setOutboundByHost).toHaveBeenCalledWith('r2.internal', 'r2Mount');
+    expect(execInternal).toHaveBeenNthCalledWith(1, "mkdir -p '/mnt/data'");
+    expect(execInternal).toHaveBeenCalledTimes(2);
+    expect(removeOutboundByHost).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sandbox/tests/storage-mount/validation.test.ts
+++ b/packages/sandbox/tests/storage-mount/validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildS3fsSource,
+  validateBucketBindingName,
   validateBucketName,
   validatePrefix
 } from '../../src/storage-mount/validation';
@@ -44,6 +45,33 @@ describe('validateBucketName', () => {
     (bucket) => {
       expect(() => validateBucketName(bucket, '/mount')).toThrow(
         'Invalid bucket name'
+      );
+    }
+  );
+});
+
+describe('validateBucketBindingName', () => {
+  it.each(['MY_BUCKET', 'my_bucket', '_bucket1', 'Bucket123'])(
+    'accepts valid binding name: %s',
+    (bucket) => {
+      expect(() => validateBucketBindingName(bucket, '/mount')).not.toThrow();
+    }
+  );
+
+  it('rejects binding name with colon and suggests prefix option', () => {
+    expect(() =>
+      validateBucketBindingName('MY_BUCKET:/data/path', '/mount')
+    ).toThrow("Bucket name cannot contain ':'");
+    expect(() =>
+      validateBucketBindingName('MY_BUCKET:/data/path', '/mount')
+    ).toThrow("prefix: '/data/path'");
+  });
+
+  it.each(['has spaces', 'my-bucket', '1startsWithNumber'])(
+    'rejects invalid binding name: %s',
+    (bucket) => {
+      expect(() => validateBucketBindingName(bucket, '/mount')).toThrow(
+        'Invalid R2 binding name'
       );
     }
   );

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -195,6 +195,7 @@ export type {
   // Process management result types
   ProcessStartResult,
   ProcessStatus,
+  R2BindingMountBucketOptions,
   ReadFileResult,
   ReadFileStreamResult,
   RemoteMountBucketOptions,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1299,11 +1299,43 @@ export interface LocalMountBucketOptions {
 }
 
 /**
- * Options for mounting a bucket — either remote (s3fs-FUSE) or local (R2 binding sync)
+ * Options for mounting an R2 binding via credential-less egress interception.
+ */
+export interface R2BindingMountBucketOptions {
+  /**
+   * Must not be set — distinguishes this variant from RemoteMountBucketOptions.
+   */
+  endpoint?: never;
+
+  /**
+   * Optional prefix/subdirectory within the bucket to mount.
+   *
+   * When specified, only the contents under this prefix will be visible
+   * at the mount point.
+   */
+  prefix?: string;
+
+  /**
+   * Mount filesystem as read-only
+   * Default: false
+   */
+  readOnly?: boolean;
+
+  /**
+   * Advanced: Override or extend s3fs options.
+   * Provider defaults for R2 are still applied automatically.
+   */
+  s3fsOptions?: string[];
+}
+
+/**
+ * Options for mounting a bucket — remote (s3fs-FUSE), local (R2 binding sync),
+ * or R2 egress (credential-less s3fs via egress interception).
  */
 export type MountBucketOptions =
   | RemoteMountBucketOptions
-  | LocalMountBucketOptions;
+  | LocalMountBucketOptions
+  | R2BindingMountBucketOptions;
 
 // Main Sandbox interface
 export interface ISandbox {

--- a/tests/e2e/bucket-mounting.test.ts
+++ b/tests/e2e/bucket-mounting.test.ts
@@ -205,4 +205,134 @@ describe('Bucket Mounting E2E', () => {
       sandbox = null;
     }, 120000);
   });
+
+  /**
+   * Credential-less R2 egress mount: mountBucket is called with no endpoint,
+   * so the SDK resolves the bucket via its R2 binding and routes s3fs traffic
+   * through the outbound egress handler. This path previously had two bugs:
+   * 1. setOutboundByHost('r2.internal', 'r2Mount') threw "not found" because
+   *    the CF runtime couldn't find the handler name in outboundHandlers.
+   * 2. s3fs exited with "could not determine security credentials" even with
+   *    nosignrequest, because it validates credentials before applying that flag.
+   * Both only surface at runtime against a real container + CF runtime.
+   */
+  describe('r2-egress', () => {
+    let sandbox: TestSandbox | null = null;
+    let workerUrl: string;
+    let headers: Record<string, string>;
+
+    const MOUNT_PATH = '/mnt/r2-egress-test';
+    const PRE_EXISTING_FILE = `r2-egress-pre-${Date.now()}.txt`;
+    const PRE_EXISTING_CONTENT = 'Written to R2 before egress mount';
+    const WRITTEN_FILE = `r2-egress-write-${Date.now()}.txt`;
+    const WRITTEN_CONTENT = `Written via egress mount - ${new Date().toISOString()}`;
+
+    beforeAll(async () => {
+      sandbox = await createTestSandbox();
+      workerUrl = sandbox.workerUrl;
+      headers = sandbox.headers(createUniqueSession());
+    }, 120000);
+
+    test('should mount R2 binding without credentials and perform bidirectional file operations', async () => {
+      try {
+        // 1. Write a file to the R2 bucket via binding before mounting
+        const putResponse = await fetch(`${workerUrl}/api/bucket/put`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            key: PRE_EXISTING_FILE,
+            content: PRE_EXISTING_CONTENT,
+            contentType: 'text/plain'
+          })
+        });
+        expect(putResponse.ok).toBe(true);
+
+        // 2. Mount via R2 binding — no endpoint means the egress handler path is used.
+        //    This catches: outboundHandlers name-lookup errors, s3fs credential-check
+        //    errors, and any other runtime failures specific to this mount path.
+        const mountResponse = await fetch(`${workerUrl}/api/bucket/mount`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            bucket: 'TEST_BUCKET',
+            mountPath: MOUNT_PATH,
+            options: {}
+          })
+        });
+        expect(mountResponse.ok).toBe(true);
+        const mountResult = (await mountResponse.json()) as SuccessResponse;
+        expect(mountResult.success).toBe(true);
+
+        // 3. Verify the pre-existing R2 file is visible through the mount (R2 → container)
+        const readResponse = await fetch(`${workerUrl}/api/execute`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            command: `cat ${MOUNT_PATH}/${PRE_EXISTING_FILE}`
+          })
+        });
+        const readResult = (await readResponse.json()) as ExecResult;
+        expect(readResult.exitCode).toBe(0);
+        expect(readResult.stdout?.trim()).toBe(PRE_EXISTING_CONTENT);
+
+        // 4. Write a new file through the mount (container → R2)
+        const writeResponse = await fetch(`${workerUrl}/api/execute`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            command: `echo "${WRITTEN_CONTENT}" > ${MOUNT_PATH}/${WRITTEN_FILE}`
+          })
+        });
+        const writeResult = (await writeResponse.json()) as ExecResult;
+        expect(writeResult.exitCode).toBe(0);
+
+        // 5. Verify the written file is visible in R2 via binding
+        const getResponse = await fetch(
+          `${workerUrl}/api/bucket/get?key=${WRITTEN_FILE}`,
+          { method: 'GET', headers }
+        );
+        expect(getResponse.ok).toBe(true);
+        const getResult = (await getResponse.json()) as BucketGetResponse;
+        expect(getResult.success).toBe(true);
+        expect(getResult.content.trim()).toBe(WRITTEN_CONTENT);
+
+        // 6. Unmount
+        const unmountResponse = await fetch(`${workerUrl}/api/bucket/unmount`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ mountPath: MOUNT_PATH })
+        });
+        expect(unmountResponse.ok).toBe(true);
+        const unmountResult =
+          (await unmountResponse.json()) as BucketUnmountResponse;
+        expect(unmountResult.success).toBe(true);
+
+        // 7. Mount point should no longer be active
+        const mountCheck = await fetch(`${workerUrl}/api/execute`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ command: `mountpoint -q ${MOUNT_PATH}` })
+        });
+        const mountCheckResult = (await mountCheck.json()) as ExecResult;
+        expect(mountCheckResult.exitCode).not.toBe(0);
+      } finally {
+        // Cleanup: delete test files from R2
+        await fetch(`${workerUrl}/api/bucket/delete`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ key: PRE_EXISTING_FILE })
+        }).catch(() => {});
+        await fetch(`${workerUrl}/api/bucket/delete`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ key: WRITTEN_FILE })
+        }).catch(() => {});
+      }
+    }, 120000);
+
+    afterAll(async () => {
+      await cleanupTestSandbox(sandbox);
+      sandbox = null;
+    }, 120000);
+  });
 });

--- a/tests/e2e/bucket-mounting.test.ts
+++ b/tests/e2e/bucket-mounting.test.ts
@@ -221,6 +221,7 @@ describe('Bucket Mounting E2E', () => {
     let workerUrl: string;
     let headers: Record<string, string>;
 
+    const TEST_BUCKET = 'TEST_BUCKET';
     const MOUNT_PATH = '/mnt/r2-egress-test';
     const PRE_EXISTING_FILE = `r2-egress-pre-${Date.now()}.txt`;
     const PRE_EXISTING_CONTENT = 'Written to R2 before egress mount';
@@ -254,7 +255,7 @@ describe('Bucket Mounting E2E', () => {
           method: 'POST',
           headers,
           body: JSON.stringify({
-            bucket: 'TEST_BUCKET',
+            bucket: TEST_BUCKET,
             mountPath: MOUNT_PATH,
             options: {}
           })

--- a/tests/e2e/test-worker/index.ts
+++ b/tests/e2e/test-worker/index.ts
@@ -14,7 +14,12 @@
  * Use X-Sandbox-Type header to select: 'python', 'opencode', 'standalone', 'musl', or default
  */
 
-import { getSandbox, proxyToSandbox, Sandbox } from '@cloudflare/sandbox';
+import {
+  ContainerProxy,
+  getSandbox,
+  proxyToSandbox,
+  Sandbox
+} from '@cloudflare/sandbox';
 import {
   createOpencodeServer,
   proxyToOpencodeServer
@@ -37,6 +42,7 @@ import type {
 
 // Export Sandbox class with different names for each container type
 // The actual image is determined by the container binding in wrangler.jsonc
+export { ContainerProxy };
 export { Sandbox };
 export { Sandbox as SandboxPython };
 export { Sandbox as SandboxOpencode };

--- a/tests/e2e/test-worker/index.ts
+++ b/tests/e2e/test-worker/index.ts
@@ -14,8 +14,12 @@
  * Use X-Sandbox-Type header to select: 'python', 'opencode', 'standalone', 'musl', or default
  */
 
-import { ContainerProxy as BaseContainerProxy } from '@cloudflare/containers';
-import { getSandbox, proxyToSandbox, Sandbox } from '@cloudflare/sandbox';
+import {
+  ContainerProxy,
+  getSandbox,
+  proxyToSandbox,
+  Sandbox
+} from '@cloudflare/sandbox';
 import {
   createOpencodeServer,
   proxyToOpencodeServer
@@ -38,7 +42,7 @@ import type {
 
 // Export Sandbox class with different names for each container type
 // The actual image is determined by the container binding in wrangler.jsonc
-export class ContainerProxy extends BaseContainerProxy {}
+export { ContainerProxy };
 export { Sandbox };
 export { Sandbox as SandboxPython };
 export { Sandbox as SandboxOpencode };

--- a/tests/e2e/test-worker/index.ts
+++ b/tests/e2e/test-worker/index.ts
@@ -14,12 +14,8 @@
  * Use X-Sandbox-Type header to select: 'python', 'opencode', 'standalone', 'musl', or default
  */
 
-import {
-  ContainerProxy,
-  getSandbox,
-  proxyToSandbox,
-  Sandbox
-} from '@cloudflare/sandbox';
+import { ContainerProxy as BaseContainerProxy } from '@cloudflare/containers';
+import { getSandbox, proxyToSandbox, Sandbox } from '@cloudflare/sandbox';
 import {
   createOpencodeServer,
   proxyToOpencodeServer
@@ -42,7 +38,7 @@ import type {
 
 // Export Sandbox class with different names for each container type
 // The actual image is determined by the container binding in wrangler.jsonc
-export { ContainerProxy };
+export class ContainerProxy extends BaseContainerProxy {}
 export { Sandbox };
 export { Sandbox as SandboxPython };
 export { Sandbox as SandboxOpencode };

--- a/tests/e2e/test-worker/wrangler.perf.template.jsonc
+++ b/tests/e2e/test-worker/wrangler.perf.template.jsonc
@@ -20,7 +20,8 @@
       "image": "{{IMAGE_SANDBOX}}",
       "name": "{{CONTAINER_NAME}}",
       "max_instances": 50,
-      "instance_type": "standard-2"
+      "instance_type": "standard-2",
+      "durable_object_offset_instances": 25
     }
   ],
 

--- a/tests/e2e/test-worker/wrangler.perf.template.jsonc
+++ b/tests/e2e/test-worker/wrangler.perf.template.jsonc
@@ -21,7 +21,11 @@
       "name": "{{CONTAINER_NAME}}",
       "max_instances": 50,
       "instance_type": "standard-2",
-      "durable_object_offset_instances": 25
+      "unsafe": {
+        "configuration": {
+          "durable_object_offset_instances": 25
+        }
+      }
     }
   ],
 

--- a/tests/e2e/test-worker/wrangler.template.jsonc
+++ b/tests/e2e/test-worker/wrangler.template.jsonc
@@ -23,37 +23,43 @@
       "image": "{{IMAGE_SANDBOX}}",
       "name": "{{CONTAINER_NAME}}",
       "instance_type": "standard-4",
-      "max_instances": 50
+      "max_instances": 50,
+      "durable_object_offset_instances": 25
     },
     {
       "class_name": "SandboxPython",
       "image": "{{IMAGE_PYTHON}}",
       "name": "{{CONTAINER_NAME}}-python",
-      "instance_type": "standard-4"
+      "instance_type": "standard-4",
+      "durable_object_offset_instances": 25
     },
     {
       "class_name": "SandboxOpencode",
       "image": "{{IMAGE_OPENCODE}}",
       "name": "{{CONTAINER_NAME}}-opencode",
-      "instance_type": "standard-4"
+      "instance_type": "standard-4",
+      "durable_object_offset_instances": 25
     },
     {
       "class_name": "SandboxStandalone",
       "image": "{{IMAGE_STANDALONE}}",
       "name": "{{CONTAINER_NAME}}-standalone",
-      "instance_type": "standard-4"
+      "instance_type": "standard-4",
+      "durable_object_offset_instances": 25
     },
     {
       "class_name": "SandboxMusl",
       "image": "{{IMAGE_MUSL}}",
       "name": "{{CONTAINER_NAME}}-musl",
-      "instance_type": "standard-4"
+      "instance_type": "standard-4",
+      "durable_object_offset_instances": 25
     },
     {
       "class_name": "SandboxDesktop",
       "image": "{{IMAGE_DESKTOP}}",
       "name": "{{CONTAINER_NAME}}-desktop",
-      "instance_type": "standard-4"
+      "instance_type": "standard-4",
+      "durable_object_offset_instances": 25
     }
   ],
 

--- a/tests/e2e/test-worker/wrangler.template.jsonc
+++ b/tests/e2e/test-worker/wrangler.template.jsonc
@@ -2,7 +2,7 @@
   "name": "{{WORKER_NAME}}",
   "main": "index.ts",
   "compatibility_date": "2025-05-06",
-  "compatibility_flags": ["nodejs_compat"],
+  "compatibility_flags": ["nodejs_compat", "enable_ctx_exports"],
   "account_id": "b8afc92c7a87f699592038b756153d22",
 
   "vars": {

--- a/tests/e2e/test-worker/wrangler.template.jsonc
+++ b/tests/e2e/test-worker/wrangler.template.jsonc
@@ -24,42 +24,66 @@
       "name": "{{CONTAINER_NAME}}",
       "instance_type": "standard-4",
       "max_instances": 50,
-      "durable_object_offset_instances": 25
+      "unsafe": {
+        "configuration": {
+          "durable_object_offset_instances": 25
+        }
+      }
     },
     {
       "class_name": "SandboxPython",
       "image": "{{IMAGE_PYTHON}}",
       "name": "{{CONTAINER_NAME}}-python",
       "instance_type": "standard-4",
-      "durable_object_offset_instances": 25
+      "unsafe": {
+        "configuration": {
+          "durable_object_offset_instances": 25
+        }
+      }
     },
     {
       "class_name": "SandboxOpencode",
       "image": "{{IMAGE_OPENCODE}}",
       "name": "{{CONTAINER_NAME}}-opencode",
       "instance_type": "standard-4",
-      "durable_object_offset_instances": 25
+      "unsafe": {
+        "configuration": {
+          "durable_object_offset_instances": 25
+        }
+      }
     },
     {
       "class_name": "SandboxStandalone",
       "image": "{{IMAGE_STANDALONE}}",
       "name": "{{CONTAINER_NAME}}-standalone",
       "instance_type": "standard-4",
-      "durable_object_offset_instances": 25
+      "unsafe": {
+        "configuration": {
+          "durable_object_offset_instances": 25
+        }
+      }
     },
     {
       "class_name": "SandboxMusl",
       "image": "{{IMAGE_MUSL}}",
       "name": "{{CONTAINER_NAME}}-musl",
       "instance_type": "standard-4",
-      "durable_object_offset_instances": 25
+      "unsafe": {
+        "configuration": {
+          "durable_object_offset_instances": 25
+        }
+      }
     },
     {
       "class_name": "SandboxDesktop",
       "image": "{{IMAGE_DESKTOP}}",
       "name": "{{CONTAINER_NAME}}-desktop",
       "instance_type": "standard-4",
-      "durable_object_offset_instances": 25
+      "unsafe": {
+        "configuration": {
+          "durable_object_offset_instances": 25
+        }
+      }
     }
   ],
 


### PR DESCRIPTION
### Summary

This PR implements a new mount path for R2 bindings that never passes credentials into the container. Instead of supplying an S3-compatible endpoint and access keys, users pass a `bindingName` referencing an R2 binding on their Worker. The DO intercepts s3fs HTTP traffic at the Worker boundary, translates S3 API calls into native R2 binding calls, and proxies the result back — keeping credentials entirely in the Worker runtime.

### How it works

1. When `mountBucket()` detects no `endpoint` on the options, it takes the R2 egress path.
2. A one-time password file is written to `/tmp/.passwd-s3fs-<uuid>` inside the container (dummy credentials — s3fs requires them syntactically, but they are never validated by R2).
3. s3fs is launched pointing at `http://r2.internal/<bucket>` (not HTTPS, meaning `interceptHttps` is not required for this feature).
4. Outbound traffic to `r2.internal` is intercepted by the new R2 egress handler, which:
   - Validates the bucket name against an allowlist of mounted buckets.
   - Enforces `readOnly` by rejecting mutating operations with 403.
   - Translates S3 path-style operations (list, get, put, delete, multipart, copy, range) to native R2 binding API calls.
   - Returns S3-compatible XML responses that s3fs can parse.
5. On unmount or sandbox destroy, the password file and outbound handler registration are cleaned up.

<details>
<summary><h3>Speed comparison R2 binding vs S3 native</h3></summary>


_The R2 path does introduce a slight overhead for most operations (mostly negligible ~few ms), except for writes. We have a pretty noticeable overhead for write operations through R2 bindings (~1.5x-2x slower). I'm yet to find an approach to speed this up, so this will likely be come back to in future._

| Operation | R2 (ms) | S3 (ms) | Delta | Winner |
|---|---|---|---|---|
| Mount bucket | 2270 | 8406 | -6136ms | R2 |
| List directory (initial) | 560 | 594 | -34ms | R2 |
| Read seeded sample file | 145 | 158 | -13ms | R2 |
| Stat sample file (exec) | 42 | 54 | -12ms | R2 |
| Write tiny file (~150 B) | 1703 | 1430 | +273ms | S3 |
| Read tiny file back | 167 | 186 | -19ms | R2 |
| Write 1 KB file | 1788 | 1367 | +421ms | S3 |
| Read 1 KB file back | 361 | 366 | -5ms | R2 |
| Write 10 KB file | 1366 | 663 | +703ms | S3 |
| Read 10 KB file back | 420 | 273 | +147ms | S3 |
| Write 100 KB file | 1416 | 735 | +681ms | S3 |
| Read 100 KB file back | 324 | 283 | +41ms | S3 |
| Write 512 KB file | 1405 | 567 | +838ms | S3 |
| Read 512 KB file back | 944 | 382 | +562ms | S3 |
| Overwrite test: write V1 | 1626 | 1319 | +307ms | S3 |
| Overwrite test: replace with V2 | 1406 | 306 | +1100ms | S3 |
| Overwrite test: read back | 167 | 133 | +34ms | S3 |
| Concurrent write 3 × 2 KB files | 4340 | 2366 | +1974ms | S3 |
| Concurrent read 3 files back | 890 | 816 | +74ms | S3 |
| Check file exists | 99 | 82 | +17ms | S3 |
| List directory (post-write) | 534 | 704 | -170ms | R2 |
| Delete written files (exec rm) | 1952 | 1998 | -46ms | R2 |
| Unmount bucket | 173 | 160 | +13ms | S3 |

</details>

### New usage

**SDK (production — R2 binding, no credentials):**

```ts
await sandbox.mountBucket('MY_BUCKET', '/mnt/data');

// with options:
await sandbox.mountBucket('MY_BUCKET', '/mnt/data', {
  prefix: '/uploads',
  readOnly: true,
  s3fsOptions: ['parallel_count=16'],
});
```

**SDK (existing — remote S3/R2 endpoint with explicit credentials, unchanged):**

```ts
await sandbox.mountBucket('my-bucket', '/mnt/data', {
  endpoint: 'https://<account>.r2.cloudflarestorage.com',
  credentials: { accessKeyId: '...', secretAccessKey: '...' },
});
```

**Bridge HTTP API:**

```jsonc
// POST /v1/sandbox/:id/mount
{
  "bucket": "MY_BUCKET",       // binding name — no endpoint means R2 egress path
  "mountPath": "/mnt/data",
  "options": {
    "prefix": "/uploads",      // optional — must start with /
    "readOnly": false,
    "s3fsOptions": ["parallel_count=8"]
  }
}
```

### Bridge types

The old bridge-specific mount option types were replaced with a direct union alias over the SDK's own `MountBucketOptions`. This removes the impedance mismatch between the bridge API surface and the SDK:

- `MountBucketRequestOptions` is now a union of `RemoteMountBucketOptions | R2BindingMountBucketOptions | LocalMountBucketOptions` — the same union exported from the SDK package.
- Mount option validation and conversion to SDK types are centralised in `routes.ts` — all type narrowing happens once before `sandbox.mountBucket()` is called.
- Input validation now explicitly rejects: non-string `endpoint`, non-object or array `options`, non-string `credentials.accessKeyId` / `secretAccessKey`, non-boolean `readOnly`, non-string `prefix`.

### Files changed

| File                                                      | Change                                                                                                                                                                                               |
| -----------------------------------------------------------| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `packages/sandbox/src/storage-mount/r2-egress-handler.ts` | **New** — full R2 egress HTTP handler: list, get, put, delete, multipart, copy, range requests, read-only enforcement, S3-compatible XML serialisation                                               |
| `packages/sandbox/src/sandbox.ts`                         | New `mountBucketR2Egress()` path; password file lifecycle; outbound handler registration and cleanup; mountpoint check enforcement; unmount/destroy cleanup                                          |
| `packages/sandbox/src/bridge/types.ts`                    | Replaced bridge-specific mount option types with SDK union alias                                                                                                                                     |
| `packages/sandbox/src/bridge/routes.ts`                   | Centralised `validateMountOptions()` and `toSDKMountOptions()` helpers; tightened primitive type validation                                                                                          |
| `packages/sandbox/src/bridge/openapi.ts`                  | Updated `s3fsOptions` description to cover both remote and R2 mounts; fixed `prefix` description                                                                                                     |
| `packages/sandbox/src/storage-mount/validation.ts`        | Bucket name, binding name, and prefix validators; `isR2BindingMount` type guard                                                                                                                      |
| `packages/sandbox/src/storage-mount/types.ts`             | Added `R2EgressMountInfo` discriminant to the `MountInfo` union                                                                                                                                      |
| `packages/sandbox/src/storage-mount/index.ts`             | Re-exports for new types                                                                                                                                                                             |
| `packages/shared/src/types.ts`                            | Added `R2BindingMountBucketOptions`; updated `MountBucketOptions` union                                                                                                                              |
| `bridge/worker/README.md`                                 | Documented R2 binding mount, `s3fsOptions`, `prefix`, and `readOnly` in the mount API reference                                                                                                      |
| `packages/sandbox/tests/r2-egress-handler.test.ts`        | 28 unit tests for egress handler operations                                                                                                                                                          |
| `packages/sandbox/tests/r2-egress-mount.test.ts`          | 11 unit tests for mount lifecycle, prefix handling, failure cleanup, protected option rejection, and mountpoint check enforcement                                                                    |
| `packages/sandbox/tests/storage-mount/validation.test.ts` | 27 unit tests for the new validators                                                                                                                                                                 |
| `bridge/worker/src/__tests__/mount.test.ts`               | Extended with malformed credential, invalid primitive, and array options rejection tests                                                                                                             |
| `tests/e2e/bucket-mounting.test.ts`                       | E2E test: mount via R2 binding, verify pre-existing R2 file is visible in the container, write a file from the container, verify it appears in R2, then unmount and confirm mountpoint is cleaned up |
