### PR TITLE
Add `enableDefaultSession` flag for isolated/session executions

### DIFF
--- a/.changeset/isolated-implicit-sessions.md
+++ b/.changeset/isolated-implicit-sessions.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Add an opt-in `enableDefaultSession: false` sandbox option for callers that want implicit operations to run in isolated per-operation sessions. Existing behavior remains the default; create an explicit session with `sandbox.createSession()` when you want state to persist across calls.

--- a/packages/sandbox-container/src/control-plane/api.ts
+++ b/packages/sandbox-container/src/control-plane/api.ts
@@ -37,6 +37,7 @@ import type {
 } from '../core/types';
 import type { BackupService } from '../services/backup-service';
 import type { DesktopService } from '../services/desktop-service';
+import { canonicalizeExecutionSessionId } from '../services/execution-service';
 import type { FileService } from '../services/file-service';
 import type { GitService } from '../services/git-service';
 import type {
@@ -90,6 +91,10 @@ function throwIfError(result: ServiceResult<any, any>): void {
 function extractData<T>(result: ServiceResult<any, any>): T {
   throwIfError(result);
   return (result as { data: T }).data;
+}
+
+function resolveRPCSessionId(options: { sessionId?: string }): string {
+  return canonicalizeExecutionSessionId(options);
 }
 
 /**
@@ -159,7 +164,6 @@ class CommandsRPCAPI extends RpcTarget {
       timeoutMs?: number;
       env?: Record<string, string | undefined>;
       cwd?: string;
-      sessionless?: boolean;
     }
   ): Promise<{
     success: boolean;
@@ -169,12 +173,14 @@ class CommandsRPCAPI extends RpcTarget {
     command: string;
     timestamp: string;
   }> {
+    const resolvedSessionId = resolveRPCSessionId({
+      sessionId
+    });
     const result = await this.#svc.executeCommand(command, {
-      sessionId,
+      sessionId: resolvedSessionId,
       timeoutMs: options?.timeoutMs,
       env: options?.env,
-      cwd: options?.cwd,
-      sessionless: options?.sessionless
+      cwd: options?.cwd
     });
     const data = extractData<CommandResult>(result);
     return {
@@ -194,16 +200,17 @@ class CommandsRPCAPI extends RpcTarget {
       timeoutMs?: number;
       env?: Record<string, string | undefined>;
       cwd?: string;
-      sessionless?: boolean;
     }
   ): Promise<ReadableStream<Uint8Array>> {
     const encoder = new TextEncoder();
+    const resolvedSessionId = resolveRPCSessionId({
+      sessionId
+    });
     const result = await this.#svc.startProcess(command, {
-      sessionId,
+      sessionId: resolvedSessionId,
       timeoutMs: options?.timeoutMs,
       env: options?.env,
-      cwd: options?.cwd,
-      sessionless: options?.sessionless
+      cwd: options?.cwd
     });
 
     if (!result.success) {
@@ -227,7 +234,7 @@ class CommandsRPCAPI extends RpcTarget {
       start(controller) {
         controller.enqueue(
           encoder.encode(
-            `event: start\ndata: ${JSON.stringify({ type: 'start', command, sessionId, pid: proc.pid, timestamp: new Date().toISOString() })}\n\n`
+            `event: start\ndata: ${JSON.stringify({ type: 'start', command, sessionId: resolvedSessionId, pid: proc.pid, timestamp: new Date().toISOString() })}\n\n`
           )
         );
         if (proc.stdout) {
@@ -326,8 +333,12 @@ class FilesRPCAPI extends RpcTarget {
     sessionId: string,
     options?: { encoding?: FileEncoding }
   ) {
+    const resolvedSessionId = resolveRPCSessionId({ sessionId });
     if (options?.encoding === 'none') {
-      const result = await this.#svc.readFileBinaryStream(path, sessionId);
+      const result = await this.#svc.readFileBinaryStream(
+        path,
+        resolvedSessionId
+      );
       const { content, size, mimeType } = extractData<{
         content: ReadableStream<Uint8Array>;
         size: number;
@@ -342,7 +353,7 @@ class FilesRPCAPI extends RpcTarget {
         timestamp: new Date().toISOString()
       };
     }
-    const result = await this.#svc.readFile(path, options, sessionId);
+    const result = await this.#svc.readFile(path, options, resolvedSessionId);
     const content = extractData<string>(result);
     const metadata = (
       result as {
@@ -372,7 +383,10 @@ class FilesRPCAPI extends RpcTarget {
     path: string,
     sessionId: string
   ): Promise<ReadableStream<Uint8Array>> {
-    return this.#svc.readFileStreamOperation(path, sessionId);
+    return this.#svc.readFileStreamOperation(
+      path,
+      resolveRPCSessionId({ sessionId })
+    );
   }
 
   async writeFile(
@@ -381,7 +395,12 @@ class FilesRPCAPI extends RpcTarget {
     sessionId: string,
     options?: { encoding?: string; permissions?: string }
   ) {
-    const result = await this.#svc.writeFile(path, content, options, sessionId);
+    const result = await this.#svc.writeFile(
+      path,
+      content,
+      options,
+      resolveRPCSessionId({ sessionId })
+    );
     throwIfError(result);
     return {
       success: true,
@@ -396,7 +415,11 @@ class FilesRPCAPI extends RpcTarget {
     stream: ReadableStream<Uint8Array>,
     sessionId: string
   ) {
-    const result = await this.#svc.writeFileStream(path, stream, sessionId);
+    const result = await this.#svc.writeFileStream(
+      path,
+      stream,
+      resolveRPCSessionId({ sessionId })
+    );
     throwIfError(result);
     const data = (result as { data?: { bytesWritten: number } }).data;
     return {
@@ -408,13 +431,20 @@ class FilesRPCAPI extends RpcTarget {
   }
 
   async deleteFile(path: string, sessionId: string) {
-    const result = await this.#svc.deleteFile(path, sessionId);
+    const result = await this.#svc.deleteFile(
+      path,
+      resolveRPCSessionId({ sessionId })
+    );
     throwIfError(result);
     return { success: true, path, timestamp: new Date().toISOString() };
   }
 
   async renameFile(oldPath: string, newPath: string, sessionId: string) {
-    const result = await this.#svc.renameFile(oldPath, newPath, sessionId);
+    const result = await this.#svc.renameFile(
+      oldPath,
+      newPath,
+      resolveRPCSessionId({ sessionId })
+    );
     throwIfError(result);
     return {
       success: true,
@@ -433,7 +463,7 @@ class FilesRPCAPI extends RpcTarget {
     const result = await this.#svc.moveFile(
       sourcePath,
       destinationPath,
-      sessionId
+      resolveRPCSessionId({ sessionId })
     );
     throwIfError(result);
     return {
@@ -449,7 +479,11 @@ class FilesRPCAPI extends RpcTarget {
     sessionId: string,
     options?: { recursive?: boolean }
   ) {
-    const result = await this.#svc.createDirectory(path, options, sessionId);
+    const result = await this.#svc.createDirectory(
+      path,
+      options,
+      resolveRPCSessionId({ sessionId })
+    );
     throwIfError(result);
     return {
       success: true,
@@ -470,7 +504,11 @@ class FilesRPCAPI extends RpcTarget {
     path: string;
     timestamp: string;
   }> {
-    const result = await this.#svc.listFiles(path, options, sessionId);
+    const result = await this.#svc.listFiles(
+      path,
+      options,
+      resolveRPCSessionId({ sessionId })
+    );
     const files = extractData<FileInfo[]>(result);
     return {
       success: true,
@@ -482,7 +520,10 @@ class FilesRPCAPI extends RpcTarget {
   }
 
   async exists(path: string, sessionId: string) {
-    const result = await this.#svc.exists(path, sessionId);
+    const result = await this.#svc.exists(
+      path,
+      resolveRPCSessionId({ sessionId })
+    );
     const exists = extractData<boolean>(result);
     return { success: true, exists, path, timestamp: new Date().toISOString() };
   }
@@ -504,8 +545,9 @@ class ProcessesRPCAPI extends RpcTarget {
     sessionId: string,
     options?: { processId?: string; timeoutMs?: number }
   ) {
+    const resolvedSessionId = resolveRPCSessionId({ sessionId });
     const result = await this.#svc.startProcess(command, {
-      sessionId,
+      sessionId: resolvedSessionId,
       ...options
     });
     const proc = extractData<ProcessRecord>(result);
@@ -804,7 +846,7 @@ class GitRPCAPI extends RpcTarget {
       targetDir: options?.targetDir,
       depth: options?.depth,
       timeoutMs: options?.timeoutMs,
-      sessionId
+      sessionId: resolveRPCSessionId({ sessionId })
     });
     const data = extractData<{ path: string; branch: string }>(result);
     return {
@@ -1074,7 +1116,7 @@ class BackupRPCAPI extends RpcTarget {
     const result = await this.#svc.createArchive(
       dir,
       archivePath,
-      sessionId,
+      resolveRPCSessionId({ sessionId }),
       options?.gitignore ?? false,
       options?.excludes ?? [],
       options?.compression
@@ -1090,7 +1132,11 @@ class BackupRPCAPI extends RpcTarget {
   }
 
   async restoreArchive(dir: string, archivePath: string, sessionId: string) {
-    const result = await this.#svc.restoreArchive(dir, archivePath, sessionId);
+    const result = await this.#svc.restoreArchive(
+      dir,
+      archivePath,
+      resolveRPCSessionId({ sessionId })
+    );
     throwIfError(result);
     return { success: true, dir };
   }
@@ -1108,7 +1154,7 @@ class BackupRPCAPI extends RpcTarget {
     const result = await this.#svc.uploadParts(
       request.archivePath,
       request.parts,
-      request.sessionId ?? 'default'
+      resolveRPCSessionId({ sessionId: request.sessionId })
     );
     const data = extractData<{
       parts: Array<{ partNumber: number; etag: string }>;

--- a/packages/sandbox-container/src/control-plane/api.ts
+++ b/packages/sandbox-container/src/control-plane/api.ts
@@ -154,11 +154,12 @@ class CommandsRPCAPI extends RpcTarget {
 
   async execute(
     command: string,
-    sessionId: string,
+    sessionId: string | undefined,
     options?: {
       timeoutMs?: number;
       env?: Record<string, string | undefined>;
       cwd?: string;
+      sessionless?: boolean;
     }
   ): Promise<{
     success: boolean;
@@ -172,7 +173,8 @@ class CommandsRPCAPI extends RpcTarget {
       sessionId,
       timeoutMs: options?.timeoutMs,
       env: options?.env,
-      cwd: options?.cwd
+      cwd: options?.cwd,
+      sessionless: options?.sessionless
     });
     const data = extractData<CommandResult>(result);
     return {
@@ -187,11 +189,12 @@ class CommandsRPCAPI extends RpcTarget {
 
   async executeStream(
     command: string,
-    sessionId: string,
+    sessionId: string | undefined,
     options?: {
       timeoutMs?: number;
       env?: Record<string, string | undefined>;
       cwd?: string;
+      sessionless?: boolean;
     }
   ): Promise<ReadableStream<Uint8Array>> {
     const encoder = new TextEncoder();
@@ -199,7 +202,8 @@ class CommandsRPCAPI extends RpcTarget {
       sessionId,
       timeoutMs: options?.timeoutMs,
       env: options?.env,
-      cwd: options?.cwd
+      cwd: options?.cwd,
+      sessionless: options?.sessionless
     });
 
     if (!result.success) {

--- a/packages/sandbox-container/src/core/container.ts
+++ b/packages/sandbox-container/src/core/container.ts
@@ -18,6 +18,7 @@ import { SecurityServiceAdapter } from '../security/security-adapter';
 import { SecurityService } from '../security/security-service';
 import { BackupService } from '../services/backup-service';
 import { DesktopService } from '../services/desktop-service';
+import { ExecutionService } from '../services/execution-service';
 import { FileService } from '../services/file-service';
 import { GitService } from '../services/git-service';
 import { InterpreterService } from '../services/interpreter-service';
@@ -105,6 +106,7 @@ export class Container {
 
     // Initialize SessionManager
     const sessionManager = new SessionManager(logger);
+    const executionService = new ExecutionService(sessionManager);
 
     // Create git-specific logger that automatically sanitizes credentials
     const gitLogger = new GitLogger(logger);
@@ -113,21 +115,21 @@ export class Container {
     const processService = new ProcessService(
       processStore,
       logger,
-      sessionManager
+      executionService
     );
     const fileService = new FileService(
       securityAdapter,
       logger,
-      sessionManager
+      executionService
     );
     const portService = new PortService(portStore, securityAdapter, logger);
     const gitService = new GitService(
       securityAdapter,
-      sessionManager,
+      executionService,
       gitLogger
     );
     const interpreterService = new InterpreterService(logger);
-    const backupService = new BackupService(logger, sessionManager);
+    const backupService = new BackupService(logger, executionService);
     const desktopService = new DesktopService(logger);
     const watchService = new WatchService(logger);
 

--- a/packages/sandbox-container/src/core/types.ts
+++ b/packages/sandbox-container/src/core/types.ts
@@ -232,6 +232,24 @@ export interface SessionData {
   cwd?: string;
 }
 
+export type ExecutionMode = 'session' | 'sessionless';
+
+export interface ExecutionTarget {
+  mode: ExecutionMode;
+  sessionId?: string;
+}
+
+export type ProcessCommandHandle =
+  | {
+      mode: 'session';
+      sessionId: string;
+      commandId: string;
+    }
+  | {
+      mode: 'sessionless';
+      pid: number;
+    };
+
 // Process types (enhanced from existing)
 export type ProcessStatus =
   | 'starting'
@@ -255,10 +273,7 @@ export interface ProcessRecord {
   outputListeners: Set<(stream: 'stdout' | 'stderr', data: string) => void>;
   statusListeners: Set<(status: ProcessStatus) => void>;
   // Unified execution model: All processes use SessionManager
-  commandHandle?: {
-    sessionId: string;
-    commandId: string;
-  };
+  commandHandle?: ProcessCommandHandle;
   // Promise that resolves when all streaming events have been processed
   streamingComplete?: Promise<void>;
   // For isolation layer (file-based IPC)
@@ -273,7 +288,6 @@ export type ProcessInfo = ProcessRecord;
 // Process options for container-internal execution (includes session routing)
 export interface ProcessOptions {
   sessionId?: string;
-  sessionless?: boolean;
   processId?: string;
   timeoutMs?: number;
   env?: Record<string, string | undefined>;

--- a/packages/sandbox-container/src/core/types.ts
+++ b/packages/sandbox-container/src/core/types.ts
@@ -273,6 +273,7 @@ export type ProcessInfo = ProcessRecord;
 // Process options for container-internal execution (includes session routing)
 export interface ProcessOptions {
   sessionId?: string;
+  sessionless?: boolean;
   processId?: string;
   timeoutMs?: number;
   env?: Record<string, string | undefined>;

--- a/packages/sandbox-container/src/handlers/backup-handler.ts
+++ b/packages/sandbox-container/src/handlers/backup-handler.ts
@@ -241,7 +241,10 @@ export class BackupHandler extends BaseHandler<Request, Response> {
       );
     }
 
-    const sessionId = body.sessionId ?? context.sessionId ?? 'default';
+    const sessionId = this.resolveExecutionSessionId({
+      sessionId: body.sessionId,
+      fallbackSessionId: context.sessionId
+    });
 
     const result = await this.backupService.createArchive(
       body.dir,
@@ -311,7 +314,10 @@ export class BackupHandler extends BaseHandler<Request, Response> {
       }
     }
 
-    const sessionId = body.sessionId ?? context.sessionId ?? 'default';
+    const sessionId = this.resolveExecutionSessionId({
+      sessionId: body.sessionId,
+      fallbackSessionId: context.sessionId
+    });
     const result = await this.backupService.uploadParts(
       body.archivePath,
       body.parts,
@@ -362,7 +368,10 @@ export class BackupHandler extends BaseHandler<Request, Response> {
       );
     }
 
-    const sessionId = body.sessionId ?? context.sessionId ?? 'default';
+    const sessionId = this.resolveExecutionSessionId({
+      sessionId: body.sessionId,
+      fallbackSessionId: context.sessionId
+    });
 
     const result = await this.backupService.restoreArchive(
       body.dir,

--- a/packages/sandbox-container/src/handlers/base-handler.ts
+++ b/packages/sandbox-container/src/handlers/base-handler.ts
@@ -8,10 +8,12 @@ import {
   type OperationType
 } from '@repo/shared/errors';
 import type { Handler, RequestContext, ServiceError } from '../core/types';
+import { canonicalizeExecutionSessionId } from '../services/execution-service';
 
-export abstract class BaseHandler<TRequest, TResponse>
-  implements Handler<TRequest, TResponse>
-{
+export abstract class BaseHandler<TRequest, TResponse> implements Handler<
+  TRequest,
+  TResponse
+> {
   constructor(protected logger: Logger) {}
 
   abstract handle(
@@ -103,6 +105,13 @@ export abstract class BaseHandler<TRequest, TResponse>
   protected extractQueryParam(request: Request, param: string): string | null {
     const url = new URL(request.url);
     return url.searchParams.get(param);
+  }
+
+  protected resolveExecutionSessionId(options: {
+    sessionId?: string;
+    fallbackSessionId?: string;
+  }): string {
+    return canonicalizeExecutionSessionId(options);
   }
 
   /**

--- a/packages/sandbox-container/src/handlers/execute-handler.ts
+++ b/packages/sandbox-container/src/handlers/execute-handler.ts
@@ -45,7 +45,10 @@ export class ExecuteHandler extends BaseHandler<Request, Response> {
   ): Promise<Response> {
     // Parse request body directly
     const body = await this.parseRequestBody<ExecuteRequest>(request);
-    const sessionId = body.sessionId || context.sessionId;
+    const sessionId = this.resolveExecutionSessionId({
+      sessionId: body.sessionId,
+      fallbackSessionId: context.sessionId
+    });
 
     // If this is a background process, start it as a process
     if (body.background) {
@@ -80,7 +83,6 @@ export class ExecuteHandler extends BaseHandler<Request, Response> {
     // For non-background commands, execute and return result
     const result = await this.processService.executeCommand(body.command, {
       sessionId,
-      sessionless: body.sessionless,
       timeoutMs: body.timeoutMs,
       env: body.env,
       cwd: body.cwd,
@@ -113,12 +115,14 @@ export class ExecuteHandler extends BaseHandler<Request, Response> {
   ): Promise<Response> {
     // Parse request body directly
     const body = await this.parseRequestBody<ExecuteRequest>(request);
-    const sessionId = body.sessionId || context.sessionId;
+    const sessionId = this.resolveExecutionSessionId({
+      sessionId: body.sessionId,
+      fallbackSessionId: context.sessionId
+    });
 
     // Start the process for streaming
     const processResult = await this.processService.startProcess(body.command, {
       sessionId,
-      sessionless: body.sessionless,
       timeoutMs: body.timeoutMs,
       env: body.env,
       cwd: body.cwd,

--- a/packages/sandbox-container/src/handlers/execute-handler.ts
+++ b/packages/sandbox-container/src/handlers/execute-handler.ts
@@ -80,6 +80,7 @@ export class ExecuteHandler extends BaseHandler<Request, Response> {
     // For non-background commands, execute and return result
     const result = await this.processService.executeCommand(body.command, {
       sessionId,
+      sessionless: body.sessionless,
       timeoutMs: body.timeoutMs,
       env: body.env,
       cwd: body.cwd,
@@ -117,6 +118,8 @@ export class ExecuteHandler extends BaseHandler<Request, Response> {
     // Start the process for streaming
     const processResult = await this.processService.startProcess(body.command, {
       sessionId,
+      sessionless: body.sessionless,
+      timeoutMs: body.timeoutMs,
       env: body.env,
       cwd: body.cwd,
       origin: body.origin

--- a/packages/sandbox-container/src/handlers/file-handler.ts
+++ b/packages/sandbox-container/src/handlers/file-handler.ts
@@ -71,13 +71,17 @@ export class FileHandler extends BaseHandler<Request, Response> {
     context: RequestContext
   ): Promise<Response> {
     const body = await this.parseRequestBody<ReadFileRequest>(request);
+    const sessionId = this.resolveExecutionSessionId({
+      sessionId: body.sessionId,
+      fallbackSessionId: context.sessionId
+    });
 
     const result = await this.fileService.readFile(
       body.path,
       {
         encoding: body.encoding
       },
-      body.sessionId
+      sessionId
     );
 
     if (result.success) {
@@ -103,12 +107,16 @@ export class FileHandler extends BaseHandler<Request, Response> {
     context: RequestContext
   ): Promise<Response> {
     const body = await this.parseRequestBody<ReadFileRequest>(request);
+    const sessionId = this.resolveExecutionSessionId({
+      sessionId: body.sessionId,
+      fallbackSessionId: context.sessionId
+    });
 
     try {
       // Create SSE stream (handles metadata fetching and errors internally)
       const stream = await this.fileService.readFileStreamOperation(
         body.path,
-        body.sessionId
+        sessionId
       );
 
       return new Response(stream, {
@@ -160,6 +168,10 @@ export class FileHandler extends BaseHandler<Request, Response> {
     context: RequestContext
   ): Promise<Response> {
     const body = await this.parseRequestBody<WriteFileRequest>(request);
+    const sessionId = this.resolveExecutionSessionId({
+      sessionId: body.sessionId,
+      fallbackSessionId: context.sessionId
+    });
 
     const options =
       body.encoding !== undefined ? { encoding: body.encoding } : {};
@@ -168,7 +180,7 @@ export class FileHandler extends BaseHandler<Request, Response> {
       body.path,
       body.content,
       options,
-      body.sessionId
+      sessionId
     );
 
     if (result.success) {
@@ -189,8 +201,12 @@ export class FileHandler extends BaseHandler<Request, Response> {
     context: RequestContext
   ): Promise<Response> {
     const body = await this.parseRequestBody<DeleteFileRequest>(request);
+    const sessionId = this.resolveExecutionSessionId({
+      sessionId: body.sessionId,
+      fallbackSessionId: context.sessionId
+    });
 
-    const result = await this.fileService.deleteFile(body.path);
+    const result = await this.fileService.deleteFile(body.path, sessionId);
 
     if (result.success) {
       const response: DeleteFileResult = {
@@ -210,10 +226,15 @@ export class FileHandler extends BaseHandler<Request, Response> {
     context: RequestContext
   ): Promise<Response> {
     const body = await this.parseRequestBody<RenameFileRequest>(request);
+    const sessionId = this.resolveExecutionSessionId({
+      sessionId: body.sessionId,
+      fallbackSessionId: context.sessionId
+    });
 
     const result = await this.fileService.renameFile(
       body.oldPath,
-      body.newPath
+      body.newPath,
+      sessionId
     );
 
     if (result.success) {
@@ -235,10 +256,15 @@ export class FileHandler extends BaseHandler<Request, Response> {
     context: RequestContext
   ): Promise<Response> {
     const body = await this.parseRequestBody<MoveFileRequest>(request);
+    const sessionId = this.resolveExecutionSessionId({
+      sessionId: body.sessionId,
+      fallbackSessionId: context.sessionId
+    });
 
     const result = await this.fileService.moveFile(
       body.sourcePath,
-      body.destinationPath
+      body.destinationPath,
+      sessionId
     );
 
     if (result.success) {
@@ -260,10 +286,18 @@ export class FileHandler extends BaseHandler<Request, Response> {
     context: RequestContext
   ): Promise<Response> {
     const body = await this.parseRequestBody<MkdirRequest>(request);
-
-    const result = await this.fileService.createDirectory(body.path, {
-      recursive: body.recursive
+    const sessionId = this.resolveExecutionSessionId({
+      sessionId: body.sessionId,
+      fallbackSessionId: context.sessionId
     });
+
+    const result = await this.fileService.createDirectory(
+      body.path,
+      {
+        recursive: body.recursive
+      },
+      sessionId
+    );
 
     if (result.success) {
       const response: MkdirResult = {
@@ -284,11 +318,15 @@ export class FileHandler extends BaseHandler<Request, Response> {
     context: RequestContext
   ): Promise<Response> {
     const body = await this.parseRequestBody<ListFilesRequest>(request);
+    const sessionId = this.resolveExecutionSessionId({
+      sessionId: body.sessionId,
+      fallbackSessionId: context.sessionId
+    });
 
     const result = await this.fileService.listFiles(
       body.path,
       body.options || {},
-      body.sessionId
+      sessionId
     );
 
     if (result.success) {
@@ -311,8 +349,12 @@ export class FileHandler extends BaseHandler<Request, Response> {
     context: RequestContext
   ): Promise<Response> {
     const body = await this.parseRequestBody<FileExistsRequest>(request);
+    const sessionId = this.resolveExecutionSessionId({
+      sessionId: body.sessionId,
+      fallbackSessionId: context.sessionId
+    });
 
-    const result = await this.fileService.exists(body.path, body.sessionId);
+    const result = await this.fileService.exists(body.path, sessionId);
 
     if (result.success) {
       const response: FileExistsResult = {

--- a/packages/sandbox-container/src/handlers/git-handler.ts
+++ b/packages/sandbox-container/src/handlers/git-handler.ts
@@ -41,7 +41,10 @@ export class GitHandler extends BaseHandler<Request, Response> {
     context: RequestContext
   ): Promise<Response> {
     const body = await this.parseRequestBody<GitCheckoutRequest>(request);
-    const sessionId = body.sessionId || context.sessionId;
+    const sessionId = this.resolveExecutionSessionId({
+      sessionId: body.sessionId,
+      fallbackSessionId: context.sessionId
+    });
 
     const result = await this.gitService.cloneRepository(body.repoUrl, {
       branch: body.branch,

--- a/packages/sandbox-container/src/services/backup-service.ts
+++ b/packages/sandbox-container/src/services/backup-service.ts
@@ -7,7 +7,7 @@ import {
 import { ErrorCode, Operation } from '@repo/shared/errors';
 import type { ServiceResult } from '../core/types';
 import { serviceError, serviceSuccess } from '../core/types';
-import type { SessionManager } from './session-manager';
+import type { ExecutionService } from './execution-service';
 
 export const BACKUP_WORK_DIR = '/var/backups';
 const BACKUP_MOUNTS_DIR = '/var/backups/mounts';
@@ -116,8 +116,15 @@ interface UploadedBackupPart {
 export class BackupService {
   constructor(
     private logger: Logger,
-    private sessionManager: SessionManager
+    private executionService: ExecutionService
   ) {}
+
+  private async executeCommand(sessionId: string, command: string) {
+    return this.executionService.execute(command, {
+      sessionId,
+      origin: 'internal'
+    });
+  }
 
   /**
    * Create a squashfs archive from a directory.
@@ -162,10 +169,9 @@ export class BackupService {
         });
       }
       // Ensure the work directory exists
-      const mkdirResult = await this.sessionManager.executeInSession(
+      const mkdirResult = await this.executeCommand(
         sessionId,
-        `mkdir -p ${shellEscape(BACKUP_WORK_DIR)}`,
-        { origin: 'internal' }
+        `mkdir -p ${shellEscape(BACKUP_WORK_DIR)}`
       );
       if (!mkdirResult.success) {
         outcome = 'error';
@@ -178,10 +184,9 @@ export class BackupService {
       }
 
       // Verify the source directory exists
-      const checkResult = await this.sessionManager.executeInSession(
+      const checkResult = await this.executeCommand(
         sessionId,
-        `test -d ${shellEscape(dir)}`,
-        { origin: 'internal' }
+        `test -d ${shellEscape(dir)}`
       );
       if (!checkResult.success || checkResult.data.exitCode !== 0) {
         errorMessage = 'Source directory does not exist';
@@ -194,10 +199,9 @@ export class BackupService {
 
       // Pre-flight check: verify mksquashfs binary exists
       // This provides a clearer error than "command not found" from bash
-      const checkBinaryResult = await this.sessionManager.executeInSession(
+      const checkBinaryResult = await this.executeCommand(
         sessionId,
-        `test -x ${BIN.mksquashfs} && echo exists || echo "missing: ${BIN.mksquashfs}"`,
-        { origin: 'internal' }
+        `test -x ${BIN.mksquashfs} && echo exists || echo "missing: ${BIN.mksquashfs}"`
       );
       if (
         checkBinaryResult.success &&
@@ -244,10 +248,9 @@ export class BackupService {
       ];
 
       if (excludePatterns.length > 0) {
-        const writeExcludeResult = await this.sessionManager.executeInSession(
+        const writeExcludeResult = await this.executeCommand(
           sessionId,
-          `printf '%s\\n' ${excludePatterns.map(shellEscape).join(' ')} > ${shellEscape(excludeFilePath)}`,
-          { origin: 'internal' }
+          `printf '%s\\n' ${excludePatterns.map(shellEscape).join(' ')} > ${shellEscape(excludeFilePath)}`
         );
         if (
           !writeExcludeResult.success ||
@@ -282,11 +285,7 @@ export class BackupService {
       }
       const squashCmd = squashCmdParts.join(' ');
 
-      const createResult = await this.sessionManager.executeInSession(
-        sessionId,
-        squashCmd,
-        { origin: 'internal' }
-      );
+      const createResult = await this.executeCommand(sessionId, squashCmd);
 
       if (!createResult.success) {
         errorMessage = 'Failed to create squashfs archive';
@@ -313,10 +312,9 @@ export class BackupService {
 
       // Get the archive size
       // `stat -c` is GNU/Linux-specific (the container is always Linux)
-      const statResult = await this.sessionManager.executeInSession(
+      const statResult = await this.executeCommand(
         sessionId,
-        `stat -c %s ${shellEscape(archivePath)}`,
-        { origin: 'internal' }
+        `stat -c %s ${shellEscape(archivePath)}`
       );
 
       sizeBytes = 0;
@@ -340,18 +338,15 @@ export class BackupService {
       });
     } finally {
       if (shouldCleanupExcludeFile) {
-        await this.sessionManager
-          .executeInSession(
-            sessionId,
-            `rm -f ${shellEscape(excludeFilePath)}`,
-            { origin: 'internal' }
-          )
-          .catch((err) => {
-            opLogger.warn('Failed to clean up exclude file', {
-              excludeFilePath,
-              error: err instanceof Error ? err.message : String(err)
-            });
+        await this.executeCommand(
+          sessionId,
+          `rm -f ${shellEscape(excludeFilePath)}`
+        ).catch((err) => {
+          opLogger.warn('Failed to clean up exclude file', {
+            excludeFilePath,
+            error: err instanceof Error ? err.message : String(err)
           });
+        });
       }
 
       logCanonicalEvent(this.logger, {
@@ -372,10 +367,9 @@ export class BackupService {
     sessionId: string,
     opLogger: Logger
   ): Promise<string[]> {
-    const gitAvailableResult = await this.sessionManager.executeInSession(
+    const gitAvailableResult = await this.executeCommand(
       sessionId,
-      'command -v git >/dev/null 2>&1',
-      { origin: 'internal' }
+      'command -v git >/dev/null 2>&1'
     );
     if (!gitAvailableResult.success || gitAvailableResult.data.exitCode !== 0) {
       opLogger.warn(
@@ -385,10 +379,9 @@ export class BackupService {
       return [];
     }
 
-    const insideWorkTreeResult = await this.sessionManager.executeInSession(
+    const insideWorkTreeResult = await this.executeCommand(
       sessionId,
-      `git -C ${shellEscape(dir)} rev-parse --is-inside-work-tree`,
-      { origin: 'internal' }
+      `git -C ${shellEscape(dir)} rev-parse --is-inside-work-tree`
     );
     if (
       !insideWorkTreeResult.success ||
@@ -405,10 +398,9 @@ export class BackupService {
     // relative to the directory mksquashfs will archive.
     // Use core.quotePath=false to ensure special characters (spaces, unicode)
     // are output literally rather than quoted, so they match archive entries.
-    const ignoredFilesResult = await this.sessionManager.executeInSession(
+    const ignoredFilesResult = await this.executeCommand(
       sessionId,
-      `git -C ${shellEscape(dir)} -c core.quotePath=false ls-files --others -i --exclude-standard -- .`,
-      { origin: 'internal' }
+      `git -C ${shellEscape(dir)} -c core.quotePath=false ls-files --others -i --exclude-standard -- .`
     );
     if (!ignoredFilesResult.success || ignoredFilesResult.data.exitCode !== 0) {
       opLogger.warn('Failed to resolve gitignored backup paths', { dir });
@@ -603,10 +595,9 @@ export class BackupService {
       const upperDir = `${mountBase}/upper`;
       const workDir = `${mountBase}/work`;
       // Verify the archive exists
-      const checkResult = await this.sessionManager.executeInSession(
+      const checkResult = await this.executeCommand(
         sessionId,
-        `test -f ${shellEscape(archivePath)}`,
-        { origin: 'internal' }
+        `test -f ${shellEscape(archivePath)}`
       );
       if (!checkResult.success || checkResult.data.exitCode !== 0) {
         errorMessage = 'Archive file does not exist';
@@ -618,10 +609,9 @@ export class BackupService {
       }
 
       // Unmount the overlay on `dir` (from a previous restore of any backup).
-      await this.sessionManager.executeInSession(
+      await this.executeCommand(
         sessionId,
-        `${BIN.fusermount} -u ${shellEscape(dir)} 2>/dev/null; ${BIN.fusermount} -uz ${shellEscape(dir)} 2>/dev/null; true`,
-        { origin: 'internal' }
+        `${BIN.fusermount} -u ${shellEscape(dir)} 2>/dev/null; ${BIN.fusermount} -uz ${shellEscape(dir)} 2>/dev/null; true`
       );
 
       // Tear down all previous mount bases for this backup ID.
@@ -629,24 +619,21 @@ export class BackupService {
       // those before removing the directories.  The glob covers both the
       // new suffixed layout (UUID_*) and the legacy unsuffixed layout (UUID/).
       const mountGlob = `${BACKUP_MOUNTS_DIR}/${backupId}`;
-      await this.sessionManager.executeInSession(
+      await this.executeCommand(
         sessionId,
-        `for d in ${shellEscape(mountGlob)}_*/lower ${shellEscape(mountGlob)}/lower; do [ -d "$d" ] && ${BIN.fusermount} -u "$d" 2>/dev/null; ${BIN.fusermount} -uz "$d" 2>/dev/null; done; true`,
-        { origin: 'internal' }
+        `for d in ${shellEscape(mountGlob)}_*/lower ${shellEscape(mountGlob)}/lower; do [ -d "$d" ] && ${BIN.fusermount} -u "$d" 2>/dev/null; ${BIN.fusermount} -uz "$d" 2>/dev/null; done; true`
       );
 
       // Remove old mount bases (best-effort)
-      await this.sessionManager.executeInSession(
+      await this.executeCommand(
         sessionId,
-        `rm -rf ${shellEscape(mountGlob)}_* ${shellEscape(mountGlob)} 2>/dev/null; true`,
-        { origin: 'internal' }
+        `rm -rf ${shellEscape(mountGlob)}_* ${shellEscape(mountGlob)} 2>/dev/null; true`
       );
 
       // Create fresh mount directories
-      const mkdirResult = await this.sessionManager.executeInSession(
+      const mkdirResult = await this.executeCommand(
         sessionId,
-        `mkdir -p ${shellEscape(lowerDir)} ${shellEscape(upperDir)} ${shellEscape(workDir)} ${shellEscape(dir)}`,
-        { origin: 'internal' }
+        `mkdir -p ${shellEscape(lowerDir)} ${shellEscape(upperDir)} ${shellEscape(workDir)} ${shellEscape(dir)}`
       );
       if (!mkdirResult.success) {
         errorMessage = 'Failed to create mount directories';
@@ -667,10 +654,9 @@ export class BackupService {
 
       // Mount squashfs as the lower (read-only) layer
       const squashMountCmd = `${BIN.squashfuse} ${shellEscape(archivePath)} ${shellEscape(lowerDir)}`;
-      const squashMountResult = await this.sessionManager.executeInSession(
+      const squashMountResult = await this.executeCommand(
         sessionId,
-        squashMountCmd,
-        { origin: 'internal' }
+        squashMountCmd
       );
       if (!squashMountResult.success) {
         errorMessage = 'Failed to mount squashfs';
@@ -698,17 +684,15 @@ export class BackupService {
         shellEscape(dir)
       ].join(' ');
 
-      const overlayMountResult = await this.sessionManager.executeInSession(
+      const overlayMountResult = await this.executeCommand(
         sessionId,
-        overlayMountCmd,
-        { origin: 'internal' }
+        overlayMountCmd
       );
       if (!overlayMountResult.success) {
         // Cleanup: unmount squashfs on failure
-        await this.sessionManager.executeInSession(
+        await this.executeCommand(
           sessionId,
-          `${BIN.fusermount} -u ${shellEscape(lowerDir)} 2>/dev/null || true`,
-          { origin: 'internal' }
+          `${BIN.fusermount} -u ${shellEscape(lowerDir)} 2>/dev/null || true`
         );
         errorMessage = 'Failed to mount overlayfs';
         return serviceError({
@@ -719,10 +703,9 @@ export class BackupService {
       }
       if (overlayMountResult.data.exitCode !== 0) {
         // Cleanup: unmount squashfs on failure
-        await this.sessionManager.executeInSession(
+        await this.executeCommand(
           sessionId,
-          `${BIN.fusermount} -u ${shellEscape(lowerDir)} 2>/dev/null || true`,
-          { origin: 'internal' }
+          `${BIN.fusermount} -u ${shellEscape(lowerDir)} 2>/dev/null || true`
         );
         errorMessage = 'Failed to mount overlayfs';
         return serviceError({
@@ -741,13 +724,10 @@ export class BackupService {
       // Best-effort cleanup of any FUSE mounts that may have been established.
       // Clean up the overlay on dir; per-restore lowerDir is scoped inside try
       // and cleaned up by the mount-base glob teardown on the next restore.
-      await this.sessionManager
-        .executeInSession(
-          sessionId,
-          `${BIN.fusermount} -u ${shellEscape(dir)} 2>/dev/null || true`,
-          { origin: 'internal' }
-        )
-        .catch(() => {});
+      await this.executeCommand(
+        sessionId,
+        `${BIN.fusermount} -u ${shellEscape(dir)} 2>/dev/null || true`
+      ).catch(() => {});
       return serviceError({
         message: `Unexpected error restoring backup: ${caughtError.message}`,
         code: ErrorCode.BACKUP_RESTORE_FAILED,
@@ -814,25 +794,22 @@ export class BackupService {
 
     try {
       // Unmount overlayfs first
-      await this.sessionManager.executeInSession(
+      await this.executeCommand(
         sessionId,
-        `${BIN.fusermount} -u ${shellEscape(dir)} 2>/dev/null || umount ${shellEscape(dir)} 2>/dev/null || true`,
-        { origin: 'internal' }
+        `${BIN.fusermount} -u ${shellEscape(dir)} 2>/dev/null || umount ${shellEscape(dir)} 2>/dev/null || true`
       );
 
       // Unmount squashfuse on all mount bases for this backup ID
       // (both suffixed UUID_* and legacy unsuffixed UUID)
-      await this.sessionManager.executeInSession(
+      await this.executeCommand(
         sessionId,
-        `for d in ${shellEscape(mountGlob)}_*/lower ${shellEscape(mountGlob)}/lower; do [ -d "$d" ] && ${BIN.fusermount} -u "$d" 2>/dev/null; done; true`,
-        { origin: 'internal' }
+        `for d in ${shellEscape(mountGlob)}_*/lower ${shellEscape(mountGlob)}/lower; do [ -d "$d" ] && ${BIN.fusermount} -u "$d" 2>/dev/null; done; true`
       );
 
       // Verify overlay mount is gone before removing directories
-      const mountCheck = await this.sessionManager.executeInSession(
+      const mountCheck = await this.executeCommand(
         sessionId,
-        `mountpoint -q ${shellEscape(dir)} 2>/dev/null && echo "mounted" || echo "unmounted"`,
-        { origin: 'internal' }
+        `mountpoint -q ${shellEscape(dir)} 2>/dev/null && echo "mounted" || echo "unmounted"`
       );
       if (mountCheck.success && mountCheck.data.stdout.trim() === 'mounted') {
         errorMessage = `Overlay mount still active at ${dir}`;
@@ -844,10 +821,9 @@ export class BackupService {
       }
 
       // Clean up all mount directories for this backup ID (but keep the archive)
-      await this.sessionManager.executeInSession(
+      await this.executeCommand(
         sessionId,
-        `rm -rf ${shellEscape(mountGlob)}_* ${shellEscape(mountGlob)} 2>/dev/null; true`,
-        { origin: 'internal' }
+        `rm -rf ${shellEscape(mountGlob)}_* ${shellEscape(mountGlob)} 2>/dev/null; true`
       );
 
       outcome = 'success';

--- a/packages/sandbox-container/src/services/execution-service.ts
+++ b/packages/sandbox-container/src/services/execution-service.ts
@@ -1,0 +1,563 @@
+import { existsSync } from 'node:fs';
+import type { ExecEvent } from '@repo/shared';
+import { ErrorCode } from '@repo/shared/errors';
+import { spawn } from 'bun';
+import type {
+  ExecutionTarget,
+  ProcessCommandHandle,
+  ServiceResult
+} from '../core/types';
+import { serviceError, serviceSuccess } from '../core/types';
+import type { RawExecResult } from '../session';
+import type { SessionManager } from './session-manager';
+
+export const SESSIONLESS_SESSION_ID = 'none';
+const SESSIONLESS_SESSION_ID_ALIASES = new Set(['none', 'sessionless']);
+
+const DEFAULT_CWD = existsSync('/workspace') ? '/workspace' : process.cwd();
+const SETSID_PATH = existsSync('/usr/bin/setsid') ? '/usr/bin/setsid' : null;
+
+function sessionlessCmd(command: string): string[] {
+  return SETSID_PATH !== null
+    ? [SETSID_PATH, 'bash', '-lc', command]
+    : ['bash', '-lc', command];
+}
+
+function sessionlessKillPid(pid: number): number {
+  return SETSID_PATH !== null ? -pid : pid;
+}
+
+export interface ExecutionOptions {
+  target?: ExecutionTarget;
+  sessionId?: string;
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+  timeoutMs?: number;
+  origin?: 'user' | 'internal';
+}
+
+export interface ExecutionStreamOptions {
+  target?: ExecutionTarget;
+  sessionId?: string;
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+  timeoutMs?: number;
+  origin?: 'user' | 'internal';
+  commandId: string;
+  background?: boolean;
+}
+
+export interface ExecutionStreamResult {
+  continueStreaming: Promise<void>;
+  commandHandle: ProcessCommandHandle;
+}
+
+export type ExecutionCallback = (
+  command: string,
+  options?: {
+    cwd?: string;
+    env?: Record<string, string | undefined>;
+    timeoutMs?: number;
+    origin?: 'user' | 'internal';
+  }
+) => Promise<RawExecResult>;
+
+export function isSessionlessSessionId(sessionId: string | undefined): boolean {
+  return (
+    sessionId !== undefined &&
+    SESSIONLESS_SESSION_ID_ALIASES.has(sessionId.trim().toLowerCase())
+  );
+}
+
+export function canonicalizeExecutionSessionId(options: {
+  sessionId?: string;
+  fallbackSessionId?: string;
+}): string {
+  if (isSessionlessSessionId(options.sessionId)) {
+    return SESSIONLESS_SESSION_ID;
+  }
+
+  if (options.sessionId && options.sessionId.trim().length > 0) {
+    return options.sessionId.trim();
+  }
+
+  if (
+    options.fallbackSessionId &&
+    options.fallbackSessionId.trim().length > 0
+  ) {
+    return options.fallbackSessionId.trim();
+  }
+
+  return 'default';
+}
+
+export class ExecutionService {
+  constructor(private sessionManager: SessionManager) {}
+
+  resolveTarget(options: {
+    target?: ExecutionTarget;
+    sessionId?: string;
+  }): ExecutionTarget {
+    if (options.target) {
+      return options.target;
+    }
+
+    if (isSessionlessSessionId(options.sessionId)) {
+      return { mode: 'sessionless' };
+    }
+
+    return {
+      mode: 'session',
+      sessionId:
+        options.sessionId && options.sessionId.trim().length > 0
+          ? options.sessionId.trim()
+          : 'default'
+    };
+  }
+
+  targetToSessionId(target: ExecutionTarget): string | undefined {
+    if (target.mode === 'session') {
+      return target.sessionId;
+    }
+
+    return SESSIONLESS_SESSION_ID;
+  }
+
+  async execute(
+    command: string,
+    options: ExecutionOptions = {}
+  ): Promise<ServiceResult<RawExecResult>> {
+    const target = this.resolveTarget(options);
+
+    if (target.mode === 'session') {
+      return this.sessionManager.executeInSession(target.sessionId!, command, {
+        cwd: options.cwd,
+        timeoutMs: options.timeoutMs,
+        env: options.env,
+        origin: options.origin
+      });
+    }
+
+    return this.executeOneShot(command, options);
+  }
+
+  async withExecution<T>(
+    fn: (exec: ExecutionCallback) => Promise<T>,
+    options: {
+      target?: ExecutionTarget;
+      sessionId?: string;
+      cwd?: string;
+    } = {}
+  ): Promise<ServiceResult<T>> {
+    const target = this.resolveTarget(options);
+
+    if (target.mode === 'session') {
+      return this.sessionManager.withSession(
+        target.sessionId!,
+        fn,
+        options.cwd
+      );
+    }
+
+    try {
+      const result = await fn((command, execOptions) =>
+        this.executeOneShot(command, {
+          cwd: execOptions?.cwd ?? options.cwd,
+          env: execOptions?.env,
+          timeoutMs: execOptions?.timeoutMs,
+          origin: execOptions?.origin
+        }).then((executionResult) => {
+          if (!executionResult.success) {
+            throw executionResult.error;
+          }
+
+          return executionResult.data;
+        })
+      );
+
+      return serviceSuccess(result);
+    } catch (error) {
+      if (
+        error &&
+        typeof error === 'object' &&
+        'code' in error &&
+        'message' in error &&
+        typeof (error as { code: unknown }).code === 'string' &&
+        Object.values(ErrorCode).includes(
+          (error as { code: string }).code as ErrorCode
+        )
+      ) {
+        const customError = error as {
+          message: string;
+          code: string;
+          details?: Record<string, unknown>;
+        };
+        return serviceError<T>({
+          message: customError.message,
+          code: customError.code,
+          details: customError.details
+        });
+      }
+
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+
+      return serviceError<T>({
+        message: `withExecution callback failed for '${SESSIONLESS_SESSION_ID}': ${errorMessage}`,
+        code: ErrorCode.INTERNAL_ERROR,
+        details: {
+          sessionId: SESSIONLESS_SESSION_ID,
+          originalError: errorMessage
+        }
+      });
+    }
+  }
+
+  async executeStream(
+    command: string,
+    onEvent: (event: ExecEvent) => Promise<void>,
+    options: ExecutionStreamOptions
+  ): Promise<ServiceResult<ExecutionStreamResult>> {
+    const target = this.resolveTarget(options);
+
+    if (target.mode === 'session') {
+      const result = await this.sessionManager.executeStreamInSession(
+        target.sessionId!,
+        command,
+        onEvent,
+        {
+          cwd: options.cwd,
+          env: options.env,
+          origin: options.origin
+        },
+        options.commandId,
+        { background: options.background }
+      );
+
+      if (!result.success) {
+        return result as ServiceResult<ExecutionStreamResult>;
+      }
+
+      return serviceSuccess({
+        continueStreaming: result.data.continueStreaming,
+        commandHandle: {
+          mode: 'session',
+          sessionId: target.sessionId!,
+          commandId: options.commandId
+        }
+      });
+    }
+
+    return this.executeStreamOneShot(command, onEvent, options);
+  }
+
+  async kill(
+    commandHandle: ProcessCommandHandle
+  ): Promise<ServiceResult<void>> {
+    if (commandHandle.mode === 'session') {
+      return this.sessionManager.killCommand(
+        commandHandle.sessionId,
+        commandHandle.commandId
+      );
+    }
+
+    if (commandHandle.pid <= 0) {
+      return serviceError({
+        message: `Invalid PID ${commandHandle.pid}`,
+        code: ErrorCode.PROCESS_ERROR,
+        details: { processId: String(commandHandle.pid) }
+      });
+    }
+
+    try {
+      process.kill(sessionlessKillPid(commandHandle.pid), 'SIGTERM');
+      const pid = commandHandle.pid;
+      setTimeout(() => {
+        try {
+          process.kill(sessionlessKillPid(pid), 'SIGKILL');
+        } catch {
+          // Process already exited — expected
+        }
+      }, 5000).unref();
+      return { success: true };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      const errorCode =
+        error instanceof Error && 'code' in error && error.code === 'ESRCH'
+          ? ErrorCode.PROCESS_NOT_FOUND
+          : ErrorCode.PROCESS_ERROR;
+
+      return serviceError({
+        message: `Failed to kill process '${commandHandle.pid}': ${errorMessage}`,
+        code: errorCode,
+        details: {
+          processId: String(commandHandle.pid),
+          stderr: errorMessage
+        }
+      });
+    }
+  }
+
+  private async executeOneShot(
+    command: string,
+    options: Omit<ExecutionOptions, 'target' | 'sessionId'>
+  ): Promise<ServiceResult<RawExecResult>> {
+    const startTime = Date.now();
+    let timedOut = false;
+    let subprocessPid: number | undefined;
+    const timeout =
+      options.timeoutMs === undefined
+        ? undefined
+        : setTimeout(() => {
+            timedOut = true;
+            if (subprocessPid !== undefined) {
+              try {
+                process.kill(sessionlessKillPid(subprocessPid), 'SIGKILL');
+              } catch {
+                // Process already exited
+              }
+            }
+          }, options.timeoutMs);
+
+    try {
+      const env = Object.fromEntries(
+        Object.entries(options.env ?? {}).filter(
+          (entry): entry is [string, string] => entry[1] !== undefined
+        )
+      );
+      const subprocess = spawn({
+        cmd: sessionlessCmd(command),
+        cwd: options.cwd ?? DEFAULT_CWD,
+        env: {
+          ...process.env,
+          ...env
+        },
+        stdout: 'pipe',
+        stderr: 'pipe',
+        stdin: 'ignore'
+      });
+
+      subprocessPid = subprocess.pid;
+
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(subprocess.stdout).text(),
+        new Response(subprocess.stderr).text(),
+        subprocess.exited
+      ]);
+
+      if (timedOut) {
+        return serviceSuccess({
+          stdout,
+          stderr: stderr || `Command timed out after ${options.timeoutMs}ms`,
+          exitCode: 124,
+          command,
+          duration: Date.now() - startTime,
+          timestamp: new Date(startTime).toISOString()
+        });
+      }
+
+      return serviceSuccess({
+        stdout,
+        stderr,
+        exitCode,
+        command,
+        duration: Date.now() - startTime,
+        timestamp: new Date(startTime).toISOString()
+      });
+    } catch (error) {
+      if (timedOut) {
+        return serviceSuccess({
+          stdout: '',
+          stderr: `Command timed out after ${options.timeoutMs}ms`,
+          exitCode: 124,
+          command,
+          duration: Date.now() - startTime,
+          timestamp: new Date(startTime).toISOString()
+        });
+      }
+
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+
+      return serviceError({
+        message: `Failed to execute command '${command}': ${errorMessage}`,
+        code: ErrorCode.COMMAND_EXECUTION_ERROR,
+        details: {
+          command,
+          stderr: errorMessage
+        }
+      });
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
+  }
+
+  private async executeStreamOneShot(
+    command: string,
+    onEvent: (event: ExecEvent) => Promise<void>,
+    options: Omit<ExecutionStreamOptions, 'target' | 'sessionId'>
+  ): Promise<ServiceResult<ExecutionStreamResult>> {
+    const startTime = Date.now();
+    let timedOut = false;
+    let subprocessPid: number | undefined;
+    const timeoutHandle =
+      options.timeoutMs === undefined
+        ? undefined
+        : setTimeout(() => {
+            timedOut = true;
+            if (subprocessPid !== undefined) {
+              try {
+                process.kill(sessionlessKillPid(subprocessPid), 'SIGKILL');
+              } catch {
+                // Process already exited
+              }
+            }
+          }, options.timeoutMs);
+
+    try {
+      const env = Object.fromEntries(
+        Object.entries(options.env ?? {}).filter(
+          (entry): entry is [string, string] => entry[1] !== undefined
+        )
+      );
+      const subprocess = spawn({
+        cmd: sessionlessCmd(command),
+        cwd: options.cwd ?? DEFAULT_CWD,
+        env: {
+          ...process.env,
+          ...env
+        },
+        stdout: 'pipe',
+        stderr: 'pipe',
+        stdin: 'ignore'
+      });
+
+      subprocessPid = subprocess.pid;
+
+      const commandHandle: ProcessCommandHandle = {
+        mode: 'sessionless',
+        pid: subprocess.pid
+      };
+
+      await onEvent({
+        type: 'start',
+        timestamp: new Date().toISOString(),
+        command,
+        pid: subprocess.pid,
+        sessionId: SESSIONLESS_SESSION_ID
+      });
+
+      const streamOutput = async (
+        stream: ReadableStream<Uint8Array> | null,
+        type: 'stdout' | 'stderr'
+      ) => {
+        if (!stream) {
+          return;
+        }
+
+        const decoder = new TextDecoder();
+        const reader = stream.getReader();
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) {
+              break;
+            }
+
+            const data = decoder.decode(value, { stream: true });
+            if (data.length > 0) {
+              await onEvent({
+                type,
+                timestamp: new Date().toISOString(),
+                data,
+                command,
+                sessionId: SESSIONLESS_SESSION_ID
+              });
+            }
+          }
+
+          const remaining = decoder.decode();
+          if (remaining.length > 0) {
+            await onEvent({
+              type,
+              timestamp: new Date().toISOString(),
+              data: remaining,
+              command,
+              sessionId: SESSIONLESS_SESSION_ID
+            });
+          }
+        } finally {
+          reader.releaseLock();
+        }
+      };
+
+      const continueStreaming = Promise.all([
+        streamOutput(subprocess.stdout, 'stdout'),
+        streamOutput(subprocess.stderr, 'stderr'),
+        subprocess.exited
+      ])
+        .then(async ([, , exitCode]) => {
+          if (timedOut) {
+            await onEvent({
+              type: 'error',
+              timestamp: new Date().toISOString(),
+              error: `Command timed out after ${options.timeoutMs}ms`,
+              exitCode: 124,
+              command,
+              sessionId: SESSIONLESS_SESSION_ID
+            });
+            return;
+          }
+
+          await onEvent({
+            type: 'complete',
+            timestamp: new Date().toISOString(),
+            exitCode,
+            command,
+            sessionId: SESSIONLESS_SESSION_ID
+          });
+        })
+        .catch(async (error) => {
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
+          await onEvent({
+            type: 'error',
+            timestamp: new Date().toISOString(),
+            error: errorMessage,
+            command,
+            sessionId: SESSIONLESS_SESSION_ID
+          });
+        })
+        .finally(() => {
+          if (timeoutHandle) {
+            clearTimeout(timeoutHandle);
+          }
+        });
+
+      return serviceSuccess({
+        continueStreaming,
+        commandHandle
+      });
+    } catch (error) {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+
+      return serviceError({
+        message: `Failed to start streaming command '${command}': ${errorMessage}`,
+        code: ErrorCode.STREAM_START_ERROR,
+        details: {
+          command,
+          stderr: errorMessage,
+          durationMs: Date.now() - startTime
+        }
+      });
+    }
+  }
+}

--- a/packages/sandbox-container/src/services/file-service.ts
+++ b/packages/sandbox-container/src/services/file-service.ts
@@ -18,7 +18,7 @@ import type {
   WriteOptions
 } from '../core/types';
 import { FileManager } from '../managers/file-manager';
-import type { SessionManager } from './session-manager';
+import type { ExecutionService } from './execution-service';
 
 export interface SecurityService {
   validatePath(path: string): { isValid: boolean; errors: string[] };
@@ -67,13 +67,61 @@ export interface FileSystemOperations {
 
 export class FileService implements FileSystemOperations {
   private manager: FileManager;
+  private executionService: ExecutionService;
 
   constructor(
     private security: SecurityService,
     private logger: Logger,
-    private sessionManager: SessionManager
+    executionService: ExecutionService
   ) {
     this.manager = new FileManager();
+    this.executionService = executionService;
+  }
+
+  private normalizeSessionId(sessionId: string | undefined): string {
+    return (
+      this.executionService.targetToSessionId(
+        this.executionService.resolveTarget({ sessionId })
+      ) ?? 'default'
+    );
+  }
+
+  private withExecution<T>(
+    sessionId: string | undefined,
+    fn: (
+      exec: (
+        command: string,
+        options?: {
+          cwd?: string;
+          env?: Record<string, string | undefined>;
+          timeoutMs?: number;
+          origin?: 'user' | 'internal';
+        }
+      ) => Promise<{
+        exitCode: number;
+        stdout: string;
+        stderr: string;
+      }>
+    ) => Promise<T>
+  ): Promise<ServiceResult<T>> {
+    return this.executionService.withExecution(fn, { sessionId });
+  }
+
+  private executeCommand(
+    sessionId: string | undefined,
+    command: string,
+    options?: {
+      cwd?: string;
+      env?: Record<string, string | undefined>;
+      origin?: 'user' | 'internal';
+    }
+  ) {
+    return this.executionService.execute(command, {
+      sessionId,
+      cwd: options?.cwd,
+      env: options?.env,
+      origin: options?.origin
+    });
   }
 
   async read(
@@ -110,103 +158,100 @@ export class FileService implements FileSystemOperations {
         };
       }
 
-      const result = await this.sessionManager
-        .withSession(sessionId, async (exec) => {
-          const absolutePath = await this.resolvePathInSession(path, exec);
+      const result = await this.withExecution(sessionId, async (exec) => {
+        const absolutePath = await this.resolvePathInSession(path, exec);
 
-          const bunFile = Bun.file(absolutePath);
+        const bunFile = Bun.file(absolutePath);
 
-          const fileExists = await bunFile.exists();
-          if (!fileExists) {
-            throw {
-              message: `File not found: ${path}`,
-              code: ErrorCode.FILE_NOT_FOUND,
-              details: {
-                path,
-                operation: Operation.FILE_READ
-              } satisfies FileNotFoundContext
-            };
-          }
-
-          // Size and MIME type come directly from the BunFile object.
-          const fileSize = bunFile.size;
-          // RPC transfers have a hard limit of 32 MiB to prevent issues for large files, enforce this limit upfront before reading content.
-          if (fileSize > MAX_RPC_FILE_SIZE) {
-            throw {
-              message: `File too large. Size ${fileSize} bytes exceeds the 32 MiB limit. Consider using streaming APIs for large files.`,
-              code: ErrorCode.FILE_TOO_LARGE,
-              details: {
-                path,
-                operation: Operation.FILE_READ,
-                actualSize: fileSize,
-                maxSize: MAX_RPC_FILE_SIZE
-              } satisfies FileTooLargeContext
-            };
-          }
-
-          // Bun.file() derives the MIME type from the file extension and falls back
-          // to 'application/octet-stream' for unknown types.
-          let mimeType = bunFile.type.split(';')[0].trim();
-          if (mimeType === 'application/octet-stream') {
-            const escapedPath = shellEscape(path);
-            const mimeResult = await exec(
-              `file --mime-type -b ${escapedPath}`,
-              { origin: 'internal' }
-            );
-            if (mimeResult.exitCode === 0) {
-              mimeType = mimeResult.stdout.trim();
-            }
-          }
-
-          const isBinary = this.isBinaryMimeType(mimeType);
-
-          // Determine encoding: honour explicit caller preference, otherwise fall
-          // back to MIME-based detection.
-          let actualEncoding: 'utf-8' | 'base64';
-          if (options.encoding === 'base64') {
-            actualEncoding = 'base64';
-          } else if (
-            options.encoding === 'utf-8' ||
-            options.encoding === 'utf8'
-          ) {
-            actualEncoding = 'utf-8';
-          } else {
-            actualEncoding = isBinary ? 'base64' : 'utf-8';
-          }
-
-          // 3. Read file content natively.
-          let content: string;
-          if (actualEncoding === 'base64') {
-            const buffer = await bunFile.arrayBuffer();
-            content = Buffer.from(buffer).toString('base64');
-          } else {
-            content = await bunFile.text();
-          }
-
-          sizeBytes = fileSize;
-
-          return {
-            success: true as const,
-            content,
-            metadata: {
-              encoding: actualEncoding,
-              isBinary: actualEncoding === 'base64',
-              mimeType,
-              size: fileSize
-            }
+        const fileExists = await bunFile.exists();
+        if (!fileExists) {
+          throw {
+            message: `File not found: ${path}`,
+            code: ErrorCode.FILE_NOT_FOUND,
+            details: {
+              path,
+              operation: Operation.FILE_READ
+            } satisfies FileNotFoundContext
           };
-        })
-        .then((r) => {
-          if (!r.success) {
-            return r as ServiceResult<string, FileMetadata>;
-          }
+        }
 
-          return {
-            success: true as const,
-            data: r.data.content,
-            metadata: r.data.metadata
+        // Size and MIME type come directly from the BunFile object.
+        const fileSize = bunFile.size;
+        // RPC transfers have a hard limit of 32 MiB to prevent issues for large files, enforce this limit upfront before reading content.
+        if (fileSize > MAX_RPC_FILE_SIZE) {
+          throw {
+            message: `File too large. Size ${fileSize} bytes exceeds the 32 MiB limit. Consider using streaming APIs for large files.`,
+            code: ErrorCode.FILE_TOO_LARGE,
+            details: {
+              path,
+              operation: Operation.FILE_READ,
+              actualSize: fileSize,
+              maxSize: MAX_RPC_FILE_SIZE
+            } satisfies FileTooLargeContext
           };
-        });
+        }
+
+        // Bun.file() derives the MIME type from the file extension and falls back
+        // to 'application/octet-stream' for unknown types.
+        let mimeType = bunFile.type.split(';')[0].trim();
+        if (mimeType === 'application/octet-stream') {
+          const escapedPath = shellEscape(path);
+          const mimeResult = await exec(`file --mime-type -b ${escapedPath}`, {
+            origin: 'internal'
+          });
+          if (mimeResult.exitCode === 0) {
+            mimeType = mimeResult.stdout.trim();
+          }
+        }
+
+        const isBinary = this.isBinaryMimeType(mimeType);
+
+        // Determine encoding: honour explicit caller preference, otherwise fall
+        // back to MIME-based detection.
+        let actualEncoding: 'utf-8' | 'base64';
+        if (options.encoding === 'base64') {
+          actualEncoding = 'base64';
+        } else if (
+          options.encoding === 'utf-8' ||
+          options.encoding === 'utf8'
+        ) {
+          actualEncoding = 'utf-8';
+        } else {
+          actualEncoding = isBinary ? 'base64' : 'utf-8';
+        }
+
+        // 3. Read file content natively.
+        let content: string;
+        if (actualEncoding === 'base64') {
+          const buffer = await bunFile.arrayBuffer();
+          content = Buffer.from(buffer).toString('base64');
+        } else {
+          content = await bunFile.text();
+        }
+
+        sizeBytes = fileSize;
+
+        return {
+          success: true as const,
+          content,
+          metadata: {
+            encoding: actualEncoding,
+            isBinary: actualEncoding === 'base64',
+            mimeType,
+            size: fileSize
+          }
+        };
+      }).then((r) => {
+        if (!r.success) {
+          return r as ServiceResult<string, FileMetadata>;
+        }
+
+        return {
+          success: true as const,
+          data: r.data.content,
+          metadata: r.data.metadata
+        };
+      });
 
       outcome = result.success ? 'success' : 'error';
       if (!result.success) {
@@ -300,51 +345,48 @@ export class FileService implements FileSystemOperations {
         }
       }
 
-      const writeResult = await this.sessionManager.withSession(
-        sessionId,
-        async (exec) => {
-          let targetPath = path;
+      const writeResult = await this.withExecution(sessionId, async (exec) => {
+        let targetPath = path;
 
-          if (!path.startsWith('/')) {
-            const pwdResult = await exec('pwd', { origin: 'internal' });
-            if (pwdResult.exitCode !== 0) {
-              throw {
-                code: ErrorCode.FILESYSTEM_ERROR,
-                message: `Failed to resolve working directory for '${path}'`,
-                details: {
-                  path,
-                  operation: Operation.FILE_WRITE,
-                  exitCode: pwdResult.exitCode,
-                  stderr: pwdResult.stderr
-                } satisfies FileSystemContext
-              };
-            }
-
-            const cwd = pwdResult.stdout.trim();
-            targetPath = resolve(cwd, path);
-          }
-
-          try {
-            const data =
-              normalizedEncoding === 'base64'
-                ? Buffer.from(content, 'base64')
-                : content;
-            await Bun.write(targetPath, data);
-          } catch (error) {
-            const errorMessage =
-              error instanceof Error ? error.message : 'Unknown error';
+        if (!path.startsWith('/')) {
+          const pwdResult = await exec('pwd', { origin: 'internal' });
+          if (pwdResult.exitCode !== 0) {
             throw {
               code: ErrorCode.FILESYSTEM_ERROR,
-              message: `Failed to write file '${path}': ${errorMessage}`,
+              message: `Failed to resolve working directory for '${path}'`,
               details: {
                 path,
                 operation: Operation.FILE_WRITE,
-                stderr: errorMessage
+                exitCode: pwdResult.exitCode,
+                stderr: pwdResult.stderr
               } satisfies FileSystemContext
             };
           }
+
+          const cwd = pwdResult.stdout.trim();
+          targetPath = resolve(cwd, path);
         }
-      );
+
+        try {
+          const data =
+            normalizedEncoding === 'base64'
+              ? Buffer.from(content, 'base64')
+              : content;
+          await Bun.write(targetPath, data);
+        } catch (error) {
+          const errorMessage =
+            error instanceof Error ? error.message : 'Unknown error';
+          throw {
+            code: ErrorCode.FILESYSTEM_ERROR,
+            message: `Failed to write file '${path}': ${errorMessage}`,
+            details: {
+              path,
+              operation: Operation.FILE_WRITE,
+              stderr: errorMessage
+            } satisfies FileSystemContext
+          };
+        }
+      });
 
       if (!writeResult.success) {
         outcome = 'error';
@@ -427,59 +469,56 @@ export class FileService implements FileSystemOperations {
       // 2. Execute exists→isdir→rm sequence atomically within session
       const escapedPath = shellEscape(path);
 
-      const result = await this.sessionManager.withSession(
-        sessionId,
-        async (exec) => {
-          // Check if file exists
-          const existsResult = await exec(`test -e ${escapedPath}`, {
-            origin: 'internal'
-          });
-          if (existsResult.exitCode !== 0) {
-            throw {
-              code: ErrorCode.FILE_NOT_FOUND,
-              message: `File not found: ${path}`,
-              details: {
-                path,
-                operation: Operation.FILE_DELETE
-              } satisfies FileNotFoundContext
-            };
-          }
-
-          // Check if path is a directory (deleteFile only works on files)
-          const isDirResult = await exec(`test -d ${escapedPath}`, {
-            origin: 'internal'
-          });
-          if (isDirResult.exitCode === 0) {
-            throw {
-              code: ErrorCode.IS_DIRECTORY,
-              message: `Cannot delete directory with deleteFile() at '${path}'. Use exec('rm -rf <path>') instead.`,
-              details: {
-                path,
-                operation: Operation.FILE_DELETE
-              } satisfies FileSystemContext
-            };
-          }
-
-          // Delete file using rm command
-          const command = `rm ${escapedPath}`;
-          const rmResult = await exec(command, { origin: 'internal' });
-
-          if (rmResult.exitCode !== 0) {
-            throw {
-              code: ErrorCode.FILESYSTEM_ERROR,
-              message: `Failed to delete file '${path}': ${
-                rmResult.stderr || `exit code ${rmResult.exitCode}`
-              }`,
-              details: {
-                path,
-                operation: Operation.FILE_DELETE,
-                exitCode: rmResult.exitCode,
-                stderr: rmResult.stderr
-              } satisfies FileSystemContext
-            };
-          }
+      const result = await this.withExecution(sessionId, async (exec) => {
+        // Check if file exists
+        const existsResult = await exec(`test -e ${escapedPath}`, {
+          origin: 'internal'
+        });
+        if (existsResult.exitCode !== 0) {
+          throw {
+            code: ErrorCode.FILE_NOT_FOUND,
+            message: `File not found: ${path}`,
+            details: {
+              path,
+              operation: Operation.FILE_DELETE
+            } satisfies FileNotFoundContext
+          };
         }
-      );
+
+        // Check if path is a directory (deleteFile only works on files)
+        const isDirResult = await exec(`test -d ${escapedPath}`, {
+          origin: 'internal'
+        });
+        if (isDirResult.exitCode === 0) {
+          throw {
+            code: ErrorCode.IS_DIRECTORY,
+            message: `Cannot delete directory with deleteFile() at '${path}'. Use exec('rm -rf <path>') instead.`,
+            details: {
+              path,
+              operation: Operation.FILE_DELETE
+            } satisfies FileSystemContext
+          };
+        }
+
+        // Delete file using rm command
+        const command = `rm ${escapedPath}`;
+        const rmResult = await exec(command, { origin: 'internal' });
+
+        if (rmResult.exitCode !== 0) {
+          throw {
+            code: ErrorCode.FILESYSTEM_ERROR,
+            message: `Failed to delete file '${path}': ${
+              rmResult.stderr || `exit code ${rmResult.exitCode}`
+            }`,
+            details: {
+              path,
+              operation: Operation.FILE_DELETE,
+              exitCode: rmResult.exitCode,
+              stderr: rmResult.stderr
+            } satisfies FileSystemContext
+          };
+        }
+      });
 
       outcome = result.success ? 'success' : 'error';
       if (!result.success) {
@@ -561,11 +600,9 @@ export class FileService implements FileSystemOperations {
       const escapedNewPath = shellEscape(newPath);
       const command = `mv ${escapedOldPath} ${escapedNewPath}`;
 
-      const execResult = await this.sessionManager.executeInSession(
-        sessionId,
-        command,
-        { origin: 'internal' }
-      );
+      const execResult = await this.executeCommand(sessionId, command, {
+        origin: 'internal'
+      });
 
       if (!execResult.success) {
         return execResult as ServiceResult<void>;
@@ -658,11 +695,9 @@ export class FileService implements FileSystemOperations {
       const escapedDest = shellEscape(destinationPath);
       const command = `mv ${escapedSource} ${escapedDest}`;
 
-      const execResult = await this.sessionManager.executeInSession(
-        sessionId,
-        command,
-        { origin: 'internal' }
-      );
+      const execResult = await this.executeCommand(sessionId, command, {
+        origin: 'internal'
+      });
 
       if (!execResult.success) {
         return execResult as ServiceResult<void>;
@@ -752,11 +787,9 @@ export class FileService implements FileSystemOperations {
       command += ` ${escapedPath}`;
 
       // 4. Create directory using SessionManager
-      const execResult = await this.sessionManager.executeInSession(
-        sessionId,
-        command,
-        { origin: 'internal' }
-      );
+      const execResult = await this.executeCommand(sessionId, command, {
+        origin: 'internal'
+      });
 
       if (!execResult.success) {
         outcome = 'error';
@@ -847,11 +880,9 @@ export class FileService implements FileSystemOperations {
       const escapedPath = shellEscape(path);
       const command = `test -e ${escapedPath}`;
 
-      const execResult = await this.sessionManager.executeInSession(
-        sessionId,
-        command,
-        { origin: 'internal' }
-      );
+      const execResult = await this.executeCommand(sessionId, command, {
+        origin: 'internal'
+      });
 
       if (!execResult.success) {
         // If execution fails, treat as non-existent
@@ -945,11 +976,9 @@ export class FileService implements FileSystemOperations {
       const command = `stat ${statCmd.args[0]} ${statCmd.args[1]} ${escapedPath}`;
 
       // 5. Get file stats using SessionManager
-      const execResult = await this.sessionManager.executeInSession(
-        sessionId,
-        command,
-        { origin: 'internal' }
-      );
+      const execResult = await this.executeCommand(sessionId, command, {
+        origin: 'internal'
+      });
 
       if (!execResult.success) {
         return execResult as ServiceResult<FileStats>;
@@ -1149,69 +1178,66 @@ export class FileService implements FileSystemOperations {
         };
       }
 
-      const writeResult = await this.sessionManager.withSession(
-        sessionId,
-        async (exec) => {
-          let targetPath = path;
+      const writeResult = await this.withExecution(sessionId, async (exec) => {
+        let targetPath = path;
 
-          if (!path.startsWith('/')) {
-            const pwdResult = await exec('pwd');
-            if (pwdResult.exitCode !== 0) {
-              throw {
-                code: ErrorCode.FILESYSTEM_ERROR,
-                message: `Failed to resolve working directory for '${path}'`,
-                details: {
-                  path,
-                  operation: Operation.FILE_WRITE,
-                  exitCode: pwdResult.exitCode,
-                  stderr: pwdResult.stderr
-                } satisfies FileSystemContext
-              };
-            }
-            const cwd = pwdResult.stdout.trim();
-            targetPath = resolve(cwd, path);
+        if (!path.startsWith('/')) {
+          const pwdResult = await exec('pwd');
+          if (pwdResult.exitCode !== 0) {
+            throw {
+              code: ErrorCode.FILESYSTEM_ERROR,
+              message: `Failed to resolve working directory for '${path}'`,
+              details: {
+                path,
+                operation: Operation.FILE_WRITE,
+                exitCode: pwdResult.exitCode,
+                stderr: pwdResult.stderr
+              } satisfies FileSystemContext
+            };
           }
-
-          // Ensure parent directory exists
-          const dir = targetPath.substring(0, targetPath.lastIndexOf('/'));
-          if (dir) {
-            await exec(`mkdir -p ${shellEscape(dir)}`);
-          }
-
-          // Atomic write: stream to a temporary file, then rename into place.
-          // Prevents partial reads if another process opens the file mid-write.
-          // Preserves the original file's permission bits (e.g. executables).
-          const tmpPath = `${targetPath}.tmp.${crypto.randomUUID()}`;
-          const existingMode = await stat(targetPath)
-            .then((s) => s.mode)
-            .catch(() => null);
-          const writer = Bun.file(tmpPath).writer();
-          let bytesWritten = 0;
-          const reader = stream.getReader();
-          try {
-            while (true) {
-              const { done, value } = await reader.read();
-              if (done) break;
-              writer.write(value);
-              bytesWritten += value.byteLength;
-            }
-            await writer.flush();
-            writer.end();
-            reader.releaseLock();
-            if (existingMode !== null) {
-              await chmod(tmpPath, existingMode);
-            }
-            await rename(tmpPath, targetPath);
-          } catch (err) {
-            writer.end();
-            reader.releaseLock();
-            await stream.cancel().catch(() => {});
-            await unlink(tmpPath).catch(() => {});
-            throw err;
-          }
-          return { bytesWritten };
+          const cwd = pwdResult.stdout.trim();
+          targetPath = resolve(cwd, path);
         }
-      );
+
+        // Ensure parent directory exists
+        const dir = targetPath.substring(0, targetPath.lastIndexOf('/'));
+        if (dir) {
+          await exec(`mkdir -p ${shellEscape(dir)}`);
+        }
+
+        // Atomic write: stream to a temporary file, then rename into place.
+        // Prevents partial reads if another process opens the file mid-write.
+        // Preserves the original file's permission bits (e.g. executables).
+        const tmpPath = `${targetPath}.tmp.${crypto.randomUUID()}`;
+        const existingMode = await stat(targetPath)
+          .then((s) => s.mode)
+          .catch(() => null);
+        const writer = Bun.file(tmpPath).writer();
+        let bytesWritten = 0;
+        const reader = stream.getReader();
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            writer.write(value);
+            bytesWritten += value.byteLength;
+          }
+          await writer.flush();
+          writer.end();
+          reader.releaseLock();
+          if (existingMode !== null) {
+            await chmod(tmpPath, existingMode);
+          }
+          await rename(tmpPath, targetPath);
+        } catch (err) {
+          writer.end();
+          reader.releaseLock();
+          await stream.cancel().catch(() => {});
+          await unlink(tmpPath).catch(() => {});
+          throw err;
+        }
+        return { bytesWritten };
+      });
 
       if (!writeResult.success) {
         return writeResult as ServiceResult<{ bytesWritten: number }>;
@@ -1382,11 +1408,9 @@ export class FileService implements FileSystemOperations {
       // Skip the base directory itself and format output
       findCommand += ` -not -path ${escapedPath} -printf '%p\\t%y\\t%s\\t%TY-%Tm-%TdT%TH:%TM:%TS\\t%m\\n'`;
 
-      const execResult = await this.sessionManager.executeInSession(
-        sessionId,
-        findCommand,
-        { origin: 'internal' }
-      );
+      const execResult = await this.executeCommand(sessionId, findCommand, {
+        origin: 'internal'
+      });
 
       if (!execResult.success) {
         return {
@@ -1570,116 +1594,114 @@ export class FileService implements FileSystemOperations {
 
     const CHUNK_SIZE = 65535;
 
-    return await this.sessionManager
-      .withSession(sessionId, async (exec) => {
-        const absolutePath = await this.resolvePathInSession(path, exec);
-        const metadataResult = await this.getFileMetadata(absolutePath, exec);
+    return await this.withExecution(sessionId, async (exec) => {
+      const absolutePath = await this.resolvePathInSession(path, exec);
+      const metadataResult = await this.getFileMetadata(absolutePath, exec);
 
-        if (!metadataResult.success) {
-          return new ReadableStream({
-            start(controller) {
-              const errorEvent = {
-                type: 'error',
-                error: metadataResult.error.message
-              };
-              controller.enqueue(
-                encoder.encode(`data: ${JSON.stringify(errorEvent)}\n\n`)
-              );
-              controller.close();
-            }
-          });
-        }
-
-        const metadata = metadataResult.data;
-
-        const fileStream = Bun.file(absolutePath).stream();
-
-        // Carry-over buffer for chunks that arrive smaller than CHUNK_SIZE from
-        // Bun's internal read buffer so we always emit full-sized SSE events.
-        let carry = new Uint8Array(0);
-        let totalBytesEmitted = 0;
-
-        const sseTransform = new TransformStream<Uint8Array, Uint8Array>({
+      if (!metadataResult.success) {
+        return new ReadableStream({
           start(controller) {
-            // Emit the metadata SSE event as the very first bytes of the stream.
-            const metadataEvent = {
-              type: 'metadata',
-              mimeType: metadata.mimeType,
-              size: metadata.size,
-              isBinary: metadata.isBinary,
-              encoding: metadata.encoding
+            const errorEvent = {
+              type: 'error',
+              error: metadataResult.error.message
             };
             controller.enqueue(
-              encoder.encode(`data: ${JSON.stringify(metadataEvent)}\n\n`)
+              encoder.encode(`data: ${JSON.stringify(errorEvent)}\n\n`)
             );
-          },
-
-          transform(incoming, controller) {
-            const combined = new Uint8Array(carry.length + incoming.length);
-            combined.set(carry);
-            combined.set(incoming, carry.length);
-
-            let offset = 0;
-            while (offset + CHUNK_SIZE <= combined.length) {
-              const slice = combined.subarray(offset, offset + CHUNK_SIZE);
-              emitChunk(
-                slice,
-                metadata.isBinary,
-                encoder,
-                decoder,
-                controller,
-                true
-              );
-              totalBytesEmitted += slice.length;
-              offset += CHUNK_SIZE;
-            }
-
-            carry = combined.subarray(offset);
-          },
-
-          flush(controller) {
-            if (carry.length > 0) {
-              emitChunk(
-                carry,
-                metadata.isBinary,
-                encoder,
-                decoder,
-                controller,
-                false
-              );
-              totalBytesEmitted += carry.length;
-              carry = new Uint8Array(0);
-            }
-            if (!metadata.isBinary) {
-              const remaining = decoder.decode();
-              if (remaining.length > 0) {
-                const chunkEvent = { type: 'chunk', data: remaining };
-                controller.enqueue(
-                  encoder.encode(`data: ${JSON.stringify(chunkEvent)}\n\n`)
-                );
-              }
-            }
-
-            const completeEvent = {
-              type: 'complete',
-              bytesRead: totalBytesEmitted
-            };
-            controller.enqueue(
-              encoder.encode(`data: ${JSON.stringify(completeEvent)}\n\n`)
-            );
+            controller.close();
           }
         });
+      }
 
-        return fileStream.pipeThrough(sseTransform);
-      })
-      .then((result) => {
-        if (!result.success) {
-          throw new Error(
-            `Failed to create file stream: ${result.error.message}`
+      const metadata = metadataResult.data;
+
+      const fileStream = Bun.file(absolutePath).stream();
+
+      // Carry-over buffer for chunks that arrive smaller than CHUNK_SIZE from
+      // Bun's internal read buffer so we always emit full-sized SSE events.
+      let carry = new Uint8Array(0);
+      let totalBytesEmitted = 0;
+
+      const sseTransform = new TransformStream<Uint8Array, Uint8Array>({
+        start(controller) {
+          // Emit the metadata SSE event as the very first bytes of the stream.
+          const metadataEvent = {
+            type: 'metadata',
+            mimeType: metadata.mimeType,
+            size: metadata.size,
+            isBinary: metadata.isBinary,
+            encoding: metadata.encoding
+          };
+          controller.enqueue(
+            encoder.encode(`data: ${JSON.stringify(metadataEvent)}\n\n`)
+          );
+        },
+
+        transform(incoming, controller) {
+          const combined = new Uint8Array(carry.length + incoming.length);
+          combined.set(carry);
+          combined.set(incoming, carry.length);
+
+          let offset = 0;
+          while (offset + CHUNK_SIZE <= combined.length) {
+            const slice = combined.subarray(offset, offset + CHUNK_SIZE);
+            emitChunk(
+              slice,
+              metadata.isBinary,
+              encoder,
+              decoder,
+              controller,
+              true
+            );
+            totalBytesEmitted += slice.length;
+            offset += CHUNK_SIZE;
+          }
+
+          carry = combined.subarray(offset);
+        },
+
+        flush(controller) {
+          if (carry.length > 0) {
+            emitChunk(
+              carry,
+              metadata.isBinary,
+              encoder,
+              decoder,
+              controller,
+              false
+            );
+            totalBytesEmitted += carry.length;
+            carry = new Uint8Array(0);
+          }
+          if (!metadata.isBinary) {
+            const remaining = decoder.decode();
+            if (remaining.length > 0) {
+              const chunkEvent = { type: 'chunk', data: remaining };
+              controller.enqueue(
+                encoder.encode(`data: ${JSON.stringify(chunkEvent)}\n\n`)
+              );
+            }
+          }
+
+          const completeEvent = {
+            type: 'complete',
+            bytesRead: totalBytesEmitted
+          };
+          controller.enqueue(
+            encoder.encode(`data: ${JSON.stringify(completeEvent)}\n\n`)
           );
         }
-        return result.data;
       });
+
+      return fileStream.pipeThrough(sseTransform);
+    }).then((result) => {
+      if (!result.success) {
+        throw new Error(
+          `Failed to create file stream: ${result.error.message}`
+        );
+      }
+      return result.data;
+    });
   }
 
   /*
@@ -1729,9 +1751,8 @@ export class FileService implements FileSystemOperations {
     // Resolve relative paths via the session's working directory.
     let resolvedPath = path;
     if (!path.startsWith('/')) {
-      const result = await this.sessionManager.withSession(
-        sessionId,
-        async (exec) => this.resolvePathInSession(path, exec)
+      const result = await this.withExecution(sessionId, async (exec) =>
+        this.resolvePathInSession(path, exec)
       );
       if (!result.success) {
         return {

--- a/packages/sandbox-container/src/services/git-service.ts
+++ b/packages/sandbox-container/src/services/git-service.ts
@@ -15,7 +15,7 @@ import type {
 import { ErrorCode } from '@repo/shared/errors';
 import type { CloneOptions, ServiceError, ServiceResult } from '../core/types';
 import { GitManager, gitCloneTimeoutSeconds } from '../managers/git-manager';
-import type { SessionManager } from './session-manager';
+import type { ExecutionService } from './execution-service';
 
 export interface SecurityService {
   validateGitUrl(url: string): { isValid: boolean; errors: string[] };
@@ -27,7 +27,7 @@ export class GitService {
 
   constructor(
     private security: SecurityService,
-    private sessionManager: SessionManager,
+    private executionService: ExecutionService,
     private logger: Logger
   ) {
     this.manager = new GitManager();
@@ -69,7 +69,11 @@ export class GitService {
     let outcome: 'success' | 'error' = 'error';
     let caughtError: Error | undefined;
     let errorMessage: string | undefined;
-    const sessionId = options.sessionId || 'default';
+    const target = this.executionService.resolveTarget({
+      sessionId: options.sessionId
+    });
+    const sessionId =
+      this.executionService.targetToSessionId(target) ?? 'default';
 
     try {
       // Validate repository URL
@@ -137,70 +141,73 @@ export class GitService {
       );
       const command = this.buildCommand(args);
 
-      const result = await this.sessionManager
-        .withSession(sessionId, async (exec) => {
-          // Execute git clone
-          const cloneResult = await exec(command, { origin: 'internal' });
+      const result = await this.executionService
+        .withExecution(
+          async (exec) => {
+            // Execute git clone
+            const cloneResult = await exec(command, { origin: 'internal' });
 
-          if (cloneResult.exitCode !== 0) {
-            if (cloneResult.exitCode === 124) {
+            if (cloneResult.exitCode !== 0) {
+              if (cloneResult.exitCode === 124) {
+                throw {
+                  message: `Git clone timed out after ${gitCloneTimeoutSeconds(
+                    cloneTimeoutMs
+                  )} seconds for '${redactCommand(repoUrl)}'`,
+                  code: ErrorCode.GIT_NETWORK_ERROR,
+                  details: {
+                    repository: redactCommand(repoUrl),
+                    targetDir: targetDirectory,
+                    exitCode: 124,
+                    stderr: 'Operation timed out'
+                  } satisfies GitErrorContext
+                };
+              }
+
+              const errorCode = this.manager.determineErrorCode(
+                'clone',
+                cloneResult.stderr || 'Unknown error',
+                cloneResult.exitCode
+              );
               throw {
-                message: `Git clone timed out after ${gitCloneTimeoutSeconds(
-                  cloneTimeoutMs
-                )} seconds for '${redactCommand(repoUrl)}'`,
-                code: ErrorCode.GIT_NETWORK_ERROR,
+                message: `Failed to clone repository '${redactCommand(repoUrl)}': ${
+                  redactCommand(cloneResult.stderr || '') ||
+                  `exit code ${cloneResult.exitCode}`
+                }`,
+                code: errorCode,
                 details: {
                   repository: redactCommand(repoUrl),
                   targetDir: targetDirectory,
-                  exitCode: 124,
-                  stderr: 'Operation timed out'
+                  exitCode: cloneResult.exitCode,
+                  stderr: redactCommand(cloneResult.stderr || '')
                 } satisfies GitErrorContext
               };
             }
 
-            const errorCode = this.manager.determineErrorCode(
-              'clone',
-              cloneResult.stderr || 'Unknown error',
-              cloneResult.exitCode
-            );
-            throw {
-              message: `Failed to clone repository '${redactCommand(repoUrl)}': ${
-                redactCommand(cloneResult.stderr || '') ||
-                `exit code ${cloneResult.exitCode}`
-              }`,
-              code: errorCode,
-              details: {
-                repository: redactCommand(repoUrl),
-                targetDir: targetDirectory,
-                exitCode: cloneResult.exitCode,
-                stderr: redactCommand(cloneResult.stderr || '')
-              } satisfies GitErrorContext
+            // Determine the actual branch that was checked out by querying Git
+            // This ensures we always return the true current branch, whether it was
+            // explicitly specified or defaulted to the repository's HEAD
+            const branchArgs = this.manager.buildGetCurrentBranchArgs();
+            const branchCommand = this.buildCommand(branchArgs);
+            const branchResult = await exec(branchCommand, {
+              cwd: targetDirectory,
+              origin: 'internal'
+            });
+
+            let actualBranch: string;
+            if (branchResult.exitCode === 0 && branchResult.stdout.trim()) {
+              actualBranch = branchResult.stdout.trim();
+            } else {
+              // Fallback: use the requested branch or 'unknown'
+              actualBranch = options.branch || 'unknown';
+            }
+
+            return {
+              path: targetDirectory,
+              branch: actualBranch
             };
-          }
-
-          // Determine the actual branch that was checked out by querying Git
-          // This ensures we always return the true current branch, whether it was
-          // explicitly specified or defaulted to the repository's HEAD
-          const branchArgs = this.manager.buildGetCurrentBranchArgs();
-          const branchCommand = this.buildCommand(branchArgs);
-          const branchResult = await exec(branchCommand, {
-            cwd: targetDirectory,
-            origin: 'internal'
-          });
-
-          let actualBranch: string;
-          if (branchResult.exitCode === 0 && branchResult.stdout.trim()) {
-            actualBranch = branchResult.stdout.trim();
-          } else {
-            // Fallback: use the requested branch or 'unknown'
-            actualBranch = options.branch || 'unknown';
-          }
-
-          return {
-            path: targetDirectory,
-            branch: actualBranch
-          };
-        })
+          },
+          { target }
+        )
         .then((r) => {
           if (!r.success) {
             return r as ServiceResult<{ path: string; branch: string }>;
@@ -252,6 +259,9 @@ export class GitService {
     let outcome: 'success' | 'error' = 'error';
     let caughtError: Error | undefined;
     let errorMessage: string | undefined;
+    const target = this.executionService.resolveTarget({ sessionId });
+    const resolvedSessionId =
+      this.executionService.targetToSessionId(target) ?? 'default';
 
     try {
       // Validate repository path
@@ -295,11 +305,11 @@ export class GitService {
       const command = this.buildCommand(args);
 
       // Execute git checkout (via SessionManager)
-      const execResult = await this.sessionManager.executeInSession(
-        sessionId,
-        command,
-        { cwd: repoPath, origin: 'internal' }
-      );
+      const execResult = await this.executionService.execute(command, {
+        target,
+        cwd: repoPath,
+        origin: 'internal'
+      });
 
       if (!execResult.success) {
         outcome = 'error';
@@ -353,7 +363,7 @@ export class GitService {
         durationMs: Date.now() - startTime,
         repoPath,
         branch,
-        sessionId,
+        sessionId: resolvedSessionId,
         errorMessage,
         error: caughtError
       });
@@ -364,6 +374,7 @@ export class GitService {
     repoPath: string,
     sessionId = 'default'
   ): Promise<ServiceResult<string>> {
+    const target = this.executionService.resolveTarget({ sessionId });
     try {
       // Validate repository path
       const pathValidation = this.security.validatePath(repoPath);
@@ -385,12 +396,11 @@ export class GitService {
       const args = this.manager.buildGetCurrentBranchArgs();
       const command = this.buildCommand(args);
 
-      // Execute command (via SessionManager)
-      const execResult = await this.sessionManager.executeInSession(
-        sessionId,
-        command,
-        { cwd: repoPath, origin: 'internal' }
-      );
+      const execResult = await this.executionService.execute(command, {
+        target,
+        cwd: repoPath,
+        origin: 'internal'
+      });
 
       if (!execResult.success) {
         return execResult as ServiceResult<string>;
@@ -439,6 +449,7 @@ export class GitService {
     repoPath: string,
     sessionId = 'default'
   ): Promise<ServiceResult<string[]>> {
+    const target = this.executionService.resolveTarget({ sessionId });
     try {
       // Validate repository path
       const pathValidation = this.security.validatePath(repoPath);
@@ -460,12 +471,11 @@ export class GitService {
       const args = this.manager.buildListBranchesArgs();
       const command = this.buildCommand(args);
 
-      // Execute command (via SessionManager)
-      const execResult = await this.sessionManager.executeInSession(
-        sessionId,
-        command,
-        { cwd: repoPath, origin: 'internal' }
-      );
+      const execResult = await this.executionService.execute(command, {
+        target,
+        cwd: repoPath,
+        origin: 'internal'
+      });
 
       if (!execResult.success) {
         return execResult as ServiceResult<string[]>;

--- a/packages/sandbox-container/src/services/process-service.ts
+++ b/packages/sandbox-container/src/services/process-service.ts
@@ -1,22 +1,21 @@
-import { existsSync } from 'node:fs';
-import { type Logger, logCanonicalEvent } from '@repo/shared';
+import { type ExecEvent, type Logger, logCanonicalEvent } from '@repo/shared';
 import type {
   CommandErrorContext,
   ProcessErrorContext,
   ProcessNotFoundContext
 } from '@repo/shared/errors';
 import { ErrorCode } from '@repo/shared/errors';
-import { spawn } from 'bun';
 import type {
   CommandResult,
+  ExecutionTarget,
   ProcessOptions,
   ProcessRecord,
   ProcessStatus,
   ServiceResult
 } from '../core/types';
 import { ProcessManager } from '../managers/process-manager';
+import type { ExecutionService } from './execution-service';
 import type { ProcessStore } from './process-store';
-import type { SessionManager } from './session-manager';
 
 // Re-export types for use by ProcessStore implementations
 export type { ProcessRecord, ProcessStatus } from '../core/types';
@@ -32,9 +31,15 @@ export class ProcessService {
   constructor(
     private store: ProcessStore,
     private logger: Logger,
-    private sessionManager: SessionManager
+    private executionService: ExecutionService
   ) {
     this.manager = new ProcessManager();
+  }
+
+  private resolveExecutionTarget(options: ProcessOptions): ExecutionTarget {
+    return this.executionService.resolveTarget({
+      sessionId: options.sessionId
+    });
   }
 
   /**
@@ -53,23 +58,14 @@ export class ProcessService {
     command: string,
     options: ProcessOptions = {}
   ): Promise<ServiceResult<CommandResult>> {
-    if (options.sessionless) {
-      return this.executeCommandOneShot(command, options);
-    }
-
     try {
-      // Always use SessionManager for execution (unified model)
-      const sessionId = options.sessionId || 'default';
-      const result = await this.sessionManager.executeInSession(
-        sessionId,
-        command,
-        {
-          cwd: options.cwd,
-          timeoutMs: options.timeoutMs,
-          env: options.env,
-          origin: options.origin
-        }
-      );
+      const result = await this.executionService.execute(command, {
+        sessionId: options.sessionId,
+        cwd: options.cwd,
+        timeoutMs: options.timeoutMs,
+        env: options.env,
+        origin: options.origin
+      });
 
       if (!result.success) {
         return result as ServiceResult<CommandResult>;
@@ -105,109 +101,6 @@ export class ProcessService {
     }
   }
 
-  private async executeCommandOneShot(
-    command: string,
-    options: ProcessOptions
-  ): Promise<ServiceResult<CommandResult>> {
-    const validation = this.manager.validateCommand(command);
-    if (!validation.valid) {
-      return {
-        success: false,
-        error: {
-          message: validation.error || 'Invalid command',
-          code: validation.code || 'INVALID_COMMAND'
-        }
-      };
-    }
-
-    const controller = new AbortController();
-    const timeout =
-      options.timeoutMs === undefined
-        ? undefined
-        : setTimeout(() => controller.abort(), options.timeoutMs);
-
-    try {
-      const env = Object.fromEntries(
-        Object.entries(options.env ?? {}).filter(
-          (entry): entry is [string, string] => entry[1] !== undefined
-        )
-      );
-      const subprocess = spawn({
-        cmd: ['bash', '-lc', command],
-        cwd:
-          options.cwd ??
-          (existsSync('/workspace') ? '/workspace' : process.cwd()),
-        env: {
-          ...process.env,
-          ...env
-        },
-        stdout: 'pipe',
-        stderr: 'pipe',
-        stdin: 'ignore',
-        signal: controller.signal
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([
-        new Response(subprocess.stdout).text(),
-        new Response(subprocess.stderr).text(),
-        subprocess.exited
-      ]);
-
-      if (controller.signal.aborted) {
-        return {
-          success: true,
-          data: {
-            success: false,
-            exitCode: 124,
-            stdout: '',
-            stderr: `Command timed out after ${options.timeoutMs}ms`
-          }
-        };
-      }
-
-      return {
-        success: true,
-        data: {
-          success: exitCode === 0,
-          exitCode,
-          stdout,
-          stderr
-        }
-      };
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-
-      if (controller.signal.aborted) {
-        return {
-          success: true,
-          data: {
-            success: false,
-            exitCode: 124,
-            stdout: '',
-            stderr: `Command timed out after ${options.timeoutMs}ms`
-          }
-        };
-      }
-
-      return {
-        success: false,
-        error: {
-          message: `Failed to execute command '${command}': ${errorMessage}`,
-          code: ErrorCode.COMMAND_EXECUTION_ERROR,
-          details: {
-            command,
-            stderr: errorMessage
-          } satisfies CommandErrorContext
-        }
-      };
-    } finally {
-      if (timeout) {
-        clearTimeout(timeout);
-      }
-    }
-  }
-
   /**
    * Execute a command with streaming output via SessionManager
    * Used by both execStream() and startProcess()
@@ -216,11 +109,9 @@ export class ProcessService {
     command: string,
     options: ProcessOptions = {}
   ): Promise<ServiceResult<ProcessRecord>> {
-    if (options.sessionless) {
-      return this.executeCommandStreamOneShot(command, options);
-    }
-
     const startTime = Date.now();
+    const target = this.resolveExecutionTarget(options);
+    const resolvedSessionId = this.executionService.targetToSessionId(target);
     try {
       // 1. Validate command (business logic via manager)
       const validation = this.manager.validateCommand(command);
@@ -238,30 +129,22 @@ export class ProcessService {
       const processRecordData = this.manager.createProcessRecord(
         command,
         undefined,
-        options
+        {
+          ...options,
+          sessionId: resolvedSessionId
+        }
       );
 
-      // 3. Build full process record with commandHandle instead of subprocess
-      const sessionId = options.sessionId || 'default';
       const processRecord: ProcessRecord = {
-        ...processRecordData,
-        commandHandle: {
-          sessionId,
-          commandId: processRecordData.id // Use process ID as command ID
-        }
+        ...processRecordData
       };
 
-      // 4. Store record (data layer)
+      // 3. Store record (data layer)
       await this.store.create(processRecord);
 
-      // 5. Execute command via SessionManager with streaming
-      // Pass process ID as commandId for tracking and killing
-      // CRITICAL: Await the initial result to ensure command is tracked before returning
-      const streamResult = await this.sessionManager.executeStreamInSession(
-        sessionId,
+      const streamResult = await this.executionService.executeStream(
         command,
-        async (event) => {
-          // Route events to process record listeners
+        async (event: ExecEvent) => {
           if (event.type === 'start' && event.pid !== undefined) {
             processRecord.pid = event.pid;
             await this.store.update(processRecord.id, { pid: event.pid });
@@ -272,7 +155,7 @@ export class ProcessService {
               pid: event.pid,
               durationMs: Date.now() - startTime,
               processId: processRecord.id,
-              sessionId,
+              sessionId: resolvedSessionId,
               origin: options.origin
             });
           } else if (event.type === 'stdout' && event.data) {
@@ -305,15 +188,10 @@ export class ProcessService {
                   ? endTime.getTime() - processRecord.startTime.getTime()
                   : Date.now() - startTime,
               processId: processRecord.id,
-              sessionId,
+              sessionId: resolvedSessionId,
               origin: options.origin
             });
 
-            processRecord.statusListeners.forEach((listener) => {
-              listener(status);
-            });
-
-            // Await store update to ensure consistency before next event
             try {
               await this.store.update(processRecord.id, {
                 status,
@@ -329,43 +207,72 @@ export class ProcessService {
                 }
               );
             }
-          } else if (event.type === 'error') {
-            processRecord.status = 'error';
-            processRecord.endTime = new Date();
+
             processRecord.statusListeners.forEach((listener) => {
-              listener('error');
+              listener(status);
             });
+          } else if (event.type === 'error') {
+            const endTime = new Date();
+            processRecord.status = 'error';
+            processRecord.endTime = endTime;
+            if (event.exitCode !== undefined) {
+              processRecord.exitCode = event.exitCode;
+            }
 
             logCanonicalEvent(this.logger, {
               event: 'process.error',
               outcome: 'error',
               command,
               processId: processRecord.id,
-              sessionId,
+              sessionId: resolvedSessionId,
               durationMs: Date.now() - startTime,
               errorMessage: event.error,
-              error: new Error(event.error),
+              error: new Error(event.error ?? 'Unknown error'),
               origin: options.origin
+            });
+
+            try {
+              await this.store.update(processRecord.id, {
+                status: 'error',
+                endTime,
+                ...(event.exitCode !== undefined && {
+                  exitCode: event.exitCode
+                })
+              });
+            } catch (error) {
+              this.logger.error(
+                'Failed to update process status',
+                error instanceof Error ? error : undefined,
+                {
+                  processId: processRecord.id
+                }
+              );
+            }
+
+            processRecord.statusListeners.forEach((listener) => {
+              listener('error');
             });
           }
         },
         {
+          target,
           cwd: options.cwd,
           env: options.env,
-          origin: options.origin
-        },
-        processRecordData.id, // Pass process ID as commandId for tracking and killing
-        { background: true } // Release lock after startup
+          timeoutMs: options.timeoutMs,
+          origin: options.origin,
+          commandId: processRecordData.id,
+          background: true
+        }
       );
 
       if (!streamResult.success) {
         return streamResult as ServiceResult<ProcessRecord>;
       }
 
-      // Store streaming promise so getLogs() can await it for completed processes
-      // This ensures all output is captured before returning logs
+      processRecord.commandHandle = streamResult.data.commandHandle;
+
       processRecord.streamingComplete =
-        streamResult.data.continueStreaming.catch((error) => {
+        streamResult.data.continueStreaming.catch((error: unknown) => {
           this.logger.debug('process.streamComplete', {
             processId: processRecord.id,
             outcome: 'error',
@@ -378,214 +285,6 @@ export class ProcessService {
         data: processRecord
       };
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-
-      return {
-        success: false,
-        error: {
-          message: `Failed to start streaming command '${command}': ${errorMessage}`,
-          code: ErrorCode.STREAM_START_ERROR,
-          details: {
-            command,
-            stderr: errorMessage
-          } satisfies CommandErrorContext
-        }
-      };
-    }
-  }
-
-  private async executeCommandStreamOneShot(
-    command: string,
-    options: ProcessOptions
-  ): Promise<ServiceResult<ProcessRecord>> {
-    const startTime = Date.now();
-    const validation = this.manager.validateCommand(command);
-    if (!validation.valid) {
-      return {
-        success: false,
-        error: {
-          message: validation.error || 'Invalid command',
-          code: validation.code || 'INVALID_COMMAND'
-        }
-      };
-    }
-
-    const controller = new AbortController();
-    const timeout =
-      options.timeoutMs === undefined
-        ? undefined
-        : setTimeout(() => controller.abort(), options.timeoutMs);
-
-    try {
-      const processRecordData = this.manager.createProcessRecord(
-        command,
-        undefined,
-        options
-      );
-      const processRecord: ProcessRecord = {
-        ...processRecordData,
-        sessionId: options.sessionId
-      };
-
-      const env = Object.fromEntries(
-        Object.entries(options.env ?? {}).filter(
-          (entry): entry is [string, string] => entry[1] !== undefined
-        )
-      );
-      const subprocess = spawn({
-        cmd: ['bash', '-lc', command],
-        cwd:
-          options.cwd ??
-          (existsSync('/workspace') ? '/workspace' : process.cwd()),
-        env: {
-          ...process.env,
-          ...env
-        },
-        stdout: 'pipe',
-        stderr: 'pipe',
-        stdin: 'ignore',
-        signal: controller.signal
-      });
-
-      processRecord.pid = subprocess.pid;
-      await this.store.create(processRecord);
-
-      logCanonicalEvent(this.logger, {
-        event: 'process.start',
-        outcome: 'success',
-        command,
-        pid: subprocess.pid,
-        durationMs: Date.now() - startTime,
-        processId: processRecord.id,
-        sessionId: options.sessionId,
-        origin: options.origin
-      });
-
-      const emitOutput = (stream: 'stdout' | 'stderr', data: string) => {
-        if (stream === 'stdout') {
-          processRecord.stdout += data;
-        } else {
-          processRecord.stderr += data;
-        }
-        processRecord.outputListeners.forEach((listener) => {
-          listener(stream, data);
-        });
-      };
-
-      const streamOutput = async (
-        stream: ReadableStream<Uint8Array> | null,
-        type: 'stdout' | 'stderr'
-      ) => {
-        if (!stream) {
-          return;
-        }
-
-        const decoder = new TextDecoder();
-        const reader = stream.getReader();
-        try {
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) {
-              break;
-            }
-            emitOutput(type, decoder.decode(value, { stream: true }));
-          }
-
-          const remaining = decoder.decode();
-          if (remaining) {
-            emitOutput(type, remaining);
-          }
-        } finally {
-          reader.releaseLock();
-        }
-      };
-
-      // Note: streamingComplete is assigned after store.create, so a concurrent
-      // getProcess call in the brief window between create and this assignment
-      // will see streamingComplete as undefined and skip the wait. This is a
-      // known race shared with the session-based path; in practice the window
-      // is sub-millisecond and harmless for the current use-cases.
-      processRecord.streamingComplete = Promise.all([
-        streamOutput(subprocess.stdout, 'stdout'),
-        streamOutput(subprocess.stderr, 'stderr'),
-        subprocess.exited
-      ])
-        .then(async ([, , exitCode]) => {
-          clearTimeout(timeout);
-          const status = this.manager.interpretExitCode(exitCode);
-          const endTime = new Date();
-          processRecord.status = status;
-          processRecord.endTime = endTime;
-          processRecord.exitCode = exitCode;
-
-          await this.store.update(processRecord.id, {
-            status,
-            endTime,
-            exitCode
-          });
-
-          logCanonicalEvent(this.logger, {
-            event: 'process.exit',
-            outcome: 'success',
-            command,
-            pid: processRecord.pid,
-            exitCode,
-            durationMs:
-              processRecord.startTime instanceof Date
-                ? endTime.getTime() - processRecord.startTime.getTime()
-                : Date.now() - startTime,
-            processId: processRecord.id,
-            sessionId: options.sessionId,
-            origin: options.origin
-          });
-
-          processRecord.statusListeners.forEach((listener) => {
-            listener(status);
-          });
-        })
-        .catch(async (error) => {
-          clearTimeout(timeout);
-          const timedOut = controller.signal.aborted;
-          const endTime = new Date();
-          processRecord.status = 'error';
-          processRecord.endTime = endTime;
-          if (timedOut) {
-            processRecord.exitCode = 124;
-          }
-          await this.store.update(processRecord.id, {
-            status: 'error',
-            endTime,
-            ...(timedOut && { exitCode: 124 })
-          });
-          processRecord.statusListeners.forEach((listener) => {
-            listener('error');
-          });
-
-          const errorMessage = timedOut
-            ? `Command timed out after ${options.timeoutMs}ms`
-            : error instanceof Error
-              ? error.message
-              : String(error);
-          logCanonicalEvent(this.logger, {
-            event: 'process.error',
-            outcome: 'error',
-            command,
-            processId: processRecord.id,
-            sessionId: options.sessionId,
-            durationMs: Date.now() - startTime,
-            errorMessage,
-            error: error instanceof Error ? error : new Error(errorMessage),
-            origin: options.origin
-          });
-        });
-
-      return {
-        success: true,
-        data: processRecord
-      };
-    } catch (error) {
-      clearTimeout(timeout);
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
 
@@ -700,10 +399,7 @@ export class ProcessService {
         };
       }
 
-      const result = await this.sessionManager.killCommand(
-        process.commandHandle.sessionId,
-        process.commandHandle.commandId
-      );
+      const result = await this.executionService.kill(process.commandHandle);
 
       if (result.success) {
         await this.store.update(id, {

--- a/packages/sandbox-container/src/services/process-service.ts
+++ b/packages/sandbox-container/src/services/process-service.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { type Logger, logCanonicalEvent } from '@repo/shared';
 import type {
   CommandErrorContext,
@@ -5,6 +6,7 @@ import type {
   ProcessNotFoundContext
 } from '@repo/shared/errors';
 import { ErrorCode } from '@repo/shared/errors';
+import { spawn } from 'bun';
 import type {
   CommandResult,
   ProcessOptions,
@@ -51,6 +53,10 @@ export class ProcessService {
     command: string,
     options: ProcessOptions = {}
   ): Promise<ServiceResult<CommandResult>> {
+    if (options.sessionless) {
+      return this.executeCommandOneShot(command, options);
+    }
+
     try {
       // Always use SessionManager for execution (unified model)
       const sessionId = options.sessionId || 'default';
@@ -99,6 +105,109 @@ export class ProcessService {
     }
   }
 
+  private async executeCommandOneShot(
+    command: string,
+    options: ProcessOptions
+  ): Promise<ServiceResult<CommandResult>> {
+    const validation = this.manager.validateCommand(command);
+    if (!validation.valid) {
+      return {
+        success: false,
+        error: {
+          message: validation.error || 'Invalid command',
+          code: validation.code || 'INVALID_COMMAND'
+        }
+      };
+    }
+
+    const controller = new AbortController();
+    const timeout =
+      options.timeoutMs === undefined
+        ? undefined
+        : setTimeout(() => controller.abort(), options.timeoutMs);
+
+    try {
+      const env = Object.fromEntries(
+        Object.entries(options.env ?? {}).filter(
+          (entry): entry is [string, string] => entry[1] !== undefined
+        )
+      );
+      const subprocess = spawn({
+        cmd: ['bash', '-lc', command],
+        cwd:
+          options.cwd ??
+          (existsSync('/workspace') ? '/workspace' : process.cwd()),
+        env: {
+          ...process.env,
+          ...env
+        },
+        stdout: 'pipe',
+        stderr: 'pipe',
+        stdin: 'ignore',
+        signal: controller.signal
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(subprocess.stdout).text(),
+        new Response(subprocess.stderr).text(),
+        subprocess.exited
+      ]);
+
+      if (controller.signal.aborted) {
+        return {
+          success: true,
+          data: {
+            success: false,
+            exitCode: 124,
+            stdout: '',
+            stderr: `Command timed out after ${options.timeoutMs}ms`
+          }
+        };
+      }
+
+      return {
+        success: true,
+        data: {
+          success: exitCode === 0,
+          exitCode,
+          stdout,
+          stderr
+        }
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+
+      if (controller.signal.aborted) {
+        return {
+          success: true,
+          data: {
+            success: false,
+            exitCode: 124,
+            stdout: '',
+            stderr: `Command timed out after ${options.timeoutMs}ms`
+          }
+        };
+      }
+
+      return {
+        success: false,
+        error: {
+          message: `Failed to execute command '${command}': ${errorMessage}`,
+          code: ErrorCode.COMMAND_EXECUTION_ERROR,
+          details: {
+            command,
+            stderr: errorMessage
+          } satisfies CommandErrorContext
+        }
+      };
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
+  }
+
   /**
    * Execute a command with streaming output via SessionManager
    * Used by both execStream() and startProcess()
@@ -107,6 +216,10 @@ export class ProcessService {
     command: string,
     options: ProcessOptions = {}
   ): Promise<ServiceResult<ProcessRecord>> {
+    if (options.sessionless) {
+      return this.executeCommandStreamOneShot(command, options);
+    }
+
     const startTime = Date.now();
     try {
       // 1. Validate command (business logic via manager)
@@ -265,6 +378,214 @@ export class ProcessService {
         data: processRecord
       };
     } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+
+      return {
+        success: false,
+        error: {
+          message: `Failed to start streaming command '${command}': ${errorMessage}`,
+          code: ErrorCode.STREAM_START_ERROR,
+          details: {
+            command,
+            stderr: errorMessage
+          } satisfies CommandErrorContext
+        }
+      };
+    }
+  }
+
+  private async executeCommandStreamOneShot(
+    command: string,
+    options: ProcessOptions
+  ): Promise<ServiceResult<ProcessRecord>> {
+    const startTime = Date.now();
+    const validation = this.manager.validateCommand(command);
+    if (!validation.valid) {
+      return {
+        success: false,
+        error: {
+          message: validation.error || 'Invalid command',
+          code: validation.code || 'INVALID_COMMAND'
+        }
+      };
+    }
+
+    const controller = new AbortController();
+    const timeout =
+      options.timeoutMs === undefined
+        ? undefined
+        : setTimeout(() => controller.abort(), options.timeoutMs);
+
+    try {
+      const processRecordData = this.manager.createProcessRecord(
+        command,
+        undefined,
+        options
+      );
+      const processRecord: ProcessRecord = {
+        ...processRecordData,
+        sessionId: options.sessionId
+      };
+
+      const env = Object.fromEntries(
+        Object.entries(options.env ?? {}).filter(
+          (entry): entry is [string, string] => entry[1] !== undefined
+        )
+      );
+      const subprocess = spawn({
+        cmd: ['bash', '-lc', command],
+        cwd:
+          options.cwd ??
+          (existsSync('/workspace') ? '/workspace' : process.cwd()),
+        env: {
+          ...process.env,
+          ...env
+        },
+        stdout: 'pipe',
+        stderr: 'pipe',
+        stdin: 'ignore',
+        signal: controller.signal
+      });
+
+      processRecord.pid = subprocess.pid;
+      await this.store.create(processRecord);
+
+      logCanonicalEvent(this.logger, {
+        event: 'process.start',
+        outcome: 'success',
+        command,
+        pid: subprocess.pid,
+        durationMs: Date.now() - startTime,
+        processId: processRecord.id,
+        sessionId: options.sessionId,
+        origin: options.origin
+      });
+
+      const emitOutput = (stream: 'stdout' | 'stderr', data: string) => {
+        if (stream === 'stdout') {
+          processRecord.stdout += data;
+        } else {
+          processRecord.stderr += data;
+        }
+        processRecord.outputListeners.forEach((listener) => {
+          listener(stream, data);
+        });
+      };
+
+      const streamOutput = async (
+        stream: ReadableStream<Uint8Array> | null,
+        type: 'stdout' | 'stderr'
+      ) => {
+        if (!stream) {
+          return;
+        }
+
+        const decoder = new TextDecoder();
+        const reader = stream.getReader();
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) {
+              break;
+            }
+            emitOutput(type, decoder.decode(value, { stream: true }));
+          }
+
+          const remaining = decoder.decode();
+          if (remaining) {
+            emitOutput(type, remaining);
+          }
+        } finally {
+          reader.releaseLock();
+        }
+      };
+
+      // Note: streamingComplete is assigned after store.create, so a concurrent
+      // getProcess call in the brief window between create and this assignment
+      // will see streamingComplete as undefined and skip the wait. This is a
+      // known race shared with the session-based path; in practice the window
+      // is sub-millisecond and harmless for the current use-cases.
+      processRecord.streamingComplete = Promise.all([
+        streamOutput(subprocess.stdout, 'stdout'),
+        streamOutput(subprocess.stderr, 'stderr'),
+        subprocess.exited
+      ])
+        .then(async ([, , exitCode]) => {
+          clearTimeout(timeout);
+          const status = this.manager.interpretExitCode(exitCode);
+          const endTime = new Date();
+          processRecord.status = status;
+          processRecord.endTime = endTime;
+          processRecord.exitCode = exitCode;
+
+          await this.store.update(processRecord.id, {
+            status,
+            endTime,
+            exitCode
+          });
+
+          logCanonicalEvent(this.logger, {
+            event: 'process.exit',
+            outcome: 'success',
+            command,
+            pid: processRecord.pid,
+            exitCode,
+            durationMs:
+              processRecord.startTime instanceof Date
+                ? endTime.getTime() - processRecord.startTime.getTime()
+                : Date.now() - startTime,
+            processId: processRecord.id,
+            sessionId: options.sessionId,
+            origin: options.origin
+          });
+
+          processRecord.statusListeners.forEach((listener) => {
+            listener(status);
+          });
+        })
+        .catch(async (error) => {
+          clearTimeout(timeout);
+          const timedOut = controller.signal.aborted;
+          const endTime = new Date();
+          processRecord.status = 'error';
+          processRecord.endTime = endTime;
+          if (timedOut) {
+            processRecord.exitCode = 124;
+          }
+          await this.store.update(processRecord.id, {
+            status: 'error',
+            endTime,
+            ...(timedOut && { exitCode: 124 })
+          });
+          processRecord.statusListeners.forEach((listener) => {
+            listener('error');
+          });
+
+          const errorMessage = timedOut
+            ? `Command timed out after ${options.timeoutMs}ms`
+            : error instanceof Error
+              ? error.message
+              : String(error);
+          logCanonicalEvent(this.logger, {
+            event: 'process.error',
+            outcome: 'error',
+            command,
+            processId: processRecord.id,
+            sessionId: options.sessionId,
+            durationMs: Date.now() - startTime,
+            errorMessage,
+            error: error instanceof Error ? error : new Error(errorMessage),
+            origin: options.origin
+          });
+        });
+
+      return {
+        success: true,
+        data: processRecord
+      };
+    } catch (error) {
+      clearTimeout(timeout);
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
 

--- a/packages/sandbox-container/tests/handlers/file-handler.test.ts
+++ b/packages/sandbox-container/tests/handlers/file-handler.test.ts
@@ -135,7 +135,7 @@ describe('FileHandler', () => {
         {
           encoding: undefined
         },
-        undefined
+        'session-456'
       );
     });
 
@@ -206,7 +206,7 @@ describe('FileHandler', () => {
       );
     });
 
-    it('should pass undefined sessionId when not provided', async () => {
+    it('should fall back to the request context sessionId when not provided', async () => {
       const writeFileData = {
         path: '/tmp/output.txt',
         content: 'Hello, File!'
@@ -229,7 +229,7 @@ describe('FileHandler', () => {
         '/tmp/output.txt',
         'Hello, File!',
         {},
-        undefined
+        'session-456'
       );
     });
 
@@ -290,7 +290,8 @@ describe('FileHandler', () => {
       expect(responseData.timestamp).toBeDefined();
 
       expect(mockFileService.deleteFile).toHaveBeenCalledWith(
-        '/tmp/delete-me.txt'
+        '/tmp/delete-me.txt',
+        'session-456'
       );
     });
 
@@ -350,7 +351,8 @@ describe('FileHandler', () => {
 
       expect(mockFileService.renameFile).toHaveBeenCalledWith(
         '/tmp/old-name.txt',
-        '/tmp/new-name.txt'
+        '/tmp/new-name.txt',
+        'session-456'
       );
     });
 
@@ -413,7 +415,8 @@ describe('FileHandler', () => {
 
       expect(mockFileService.moveFile).toHaveBeenCalledWith(
         '/tmp/source.txt',
-        '/tmp/destination.txt'
+        '/tmp/destination.txt',
+        'session-456'
       );
     });
 
@@ -478,7 +481,8 @@ describe('FileHandler', () => {
         '/tmp/new-directory',
         {
           recursive: true
-        }
+        },
+        'session-456'
       );
     });
 
@@ -511,7 +515,8 @@ describe('FileHandler', () => {
         '/tmp/simple-dir',
         {
           recursive: undefined
-        }
+        },
+        'session-456'
       );
     });
 

--- a/packages/sandbox-container/tests/services/backup-service.test.ts
+++ b/packages/sandbox-container/tests/services/backup-service.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
 import type { Logger } from '@repo/shared';
 import type { ServiceResult } from '@sandbox-container/core/types';
 import { BackupService } from '@sandbox-container/services/backup-service';
+import { ExecutionService } from '@sandbox-container/services/execution-service.js';
 import type { SessionManager } from '@sandbox-container/services/session-manager';
 import type { RawExecResult } from '@sandbox-container/session';
 import { mocked } from '../test-utils';
@@ -55,12 +56,14 @@ function execSuccess(stdout = '', stderr = ''): ServiceResult<RawExecResult> {
 
 describe('BackupService', () => {
   let service: BackupService;
+  let executionService: ExecutionService;
 
   beforeEach(() => {
     vi.clearAllMocks();
     originalFetch = global.fetch;
     global.fetch = mockFetch as unknown as typeof fetch;
-    service = new BackupService(mockLogger, mockSessionManager);
+    executionService = new ExecutionService(mockSessionManager);
+    service = new BackupService(mockLogger, executionService);
   });
 
   afterEach(() => {

--- a/packages/sandbox-container/tests/services/execution-service.test.ts
+++ b/packages/sandbox-container/tests/services/execution-service.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'bun:test';
+import type { ServiceResult } from '@sandbox-container/core/types';
+import {
+  canonicalizeExecutionSessionId,
+  ExecutionService,
+  SESSIONLESS_SESSION_ID
+} from '@sandbox-container/services/execution-service.js';
+import type { SessionManager } from '@sandbox-container/services/session-manager';
+import type { RawExecResult } from '@sandbox-container/session';
+import { mocked } from '../test-utils';
+
+const mockSessionManager = {
+  executeInSession: vi.fn(),
+  withSession: vi.fn(),
+  executeStreamInSession: vi.fn(),
+  killCommand: vi.fn()
+} as unknown as SessionManager;
+
+describe('ExecutionService', () => {
+  let executionService: ExecutionService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executionService = new ExecutionService(mockSessionManager);
+  });
+
+  it('resolves the sentinel session ID to a sessionless target', () => {
+    expect(
+      executionService.resolveTarget({ sessionId: SESSIONLESS_SESSION_ID })
+    ).toEqual({ mode: 'sessionless' });
+    expect(
+      executionService.resolveTarget({ sessionId: 'sessionless' })
+    ).toEqual({ mode: 'sessionless' });
+  });
+
+  it('canonicalizes sessionless and fallback session inputs', () => {
+    expect(
+      canonicalizeExecutionSessionId({
+        sessionId: SESSIONLESS_SESSION_ID,
+        fallbackSessionId: 'default'
+      })
+    ).toBe(SESSIONLESS_SESSION_ID);
+
+    expect(
+      canonicalizeExecutionSessionId({
+        sessionId: 'sessionless',
+        fallbackSessionId: 'default'
+      })
+    ).toBe(SESSIONLESS_SESSION_ID);
+
+    expect(
+      canonicalizeExecutionSessionId({
+        sessionId: undefined,
+        fallbackSessionId: 'session-123'
+      })
+    ).toBe('session-123');
+
+    expect(canonicalizeExecutionSessionId({})).toBe('default');
+  });
+
+  it('routes explicit session targets through SessionManager', async () => {
+    mocked(mockSessionManager.executeInSession).mockResolvedValue({
+      success: true,
+      data: {
+        stdout: 'ok\n',
+        stderr: '',
+        exitCode: 0,
+        command: 'echo ok',
+        duration: 1,
+        timestamp: new Date().toISOString()
+      }
+    } as ServiceResult<RawExecResult>);
+
+    const result = await executionService.execute('echo ok', {
+      sessionId: 'session-123',
+      cwd: '/tmp'
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockSessionManager.executeInSession).toHaveBeenCalledWith(
+      'session-123',
+      'echo ok',
+      {
+        cwd: '/tmp',
+        timeoutMs: undefined,
+        env: undefined,
+        origin: undefined
+      }
+    );
+  });
+
+  it('routes sentinel session IDs through the one-shot backend', async () => {
+    const result = await executionService.execute('printf sessionless', {
+      sessionId: SESSIONLESS_SESSION_ID
+    });
+
+    expect(mockSessionManager.executeInSession).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.stdout).toBe('sessionless');
+      expect(result.data.exitCode).toBe(0);
+    }
+  });
+
+  it('streams sessionless commands without SessionManager', async () => {
+    const events: Array<{ type: string; data?: string; exitCode?: number }> =
+      [];
+
+    const result = await executionService.executeStream(
+      'printf streamed-output',
+      async (event) => {
+        events.push({
+          type: event.type,
+          data: event.data,
+          exitCode: event.exitCode
+        });
+      },
+      {
+        sessionId: SESSIONLESS_SESSION_ID,
+        commandId: 'cmd-1'
+      }
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockSessionManager.executeStreamInSession).not.toHaveBeenCalled();
+    if (result.success) {
+      expect(result.data.commandHandle).toEqual({
+        mode: 'sessionless',
+        pid: expect.any(Number)
+      });
+      await result.data.continueStreaming;
+    }
+
+    expect(events[0]?.type).toBe('start');
+    expect(events.some((event) => event.type === 'stdout')).toBe(true);
+    expect(events.find((event) => event.type === 'stdout')?.data).toBe(
+      'streamed-output'
+    );
+    expect(events[events.length - 1]?.type).toBe('complete');
+    expect(events[events.length - 1]?.exitCode).toBe(0);
+  });
+});

--- a/packages/sandbox-container/tests/services/file-service.test.ts
+++ b/packages/sandbox-container/tests/services/file-service.test.ts
@@ -10,6 +10,7 @@ import {
 import type { Logger } from '@repo/shared';
 import { ErrorCode } from '@repo/shared/errors';
 import type { ServiceResult } from '@sandbox-container/core/types';
+import { ExecutionService } from '@sandbox-container/services/execution-service.js';
 import {
   FileService,
   type SecurityService
@@ -88,6 +89,7 @@ const mockBunFile = (options: MockFileOptions = {}) => {
 
 describe('FileService', () => {
   let fileService: FileService;
+  let executionService: ExecutionService;
 
   afterEach(() => {
     bunFileSpy?.mockRestore();
@@ -140,11 +142,11 @@ describe('FileService', () => {
       }
     );
 
-    // Create service with mocked SessionManager
+    executionService = new ExecutionService(mockSessionManager);
     fileService = new FileService(
       mockSecurityService,
       mockLogger,
-      mockSessionManager
+      executionService
     );
   });
 

--- a/packages/sandbox-container/tests/services/git-service.test.ts
+++ b/packages/sandbox-container/tests/services/git-service.test.ts
@@ -6,6 +6,7 @@ import type {
   ServiceResult
 } from '@sandbox-container/core/types';
 import { DEFAULT_GIT_CLONE_TIMEOUT_MS } from '@sandbox-container/managers/git-manager';
+import { ExecutionService } from '@sandbox-container/services/execution-service.js';
 import {
   GitService,
   type SecurityService
@@ -45,6 +46,7 @@ const mockSessionManager = {
 
 describe('GitService', () => {
   let gitService: GitService;
+  let executionService: ExecutionService;
 
   beforeEach(async () => {
     // Reset all mocks before each test
@@ -102,9 +104,10 @@ describe('GitService', () => {
       }
     );
 
+    executionService = new ExecutionService(mockSessionManager);
     gitService = new GitService(
       mockSecurityService,
-      mockSessionManager,
+      executionService,
       mockLogger
     );
   });

--- a/packages/sandbox-container/tests/services/process-service.test.ts
+++ b/packages/sandbox-container/tests/services/process-service.test.ts
@@ -151,6 +151,19 @@ describe('ProcessService', () => {
         expect(result.error.code).toBe('SESSION_ERROR');
       }
     });
+
+    it('should execute sessionless commands without SessionManager', async () => {
+      const result = await processService.executeCommand('exit 7', {
+        sessionless: true
+      });
+
+      expect(mockSessionManager.executeInSession).not.toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.success).toBe(false);
+        expect(result.data.exitCode).toBe(7);
+      }
+    });
   });
 
   describe('startProcess', () => {
@@ -212,6 +225,20 @@ describe('ProcessService', () => {
 
       // Verify SessionManager was not called
       expect(mockSessionManager.executeStreamInSession).not.toHaveBeenCalled();
+    });
+
+    it('should start sessionless streaming commands without SessionManager', async () => {
+      const result = await processService.startProcess('printf stream-output', {
+        sessionless: true
+      });
+
+      expect(mockSessionManager.executeStreamInSession).not.toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      if (result.success) {
+        await result.data.streamingComplete;
+        expect(result.data.stdout).toBe('stream-output');
+        expect(result.data.exitCode).toBe(0);
+      }
     });
 
     it('should handle stream execution errors', async () => {

--- a/packages/sandbox-container/tests/services/process-service.test.ts
+++ b/packages/sandbox-container/tests/services/process-service.test.ts
@@ -5,6 +5,10 @@ import type {
   ServiceResult
 } from '@sandbox-container/core/types';
 import {
+  ExecutionService,
+  SESSIONLESS_SESSION_ID
+} from '@sandbox-container/services/execution-service.js';
+import {
   type ProcessFilters,
   ProcessService,
   type ProcessStore
@@ -58,6 +62,7 @@ const createMockProcess = (
   outputListeners: new Set(),
   statusListeners: new Set(),
   commandHandle: {
+    mode: 'session',
     sessionId: 'default',
     commandId: 'proc-123'
   },
@@ -66,16 +71,17 @@ const createMockProcess = (
 
 describe('ProcessService', () => {
   let processService: ProcessService;
+  let executionService: ExecutionService;
 
   beforeEach(async () => {
     // Reset all mocks before each test
     vi.clearAllMocks();
 
-    // Create service with mocked SessionManager
+    executionService = new ExecutionService(mockSessionManager);
     processService = new ProcessService(
       mockProcessStore,
       mockLogger,
-      mockSessionManager
+      executionService
     );
   });
 
@@ -154,7 +160,7 @@ describe('ProcessService', () => {
 
     it('should execute sessionless commands without SessionManager', async () => {
       const result = await processService.executeCommand('exit 7', {
-        sessionless: true
+        sessionId: SESSIONLESS_SESSION_ID
       });
 
       expect(mockSessionManager.executeInSession).not.toHaveBeenCalled();
@@ -187,6 +193,7 @@ describe('ProcessService', () => {
         expect(result.data.command).toBe('sleep 10');
         expect(result.data.status).toBe('running');
         expect(result.data.commandHandle).toEqual({
+          mode: 'session',
           sessionId: 'session-123',
           commandId: result.data.id
         });
@@ -229,7 +236,7 @@ describe('ProcessService', () => {
 
     it('should start sessionless streaming commands without SessionManager', async () => {
       const result = await processService.startProcess('printf stream-output', {
-        sessionless: true
+        sessionId: SESSIONLESS_SESSION_ID
       });
 
       expect(mockSessionManager.executeStreamInSession).not.toHaveBeenCalled();
@@ -294,6 +301,7 @@ describe('ProcessService', () => {
       const mockProcess = createMockProcess({
         command: 'sleep 10',
         commandHandle: {
+          mode: 'session',
           sessionId: 'default',
           commandId: 'proc-123'
         }
@@ -377,12 +385,20 @@ describe('ProcessService', () => {
         createMockProcess({
           id: 'proc-1',
           command: 'sleep 10',
-          commandHandle: { sessionId: 'default', commandId: 'proc-1' }
+          commandHandle: {
+            mode: 'session',
+            sessionId: 'default',
+            commandId: 'proc-1'
+          }
         }),
         createMockProcess({
           id: 'proc-2',
           command: 'sleep 20',
-          commandHandle: { sessionId: 'default', commandId: 'proc-2' }
+          commandHandle: {
+            mode: 'session',
+            sessionId: 'default',
+            commandId: 'proc-2'
+          }
         })
       ];
 

--- a/packages/sandbox-container/tests/services/process-store.test.ts
+++ b/packages/sandbox-container/tests/services/process-store.test.ts
@@ -27,6 +27,7 @@ const createMockProcess = (
   outputListeners: new Set(),
   statusListeners: new Set(),
   commandHandle: {
+    mode: 'session',
     sessionId: 'default',
     commandId: 'proc-123'
   },

--- a/packages/sandbox/src/clients/command-client.ts
+++ b/packages/sandbox/src/clients/command-client.ts
@@ -31,20 +31,24 @@ export class CommandClient extends BaseHttpClient {
    */
   async execute(
     command: string,
-    sessionId: string,
+    sessionId: string | undefined,
     options?: {
       timeoutMs?: number;
       env?: Record<string, string | undefined>;
       cwd?: string;
       origin?: 'user' | 'internal';
+      sessionless?: boolean;
     }
   ): Promise<ExecuteResponse> {
     try {
       const data: ExecuteRequest = {
         command,
-        sessionId,
+        ...(sessionId !== undefined && { sessionId }),
         ...(options?.timeoutMs !== undefined && {
           timeoutMs: options.timeoutMs
+        }),
+        ...(options?.sessionless !== undefined && {
+          sessionless: options.sessionless
         }),
         ...(options?.env !== undefined && { env: options.env }),
         ...(options?.cwd !== undefined && { cwd: options.cwd }),
@@ -82,20 +86,24 @@ export class CommandClient extends BaseHttpClient {
    */
   async executeStream(
     command: string,
-    sessionId: string,
+    sessionId: string | undefined,
     options?: {
       timeoutMs?: number;
       env?: Record<string, string | undefined>;
       cwd?: string;
       origin?: 'user' | 'internal';
+      sessionless?: boolean;
     }
   ): Promise<ReadableStream<Uint8Array>> {
     try {
       const data = {
         command,
-        sessionId,
+        ...(sessionId !== undefined && { sessionId }),
         ...(options?.timeoutMs !== undefined && {
           timeoutMs: options.timeoutMs
+        }),
+        ...(options?.sessionless !== undefined && {
+          sessionless: options.sessionless
         }),
         ...(options?.env !== undefined && { env: options.env }),
         ...(options?.cwd !== undefined && { cwd: options.cwd }),

--- a/packages/sandbox/src/clients/command-client.ts
+++ b/packages/sandbox/src/clients/command-client.ts
@@ -37,7 +37,6 @@ export class CommandClient extends BaseHttpClient {
       env?: Record<string, string | undefined>;
       cwd?: string;
       origin?: 'user' | 'internal';
-      sessionless?: boolean;
     }
   ): Promise<ExecuteResponse> {
     try {
@@ -46,9 +45,6 @@ export class CommandClient extends BaseHttpClient {
         ...(sessionId !== undefined && { sessionId }),
         ...(options?.timeoutMs !== undefined && {
           timeoutMs: options.timeoutMs
-        }),
-        ...(options?.sessionless !== undefined && {
-          sessionless: options.sessionless
         }),
         ...(options?.env !== undefined && { env: options.env }),
         ...(options?.cwd !== undefined && { cwd: options.cwd }),
@@ -92,7 +88,6 @@ export class CommandClient extends BaseHttpClient {
       env?: Record<string, string | undefined>;
       cwd?: string;
       origin?: 'user' | 'internal';
-      sessionless?: boolean;
     }
   ): Promise<ReadableStream<Uint8Array>> {
     try {
@@ -101,9 +96,6 @@ export class CommandClient extends BaseHttpClient {
         ...(sessionId !== undefined && { sessionId }),
         ...(options?.timeoutMs !== undefined && {
           timeoutMs: options.timeoutMs
-        }),
-        ...(options?.sessionless !== undefined && {
-          sessionless: options.sessionless
         }),
         ...(options?.env !== undefined && { env: options.env }),
         ...(options?.cwd !== undefined && { cwd: options.cwd }),

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -35,7 +35,8 @@ import type {
   WaitForExitResult,
   WaitForLogResult,
   WaitForPortOptions,
-  WatchOptions
+  WatchOptions,
+  WriteFileResult
 } from '@repo/shared';
 import {
   createLogger,
@@ -119,6 +120,7 @@ type SandboxConfiguration = {
   keepAlive?: boolean;
   containerTimeouts?: NonNullable<SandboxOptions['containerTimeouts']>;
   transport?: SandboxTransport;
+  enableDefaultSession?: boolean;
 };
 
 type CachedSandboxConfiguration = {
@@ -128,6 +130,7 @@ type CachedSandboxConfiguration = {
   keepAlive?: boolean;
   containerTimeouts?: NonNullable<SandboxOptions['containerTimeouts']>;
   transport?: SandboxTransport;
+  enableDefaultSession?: boolean;
 };
 
 type ConfigurableSandboxStub = {
@@ -139,6 +142,12 @@ type ConfigurableSandboxStub = {
     timeouts: NonNullable<SandboxOptions['containerTimeouts']>
   ) => Promise<void>;
   setTransport?: (transport: SandboxTransport) => Promise<void>;
+  setEnableDefaultSession?: (enableDefaultSession: boolean) => Promise<void>;
+};
+
+type ResolvedImplicitSession = {
+  sessionId: string;
+  cleanup: () => Promise<void>;
 };
 
 const sandboxConfigurationCache = new WeakMap<
@@ -305,6 +314,13 @@ function buildSandboxConfiguration(
     configuration.transport = options.transport;
   }
 
+  if (
+    options?.enableDefaultSession !== undefined &&
+    cached?.enableDefaultSession !== options.enableDefaultSession
+  ) {
+    configuration.enableDefaultSession = options.enableDefaultSession;
+  }
+
   return configuration;
 }
 
@@ -314,7 +330,8 @@ function hasSandboxConfiguration(configuration: SandboxConfiguration): boolean {
     configuration.sleepAfter !== undefined ||
     configuration.keepAlive !== undefined ||
     configuration.containerTimeouts !== undefined ||
-    configuration.transport !== undefined
+    configuration.transport !== undefined ||
+    configuration.enableDefaultSession !== undefined
   );
 }
 
@@ -339,6 +356,9 @@ function mergeSandboxConfiguration(
     }),
     ...(configuration.transport !== undefined && {
       transport: configuration.transport
+    }),
+    ...(configuration.enableDefaultSession !== undefined && {
+      enableDefaultSession: configuration.enableDefaultSession
     })
   };
 }
@@ -384,6 +404,13 @@ function applySandboxConfiguration(
   if (configuration.transport !== undefined) {
     operations.push(
       stub.setTransport?.(configuration.transport) ?? Promise.resolve()
+    );
+  }
+
+  if (configuration.enableDefaultSession !== undefined) {
+    operations.push(
+      stub.setEnableDefaultSession?.(configuration.enableDefaultSession) ??
+        Promise.resolve()
     );
   }
 
@@ -539,6 +566,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   // in-flight default-session initialization that started against a
   // now-dead container.
   private containerGeneration = 0;
+  // Incremented whenever the default session is explicitly disabled via
+  // setEnableDefaultSession(false). Persisted so that re-enabling always
+  // produces a fresh session ID that cannot collide with the just-deleted one.
+  private defaultSessionRevision: number = 0;
   private defaultSessionInit: {
     sessionId: string;
     generation: number;
@@ -547,6 +578,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   envVars: Record<string, string> = {};
   private logger: ReturnType<typeof createLogger>;
   private keepAliveEnabled: boolean = false;
+  private enableDefaultSession: boolean = true;
   private activeMounts: Map<string, MountInfo> = new Map();
   private transport: SandboxTransport = 'http';
 
@@ -828,6 +860,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         (await this.ctx.storage.get<string>('defaultSession')) ?? null;
       this.keepAliveEnabled =
         (await this.ctx.storage.get<boolean>('keepAliveEnabled')) ?? false;
+      this.enableDefaultSession =
+        (await this.ctx.storage.get<boolean>('enableDefaultSession')) ?? true;
+      this.defaultSessionRevision =
+        (await this.ctx.storage.get<number>('defaultSessionRevision')) ?? 0;
 
       // Load saved timeout configuration (highest priority)
       const storedTimeouts =
@@ -919,6 +955,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     if (configuration.transport !== undefined) {
       await this.setTransport(configuration.transport);
     }
+
+    if (configuration.enableDefaultSession !== undefined) {
+      await this.setEnableDefaultSession(configuration.enableDefaultSession);
+    }
   }
 
   // RPC method to set the sleep timeout. Idempotent: re-applying the same
@@ -943,6 +983,31 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     if (!keepAlive) {
       this.renewActivityTimeout();
     }
+  }
+
+  async setEnableDefaultSession(enableDefaultSession: boolean): Promise<void> {
+    if (this.enableDefaultSession === enableDefaultSession) return;
+    await this.ctx.storage.put('enableDefaultSession', enableDefaultSession);
+    if (!enableDefaultSession) {
+      const defaultSessionId = this.defaultSession;
+      this.containerGeneration++;
+      this.defaultSessionRevision++;
+      this.defaultSession = null;
+      this.defaultSessionInit = null;
+      await this.ctx.storage.delete('defaultSession');
+      await this.ctx.storage.put(
+        'defaultSessionRevision',
+        this.defaultSessionRevision
+      );
+
+      if (defaultSessionId) {
+        await this.client.utils.deleteSession(defaultSessionId).catch(() => {});
+      }
+    }
+    this.enableDefaultSession = enableDefaultSession;
+    // Note: changing this at runtime while exec/execStream calls are in flight
+    // is safe — each call captures its execution path at call-start — but the
+    // intended use is to set this once during sandbox initialisation.
   }
 
   async setEnvVars(envVars: Record<string, string | undefined>): Promise<void> {
@@ -1647,7 +1712,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
     const exec = sessionId
       ? (cmd: string) =>
-          this.execWithSession(cmd, sessionId, { origin: 'internal' })
+          this.executeInSession(cmd, sessionId, { origin: 'internal' })
       : (cmd: string) => this.execInternal(cmd);
 
     const result = await exec(script);
@@ -2408,7 +2473,11 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    * in-flight initialization promise.
    */
   private async ensureDefaultSession(): Promise<string> {
-    const sessionId = `sandbox-${this.sandboxName || 'default'}`;
+    const base = `sandbox-${this.sandboxName || 'default'}`;
+    const sessionId =
+      this.defaultSessionRevision === 0
+        ? base
+        : `${base}-r${this.defaultSessionRevision}`;
 
     // Fast path: session already initialized in this instance
     if (this.defaultSession === sessionId) {
@@ -2471,6 +2540,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     // Fail the attempt so the next caller starts fresh against the new
     // container.
     if (generation !== this.containerGeneration) {
+      await this.client.utils.deleteSession(sessionId).catch(() => {});
       throw new Error(
         'Default session initialization was invalidated by a container stop'
       );
@@ -2483,6 +2553,80 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     this.defaultSession = sessionId;
     this.logger.debug('Default session initialized', { sessionId });
     return sessionId;
+  }
+
+  private async resolveImplicitSession(): Promise<ResolvedImplicitSession> {
+    if (this.enableDefaultSession) {
+      const sessionId = await this.ensureDefaultSession();
+      return {
+        sessionId,
+        cleanup: async () => {}
+      };
+    }
+
+    const sessionId = `sandbox-ephemeral-${randomHex(8)}`;
+    await this.client.utils.createSession({
+      id: sessionId,
+      env: this.envVars || {},
+      cwd: '/workspace'
+    });
+
+    return {
+      sessionId,
+      cleanup: async () => {
+        await this.client.utils.deleteSession(sessionId);
+      }
+    };
+  }
+
+  private async withImplicitSession<T>(
+    operation: (sessionId: string) => Promise<T>
+  ): Promise<T> {
+    const session = await this.resolveImplicitSession();
+    try {
+      return await operation(session.sessionId);
+    } finally {
+      await session.cleanup().catch(() => {});
+    }
+  }
+
+  private streamWithCleanup<T>(
+    stream: ReadableStream<T>,
+    cleanup: () => Promise<void>
+  ): ReadableStream<T> {
+    let reader: ReadableStreamDefaultReader<T> | undefined;
+    let cleanupDone = false;
+    const runCleanup = async () => {
+      if (cleanupDone) return;
+      cleanupDone = true;
+      await cleanup();
+    };
+
+    return new ReadableStream<T>({
+      async start(controller) {
+        reader = stream.getReader();
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            controller.enqueue(value);
+          }
+          controller.close();
+        } catch (error) {
+          controller.error(error);
+        } finally {
+          reader.releaseLock();
+          await runCleanup();
+        }
+      },
+      async cancel(reason) {
+        try {
+          await reader?.cancel(reason);
+        } finally {
+          await runCleanup();
+        }
+      }
+    });
   }
 
   /**
@@ -2509,8 +2653,11 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   // Enhanced exec method - always returns ExecResult with optional streaming
   // This replaces the old exec method to match ISandbox interface
   async exec(command: string, options?: ExecOptions): Promise<ExecResult> {
-    const session = await this.ensureDefaultSession();
-    return this.execWithSession(command, session, options);
+    if (!this.enableDefaultSession) {
+      return this.execSessionless(command, options);
+    }
+
+    return this.execWithImplicitSession(command, options);
   }
 
   /**
@@ -2518,15 +2665,101 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    * tagged with origin: 'internal' so logging demotes it to debug level.
    */
   private async execInternal(command: string): Promise<ExecResult> {
-    const session = await this.ensureDefaultSession();
-    return this.execWithSession(command, session, { origin: 'internal' });
+    if (!this.enableDefaultSession) {
+      return this.execSessionless(command, { origin: 'internal' });
+    }
+
+    return this.execWithImplicitSession(command, { origin: 'internal' });
   }
 
-  /**
-   * Internal session-aware exec implementation
-   * Used by both public exec() and session wrappers
-   */
-  private async execWithSession(
+  private async execWithImplicitSession(
+    command: string,
+    options?: ExecOptions
+  ): Promise<ExecResult> {
+    return this.withImplicitSession((session) =>
+      this.executeInSession(command, session, options)
+    );
+  }
+
+  private async execSessionless(
+    command: string,
+    options?: ExecOptions
+  ): Promise<ExecResult> {
+    if (options?.stream && options.onOutput) {
+      return this.executeWithSessionlessStreaming(command, options);
+    }
+
+    return this.executeSessionless(command, options);
+  }
+
+  private async executeSessionless(
+    command: string,
+    options?: ExecOptions
+  ): Promise<ExecResult> {
+    const startTime = Date.now();
+    const sessionId = undefined;
+    const env = this.resolveCommandEnv(options?.env);
+    let execOutcome: { exitCode: number; success: boolean } | undefined;
+    let execError: Error | undefined;
+
+    try {
+      if (options?.signal?.aborted) {
+        throw new Error('Operation was aborted');
+      }
+
+      const response = await this.client.commands.execute(command, sessionId, {
+        timeoutMs: options?.timeout,
+        env,
+        cwd: options?.cwd,
+        origin: options?.origin,
+        sessionless: true
+      });
+
+      const result = this.mapExecuteResponseToExecResult(
+        response,
+        Date.now() - startTime,
+        sessionId
+      );
+      execOutcome = { exitCode: result.exitCode, success: result.success };
+
+      if (options?.onComplete) {
+        options.onComplete(result);
+      }
+
+      return result;
+    } catch (error) {
+      execError = error instanceof Error ? error : new Error(String(error));
+      if (options?.onError && error instanceof Error) {
+        options.onError(error);
+      }
+      throw error;
+    } finally {
+      logCanonicalEvent(this.logger, {
+        event: 'sandbox.exec',
+        outcome: execError ? 'error' : 'success',
+        command,
+        exitCode: execOutcome?.exitCode,
+        durationMs: Date.now() - startTime,
+        sessionId,
+        origin: options?.origin ?? 'user',
+        error: execError ?? undefined,
+        errorMessage: execError?.message
+      });
+    }
+  }
+
+  private resolveCommandEnv(
+    env?: Record<string, string | undefined>
+  ): Record<string, string | undefined> | undefined {
+    const mergedEnv = {
+      ...this.envVars,
+      ...(env ?? {})
+    };
+
+    return Object.keys(mergedEnv).length > 0 ? mergedEnv : undefined;
+  }
+
+  private async executeInSession(
     command: string,
     sessionId: string,
     options?: ExecOptions
@@ -2534,7 +2767,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     const startTime = Date.now();
     const timestamp = new Date().toISOString();
 
-    let timeoutId: NodeJS.Timeout | undefined;
     let execOutcome: { exitCode: number; success: boolean } | undefined;
     let execError: Error | undefined;
 
@@ -2557,19 +2789,14 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         );
       } else {
         // Regular execution with session
-        const commandOptions =
-          options &&
-          (options.timeout !== undefined ||
-            options.env !== undefined ||
-            options.cwd !== undefined ||
-            options.origin !== undefined)
-            ? {
-                timeoutMs: options.timeout,
-                env: options.env,
-                cwd: options.cwd,
-                origin: options.origin
-              }
-            : undefined;
+        const commandOptions = options
+          ? {
+              timeoutMs: options?.timeout,
+              env: options?.env,
+              cwd: options?.cwd,
+              origin: options?.origin
+            }
+          : undefined;
 
         const response = await this.client.commands.execute(
           command,
@@ -2600,9 +2827,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       }
       throw error;
     } finally {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
       logCanonicalEvent(this.logger, {
         event: 'sandbox.exec',
         outcome: execError ? 'error' : 'success',
@@ -2619,10 +2843,11 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
   private async executeWithStreaming(
     command: string,
-    sessionId: string,
+    sessionId: string | undefined,
     options: ExecOptions,
     startTime: number,
-    timestamp: string
+    timestamp: string,
+    sessionless = false
   ): Promise<ExecResult> {
     let stdout = '';
     let stderr = '';
@@ -2635,7 +2860,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           timeoutMs: options.timeout,
           env: options.env,
           cwd: options.cwd,
-          origin: options.origin
+          origin: options.origin,
+          ...(sessionless && { sessionless: true })
         }
       );
 
@@ -2690,6 +2916,23 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
   }
 
+  private async executeWithSessionlessStreaming(
+    command: string,
+    options: ExecOptions
+  ): Promise<ExecResult> {
+    return this.executeWithStreaming(
+      command,
+      undefined,
+      {
+        ...options,
+        env: this.resolveCommandEnv(options.env)
+      },
+      Date.now(),
+      new Date().toISOString(),
+      true
+    );
+  }
+
   private mapExecuteResponseToExecResult(
     response: ExecuteResponse,
     duration: number,
@@ -2722,7 +2965,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       endTime?: string | Date;
       exitCode?: number;
     },
-    sessionId: string
+    sessionId?: string
   ): Process {
     return {
       id: data.id,
@@ -3169,8 +3412,12 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     sessionId?: string
   ): Promise<Process> {
     // Use the new HttpClient method to start the process
+    const resolvedSession = sessionId
+      ? { sessionId, cleanup: async () => {} }
+      : await this.resolveImplicitSession();
+    const session = resolvedSession.sessionId;
+    let cleanupOwned = false;
     try {
-      const session = sessionId ?? (await this.ensureDefaultSession());
       const requestOptions = {
         ...(options?.processId !== undefined && {
           processId: options.processId
@@ -3211,15 +3458,27 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       // Start background streaming if output/exit callbacks are provided
       if (options?.onOutput || options?.onExit) {
         // Fire and forget - don't await, let it run in background
-        this.startProcessCallbackStream(response.processId, options).catch(
-          () => {
-            // Error already handled in startProcessCallbackStream
-          }
-        );
+        cleanupOwned = true;
+        this.startProcessCallbackStream(
+          response.processId,
+          options,
+          resolvedSession.cleanup
+        ).catch(() => {
+          // Error already handled in startProcessCallbackStream
+        });
+      } else if (!sessionId && !this.enableDefaultSession) {
+        cleanupOwned = true;
+        this.cleanupProcessSessionOnExit(
+          response.processId,
+          resolvedSession.cleanup
+        ).catch(() => {});
       }
 
       return processObj;
     } catch (error) {
+      if (!cleanupOwned) {
+        await resolvedSession.cleanup().catch(() => {});
+      }
       if (options?.onError && error instanceof Error) {
         options.onError(error);
       }
@@ -3234,7 +3493,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    */
   private async startProcessCallbackStream(
     processId: string,
-    options: ProcessOptions
+    options: ProcessOptions,
+    cleanup: () => Promise<void> = async () => {}
   ): Promise<void> {
     try {
       const stream = await this.client.processes.streamProcessLogs(processId);
@@ -3275,11 +3535,33 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         error instanceof Error ? error : new Error(String(error)),
         { processId }
       );
+    } finally {
+      await cleanup();
+    }
+  }
+
+  private async cleanupProcessSessionOnExit(
+    processId: string,
+    cleanup: () => Promise<void>
+  ): Promise<void> {
+    try {
+      const stream = await this.client.processes.streamProcessLogs(processId);
+      for await (const event of parseSSEStream<LogEvent>(stream)) {
+        if (event.type === 'exit') {
+          return;
+        }
+      }
+    } finally {
+      await cleanup();
     }
   }
 
   async listProcesses(sessionId?: string): Promise<Process[]> {
-    const session = sessionId ?? (await this.ensureDefaultSession());
+    const resolvedId =
+      sessionId ??
+      (this.enableDefaultSession
+        ? await this.ensureDefaultSession()
+        : undefined);
     const response = await this.client.processes.listProcesses();
 
     return response.processes.map((processData) =>
@@ -3293,14 +3575,28 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           endTime: processData.endTime,
           exitCode: processData.exitCode
         },
-        session
+        resolvedId
       )
     );
   }
 
   async getProcess(id: string, sessionId?: string): Promise<Process | null> {
-    const session = sessionId ?? (await this.ensureDefaultSession());
-    const response = await this.client.processes.getProcess(id);
+    const resolvedId =
+      sessionId ??
+      (this.enableDefaultSession
+        ? await this.ensureDefaultSession()
+        : undefined);
+    let response: Awaited<ReturnType<typeof this.client.processes.getProcess>>;
+    try {
+      response = await this.client.processes.getProcess(id);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      if (msg.toLowerCase().includes('not found')) {
+        return null;
+      }
+      throw error;
+    }
+
     if (!response.process) {
       return null;
     }
@@ -3316,7 +3612,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         endTime: processData.endTime,
         exitCode: processData.exitCode
       },
-      session
+      resolvedId
     );
   }
 
@@ -3361,13 +3657,27 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       throw new Error('Operation was aborted');
     }
 
-    const session = await this.ensureDefaultSession();
-    // Get the stream from CommandClient
-    return this.client.commands.executeStream(command, session, {
-      timeoutMs: options?.timeout,
-      env: options?.env,
-      cwd: options?.cwd
-    });
+    if (!this.enableDefaultSession) {
+      const env = this.resolveCommandEnv(options?.env);
+      return this.client.commands.executeStream(command, undefined, {
+        timeoutMs: options?.timeout,
+        env,
+        cwd: options?.cwd,
+        sessionless: true
+      });
+    }
+
+    const session = await this.resolveImplicitSession();
+    const stream = await this.client.commands.executeStream(
+      command,
+      session.sessionId,
+      {
+        timeoutMs: options?.timeout,
+        env: options?.env,
+        cwd: options?.cwd
+      }
+    );
+    return this.streamWithCleanup(stream, session.cleanup);
   }
 
   /**
@@ -3417,7 +3727,18 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       cloneTimeoutMs?: number;
     }
   ) {
-    const session = options?.sessionId ?? (await this.ensureDefaultSession());
+    if (!options?.sessionId) {
+      return this.withImplicitSession((session) =>
+        this.client.git.checkout(repoUrl, session, {
+          branch: options?.branch,
+          targetDir: options?.targetDir,
+          depth: options?.depth,
+          timeoutMs: options?.cloneTimeoutMs
+        })
+      );
+    }
+
+    const session = options.sessionId;
     return this.client.git.checkout(repoUrl, session, {
       branch: options?.branch,
       targetDir: options?.targetDir,
@@ -3430,7 +3751,15 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     path: string,
     options: { recursive?: boolean; sessionId?: string } = {}
   ) {
-    const session = options.sessionId ?? (await this.ensureDefaultSession());
+    if (!options.sessionId) {
+      return this.withImplicitSession((session) =>
+        this.client.files.mkdir(path, session, {
+          recursive: options.recursive
+        })
+      );
+    }
+
+    const session = options.sessionId;
     return this.client.files.mkdir(path, session, {
       recursive: options.recursive
     });
@@ -3441,7 +3770,17 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     content: string | ReadableStream<Uint8Array>,
     options: { encoding?: string; sessionId?: string } = {}
   ) {
-    const session = options.sessionId ?? (await this.ensureDefaultSession());
+    if (!options.sessionId) {
+      return this.withImplicitSession<WriteFileResult>((session) =>
+        content instanceof ReadableStream
+          ? this.client.files.writeFileStream(path, content, session)
+          : this.client.files.writeFile(path, content, session, {
+              encoding: options.encoding
+            })
+      );
+    }
+
+    const session = options.sessionId;
 
     if (content instanceof ReadableStream) {
       return this.client.files.writeFileStream(path, content, session);
@@ -3453,13 +3792,21 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   async deleteFile(path: string, sessionId?: string) {
-    const session = sessionId ?? (await this.ensureDefaultSession());
-    return this.client.files.deleteFile(path, session);
+    if (!sessionId) {
+      return this.withImplicitSession((session) =>
+        this.client.files.deleteFile(path, session)
+      );
+    }
+    return this.client.files.deleteFile(path, sessionId);
   }
 
   async renameFile(oldPath: string, newPath: string, sessionId?: string) {
-    const session = sessionId ?? (await this.ensureDefaultSession());
-    return this.client.files.renameFile(oldPath, newPath, session);
+    if (!sessionId) {
+      return this.withImplicitSession((session) =>
+        this.client.files.renameFile(oldPath, newPath, session)
+      );
+    }
+    return this.client.files.renameFile(oldPath, newPath, sessionId);
   }
 
   async moveFile(
@@ -3467,8 +3814,12 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     destinationPath: string,
     sessionId?: string
   ) {
-    const session = sessionId ?? (await this.ensureDefaultSession());
-    return this.client.files.moveFile(sourcePath, destinationPath, session);
+    if (!sessionId) {
+      return this.withImplicitSession((session) =>
+        this.client.files.moveFile(sourcePath, destinationPath, session)
+      );
+    }
+    return this.client.files.moveFile(sourcePath, destinationPath, sessionId);
   }
 
   /**
@@ -3493,7 +3844,22 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     path: string,
     options: { encoding?: FileEncoding; sessionId?: string } = {}
   ): Promise<ReadFileResult | ReadFileStreamResult> {
-    const session = options.sessionId ?? (await this.ensureDefaultSession());
+    if (!options.sessionId) {
+      return this.withImplicitSession<ReadFileResult | ReadFileStreamResult>(
+        (session) => {
+          if (options.encoding === 'none') {
+            return this.client.files.readFile(path, session, {
+              encoding: 'none'
+            });
+          }
+          return this.client.files.readFile(path, session, {
+            encoding: options.encoding
+          });
+        }
+      );
+    }
+
+    const session = options.sessionId;
     if (options.encoding === 'none') {
       return this.client.files.readFile(path, session, { encoding: 'none' });
     }
@@ -3512,21 +3878,34 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     path: string,
     options: { sessionId?: string } = {}
   ): Promise<ReadableStream<Uint8Array>> {
-    const session = options.sessionId ?? (await this.ensureDefaultSession());
-    return this.client.files.readFileStream(path, session);
+    if (options.sessionId) {
+      return this.client.files.readFileStream(path, options.sessionId);
+    }
+
+    const session = await this.resolveImplicitSession();
+    const stream = await this.client.files.readFileStream(
+      path,
+      session.sessionId
+    );
+    return this.streamWithCleanup(stream, session.cleanup);
   }
 
   async listFiles(
     path: string,
     options?: { recursive?: boolean; includeHidden?: boolean }
   ) {
-    const session = await this.ensureDefaultSession();
-    return this.client.files.listFiles(path, session, options);
+    return this.withImplicitSession((session) =>
+      this.client.files.listFiles(path, session, options)
+    );
   }
 
   async exists(path: string, sessionId?: string) {
-    const session = sessionId ?? (await this.ensureDefaultSession());
-    return this.client.files.exists(path, session);
+    if (!sessionId) {
+      return this.withImplicitSession((session) =>
+        this.client.files.exists(path, session)
+      );
+    }
+    return this.client.files.exists(path, sessionId);
   }
 
   /**
@@ -3614,14 +3993,25 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     path: string,
     options: WatchOptions = {}
   ): Promise<ReadableStream<Uint8Array>> {
-    const sessionId = options.sessionId ?? (await this.ensureDefaultSession());
-    return this.client.watch.watch({
+    if (options.sessionId) {
+      return this.client.watch.watch({
+        path,
+        recursive: options.recursive,
+        include: options.include,
+        exclude: options.exclude,
+        sessionId: options.sessionId
+      });
+    }
+
+    const session = await this.resolveImplicitSession();
+    const stream = await this.client.watch.watch({
       path,
       recursive: options.recursive,
       include: options.include,
       exclude: options.exclude,
-      sessionId
+      sessionId: session.sessionId
     });
+    return this.streamWithCleanup(stream, session.cleanup);
   }
 
   /**
@@ -3638,15 +4028,27 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     path: string,
     options: CheckChangesOptions = {}
   ): Promise<CheckChangesResult> {
-    const sessionId = options.sessionId ?? (await this.ensureDefaultSession());
-    return this.client.watch.checkChanges({
-      path,
-      recursive: options.recursive,
-      include: options.include,
-      exclude: options.exclude,
-      since: options.since,
-      sessionId
-    });
+    if (options.sessionId) {
+      return this.client.watch.checkChanges({
+        path,
+        recursive: options.recursive,
+        include: options.include,
+        exclude: options.exclude,
+        since: options.since,
+        sessionId: options.sessionId
+      });
+    }
+
+    return this.withImplicitSession((sessionId) =>
+      this.client.watch.checkChanges({
+        path,
+        recursive: options.recursive,
+        include: options.include,
+        exclude: options.exclude,
+        since: options.since,
+        sessionId
+      })
+    );
   }
 
   /**
@@ -3730,8 +4132,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           `Token '${token}' is already in use by port ${existingPort[0]}. Please use a different token.`
         );
       }
-      const sessionId = await this.ensureDefaultSession();
-      await this.client.ports.exposePort(port, sessionId, options?.name);
+      await this.withImplicitSession((sessionId) =>
+        this.client.ports.exposePort(port, sessionId, options?.name)
+      );
 
       tokens[port.toString()] = { token, name: options?.name };
       await this.ctx.storage.put('portTokens', tokens);
@@ -3790,9 +4193,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         await this.ctx.storage.put('portTokens', tokens);
       }
 
-      const sessionId = await this.ensureDefaultSession();
       try {
-        await this.client.ports.unexposePort(port, sessionId);
+        await this.withImplicitSession((sessionId) =>
+          this.client.ports.unexposePort(port, sessionId)
+        );
       } catch (error) {
         // A container that was asleep when we entered wakes with an
         // empty exposed-port registry; restoreExposedPorts() has
@@ -3820,8 +4224,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   async getExposedPorts(hostname: string) {
-    const sessionId = await this.ensureDefaultSession();
-    const response = await this.client.ports.getExposedPorts(sessionId);
+    const response = await this.withImplicitSession((sessionId) =>
+      this.client.ports.getExposedPorts(sessionId)
+    );
 
     // We need the sandbox name to construct preview URLs
     if (!this.sandboxName) {
@@ -3866,8 +4271,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
   async isPortExposed(port: number): Promise<boolean> {
     try {
-      const sessionId = await this.ensureDefaultSession();
-      const response = await this.client.ports.getExposedPorts(sessionId);
+      const response = await this.withImplicitSession((sessionId) =>
+        this.client.ports.getExposedPorts(sessionId)
+      );
       return response.ports.some((exposedPort) => exposedPort.port === port);
     } catch (error) {
       this.logger.error(
@@ -4108,7 +4514,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       terminal: null as unknown as ExecutionSession['terminal'],
 
       exec: (command, options) =>
-        this.execWithSession(command, sessionId, options),
+        this.executeInSession(command, sessionId, options),
       execStream: (command, options) =>
         this.execStreamWithSession(command, sessionId, options),
 
@@ -4548,7 +4954,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       shellEscape(presignedUrl)
     ].join(' ');
 
-    const result = await this.execWithSession(curlCmd, backupSession, {
+    const result = await this.executeInSession(curlCmd, backupSession, {
       timeout: 1810_000,
       origin: 'internal'
     });
@@ -4811,7 +5217,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     backupSession: string
   ): Promise<void> {
     const presignedUrl = await this.generatePresignedGetUrl(r2Key);
-    await this.execWithSession(
+    await this.executeInSession(
       `mkdir -p ${BACKUP_CONTAINER_DIR}`,
       backupSession,
       { origin: 'internal' }
@@ -4830,13 +5236,13 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         shellEscape(presignedUrl)
       ].join(' ');
 
-      const result = await this.execWithSession(curlCmd, backupSession, {
+      const result = await this.executeInSession(curlCmd, backupSession, {
         timeout: 1810_000,
         origin: 'internal'
       });
 
       if (result.exitCode !== 0) {
-        await this.execWithSession(
+        await this.executeInSession(
           `rm -f ${shellEscape(tmpPath)}`,
           backupSession,
           { origin: 'internal' }
@@ -4897,13 +5303,13 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         `if [ "$FAILED" -ne 0 ]; then rm -f ${shellEscape(tmpPath)}; exit 1; fi`
       ].join('; ');
 
-      const result = await this.execWithSession(script, backupSession, {
+      const result = await this.executeInSession(script, backupSession, {
         timeout: 1810_000,
         origin: 'internal'
       });
 
       if (result.exitCode !== 0) {
-        await this.execWithSession(
+        await this.executeInSession(
           `rm -f ${shellEscape(tmpPath)}`,
           backupSession,
           { origin: 'internal' }
@@ -4918,14 +5324,14 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       }
     }
 
-    const sizeCheck = await this.execWithSession(
+    const sizeCheck = await this.executeInSession(
       `stat -c %s ${shellEscape(tmpPath)}`,
       backupSession,
       { origin: 'internal' }
     );
     const actualSize = parseInt(sizeCheck.stdout.trim(), 10);
     if (actualSize !== expectedSize) {
-      await this.execWithSession(
+      await this.executeInSession(
         `rm -f ${shellEscape(tmpPath)}`,
         backupSession,
         { origin: 'internal' }
@@ -4939,13 +5345,13 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       });
     }
 
-    const mvResult = await this.execWithSession(
+    const mvResult = await this.executeInSession(
       `mv ${shellEscape(tmpPath)} ${shellEscape(archivePath)}`,
       backupSession,
       { origin: 'internal' }
     );
     if (mvResult.exitCode !== 0) {
-      await this.execWithSession(
+      await this.executeInSession(
         `rm -f ${shellEscape(tmpPath)}`,
         backupSession,
         { origin: 'internal' }
@@ -5150,7 +5556,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       outcome = 'success';
 
       // Clean up the local archive in the container
-      await this.execWithSession(
+      await this.executeInSession(
         `rm -f ${shellEscape(archivePath)}`,
         backupSession,
         { origin: 'internal' }
@@ -5164,7 +5570,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         const archivePath = `${BACKUP_CONTAINER_DIR}/${backupId}.sqsh`;
         const r2Key = `${BACKUP_STORAGE_PREFIX}/${backupId}/${BACKUP_ARCHIVE_OBJECT_NAME}`;
         const metaKey = `${BACKUP_STORAGE_PREFIX}/${backupId}/${BACKUP_METADATA_OBJECT_NAME}`;
-        await this.execWithSession(
+        await this.executeInSession(
           `rm -f ${shellEscape(archivePath)}`,
           backupSession,
           { origin: 'internal' }
@@ -5372,7 +5778,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       outcome = 'success';
 
       // Clean up local archive
-      await this.execWithSession(
+      await this.executeInSession(
         `rm -f ${shellEscape(archivePath)}`,
         backupSession,
         { origin: 'internal' }
@@ -5385,7 +5791,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         const archivePath = `${BACKUP_CONTAINER_DIR}/${backupId}.sqsh`;
         const r2Key = `${BACKUP_STORAGE_PREFIX}/${backupId}/${BACKUP_ARCHIVE_OBJECT_NAME}`;
         const metaKey = `${BACKUP_STORAGE_PREFIX}/${backupId}/${BACKUP_METADATA_OBJECT_NAME}`;
-        await this.execWithSession(
+        await this.executeInSession(
           `rm -f ${shellEscape(archivePath)}`,
           backupSession,
           { origin: 'internal' }
@@ -5562,12 +5968,12 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       // backup (both suffixed UUID_* and legacy unsuffixed UUID) and unmount
       // their squashfuse lower dirs.
       const mountGlob = `${BACKUP_CONTAINER_DIR}/mounts/${id}`;
-      await this.execWithSession(
+      await this.executeInSession(
         `/usr/bin/fusermount3 -uz ${shellEscape(dir)} 2>/dev/null || true`,
         backupSession,
         { origin: 'internal' }
       ).catch(() => {});
-      await this.execWithSession(
+      await this.executeInSession(
         `for d in ${shellEscape(mountGlob)}_*/lower ${shellEscape(mountGlob)}/lower; do [ -d "$d" ] && /usr/bin/fusermount3 -uz "$d" 2>/dev/null; done; true`,
         backupSession,
         { origin: 'internal' }
@@ -5576,7 +5982,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       // Step 4: Write archive to the container (skip if already present and
       // same size — avoids overwriting a file that a lazily-unmounted
       // squashfuse may still hold open).
-      const sizeCheck = await this.execWithSession(
+      const sizeCheck = await this.executeInSession(
         `stat -c %s ${shellEscape(archivePath)} 2>/dev/null || echo 0`,
         backupSession,
         { origin: 'internal' }
@@ -5624,7 +6030,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       caughtError = error instanceof Error ? error : new Error(String(error));
       if (id && backupSession) {
         const cleanupPath = `${BACKUP_CONTAINER_DIR}/${id}.sqsh`;
-        await this.execWithSession(
+        await this.executeInSession(
           `rm -f ${shellEscape(cleanupPath)}`,
           backupSession,
           { origin: 'internal' }
@@ -5768,7 +6174,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       const archivePath = `${BACKUP_CONTAINER_DIR}/${id}.sqsh`;
 
       // Ensure backup directory exists
-      await this.execWithSession(
+      await this.executeInSession(
         `mkdir -p ${BACKUP_CONTAINER_DIR}`,
         backupSession,
         { origin: 'internal' }
@@ -5825,7 +6231,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       }
 
       // Step 3: Extract archive using unsquashfs (no FUSE needed)
-      const extractResult = await this.execWithSession(
+      const extractResult = await this.executeInSession(
         `/usr/bin/unsquashfs -f -d ${shellEscape(dir)} ${shellEscape(archivePath)}`,
         backupSession,
         { origin: 'internal' }
@@ -5842,7 +6248,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       }
 
       // Clean up archive after extraction (no FUSE mount holds it open)
-      await this.execWithSession(
+      await this.executeInSession(
         `rm -f ${shellEscape(archivePath)}`,
         backupSession,
         { origin: 'internal' }
@@ -5859,7 +6265,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       caughtError = error instanceof Error ? error : new Error(String(error));
       if (id && backupSession) {
         const archivePath = `${BACKUP_CONTAINER_DIR}/${id}.sqsh`;
-        await this.execWithSession(
+        await this.executeInSession(
           `rm -f ${shellEscape(archivePath)}`,
           backupSession,
           { origin: 'internal' }

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -101,6 +101,8 @@ import type {
 } from './storage-mount/types';
 import { SDK_VERSION } from './version';
 
+const SESSIONLESS_SESSION_ID = 'none';
+
 /**
  * Persisted record for a single exposed port. `token` authorizes preview
  * URL requests; `name` is the optional friendly name the caller passed to
@@ -985,6 +987,20 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
   }
 
+  /**
+   * Toggle whether implicit operations use a persistent default session.
+   *
+   * When `false`:
+   * - `exec()` and `execStream()` run as true sessionless one-shot subprocesses
+   *   via `SESSIONLESS_SESSION_ID = 'none'` — no shell state is preserved between calls.
+   * - `startProcess()` (without an explicit `sessionId`) still creates a real
+   *   ephemeral shell session per call so the background process has a stable
+   *   environment. That session is cleaned up automatically when the process exits.
+   *
+   * Intended to be set once during sandbox initialisation. Changing this while
+   * `exec`/`execStream` calls are in flight is safe (each call captures its path
+   * at call-start), but the behaviour is unspecified for in-flight `startProcess`.
+   */
   async setEnableDefaultSession(enableDefaultSession: boolean): Promise<void> {
     if (this.enableDefaultSession === enableDefaultSession) return;
     await this.ctx.storage.put('enableDefaultSession', enableDefaultSession);
@@ -2697,7 +2713,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     options?: ExecOptions
   ): Promise<ExecResult> {
     const startTime = Date.now();
-    const sessionId = undefined;
+    const sessionId = SESSIONLESS_SESSION_ID;
     const env = this.resolveCommandEnv(options?.env);
     let execOutcome: { exitCode: number; success: boolean } | undefined;
     let execError: Error | undefined;
@@ -2711,8 +2727,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         timeoutMs: options?.timeout,
         env,
         cwd: options?.cwd,
-        origin: options?.origin,
-        sessionless: true
+        origin: options?.origin
       });
 
       const result = this.mapExecuteResponseToExecResult(
@@ -2846,8 +2861,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     sessionId: string | undefined,
     options: ExecOptions,
     startTime: number,
-    timestamp: string,
-    sessionless = false
+    timestamp: string
   ): Promise<ExecResult> {
     let stdout = '';
     let stderr = '';
@@ -2860,8 +2874,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           timeoutMs: options.timeout,
           env: options.env,
           cwd: options.cwd,
-          origin: options.origin,
-          ...(sessionless && { sessionless: true })
+          origin: options.origin
         }
       );
 
@@ -2922,14 +2935,13 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   ): Promise<ExecResult> {
     return this.executeWithStreaming(
       command,
-      undefined,
+      SESSIONLESS_SESSION_ID,
       {
         ...options,
         env: this.resolveCommandEnv(options.env)
       },
       Date.now(),
-      new Date().toISOString(),
-      true
+      new Date().toISOString()
     );
   }
 
@@ -3122,7 +3134,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           }
 
           // Process exited - do final check before throwing
-          if (event.type === 'exit') {
+          if (event.type === 'exit' || event.type === 'complete') {
             // Final check in case pattern arrived in last chunk
             const result = checkPattern();
             if (result) return result;
@@ -3283,7 +3295,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     try {
       const streamProcessor = async (): Promise<WaitForExitResult> => {
         for await (const event of parseSSEStream<LogEvent>(stream)) {
-          if (event.type === 'exit') {
+          if (event.type === 'exit' || event.type === 'complete') {
             return {
               exitCode: event.exitCode ?? 1
             };
@@ -3547,7 +3559,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     try {
       const stream = await this.client.processes.streamProcessLogs(processId);
       for await (const event of parseSSEStream<LogEvent>(stream)) {
-        if (event.type === 'exit') {
+        if (event.type === 'exit' || event.type === 'complete') {
           return;
         }
       }
@@ -3557,11 +3569,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   async listProcesses(sessionId?: string): Promise<Process[]> {
-    const resolvedId =
-      sessionId ??
-      (this.enableDefaultSession
-        ? await this.ensureDefaultSession()
-        : undefined);
+    const resolvedId = sessionId;
     const response = await this.client.processes.listProcesses();
 
     return response.processes.map((processData) =>
@@ -3581,11 +3589,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   async getProcess(id: string, sessionId?: string): Promise<Process | null> {
-    const resolvedId =
-      sessionId ??
-      (this.enableDefaultSession
-        ? await this.ensureDefaultSession()
-        : undefined);
+    const resolvedId = sessionId;
     let response: Awaited<ReturnType<typeof this.client.processes.getProcess>>;
     try {
       response = await this.client.processes.getProcess(id);
@@ -3659,12 +3663,15 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
     if (!this.enableDefaultSession) {
       const env = this.resolveCommandEnv(options?.env);
-      return this.client.commands.executeStream(command, undefined, {
-        timeoutMs: options?.timeout,
-        env,
-        cwd: options?.cwd,
-        sessionless: true
-      });
+      return this.client.commands.executeStream(
+        command,
+        SESSIONLESS_SESSION_ID,
+        {
+          timeoutMs: options?.timeout,
+          env,
+          cwd: options?.cwd
+        }
+      );
     }
 
     const session = await this.resolveImplicitSession();

--- a/packages/sandbox/tests/get-sandbox.test.ts
+++ b/packages/sandbox/tests/get-sandbox.test.ts
@@ -29,6 +29,7 @@ describe('getSandbox', () => {
         (configuration: {
           sandboxName?: { name: string; normalizeId?: boolean };
           sleepAfter?: string | number;
+          enableDefaultSession?: boolean;
         }) => {
           if (configuration.sleepAfter !== undefined) {
             mockStub.sleepAfter = configuration.sleepAfter;
@@ -40,7 +41,8 @@ describe('getSandbox', () => {
       setSleepAfter: vi.fn((value: string | number) => {
         mockStub.sleepAfter = value;
       }),
-      setKeepAlive: vi.fn()
+      setKeepAlive: vi.fn(),
+      setEnableDefaultSession: vi.fn()
     };
 
     // Mock getContainer to return our stub
@@ -297,6 +299,39 @@ describe('getSandbox', () => {
     expect(mockStub.configure).toHaveBeenCalledTimes(2);
     expect(mockStub.configure).toHaveBeenNthCalledWith(2, {
       transport: 'websocket'
+    });
+  });
+
+  it('should apply enableDefaultSession option when false', () => {
+    const mockNamespace = {} as any;
+    getSandbox(mockNamespace, 'test-sandbox', {
+      enableDefaultSession: false
+    });
+
+    expect(mockStub.configure).toHaveBeenCalledWith({
+      sandboxName: {
+        name: 'test-sandbox',
+        normalizeId: undefined
+      },
+      enableDefaultSession: false
+    });
+  });
+
+  it('should reconfigure when enableDefaultSession changes', async () => {
+    const mockNamespace = {} as any;
+
+    getSandbox(mockNamespace, 'test-sandbox', {
+      enableDefaultSession: true
+    });
+    await Promise.resolve();
+
+    getSandbox(mockNamespace, 'test-sandbox', {
+      enableDefaultSession: false
+    });
+
+    expect(mockStub.configure).toHaveBeenCalledTimes(2);
+    expect(mockStub.configure).toHaveBeenNthCalledWith(2, {
+      enableDefaultSession: false
     });
   });
 

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -149,6 +149,23 @@ describe('Sandbox - Automatic Session Management', () => {
       timestamp: new Date().toISOString()
     } as any);
 
+    vi.spyOn(sandbox.client.commands, 'executeStream').mockResolvedValue(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              `data: ${JSON.stringify({
+                type: 'complete',
+                exitCode: 0,
+                timestamp: new Date().toISOString()
+              })}\n\n`
+            )
+          );
+          controller.close();
+        }
+      })
+    );
+
     vi.spyOn(sandbox.client.files, 'writeFile').mockResolvedValue({
       success: true,
       path: '/test.txt',
@@ -245,6 +262,113 @@ describe('Sandbox - Automatic Session Management', () => {
 
       expect(firstSessionId).toBe(fileSessionId);
       expect(firstSessionId).toBe(secondSessionId);
+    });
+
+    it('should use sessionless exec when default sessions are disabled', async () => {
+      vi.spyOn(sandbox.client.utils, 'deleteSession').mockResolvedValue({
+        success: true,
+        sessionId: 'sandbox-ephemeral-test',
+        timestamp: new Date().toISOString()
+      } as any);
+
+      await sandbox.setEnableDefaultSession(false);
+
+      await sandbox.exec('echo test1');
+      await sandbox.writeFile('/test.txt', 'content');
+
+      expect(sandbox.client.utils.createSession).toHaveBeenCalledTimes(1);
+      expect(sandbox.client.utils.deleteSession).toHaveBeenCalledTimes(1);
+      expect(mockCtx.storage.put).not.toHaveBeenCalledWith(
+        'defaultSession',
+        expect.any(String)
+      );
+
+      const firstSessionId = vi.mocked(sandbox.client.commands.execute).mock
+        .calls[0][1];
+      const fileSessionId = vi.mocked(sandbox.client.files.writeFile).mock
+        .calls[0][2];
+
+      expect(firstSessionId).toBeUndefined();
+      expect(fileSessionId).toMatch(/^sandbox-ephemeral-/);
+      expect(sandbox.client.commands.execute).toHaveBeenCalledWith(
+        'echo test1',
+        undefined,
+        expect.objectContaining({ sessionless: true })
+      );
+      expect(sandbox.client.utils.deleteSession).toHaveBeenCalledWith(
+        fileSessionId
+      );
+    });
+
+    it('should merge sandbox env vars into sessionless exec', async () => {
+      await sandbox.setEnvVars({ SANDBOX_ONLY: 'sandbox-value' });
+      await sandbox.setEnableDefaultSession(false);
+
+      await sandbox.exec('echo $SANDBOX_ONLY', {
+        env: { CALL_ONLY: 'call-value', SANDBOX_ONLY: 'override-value' }
+      });
+
+      expect(sandbox.client.commands.execute).toHaveBeenCalledWith(
+        'echo $SANDBOX_ONLY',
+        undefined,
+        expect.objectContaining({
+          sessionless: true,
+          env: {
+            SANDBOX_ONLY: 'override-value',
+            CALL_ONLY: 'call-value'
+          }
+        })
+      );
+    });
+
+    it('should use sessionless execStream when default sessions are disabled', async () => {
+      await sandbox.setEnableDefaultSession(false);
+
+      await sandbox.execStream('echo stream');
+
+      expect(sandbox.client.utils.createSession).not.toHaveBeenCalled();
+      expect(sandbox.client.commands.executeStream).toHaveBeenCalledWith(
+        'echo stream',
+        undefined,
+        expect.objectContaining({ sessionless: true })
+      );
+    });
+
+    it('should merge sandbox env vars into sessionless execStream', async () => {
+      await sandbox.setEnvVars({ SANDBOX_ONLY: 'sandbox-value' });
+      await sandbox.setEnableDefaultSession(false);
+
+      await sandbox.execStream('echo stream', {
+        env: { CALL_ONLY: 'call-value', SANDBOX_ONLY: 'override-value' }
+      });
+
+      expect(sandbox.client.commands.executeStream).toHaveBeenCalledWith(
+        'echo stream',
+        undefined,
+        expect.objectContaining({
+          sessionless: true,
+          env: {
+            SANDBOX_ONLY: 'override-value',
+            CALL_ONLY: 'call-value'
+          }
+        })
+      );
+    });
+
+    it('should use sessionless streaming exec when default sessions are disabled', async () => {
+      await sandbox.setEnableDefaultSession(false);
+
+      await sandbox.exec('echo stream', {
+        stream: true,
+        onOutput: vi.fn()
+      });
+
+      expect(sandbox.client.utils.createSession).not.toHaveBeenCalled();
+      expect(sandbox.client.commands.executeStream).toHaveBeenCalledWith(
+        'echo stream',
+        undefined,
+        expect.objectContaining({ sessionless: true })
+      );
     });
 
     it('should use default session for process management', async () => {
@@ -375,6 +499,147 @@ describe('Sandbox - Automatic Session Management', () => {
       vi.mocked(mockCtx.storage.put).mockResolvedValue(undefined);
       await sandbox.exec('echo two');
 
+      expect(sandbox.client.utils.createSession).toHaveBeenCalledTimes(2);
+    });
+
+    it('clears stale default session state when disabling default sessions', async () => {
+      vi.spyOn(sandbox.client.utils, 'deleteSession').mockImplementation(
+        async (sessionId: string) =>
+          ({
+            success: true,
+            sessionId,
+            timestamp: new Date().toISOString()
+          }) as any
+      );
+
+      await sandbox.exec('echo initial');
+
+      const defaultSessionId = (sandbox as any).defaultSession;
+      expect(defaultSessionId).toBeTruthy();
+
+      await sandbox.setEnableDefaultSession(false);
+
+      expect((sandbox as any).defaultSession).toBeNull();
+      expect(mockCtx.storage.delete).toHaveBeenCalledWith('defaultSession');
+      expect(sandbox.client.utils.deleteSession).toHaveBeenCalledWith(
+        defaultSessionId
+      );
+
+      await expect(sandbox.deleteSession(defaultSessionId)).resolves.toEqual({
+        success: true,
+        sessionId: defaultSessionId,
+        timestamp: expect.any(String)
+      });
+      expect(sandbox.client.utils.deleteSession).toHaveBeenCalledTimes(2);
+
+      await sandbox.setEnvVars({ AFTER_DISABLE: '1' });
+
+      expect(sandbox.client.commands.execute).toHaveBeenCalledTimes(1);
+
+      await sandbox.exec('echo after disable');
+
+      expect(sandbox.client.commands.execute).toHaveBeenLastCalledWith(
+        'echo after disable',
+        undefined,
+        expect.objectContaining({
+          sessionless: true,
+          env: { AFTER_DISABLE: '1' }
+        })
+      );
+    });
+
+    it('does not revive stale shell state after disable then re-enable', async () => {
+      const sessionState = new Map<string, Map<string, string>>();
+
+      vi.mocked(sandbox.client.utils.createSession).mockImplementation(
+        async (request) => {
+          sessionState.set(request.id, new Map());
+          return {
+            success: true,
+            id: request.id,
+            message: 'Created'
+          } as any;
+        }
+      );
+
+      vi.spyOn(sandbox.client.utils, 'deleteSession').mockImplementation(
+        async (sessionId: string) => {
+          sessionState.delete(sessionId);
+          return {
+            success: true,
+            sessionId,
+            timestamp: new Date().toISOString()
+          } as any;
+        }
+      );
+
+      vi.mocked(sandbox.client.commands.execute).mockImplementation(
+        async (command, sessionId) => {
+          const timestamp = new Date().toISOString();
+          const state = sessionId
+            ? (sessionState.get(sessionId) ?? new Map<string, string>())
+            : new Map<string, string>();
+
+          if (sessionId && !sessionState.has(sessionId)) {
+            sessionState.set(sessionId, state);
+          }
+
+          const exportMatch = command.match(/^export ([A-Z_][A-Z0-9_]*)=(.+)$/);
+          if (exportMatch) {
+            state.set(exportMatch[1], exportMatch[2]);
+            return {
+              success: true,
+              stdout: '',
+              stderr: '',
+              exitCode: 0,
+              command,
+              timestamp
+            } as any;
+          }
+
+          const echoMatch = command.match(
+            /^echo "\$\{([A-Z_][A-Z0-9_]*):-EMPTY\}"$/
+          );
+          if (echoMatch) {
+            return {
+              success: true,
+              stdout: `${state.get(echoMatch[1]) ?? 'EMPTY'}
+`,
+              stderr: '',
+              exitCode: 0,
+              command,
+              timestamp
+            } as any;
+          }
+
+          return {
+            success: true,
+            stdout: '',
+            stderr: '',
+            exitCode: 0,
+            command,
+            timestamp
+          } as any;
+        }
+      );
+
+      await sandbox.exec('export REVIVED=stale_value');
+
+      const beforeDisable = await sandbox.exec('echo "${REVIVED:-EMPTY}"');
+      expect(beforeDisable.stdout.trim()).toBe('stale_value');
+
+      const originalDefaultSessionId = (sandbox as any).defaultSession;
+      expect(originalDefaultSessionId).toBeTruthy();
+
+      await sandbox.setEnableDefaultSession(false);
+      await sandbox.setEnableDefaultSession(true);
+
+      const afterReenable = await sandbox.exec('echo "${REVIVED:-EMPTY}"');
+
+      expect(afterReenable.stdout.trim()).toBe('EMPTY');
+      expect(sandbox.client.utils.deleteSession).toHaveBeenCalledWith(
+        originalDefaultSessionId
+      );
       expect(sandbox.client.utils.createSession).toHaveBeenCalledTimes(2);
     });
 
@@ -1899,7 +2164,7 @@ describe('Sandbox - Automatic Session Management', () => {
       vi.spyOn(backupSandbox as any, 'uploadBackupPresigned').mockResolvedValue(
         undefined
       );
-      vi.spyOn(backupSandbox as any, 'execWithSession').mockResolvedValue({
+      vi.spyOn(backupSandbox as any, 'executeInSession').mockResolvedValue({
         stdout: '',
         stderr: '',
         exitCode: 0
@@ -1947,7 +2212,7 @@ describe('Sandbox - Automatic Session Management', () => {
       vi.spyOn(backupSandbox as any, 'uploadBackupPresigned').mockResolvedValue(
         undefined
       );
-      vi.spyOn(backupSandbox as any, 'execWithSession').mockResolvedValue({
+      vi.spyOn(backupSandbox as any, 'executeInSession').mockResolvedValue({
         stdout: '',
         stderr: '',
         exitCode: 0
@@ -2044,7 +2309,7 @@ describe('Sandbox - Automatic Session Management', () => {
       const downloadBackupParallelSpy = vi
         .spyOn(backupSandbox as any, 'downloadBackupParallel')
         .mockResolvedValue(undefined);
-      vi.spyOn(backupSandbox as any, 'execWithSession').mockResolvedValue({
+      vi.spyOn(backupSandbox as any, 'executeInSession').mockResolvedValue({
         stdout: '0',
         stderr: '',
         exitCode: 0
@@ -2078,8 +2343,8 @@ describe('Sandbox - Automatic Session Management', () => {
     it('should write parallel restore ranges directly into the temp archive', async () => {
       const { backupSandbox } = await createBackupSandbox();
       const expectedSize = 16 * 1024 * 1024;
-      const execWithSessionSpy = vi
-        .spyOn(backupSandbox as any, 'execWithSession')
+      const executeInSessionSpy = vi
+        .spyOn(backupSandbox as any, 'executeInSession')
         .mockResolvedValueOnce({ stdout: '', stderr: '', exitCode: 0 })
         .mockResolvedValueOnce({ stdout: '', stderr: '', exitCode: 0 })
         .mockResolvedValueOnce({
@@ -2102,7 +2367,7 @@ describe('Sandbox - Automatic Session Management', () => {
         'backup-session'
       );
 
-      const downloadCommand = execWithSessionSpy.mock.calls[1][0] as string;
+      const downloadCommand = executeInSessionSpy.mock.calls[1][0] as string;
       expect(downloadCommand).toContain(
         "truncate -s 16777216 '/var/backups/test.sqsh.tmp'"
       );
@@ -2532,6 +2797,9 @@ describe('Sandbox - Automatic Session Management', () => {
       const second = sandbox.destroy();
       const third = sandbox.destroy();
 
+      // Wait for the async doDestroy() work to reach super.destroy().
+      await vi.waitFor(() => expect(superDestroy.calls()).toBe(1));
+
       // All three callers are awaiting the same underlying work; the parent
       // container destroy must only be invoked once.
       expect(superDestroy.calls()).toBe(1);
@@ -2549,6 +2817,8 @@ describe('Sandbox - Automatic Session Management', () => {
       const first = sandbox.destroy();
       const second = sandbox.destroy();
 
+      // Wait for doDestroy() to reach super.destroy() before rejecting it.
+      await vi.waitFor(() => expect(superDestroy.calls()).toBe(1));
       superDestroy.reject(new Error('container teardown failed'));
 
       await expect(first).rejects.toThrow('container teardown failed');
@@ -2558,14 +2828,14 @@ describe('Sandbox - Automatic Session Management', () => {
     it('runs a fresh teardown for a later destroy() after the previous one settles', async () => {
       const first = stubSuperDestroy();
       const firstCall = sandbox.destroy();
-      expect(first.calls()).toBe(1);
+      await vi.waitFor(() => expect(first.calls()).toBe(1));
       first.resolve();
       await firstCall;
 
       // Re-stub to track the second teardown independently.
       const second = stubSuperDestroy();
       const secondCall = sandbox.destroy();
-      expect(second.calls()).toBe(1);
+      await vi.waitFor(() => expect(second.calls()).toBe(1));
       second.resolve();
       await secondCall;
     });

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -288,12 +288,12 @@ describe('Sandbox - Automatic Session Management', () => {
       const fileSessionId = vi.mocked(sandbox.client.files.writeFile).mock
         .calls[0][2];
 
-      expect(firstSessionId).toBeUndefined();
+      expect(firstSessionId).toBe('none');
       expect(fileSessionId).toMatch(/^sandbox-ephemeral-/);
       expect(sandbox.client.commands.execute).toHaveBeenCalledWith(
         'echo test1',
-        undefined,
-        expect.objectContaining({ sessionless: true })
+        'none',
+        expect.any(Object)
       );
       expect(sandbox.client.utils.deleteSession).toHaveBeenCalledWith(
         fileSessionId
@@ -310,9 +310,8 @@ describe('Sandbox - Automatic Session Management', () => {
 
       expect(sandbox.client.commands.execute).toHaveBeenCalledWith(
         'echo $SANDBOX_ONLY',
-        undefined,
+        'none',
         expect.objectContaining({
-          sessionless: true,
           env: {
             SANDBOX_ONLY: 'override-value',
             CALL_ONLY: 'call-value'
@@ -329,8 +328,8 @@ describe('Sandbox - Automatic Session Management', () => {
       expect(sandbox.client.utils.createSession).not.toHaveBeenCalled();
       expect(sandbox.client.commands.executeStream).toHaveBeenCalledWith(
         'echo stream',
-        undefined,
-        expect.objectContaining({ sessionless: true })
+        'none',
+        expect.any(Object)
       );
     });
 
@@ -344,9 +343,8 @@ describe('Sandbox - Automatic Session Management', () => {
 
       expect(sandbox.client.commands.executeStream).toHaveBeenCalledWith(
         'echo stream',
-        undefined,
+        'none',
         expect.objectContaining({
-          sessionless: true,
           env: {
             SANDBOX_ONLY: 'override-value',
             CALL_ONLY: 'call-value'
@@ -366,8 +364,8 @@ describe('Sandbox - Automatic Session Management', () => {
       expect(sandbox.client.utils.createSession).not.toHaveBeenCalled();
       expect(sandbox.client.commands.executeStream).toHaveBeenCalledWith(
         'echo stream',
-        undefined,
-        expect.objectContaining({ sessionless: true })
+        'none',
+        expect.any(Object)
       );
     });
 
@@ -540,9 +538,8 @@ describe('Sandbox - Automatic Session Management', () => {
 
       expect(sandbox.client.commands.execute).toHaveBeenLastCalledWith(
         'echo after disable',
-        undefined,
+        'none',
         expect.objectContaining({
-          sessionless: true,
           env: { AFTER_DISABLE: '1' }
         })
       );

--- a/packages/shared/src/request-types.ts
+++ b/packages/shared/src/request-types.ts
@@ -11,6 +11,7 @@ import type { BackupCompressionOptions } from './types.js';
 export interface ExecuteRequest {
   command: string;
   sessionId?: string;
+  sessionless?: boolean;
   background?: boolean;
   timeoutMs?: number;
   env?: Record<string, string | undefined>;

--- a/packages/shared/src/request-types.ts
+++ b/packages/shared/src/request-types.ts
@@ -11,7 +11,6 @@ import type { BackupCompressionOptions } from './types.js';
 export interface ExecuteRequest {
   command: string;
   sessionId?: string;
-  sessionless?: boolean;
   background?: boolean;
   timeoutMs?: number;
   env?: Record<string, string | undefined>;

--- a/packages/shared/src/rpc-types.ts
+++ b/packages/shared/src/rpc-types.ts
@@ -75,11 +75,12 @@ export interface SandboxAPI {
 export interface SandboxCommandsAPI {
   execute(
     command: string,
-    sessionId: string,
+    sessionId: string | undefined,
     options?: {
       timeoutMs?: number;
       env?: Record<string, string | undefined>;
       cwd?: string;
+      sessionless?: boolean;
     }
   ): Promise<{
     success: boolean;
@@ -91,11 +92,12 @@ export interface SandboxCommandsAPI {
   }>;
   executeStream(
     command: string,
-    sessionId: string,
+    sessionId: string | undefined,
     options?: {
       timeoutMs?: number;
       env?: Record<string, string | undefined>;
       cwd?: string;
+      sessionless?: boolean;
     }
   ): Promise<ReadableStream<Uint8Array>>;
 }

--- a/packages/shared/src/rpc-types.ts
+++ b/packages/shared/src/rpc-types.ts
@@ -80,7 +80,6 @@ export interface SandboxCommandsAPI {
       timeoutMs?: number;
       env?: Record<string, string | undefined>;
       cwd?: string;
-      sessionless?: boolean;
     }
   ): Promise<{
     success: boolean;
@@ -97,7 +96,6 @@ export interface SandboxCommandsAPI {
       timeoutMs?: number;
       env?: Record<string, string | undefined>;
       cwd?: string;
-      sessionless?: boolean;
     }
   ): Promise<ReadableStream<Uint8Array>>;
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -553,6 +553,16 @@ export interface SandboxOptions {
    * @default "http"
    */
   transport?: SandboxTransport;
+
+  /**
+   * When false, methods that do not receive an explicit session run in
+   * isolated per-operation sessions instead of the persistent default session.
+   *
+   * Explicit sessions created with createSession() are unchanged.
+   *
+   * @default true
+   */
+  enableDefaultSession?: boolean;
 }
 
 /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -384,7 +384,7 @@ export interface ExecEvent {
 }
 
 export interface LogEvent {
-  type: 'stdout' | 'stderr' | 'exit' | 'error';
+  type: 'stdout' | 'stderr' | 'exit' | 'complete' | 'error';
   timestamp: string;
   data: string;
   processId: string;


### PR DESCRIPTION
## Summary

This branch adds support for isolated implicit execution behind `enableDefaultSession: false` while preserving the existing default-session behaviour when the option is `true` or omitted.

In persistent mode, implicit operations continue to reuse the default session through `ensureDefaultSession()`. In isolated mode, implicit `exec()` and `execStream()` run sessionless, while APIs that still need a session use short-lived ephemeral sessions.

## Why

Historically, implicit sandbox operations behaved as though they always shared one persistent shell. That made behaviour like `cd` and `export` convenient, but it also meant shell state could leak across unrelated implicit operations.

This branch adds an opt-in isolated mode so callers can choose between:

- persistent implicit execution with shared shell state
- isolated implicit execution without shared shell state

It also makes the mode toggle safe by ensuring old default-session state does not survive after the sandbox switches away from persistent mode.

## What Changed

### SDK behaviour

- added `enableDefaultSession` as a configurable sandbox option
- kept `enableDefaultSession: true` as the default so existing behaviour is unchanged
- routed implicit `exec()` and `execStream()` to true sessionless container execution when `enableDefaultSession: false`
- kept session-backed APIs working in isolated mode by creating short-lived ephemeral sessions when needed
- merged sandbox-level env from `setEnvVars()` into sessionless command execution
- cleared in-memory and persisted default-session state when disabling default sessions
- revisioned default-session IDs so re-enabling produces a fresh default-session identity
- cleaned up invalidated in-flight default-session initialisation

### Container behaviour

- added one-shot sessionless execution paths for commands
- added one-shot sessionless streaming paths
- updated the container API and handlers to accept optional `sessionId` plus `sessionless: true`

## Resulting Behaviour

### `enableDefaultSession: true` or omitted

- implicit operations continue to use `ensureDefaultSession()`
- shell state persists across implicit commands
- existing callers keep historical behaviour

### `enableDefaultSession: false`

- `exec()` and `execStream()` do not reuse the default session
- command execution uses sessionless container paths
- APIs that still need session context use ephemeral sessions
- sandbox-level env still applies
- disabling and re-enabling does not revive stale shell state

## Files Changed

### Core SDK

- `packages/sandbox/src/sandbox.ts`
- `packages/sandbox/src/clients/command-client.ts`

### Shared contracts

- `packages/shared/src/types.ts`
- `packages/shared/src/request-types.ts`
- `packages/shared/src/rpc-types.ts`

### Container runtime

- `packages/sandbox-container/src/core/types.ts`
- `packages/sandbox-container/src/handlers/execute-handler.ts`
- `packages/sandbox-container/src/control-plane/api.ts`
- `packages/sandbox-container/src/services/process-service.ts`

### Tests

- `packages/sandbox/tests/get-sandbox.test.ts`
- `packages/sandbox/tests/sandbox.test.ts`
- `packages/sandbox-container/tests/services/process-service.test.ts`

## Remaining Known Limitations

- top-level `sandbox.terminal()` still assumes a default session
- some internal infrastructure flows still intentionally use a stable default session for continuity, such as local mount sync and exposed-port restore

Those infrastructure flows are long-lived or startup-reconciliation paths rather than user implicit command execution, so they still benefit from a stable session identity while isolated implicit exec behaviour remains unchanged.
