### PR TITLE
Add support for Cloudflare tunnels

### DIFF
--- a/.changeset/quick-tunnels.md
+++ b/.changeset/quick-tunnels.md
@@ -1,16 +1,17 @@
 ---
-"@cloudflare/sandbox": minor
+'@cloudflare/sandbox': patch
 ---
 
-Add `sandbox.tunnels` namespace with quick-tunnel support. Call `sandbox.tunnels.create(port)` to spawn a `cloudflared` quick tunnel inside the sandbox and get back a `https://<words>.trycloudflare.com` URL that proxies to `localhost:<port>` inside the container. No Cloudflare account or DNS setup required.
+Add `sandbox.tunnels` namespace with quick-tunnel support. Call `sandbox.tunnels.get(port)` to obtain a `https://<words>.trycloudflare.com` URL that proxies to `localhost:<port>` inside the sandbox. The call is idempotent: repeated calls for the same port return the same record from per-sandbox Durable Object storage. No Cloudflare account or DNS setup required.
 
 ```ts
-const tunnel = await sandbox.tunnels.create(8080);
+const tunnel = await sandbox.tunnels.get(8080);
 console.log(tunnel.url);
 // → https://random-words-here.trycloudflare.com
 
-await sandbox.tunnels.list();
-await sandbox.tunnels.destroy(tunnel);
-```
+const same = await sandbox.tunnels.get(8080);
+console.log(same.url === tunnel.url); // true
 
-Quick tunnels require the RPC transport and the glibc sandbox image variants (default, python, opencode, desktop) — the musl/Alpine variant does not include cloudflared.
+await sandbox.tunnels.list();
+await sandbox.tunnels.destroy(8080); // or destroy(tunnel)
+```

--- a/.changeset/quick-tunnels.md
+++ b/.changeset/quick-tunnels.md
@@ -1,0 +1,16 @@
+---
+"@cloudflare/sandbox": minor
+---
+
+Add `sandbox.tunnels` namespace with quick-tunnel support. Call `sandbox.tunnels.create(port)` to spawn a `cloudflared` quick tunnel inside the sandbox and get back a `https://<words>.trycloudflare.com` URL that proxies to `localhost:<port>` inside the container. No Cloudflare account or DNS setup required.
+
+```ts
+const tunnel = await sandbox.tunnels.create(8080);
+console.log(tunnel.url);
+// → https://random-words-here.trycloudflare.com
+
+await sandbox.tunnels.list();
+await sandbox.tunnels.destroy(tunnel);
+```
+
+Quick tunnels require the RPC transport and the glibc sandbox image variants (default, python, opencode, desktop) — the musl/Alpine variant does not include cloudflared.

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -48,6 +48,41 @@ docker buildx build \
 
 Each image runs a lightweight HTTP server (port 3000) that the Sandbox SDK communicates with. The server handles command execution, file operations, process management, and port exposure. Images are built for `linux/amd64`.
 
+## Local development behind a TLS-intercepting proxy
+
+If your machine runs Cloudflare WARP / Zero Trust (or any other proxy
+that re-signs TLS with a corporate root), the sandbox container must
+trust that root or outbound HTTPS calls fail with
+`x509: certificate signed by unknown authority`. The Dockerfile accepts
+a `wrangler_ca` build secret that gets appended to the image's CA
+bundle and registered with `update-ca-certificates`:
+
+```bash
+docker build \
+  -f packages/sandbox/Dockerfile \
+  --target default \
+  --secret id=wrangler_ca,src="$NODE_EXTRA_CA_CERTS" \
+  -t my-sandbox-image .
+```
+
+WARP's installer sets `NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, and
+`REQUESTS_CA_BUNDLE` to a bundle that includes the corporate root, so
+passing `$NODE_EXTRA_CA_CERTS` is the easiest way to wire it through.
+Local builds done via `npm run docker:rebuild` already pass this
+secret — you only need this when invoking `docker build` directly.
+
+When the secret isn't passed (CI, fresh checkout without WARP), the
+build is a no-op and the resulting image trusts only the standard
+public CAs.
+
+**Known limitation for `sandbox.tunnels`.** Even with the CA bundle
+trusted, WARP's Zero Trust egress policy can block outbound traffic
+to `api.trycloudflare.com` and the cloudflared edge endpoints
+outright. When that happens, `tunnels.create()` hangs waiting for the
+edge handshake and eventually times out. The workaround is to run
+with WARP disabled or to add an egress exception for those
+destinations.
+
 ## Documentation
 
 - [Full Documentation](https://developers.cloudflare.com/sandbox/)

--- a/packages/sandbox-container/src/control-plane/api.ts
+++ b/packages/sandbox-container/src/control-plane/api.ts
@@ -25,6 +25,7 @@ import type {
   OutputMessage,
   Result,
   SandboxAPI,
+  TunnelInfo,
   WatchRequest
 } from '@repo/shared';
 import { ErrorCode } from '@repo/shared/errors';
@@ -47,6 +48,7 @@ import type {
 import type { PortService } from '../services/port-service';
 import type { ProcessService } from '../services/process-service';
 import type { SessionManager } from '../services/session-manager';
+import type { TunnelService } from '../services/tunnel-service';
 import type { WatchService } from '../services/watch-service';
 
 export interface SandboxAPIDeps {
@@ -58,6 +60,7 @@ export interface SandboxAPIDeps {
   backupService: BackupService;
   desktopService: DesktopService;
   watchService: WatchService;
+  tunnelService: TunnelService;
   sessionManager: SessionManager;
   logger: Logger;
 }
@@ -138,6 +141,9 @@ export class SandboxControlAPI extends RpcTarget implements SandboxAPI {
   }
   get watch() {
     return new WatchRPCAPI(this.#deps.watchService);
+  }
+  get tunnels() {
+    return new TunnelsRPCAPI(this.#deps.tunnelService);
   }
 }
 
@@ -1288,5 +1294,32 @@ class WatchRPCAPI extends RpcTarget {
       since: request.since
     });
     return extractData<CheckChangesResult>(result);
+  }
+}
+
+// ===========================================================================
+// Tunnels (cloudflared-based preview alternative)
+// ===========================================================================
+
+class TunnelsRPCAPI extends RpcTarget {
+  #svc: TunnelService;
+  constructor(svc: TunnelService) {
+    super();
+    this.#svc = svc;
+  }
+
+  async runQuickTunnel(id: string, port: number): Promise<TunnelInfo> {
+    const result = await this.#svc.runQuickTunnel(id, port);
+    return extractData<TunnelInfo>(result);
+  }
+
+  async destroyTunnel(id: string): Promise<{ success: true; id: string }> {
+    const result = await this.#svc.destroyTunnel(id);
+    throwIfError(result);
+    return { success: true, id };
+  }
+
+  async listTunnels(): Promise<TunnelInfo[]> {
+    return this.#svc.list();
   }
 }

--- a/packages/sandbox-container/src/core/container.ts
+++ b/packages/sandbox-container/src/core/container.ts
@@ -1,4 +1,4 @@
-import type { Logger } from '@repo/shared';
+import type { Logger, SandboxControlCallback } from '@repo/shared';
 import { createLogger, GitLogger } from '@repo/shared';
 import { BackupHandler } from '../handlers/backup-handler';
 import { DesktopHandler } from '../handlers/desktop-handler';
@@ -67,6 +67,11 @@ export interface Dependencies {
 export class Container {
   private dependencies: Partial<Dependencies> = {};
   private initialized = false;
+  // Latest capnweb remote main observed from a `capnweb` WS upgrade.
+  // Updated on every session open so tunnel exits and other future
+  // container→DO events route to the current peer. Cleared by the WS
+  // close handler. `null` between connections.
+  private controlCallback: SandboxControlCallback | null = null;
 
   get<T extends keyof Dependencies>(key: T): Dependencies[T] {
     if (!this.initialized) {
@@ -89,6 +94,20 @@ export class Container {
     implementation: Dependencies[T]
   ): void {
     this.dependencies[key] = implementation;
+  }
+
+  /**
+   * Set / clear the DO-side control callback exposed via the current
+   * capnweb session's remote main. Called from `server.ts` on each
+   * `capnweb` WS open (with the new peer) and on close (with `null`).
+   */
+  setControlCallback(cb: SandboxControlCallback | null): void {
+    this.controlCallback = cb;
+  }
+
+  /** Returns the current peer's control callback or `null`. */
+  getControlCallback(): SandboxControlCallback | null {
+    return this.controlCallback;
   }
 
   async initialize(): Promise<void> {
@@ -132,7 +151,9 @@ export class Container {
     const backupService = new BackupService(logger, sessionManager);
     const desktopService = new DesktopService(logger);
     const watchService = new WatchService(logger);
-    const tunnelService = new TunnelService(logger);
+    const tunnelService = new TunnelService(logger, () =>
+      this.getControlCallback()
+    );
 
     // Initialize handlers
     const backupHandler = new BackupHandler(backupService, logger);

--- a/packages/sandbox-container/src/core/container.ts
+++ b/packages/sandbox-container/src/core/container.ts
@@ -25,6 +25,7 @@ import { InMemoryPortStore, PortService } from '../services/port-service';
 import { ProcessService } from '../services/process-service';
 import { ProcessStore } from '../services/process-store';
 import { SessionManager } from '../services/session-manager';
+import { TunnelService } from '../services/tunnel-service';
 import { WatchService } from '../services/watch-service';
 
 export interface Dependencies {
@@ -37,6 +38,7 @@ export interface Dependencies {
   backupService: BackupService;
   desktopService: DesktopService;
   watchService: WatchService;
+  tunnelService: TunnelService;
 
   // Infrastructure
   logger: Logger;
@@ -130,6 +132,7 @@ export class Container {
     const backupService = new BackupService(logger, sessionManager);
     const desktopService = new DesktopService(logger);
     const watchService = new WatchService(logger);
+    const tunnelService = new TunnelService(logger);
 
     // Initialize handlers
     const backupHandler = new BackupHandler(backupService, logger);
@@ -163,6 +166,7 @@ export class Container {
       backupService,
       desktopService,
       watchService,
+      tunnelService,
 
       // Infrastructure
       logger,

--- a/packages/sandbox-container/src/managers/tunnel-manager.ts
+++ b/packages/sandbox-container/src/managers/tunnel-manager.ts
@@ -27,6 +27,19 @@ export interface TunnelManagerOptions {
   readyTimeoutMs?: number;
   /** Grace period between SIGTERM and SIGKILL during stop(). */
   stopGraceMs?: number;
+  /**
+   * Optional callback invoked exactly once when the supervised
+   * `cloudflared` process exits, for any reason — natural exit,
+   * graceful SIGTERM via `stop()`, or post-SIGKILL reap.
+   *
+   * `exitCode` is the integer exit status, or `null` if the process
+   * was signalled rather than exited cleanly (matches Bun's
+   * Subprocess.exited contract).
+   *
+   * Errors thrown from the callback are caught and logged so a
+   * broken consumer cannot crash the manager.
+   */
+  onExit?: (exitCode: number | null) => void | Promise<void>;
   logger: Logger;
 }
 
@@ -78,10 +91,31 @@ export class TunnelManager {
     }) as Subprocess<'ignore', 'pipe', 'pipe'>;
 
     // Track exit so the readiness loop can fail fast if cloudflared dies.
+    // We also fire the consumer's onExit callback here so a single
+    // hook covers natural exits, SIGTERM-driven stops, and SIGKILL
+    // fallbacks. Callback errors are caught and logged — a broken
+    // consumer must not crash the manager.
     this.proc.exited.then((code) => {
       this.exited = true;
       this.exitInfo = { code, signal: null };
       this.logger.info('cloudflared exited', { code });
+      const onExit = this.opts.onExit;
+      if (onExit) {
+        try {
+          const result = onExit(code);
+          if (result && typeof (result as Promise<void>).catch === 'function') {
+            (result as Promise<void>).catch((err) => {
+              this.logger.warn('onExit callback rejected', {
+                error: err instanceof Error ? err.message : String(err)
+              });
+            });
+          }
+        } catch (err) {
+          this.logger.warn('onExit callback threw', {
+            error: err instanceof Error ? err.message : String(err)
+          });
+        }
+      }
     });
 
     // Pump stderr (cloudflared logs there by default) and scrape what we

--- a/packages/sandbox-container/src/managers/tunnel-manager.ts
+++ b/packages/sandbox-container/src/managers/tunnel-manager.ts
@@ -1,0 +1,257 @@
+/**
+ * TunnelManager - supervises a single `cloudflared` child process running
+ * a quick tunnel (`cloudflared tunnel --url`).
+ */
+
+import type { Logger } from '@repo/shared';
+import type { Subprocess } from 'bun';
+
+const READY_POLL_INTERVAL_MS = 200;
+const DEFAULT_READY_TIMEOUT_MS = 90_000;
+const DEFAULT_STOP_GRACE_MS = 3_000;
+
+/**
+ * Match the metrics-endpoint announcement message cloudflared emits at
+ * startup. The exact text is `Starting metrics server on 127.0.0.1:<port>/metrics`;
+ * we capture the host:port for the readiness probe.
+ */
+const METRICS_BIND_REGEX = /metrics server on (127\.0\.0\.1:\d+)/i;
+const QUICK_URL_REGEX = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/i;
+
+export interface TunnelManagerOptions {
+  /** Local port to expose. */
+  port: number;
+  /** Optional path to the cloudflared binary. Defaults to `cloudflared`. */
+  binaryPath?: string;
+  /** Override readiness timeout. */
+  readyTimeoutMs?: number;
+  /** Grace period between SIGTERM and SIGKILL during stop(). */
+  stopGraceMs?: number;
+  logger: Logger;
+}
+
+export interface TunnelStartResult {
+  /** Public URL the tunnel resolves to, parsed from the cloudflared banner. */
+  url: string;
+  /** PID of the cloudflared child process. */
+  pid: number;
+}
+
+export class TunnelManager {
+  private readonly opts: TunnelManagerOptions;
+  private readonly logger: Logger;
+  private proc: Subprocess<'ignore', 'pipe', 'pipe'> | null = null;
+  private metricsAddr: string | null = null;
+  private quickUrl: string | null = null;
+  private exited = false;
+  private exitInfo: { code: number | null; signal: string | null } | null =
+    null;
+
+  constructor(opts: TunnelManagerOptions) {
+    this.opts = opts;
+    this.logger = opts.logger.child({ port: opts.port });
+  }
+
+  /**
+   * Spawn cloudflared and resolve once a public URL is available and the
+   * tunnel reports ready. Rejects on timeout or early process exit. On
+   * rejection the caller MUST call `stop()` to clean up the child process —
+   * `start()` does not self-clean so failures can be diagnosed by inspecting
+   * the (still-running) process.
+   */
+  async start(): Promise<TunnelStartResult> {
+    if (this.proc) {
+      throw new Error('TunnelManager: already started');
+    }
+
+    const args = this.buildArgs();
+    this.logger.info('Spawning cloudflared', { args });
+
+    const binary = this.opts.binaryPath ?? 'cloudflared';
+    this.proc = Bun.spawn([binary, ...args], {
+      stdin: 'ignore',
+      stdout: 'pipe',
+      stderr: 'pipe',
+      // Put cloudflared in its own process group so SIGTERM/SIGKILL on its
+      // pid is scoped to it (and to any future children it spawns).
+      detached: true
+    }) as Subprocess<'ignore', 'pipe', 'pipe'>;
+
+    // Track exit so the readiness loop can fail fast if cloudflared dies.
+    this.proc.exited.then((code) => {
+      this.exited = true;
+      this.exitInfo = { code, signal: null };
+      this.logger.info('cloudflared exited', { code });
+    });
+
+    // Pump stderr (cloudflared logs there by default) and scrape what we
+    // need from it. Stdout is normally empty for `tunnel` but we drain
+    // it for completeness.
+    void this.scrapeStream(this.proc.stderr, 'stderr');
+    void this.scrapeStream(this.proc.stdout, 'stdout');
+
+    const timeoutMs = this.opts.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS;
+    const url = await this.waitForReady(timeoutMs);
+
+    return { url, pid: this.proc.pid };
+  }
+
+  /** Send SIGTERM, then SIGKILL after `stopGraceMs`. */
+  async stop(): Promise<void> {
+    if (!this.proc || this.exited) return;
+    this.logger.info('Stopping cloudflared', { pid: this.proc.pid });
+
+    try {
+      this.proc.kill('SIGTERM');
+    } catch (err) {
+      this.logger.warn('SIGTERM failed', { error: String(err) });
+    }
+
+    const graceMs = this.opts.stopGraceMs ?? DEFAULT_STOP_GRACE_MS;
+    const exitedInTime = await Promise.race([
+      this.proc.exited.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), graceMs))
+    ]);
+
+    if (!exitedInTime) {
+      this.logger.warn('cloudflared did not exit on SIGTERM, sending SIGKILL');
+      try {
+        this.proc.kill('SIGKILL');
+      } catch (err) {
+        this.logger.warn('SIGKILL failed', { error: String(err) });
+      }
+      await this.proc.exited;
+    }
+  }
+
+  isRunning(): boolean {
+    return this.proc !== null && !this.exited;
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private buildArgs(): string[] {
+    const localUrl = `http://localhost:${this.opts.port}`;
+    // Always attach a metrics server on an ephemeral port so we can poll
+    // /ready for a stable readiness signal.
+    return [
+      'tunnel',
+      '--metrics',
+      '127.0.0.1:0',
+      '--no-autoupdate',
+      '--output',
+      'json',
+      '--url',
+      localUrl
+    ];
+  }
+
+  private async scrapeStream(
+    stream: ReadableStream<Uint8Array> | null,
+    label: 'stdout' | 'stderr'
+  ): Promise<void> {
+    if (!stream) return;
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        for (;;) {
+          const nl = buffer.indexOf('\n');
+          if (nl === -1) break;
+          const line = buffer.slice(0, nl);
+          buffer = buffer.slice(nl + 1);
+          this.handleLogLine(line, label);
+        }
+      }
+      if (buffer) this.handleLogLine(buffer, label);
+    } catch {
+      // Stream cancelled — expected during stop.
+    }
+  }
+
+  private handleLogLine(line: string, label: 'stdout' | 'stderr'): void {
+    if (!line.trim()) return;
+    this.logger.debug(`cloudflared:${label}`, { line });
+
+    // With `--output json`, every record is `{level, message, ...}`.
+    // Fall back to substring matching when a line isn't JSON (cloudflared
+    // occasionally writes plaintext warnings before json mode kicks in).
+    let message = line;
+    try {
+      const record = JSON.parse(line) as { message?: string };
+      if (typeof record.message === 'string') {
+        message = record.message;
+      }
+    } catch {
+      // Not JSON — use the raw line.
+    }
+
+    if (!this.metricsAddr) {
+      const m = message.match(METRICS_BIND_REGEX);
+      if (m) {
+        this.metricsAddr = m[1];
+        this.logger.info('cloudflared metrics endpoint', {
+          addr: this.metricsAddr
+        });
+      }
+    }
+
+    if (!this.quickUrl) {
+      const m = message.match(QUICK_URL_REGEX);
+      if (m) {
+        this.quickUrl = m[0];
+        this.logger.info('quick tunnel URL detected', { url: this.quickUrl });
+      }
+    }
+  }
+
+  /**
+   * Resolve once cloudflared is ready: we have a parsed
+   * `*.trycloudflare.com` URL **and** `/ready` reports >= 1 connection.
+   */
+  private async waitForReady(timeoutMs: number): Promise<string> {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      if (this.exited) {
+        throw new Error(
+          `cloudflared exited before becoming ready (code=${this.exitInfo?.code})`
+        );
+      }
+
+      const ready = await this.checkReady();
+      if (ready && this.quickUrl) return this.quickUrl;
+
+      await new Promise((r) => setTimeout(r, READY_POLL_INTERVAL_MS));
+    }
+
+    throw new Error(
+      `Timed out waiting for cloudflared to become ready after ${timeoutMs}ms`
+    );
+  }
+
+  /**
+   * Returns true once cloudflared's `/ready` reports `readyConnections >= 1`.
+   * Returns false (silently) if the metrics endpoint isn't yet known or the
+   * fetch fails — caller will retry on the poll interval.
+   */
+  private async checkReady(): Promise<boolean> {
+    if (!this.metricsAddr) return false;
+    try {
+      const res = await fetch(`http://${this.metricsAddr}/ready`, {
+        signal: AbortSignal.timeout(1_000)
+      });
+      if (!res.ok) return false;
+      const body = (await res.json()) as { readyConnections?: number };
+      return (body.readyConnections ?? 0) >= 1;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/sandbox-container/src/server.ts
+++ b/packages/sandbox-container/src/server.ts
@@ -284,6 +284,7 @@ export async function startServer(): Promise<ServerInstance> {
         const processService = app.container.get('processService');
         const portService = app.container.get('portService');
         const watchService = app.container.get('watchService');
+        const tunnelService = app.container.get('tunnelService');
 
         const stoppedWatches = await watchService.stopAllWatches();
         if (stoppedWatches > 0) {
@@ -295,6 +296,7 @@ export async function startServer(): Promise<ServerInstance> {
         await desktopService.destroy();
         await processService.destroy();
         portService.destroy();
+        await tunnelService.destroyAll();
 
         logger.info('Services cleaned up successfully');
       } catch (error) {

--- a/packages/sandbox-container/src/server.ts
+++ b/packages/sandbox-container/src/server.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '@repo/shared';
+import { createLogger, type SandboxControlCallback } from '@repo/shared';
 import type { ServerWebSocket } from 'bun';
 import { serve } from 'bun';
 import { trustRuntimeCert } from './cert';
@@ -201,11 +201,17 @@ export async function startServer(): Promise<ServerInstance> {
                 } catch {}
               });
           } else if (ws.data.type === 'capnweb') {
-            const { transport } = newBunWebSocketRpcSession(
+            const { stub, transport } = newBunWebSocketRpcSession(
               ws,
               app.controlPlaneAPI
             );
             ws.data.transport = transport;
+            // Capture the peer's remote main (the DO's
+            // SandboxControlCallback) so the container can push
+            // events back — e.g. tunnel-exit notifications.
+            app.container.setControlCallback(
+              stub as unknown as SandboxControlCallback
+            );
             logger.debug('capnweb session initialized', {
               connectionId: ws.data.connectionId
             });
@@ -227,6 +233,10 @@ export async function startServer(): Promise<ServerInstance> {
               .onClose(ws as ServerWebSocket<PtyWSData>, code, reason);
           } else if (ws.data.type === 'capnweb') {
             ws.data.transport?.dispatchClose(code, reason);
+            // Forget the peer's control callback. Subsequent tunnel
+            // exits resolve `null` from the accessor and become no-ops
+            // until a new session opens.
+            app.container.setControlCallback(null);
           } else {
             app.wsAdapter.onClose(ws, code, reason);
           }

--- a/packages/sandbox-container/src/server.ts
+++ b/packages/sandbox-container/src/server.ts
@@ -142,7 +142,7 @@ async function createApplication(): Promise<{
         }
 
         if (url.pathname === '/rpc') {
-          logger.info('Establishing capnweb connection');
+          logger.info('Establishing RPC connection');
           const upgraded = server.upgrade(req, {
             data: {
               type: 'capnweb' as const,
@@ -212,7 +212,7 @@ export async function startServer(): Promise<ServerInstance> {
             app.container.setControlCallback(
               stub as unknown as SandboxControlCallback
             );
-            logger.debug('capnweb session initialized', {
+            logger.debug('RPC session initialized', {
               connectionId: ws.data.connectionId
             });
           } else {

--- a/packages/sandbox-container/src/server.ts
+++ b/packages/sandbox-container/src/server.ts
@@ -82,6 +82,7 @@ async function createApplication(): Promise<{
     backupService: container.get('backupService'),
     desktopService: container.get('desktopService'),
     watchService: container.get('watchService'),
+    tunnelService: container.get('tunnelService'),
     sessionManager: container.get('sessionManager'),
     logger
   });

--- a/packages/sandbox-container/src/services/tunnel-service.ts
+++ b/packages/sandbox-container/src/services/tunnel-service.ts
@@ -1,0 +1,106 @@
+/**
+ * TunnelService - container-side orchestration for cloudflared quick tunnels.
+ *
+ * Owns the in-memory registry of tunnels running inside this container and
+ * delegates the actual subprocess supervision to `TunnelManager`. No
+ * Cloudflare API calls happen here; quick tunnels need no credentials.
+ *
+ * The SDK mints all tunnel ids and passes them in so the SDK can store the
+ * id without waiting for the create round-trip to resolve.
+ */
+
+import type { Logger, TunnelInfo } from '@repo/shared';
+import type { ServiceResult } from '../core/types';
+import { serviceError, serviceSuccess } from '../core/types';
+import { TunnelManager } from '../managers/tunnel-manager';
+
+
+export interface RunQuickTunnelOptions {
+  /** Override the readiness timeout. Forwarded to TunnelManager. */
+  readyTimeoutMs?: number;
+  /** Override the SIGTERM→SIGKILL grace period. Forwarded to TunnelManager. */
+  stopGraceMs?: number;
+}
+
+interface TunnelRecord {
+  info: TunnelInfo;
+  manager: TunnelManager;
+}
+
+export class TunnelService {
+  private readonly tunnels = new Map<string, TunnelRecord>();
+
+  constructor(private readonly logger: Logger) {}
+
+  async runQuickTunnel(
+    id: string,
+    port: number,
+    options?: RunQuickTunnelOptions
+  ): Promise<ServiceResult<TunnelInfo>> {
+    if (this.tunnels.has(id)) {
+      return serviceError({
+        message: `Tunnel ${id} is already running`,
+        code: 'TUNNEL_ALREADY_RUNNING',
+        details: { tunnelId: id }
+      });
+    }
+
+    const manager = new TunnelManager({
+      port,
+      logger: this.logger,
+      readyTimeoutMs: options?.readyTimeoutMs,
+      stopGraceMs: options?.stopGraceMs
+    });
+
+    try {
+      const { url } = await manager.start();
+      const hostname = new URL(url).hostname;
+      const info: TunnelInfo = {
+        id,
+        port,
+        url,
+        hostname,
+        createdAt: new Date().toISOString()
+      };
+      this.tunnels.set(id, { info, manager });
+      this.logger.info('Quick tunnel running', { id, port, url });
+      return serviceSuccess(info);
+    } catch (err) {
+      await manager.stop().catch(() => {});
+      const message = err instanceof Error ? err.message : String(err);
+      return serviceError({
+        message: `Failed to run quick tunnel: ${message}`,
+        code: 'TUNNEL_START_ERROR',
+        details: { tunnelId: id, port }
+      });
+    }
+  }
+
+  async destroyTunnel(id: string): Promise<ServiceResult<void>> {
+    const record = this.tunnels.get(id);
+    if (!record) {
+      return serviceError({
+        message: `Tunnel ${id} is not running`,
+        code: 'TUNNEL_NOT_FOUND',
+        details: { tunnelId: id }
+      });
+    }
+    try {
+      await record.manager.stop();
+    } finally {
+      this.tunnels.delete(id);
+    }
+    this.logger.info('Tunnel destroyed', { id });
+    return { success: true };
+  }
+
+  list(): TunnelInfo[] {
+    return Array.from(this.tunnels.values()).map((r) => r.info);
+  }
+
+  /** Stop every tunnel. Called on container shutdown. */
+  async destroyAll(): Promise<void> {
+    const ids = Array.from(this.tunnels.keys());
+    await Promise.all(ids.map((id) => this.destroyTunnel(id)));
+  }
+}

--- a/packages/sandbox-container/src/services/tunnel-service.ts
+++ b/packages/sandbox-container/src/services/tunnel-service.ts
@@ -9,11 +9,10 @@
  * id without waiting for the create round-trip to resolve.
  */
 
-import type { Logger, TunnelInfo } from '@repo/shared';
+import type { Logger, SandboxControlCallback, TunnelInfo } from '@repo/shared';
 import type { ServiceResult } from '../core/types';
 import { serviceError, serviceSuccess } from '../core/types';
 import { TunnelManager } from '../managers/tunnel-manager';
-
 
 export interface RunQuickTunnelOptions {
   /** Override the readiness timeout. Forwarded to TunnelManager. */
@@ -30,7 +29,19 @@ interface TunnelRecord {
 export class TunnelService {
   private readonly tunnels = new Map<string, TunnelRecord>();
 
-  constructor(private readonly logger: Logger) {}
+  /**
+   * @param logger Child logger for tunnel-service log lines.
+   * @param getControlCallback Optional accessor returning the DO-side
+   * control callback exposed over the capnweb session's remote main.
+   * Resolved fresh on every cloudflared exit, returning `null` when the
+   * session is not bound yet (legacy callers, tests, or
+   * pre-WS-upgrade window).
+   */
+  constructor(
+    private readonly logger: Logger,
+    private readonly getControlCallback: () => SandboxControlCallback | null = () =>
+      null
+  ) {}
 
   async runQuickTunnel(
     id: string,
@@ -49,7 +60,22 @@ export class TunnelService {
       port,
       logger: this.logger,
       readyTimeoutMs: options?.readyTimeoutMs,
-      stopGraceMs: options?.stopGraceMs
+      stopGraceMs: options?.stopGraceMs,
+      onExit: (code) => {
+        // Drop our in-memory registry first so list() / destroyAll()
+        // don't see a phantom record while we await the DO callback.
+        this.tunnels.delete(id);
+        const cb = this.getControlCallback();
+        if (!cb) return;
+        // Fire-and-forget the DO notification. Errors are swallowed
+        // so a misbehaving DO can't crash the manager's exit handler.
+        cb.onTunnelExit(id, port, code).catch((err) => {
+          this.logger.warn('onTunnelExit RPC failed', {
+            id,
+            error: err instanceof Error ? err.message : String(err)
+          });
+        });
+      }
     });
 
     try {

--- a/packages/sandbox-container/tests/services/tunnel-service.test.ts
+++ b/packages/sandbox-container/tests/services/tunnel-service.test.ts
@@ -365,3 +365,95 @@ describe('TunnelService > list & destroyAll', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Exit-callback wiring (container → DO via session remote main)
+// ---------------------------------------------------------------------------
+
+describe('TunnelService > exit callback', () => {
+  it('invokes the callback when cloudflared exits naturally after start', async () => {
+    const onTunnelExit = mock(async () => {});
+    const service = new TunnelService(mockLogger, () => ({
+      onTunnelExit
+    }));
+    await withFakeCloudflared(QUICK_BANNER, () =>
+      service.runQuickTunnel('quick-natural', 8080)
+    );
+    expect(service.list()).toHaveLength(1);
+
+    // Simulate cloudflared crashing.
+    fakeProcs[0].resolveExit(2);
+    // Let the exit handler chain run.
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(onTunnelExit).toHaveBeenCalledTimes(1);
+    expect(onTunnelExit).toHaveBeenCalledWith('quick-natural', 8080, 2);
+    // Service registry is cleared so list() reflects truth.
+    expect(service.list()).toHaveLength(0);
+  });
+
+  it('invokes the callback on the graceful stop path triggered by destroyTunnel', async () => {
+    const onTunnelExit = mock(async () => {});
+    const service = new TunnelService(mockLogger, () => ({
+      onTunnelExit
+    }));
+    await withFakeCloudflared(QUICK_BANNER, () =>
+      service.runQuickTunnel('quick-graceful', 8080)
+    );
+
+    const destroyPromise = service.destroyTunnel('quick-graceful');
+    await new Promise((r) => setTimeout(r, 5));
+    fakeProcs[0].resolveExit(0);
+    await destroyPromise;
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(onTunnelExit).toHaveBeenCalledTimes(1);
+    expect(onTunnelExit).toHaveBeenCalledWith('quick-graceful', 8080, 0);
+  });
+
+  it('skips the callback when the accessor returns null (no session bound)', async () => {
+    let nullCalls = 0;
+    const service = new TunnelService(mockLogger, () => {
+      nullCalls++;
+      return null;
+    });
+    await withFakeCloudflared(QUICK_BANNER, () =>
+      service.runQuickTunnel('quick-nocb', 8080)
+    );
+    fakeProcs[0].resolveExit(0);
+    await new Promise((r) => setTimeout(r, 20));
+    // Accessor was at least consulted once on exit.
+    expect(nullCalls).toBeGreaterThanOrEqual(1);
+    // Service registry still cleared even with no DO to notify.
+    expect(service.list()).toHaveLength(0);
+  });
+
+  it('swallows callback errors so a broken DO does not break the service', async () => {
+    const onTunnelExit = mock(async () => {
+      throw new Error('DO storage exploded');
+    });
+    const service = new TunnelService(mockLogger, () => ({
+      onTunnelExit
+    }));
+    await withFakeCloudflared(QUICK_BANNER, () =>
+      service.runQuickTunnel('quick-bad-cb', 8080)
+    );
+    fakeProcs[0].resolveExit(0);
+    // Should not throw, should not leave behind a registry entry.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(onTunnelExit).toHaveBeenCalledTimes(1);
+    expect(service.list()).toHaveLength(0);
+  });
+
+  it('omitting the accessor (legacy callers) is supported — no callback fired', async () => {
+    // Backward-compat path: existing tests/code that don't pass a
+    // callback accessor keep working.
+    const service = new TunnelService(mockLogger);
+    await withFakeCloudflared(QUICK_BANNER, () =>
+      service.runQuickTunnel('quick-legacy', 8080)
+    );
+    fakeProcs[0].resolveExit(0);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(service.list()).toHaveLength(0);
+  });
+});

--- a/packages/sandbox-container/tests/services/tunnel-service.test.ts
+++ b/packages/sandbox-container/tests/services/tunnel-service.test.ts
@@ -1,0 +1,367 @@
+/**
+ * TunnelService + TunnelManager unit tests.
+ *
+ * Mocks the `Bun.spawn` boundary (the cloudflared subprocess) so the real
+ * TunnelManager + TunnelService code paths run end-to-end. We feed canned
+ * cloudflared stderr through a streaming fake and stand up a minimal
+ * `/ready` endpoint via `fetch` mock so the manager's readiness probe
+ * sees what it expects.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn
+} from 'bun:test';
+import type { Logger } from '@repo/shared';
+import { TunnelService } from '@sandbox-container/services/tunnel-service';
+
+function pushableStream() {
+  const enc = new TextEncoder();
+  const { readable, writable } = new TransformStream<Uint8Array>();
+  const writer = writable.getWriter();
+  return {
+    stream: readable,
+    write(chunk: string) {
+      void writer.write(enc.encode(chunk));
+    },
+    close() {
+      void writer.close();
+    }
+  };
+}
+
+interface FakeProc {
+  pid: number;
+  stdout: ReadableStream<Uint8Array> | null;
+  stderr: ReadableStream<Uint8Array> | null;
+  exited: Promise<number>;
+  kill: ReturnType<typeof mock>;
+  killed: boolean;
+}
+
+interface FakeProcController {
+  proc: FakeProc;
+  stderr: ReturnType<typeof pushableStream>;
+  resolveExit: (code: number) => void;
+  kill: ReturnType<typeof mock>;
+  argv: string[];
+}
+
+const fakeProcs: FakeProcController[] = [];
+let originalFetch: typeof fetch;
+const fetchHandler = { ready: false };
+
+function makeFakeProc(argv: string[]): FakeProcController {
+  const stderr = pushableStream();
+  const stdoutEmpty = pushableStream();
+  stdoutEmpty.close();
+  const exit = Promise.withResolvers<number>();
+  let killFn: (signal: string) => void = () => {};
+  const kill = mock((signal: string) => killFn(signal));
+  const proc: FakeProc = {
+    pid: 4242 + fakeProcs.length,
+    stdout: stdoutEmpty.stream,
+    stderr: stderr.stream,
+    exited: exit.promise,
+    kill,
+    killed: false
+  };
+  const ctrl: FakeProcController = {
+    proc,
+    stderr,
+    argv,
+    resolveExit(code) {
+      proc.killed = true;
+      exit.resolve(code);
+    },
+    kill
+  };
+  // Auto-reap on SIGKILL so tests don't hang on TunnelManager.stop()'s
+  // post-SIGKILL `await proc.exited`. SIGTERM is left to the test.
+  killFn = (signal: string) => {
+    if (signal === 'SIGKILL' && !proc.killed) {
+      ctrl.resolveExit(137);
+    }
+  };
+  fakeProcs.push(ctrl);
+  return ctrl;
+}
+
+const mockLogger = {
+  info: mock(() => {}),
+  error: mock(() => {}),
+  warn: mock(() => {}),
+  debug: mock(() => {}),
+  child: mock(() => mockLogger)
+} as unknown as Logger;
+
+let spawnSpy: ReturnType<typeof spyOn> | null = null;
+
+beforeEach(() => {
+  fakeProcs.length = 0;
+  fetchHandler.ready = false;
+
+  spawnSpy = spyOn(Bun, 'spawn').mockImplementation(((argv: string[]) => {
+    return makeFakeProc(argv).proc as never;
+  }) as never);
+
+  originalFetch = global.fetch;
+  global.fetch = (async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (!url.includes('/ready')) {
+      return new Response('not found', { status: 404 });
+    }
+    return new Response(
+      JSON.stringify({ readyConnections: fetchHandler.ready ? 1 : 0 }),
+      { status: 200 }
+    );
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  spawnSpy?.mockRestore();
+  spawnSpy = null;
+  global.fetch = originalFetch;
+});
+
+/**
+ * Drives a TunnelService call to completion. Emits canned cloudflared
+ * stderr after a short delay so the manager has a chance to subscribe to
+ * the stream, then flips `/ready` so the readiness loop exits.
+ */
+async function withFakeCloudflared<T>(
+  banner: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const promise = fn();
+  // Let the spawn happen and the stderr reader subscribe.
+  await new Promise((r) => setTimeout(r, 20));
+  if (fakeProcs.length === 0) {
+    throw new Error(
+      'withFakeCloudflared: TunnelService never spawned cloudflared'
+    );
+  }
+  fakeProcs[fakeProcs.length - 1].stderr.write(banner);
+  // Let scrapeStream pick up the metrics line + URL.
+  await new Promise((r) => setTimeout(r, 30));
+  fetchHandler.ready = true;
+  return await promise;
+}
+
+const QUICK_BANNER = [
+  '2026-01-01T00:00:00Z INF Starting metrics server on 127.0.0.1:42424/metrics',
+  '2026-01-01T00:00:00Z INF Your quick tunnel: https://stub.trycloudflare.com',
+  ''
+].join('\n');
+
+// ---------------------------------------------------------------------------
+
+describe('TunnelService > runQuickTunnel', () => {
+  it('spawns cloudflared with the expected argv', async () => {
+    const service = new TunnelService(mockLogger);
+
+    const result = await withFakeCloudflared(QUICK_BANNER, () =>
+      service.runQuickTunnel('quick-1', 8080)
+    );
+
+    expect(result.success).toBe(true);
+    expect(fakeProcs).toHaveLength(1);
+    const argv = fakeProcs[0].argv;
+    expect(argv[0]).toBe('cloudflared');
+    expect(argv).toContain('tunnel');
+    expect(argv).toContain('--url');
+    expect(argv).toContain('http://localhost:8080');
+    expect(argv).toContain('--metrics');
+    expect(argv).toContain('127.0.0.1:0');
+    expect(argv).toContain('--no-autoupdate');
+    expect(argv).toContain('--output');
+    expect(argv).toContain('json');
+    expect(argv).not.toContain('run');
+  });
+
+  it('returns a wire-shape record with the parsed URL', async () => {
+    const service = new TunnelService(mockLogger);
+
+    const result = await withFakeCloudflared(QUICK_BANNER, () =>
+      service.runQuickTunnel('quick-1', 8080)
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.id).toBe('quick-1');
+    expect(result.data.name).toBeUndefined();
+    expect(result.data.port).toBe(8080);
+    expect(result.data.url).toBe('https://stub.trycloudflare.com');
+    expect(result.data.hostname).toBe('stub.trycloudflare.com');
+    expect(typeof result.data.createdAt).toBe('string');
+    expect(() => new Date(result.data.createdAt as string)).not.toThrow();
+  });
+
+  it('parses the URL out of JSON-per-line stderr records', async () => {
+    const service = new TunnelService(mockLogger);
+    const jsonBanner = [
+      JSON.stringify({
+        level: 'info',
+        message: 'Starting metrics server on 127.0.0.1:33333/metrics'
+      }),
+      JSON.stringify({
+        level: 'info',
+        message: '+--------------------------------------------------------+'
+      }),
+      JSON.stringify({
+        level: 'info',
+        message:
+          '|  Your quick Tunnel has been created! Visit it at (it may take some time to be reachable):  |'
+      }),
+      JSON.stringify({
+        level: 'info',
+        message: '|  https://random-words.trycloudflare.com                |'
+      }),
+      ''
+    ].join('\n');
+
+    const result = await withFakeCloudflared(jsonBanner, () =>
+      service.runQuickTunnel('quick-json', 8080)
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.url).toBe('https://random-words.trycloudflare.com');
+    expect(result.data.hostname).toBe('random-words.trycloudflare.com');
+  });
+
+  it('refuses to start a tunnel id that is already running', async () => {
+    const service = new TunnelService(mockLogger);
+    await withFakeCloudflared(QUICK_BANNER, () =>
+      service.runQuickTunnel('dup', 8080)
+    );
+
+    const second = await service.runQuickTunnel('dup', 8081);
+    expect(second.success).toBe(false);
+    if (second.success) return;
+    expect(second.error.code).toBe('TUNNEL_ALREADY_RUNNING');
+    // Only one cloudflared was spawned — the dup short-circuits before spawn.
+    expect(fakeProcs).toHaveLength(1);
+  });
+
+  it('returns TUNNEL_START_ERROR when cloudflared exits before becoming ready', async () => {
+    const service = new TunnelService(mockLogger);
+
+    const promise = service.runQuickTunnel('fail', 8080);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fakeProcs).toHaveLength(1);
+    fakeProcs[0].resolveExit(1);
+
+    const result = await promise;
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('TUNNEL_START_ERROR');
+    expect(result.error.message).toMatch(/exited before becoming ready/);
+    expect(service.list()).toHaveLength(0);
+  });
+
+  it('returns TUNNEL_START_ERROR when readiness times out', async () => {
+    const service = new TunnelService(mockLogger);
+
+    const promise = service.runQuickTunnel('slow', 8080, {
+      readyTimeoutMs: 50
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fakeProcs).toHaveLength(1);
+    // Never write a banner, never flip `/ready` — let it time out.
+
+    const result = await promise;
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('TUNNEL_START_ERROR');
+    expect(result.error.message).toMatch(/Timed out/);
+    expect(fakeProcs[0].kill).toHaveBeenCalled();
+    expect(service.list()).toHaveLength(0);
+  });
+});
+
+describe('TunnelService > destroyTunnel', () => {
+  it('SIGTERMs cloudflared and removes the record', async () => {
+    const service = new TunnelService(mockLogger);
+    await withFakeCloudflared(QUICK_BANNER, () =>
+      service.runQuickTunnel('to-kill', 8080)
+    );
+
+    const destroyPromise = service.destroyTunnel('to-kill');
+    // Cooperate so we don't race the SIGKILL fallback inside TunnelManager.stop().
+    await new Promise((r) => setTimeout(r, 5));
+    fakeProcs[0].resolveExit(0);
+    const result = await destroyPromise;
+
+    expect(result.success).toBe(true);
+    expect(fakeProcs[0].kill).toHaveBeenCalledWith('SIGTERM');
+    expect(fakeProcs[0].kill).not.toHaveBeenCalledWith('SIGKILL');
+    expect(service.list()).toHaveLength(0);
+  });
+
+  it('falls back to SIGKILL when SIGTERM does not exit the process', async () => {
+    const service = new TunnelService(mockLogger);
+    await withFakeCloudflared(QUICK_BANNER, () =>
+      service.runQuickTunnel('stubborn', 8080, { stopGraceMs: 20 })
+    );
+
+    const destroyPromise = service.destroyTunnel('stubborn');
+    // Defer the exit until after the grace period; this should force the
+    // SIGKILL fallback path.
+    await new Promise((r) => setTimeout(r, 40));
+    fakeProcs[0].resolveExit(137);
+    const result = await destroyPromise;
+
+    expect(result.success).toBe(true);
+    expect(fakeProcs[0].kill).toHaveBeenCalledWith('SIGTERM');
+    expect(fakeProcs[0].kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('returns TUNNEL_NOT_FOUND for unknown ids', async () => {
+    const service = new TunnelService(mockLogger);
+    const result = await service.destroyTunnel('ghost');
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('TUNNEL_NOT_FOUND');
+  });
+});
+
+describe('TunnelService > list & destroyAll', () => {
+  it('returns all running tunnels in insertion order', async () => {
+    const service = new TunnelService(mockLogger);
+    await withFakeCloudflared(QUICK_BANNER, () =>
+      service.runQuickTunnel('q1', 8080)
+    );
+    await withFakeCloudflared(QUICK_BANNER, () =>
+      service.runQuickTunnel('q2', 8081)
+    );
+
+    const all = service.list();
+    expect(all.map((t) => t.id)).toEqual(['q1', 'q2']);
+  });
+
+  it('destroyAll stops every running tunnel', async () => {
+    const service = new TunnelService(mockLogger);
+    await withFakeCloudflared(QUICK_BANNER, () =>
+      service.runQuickTunnel('a', 8080)
+    );
+    await withFakeCloudflared(QUICK_BANNER, () =>
+      service.runQuickTunnel('b', 8081)
+    );
+
+    const destroyAll = service.destroyAll();
+    await new Promise((r) => setTimeout(r, 5));
+    for (const p of fakeProcs) p.resolveExit(0);
+    await destroyAll;
+
+    expect(service.list()).toHaveLength(0);
+    for (const p of fakeProcs) {
+      expect(p.kill).toHaveBeenCalledWith('SIGTERM');
+    }
+  });
+});

--- a/packages/sandbox/Dockerfile
+++ b/packages/sandbox/Dockerfile
@@ -152,6 +152,38 @@ COPY --from=builder /app/packages/sandbox-container/dist/runtime/executors/javas
 # Users with custom startup scripts that call `bun /container-server/dist/index.js` need this
 COPY --from=builder /app/packages/sandbox-container/dist/index.js ./dist/
 
+# ============================================================================
+# cloudflared (Cloudflare Tunnel daemon) — enables sandbox.tunnels.*
+# Pinned version with sha256 verification per architecture.
+# Skipped in the musl/Alpine stage (no musl prebuilt).
+# ============================================================================
+ARG CLOUDFLARED_VERSION=2026.3.0
+ARG CLOUDFLARED_SHA256_AMD64=4a9e50e6d6d798e90fcd01933151a90bf7edd99a0a55c28ad18f2e16263a5c30
+ARG CLOUDFLARED_SHA256_ARM64=0755ba4cbab59980e6148367fcf53a8f3ec85a97deefd63c2420cf7850769bee
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) suffix=amd64; sha="${CLOUDFLARED_SHA256_AMD64}" ;; \
+      arm64) suffix=arm64; sha="${CLOUDFLARED_SHA256_ARM64}" ;; \
+      *) echo "Unsupported arch for cloudflared: $arch" >&2; exit 1 ;; \
+    esac; \
+    url="https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-${suffix}"; \
+    curl -fsSL -o /usr/local/bin/cloudflared "$url"; \
+    echo "$sha  /usr/local/bin/cloudflared" | sha256sum -c -; \
+    chmod +x /usr/local/bin/cloudflared; \
+    cloudflared --version
+
+# Inject the host's extra CA bundle when running locally behind a TLS-
+# intercepting proxy (e.g. Cloudflare WARP / Zero Trust). See
+# DOCKER_README.md for the local-dev setup. No-op when the secret
+# isn't passed.
+RUN --mount=type=secret,id=wrangler_ca \
+    if [ -f /run/secrets/wrangler_ca ] && [ -s /run/secrets/wrangler_ca ]; then \
+        cp /run/secrets/wrangler_ca /usr/local/share/ca-certificates/wrangler-dev-ca.crt && \
+        cat /run/secrets/wrangler_ca >> /etc/ssl/certs/ca-certificates.crt && \
+        update-ca-certificates; \
+    fi
+
 RUN mkdir -p /workspace
 
 # Expose the application port (3000 for control)

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -98,6 +98,40 @@ export default {
 };
 ```
 
+## Quick tunnels
+
+`sandbox.tunnels.create(port)` exposes a service running inside the
+sandbox on a randomly-assigned `*.trycloudflare.com` URL. No Cloudflare
+account or DNS setup required — cloudflared opens a persistent QUIC
+connection to Cloudflare's edge and Cloudflare hands back a hostname.
+
+```ts
+// Inside a Worker with an RPC-transport sandbox:
+const tunnel = await sandbox.tunnels.create(8080);
+console.log(tunnel.url);
+// → https://random-words-here.trycloudflare.com
+
+// Later:
+await sandbox.tunnels.destroy(tunnel);
+```
+
+Notes:
+
+- Requires the RPC transport. The route-based transport's `tunnels`
+  stub throws "RPC transport required".
+- Hostnames are assigned per `create()` call — restarting a sandbox or
+  calling `create()` twice yields different URLs.
+- The first fetch can take a few seconds while DNS propagates, even
+  after `create()` resolves.
+- `*.trycloudflare.com` buffers `text/event-stream` responses. WebSockets
+  work fine.
+- The musl/Alpine image variant does not ship cloudflared (no upstream
+  musl prebuilt); `sandbox.tunnels` is unavailable on that variant.
+- Local builds behind a TLS-intercepting proxy (e.g. Cloudflare WARP)
+  need the host CA bundle injected at build time — see
+  [DOCKER_README.md](../../DOCKER_README.md).
+
+
 ## Documentation
 
 **📖 [Full Documentation](https://developers.cloudflare.com/sandbox/)**
@@ -115,6 +149,7 @@ export default {
 - **File System Access** - Read, write, and manage files
 - **Command Execution** - Run any command with streaming support
 - **Preview URLs** - Expose services with public URLs
+- **Quick tunnels** - Zero-config `*.trycloudflare.com` URLs via `sandbox.tunnels.create(port)`
 - **Git Integration** - Clone repositories directly
 
 ## Contributing

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -100,37 +100,48 @@ export default {
 
 ## Quick tunnels
 
-`sandbox.tunnels.create(port)` exposes a service running inside the
-sandbox on a randomly-assigned `*.trycloudflare.com` URL. No Cloudflare
-account or DNS setup required — cloudflared opens a persistent QUIC
-connection to Cloudflare's edge and Cloudflare hands back a hostname.
+`sandbox.tunnels.get(port)` exposes a service running inside the
+sandbox on a `*.trycloudflare.com` URL. No Cloudflare account or DNS
+setup required — cloudflared opens a persistent QUIC connection to
+Cloudflare's edge and Cloudflare hands back a hostname.
 
 ```ts
 // Inside a Worker with an RPC-transport sandbox:
-const tunnel = await sandbox.tunnels.create(8080);
+const tunnel = await sandbox.tunnels.get(8080);
 console.log(tunnel.url);
 // → https://random-words-here.trycloudflare.com
 
-// Later:
-await sandbox.tunnels.destroy(tunnel);
+// Repeated calls for the same port return the same record:
+const same = await sandbox.tunnels.get(8080);
+console.log(same.url === tunnel.url); // true
+
+// Tear down by port number or by the record:
+await sandbox.tunnels.destroy(8080);
+// or: await sandbox.tunnels.destroy(tunnel);
 ```
+
+`get()` is idempotent: it consults a per-sandbox cache in Durable
+Object storage, returns the cached record on a hit, and only spawns a
+fresh cloudflared process on a miss. `list()` returns every cached
+tunnel.
 
 Notes:
 
 - Requires the RPC transport. The route-based transport's `tunnels`
   stub throws "RPC transport required".
-- Hostnames are assigned per `create()` call — restarting a sandbox or
-  calling `create()` twice yields different URLs.
-- The first fetch can take a few seconds while DNS propagates, even
-  after `create()` resolves.
-- `*.trycloudflare.com` buffers `text/event-stream` responses. WebSockets
-  work fine.
+- URLs do **not** survive a container restart. Cloudflare assigns the
+  hostname during cloudflared's startup handshake, so every restart
+  yields a new URL. The SDK clears its cache on container start, so
+  the next `get(port)` after a restart returns a fresh record.
+- The first fetch through a brand-new URL can take a couple of
+  seconds while DNS propagates, even after `get()` resolves.
+- `*.trycloudflare.com` buffers `text/event-stream` responses.
+  WebSockets work fine.
 - The musl/Alpine image variant does not ship cloudflared (no upstream
   musl prebuilt); `sandbox.tunnels` is unavailable on that variant.
 - Local builds behind a TLS-intercepting proxy (e.g. Cloudflare WARP)
   need the host CA bundle injected at build time — see
   [DOCKER_README.md](../../DOCKER_README.md).
-
 
 ## Documentation
 
@@ -149,7 +160,7 @@ Notes:
 - **File System Access** - Read, write, and manage files
 - **Command Execution** - Run any command with streaming support
 - **Preview URLs** - Expose services with public URLs
-- **Quick tunnels** - Zero-config `*.trycloudflare.com` URLs via `sandbox.tunnels.create(port)`
+- **Quick tunnels** - Zero-config `*.trycloudflare.com` URLs via `sandbox.tunnels.get(port)`
 - **Git Integration** - Clone repositories directly
 
 ## Contributing

--- a/packages/sandbox/src/clients/sandbox-client.ts
+++ b/packages/sandbox/src/clients/sandbox-client.ts
@@ -37,6 +37,14 @@ export class SandboxClient {
   public readonly desktop: DesktopClient;
   public readonly watch: WatchClient;
 
+  /**
+   * Tunnels are RPC-only — the route-based transport does not implement them.
+   * This getter exists so the `PublicKeys<SandboxClient> satisfies
+   * PublicKeys<SandboxAPI>` compile-time check holds. Calling any method on
+   * the returned proxy throws a clear `RPC transport required` error.
+   */
+  public readonly tunnels: never = createTunnelsNotImplemented() as never;
+
   private transport: ITransport | null = null;
 
   constructor(options: HttpClientOptions) {
@@ -141,3 +149,18 @@ export class SandboxClient {
 // intentionally have different concrete method shapes.
 type PublicKeys<T> = { [K in keyof T]: unknown };
 void (0 as unknown as PublicKeys<SandboxClient> satisfies PublicKeys<SandboxAPI>);
+
+function createTunnelsNotImplemented(): unknown {
+  const message =
+    'sandbox.tunnels.* requires the RPC transport. Enable it with transport: "rpc" in sandbox options.';
+  return new Proxy(
+    {},
+    {
+      get() {
+        return () => {
+          throw new Error(message);
+        };
+      }
+    }
+  );
+}

--- a/packages/sandbox/src/container-control/client.ts
+++ b/packages/sandbox/src/container-control/client.ts
@@ -395,7 +395,8 @@ export class ContainerControlClient {
       stub: options.stub,
       port: options.port,
       logger: options.logger,
-      retryTimeoutMs: options.retryTimeoutMs
+      retryTimeoutMs: options.retryTimeoutMs,
+      localMain: options.localMain
     };
     this.idleDisconnectMs =
       options.idleDisconnectMs ?? DEFAULT_IDLE_DISCONNECT_MS;

--- a/packages/sandbox/src/container-control/client.ts
+++ b/packages/sandbox/src/container-control/client.ts
@@ -80,6 +80,7 @@ import type {
   SandboxPortsAPI,
   SandboxProcessesAPI,
   SandboxTransport,
+  SandboxTunnelsAPI,
   SandboxUtilsAPI,
   SandboxWatchAPI
 } from '@repo/shared';
@@ -588,6 +589,9 @@ export class ContainerControlClient {
   }
   get watch(): SandboxWatchAPI {
     return wrapStub(this.getConnection().rpc().watch, this.renewActivity);
+  }
+  get tunnels(): SandboxTunnelsAPI {
+    return wrapStub(this.getConnection().rpc().tunnels, this.renewActivity);
   }
   get interpreter(): SandboxInterpreterAPI {
     return wrapStub(this.getConnection().rpc().interpreter, this.renewActivity);

--- a/packages/sandbox/src/container-control/client.ts
+++ b/packages/sandbox/src/container-control/client.ts
@@ -523,7 +523,7 @@ export class ContainerControlClient {
         imports <= IDLE_IMPORT_THRESHOLD &&
         exports <= IDLE_EXPORT_THRESHOLD
       ) {
-        this.logger.debug('Disconnecting idle capnweb connection');
+        this.logger.debug('Disconnecting idle RPC connection');
         this.destroyConnection();
       }
     }, this.idleDisconnectMs);

--- a/packages/sandbox/src/container-control/connection.ts
+++ b/packages/sandbox/src/container-control/connection.ts
@@ -47,6 +47,14 @@ export interface ContainerControlConnectionOptions {
    * `WebSocketTransport`. Set to 0 to disable retries.
    */
   retryTimeoutMs?: number;
+  /**
+   * Optional `localMain` exposed to the container side of the capnweb
+   * session. The container reaches it via
+   * `session.getRemoteMain()` and uses it for control-plane callbacks
+   * (e.g. notifying the DO when a tunnel's cloudflared process has
+   * exited). When omitted, the container sees an empty remote main.
+   */
+  localMain?: any;
 }
 
 /**
@@ -75,7 +83,10 @@ export class ContainerControlConnection {
     this.retryTimeoutMs = options.retryTimeoutMs ?? DEFAULT_RETRY_TIMEOUT_MS;
 
     this.transport = new DeferredTransport();
-    this.session = new RpcSession<SandboxAPI>(this.transport);
+    this.session = new RpcSession<SandboxAPI>(
+      this.transport,
+      options.localMain
+    );
     this.stub = this.session.getRemoteMain();
   }
 

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -56,6 +56,7 @@ export type {
   SandboxTransport,
   SessionOptions,
   StreamOptions,
+  TunnelInfo,
   WaitForLogResult,
   WaitForPortOptions,
   WatchOptions

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -871,6 +871,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         this.codeInterpreter = new CodeInterpreter(
           () => this.client.interpreter
         );
+        // Drop the tunnels handler; the lazy getter rebinds it to the
+        // new client on next access. Same rationale as codeInterpreter.
+        this.tunnelsHandler = null;
         previousClient.disconnect();
       }
       if (storedTransport) {
@@ -1089,6 +1092,11 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     this.hasStoredTransport = true;
     this.client = this.createClientForTransport(transport);
     this.codeInterpreter = new CodeInterpreter(() => this.client.interpreter);
+    // Drop the tunnels handler so the lazy getter rebinds it to the
+    // new client on next access. Storage is unchanged: existing
+    // tunnels are still backed by their cloudflared processes since the
+    // container did not restart.
+    this.tunnelsHandler = null;
     previousClient.disconnect();
     this.renewActivityTimeout();
     this.logger.debug('Transport updated', { transport });
@@ -1793,6 +1801,12 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       // still not atomic against concurrent writers, but the preview URL
       // authorization path is race-free.
       await this.ctx.storage.delete('portTokens');
+      // Tunnels storage is the SDK's source of truth for which
+      // *.trycloudflare.com URLs are live. Clearing it ensures any
+      // post-destroy get() reads see an empty cache and a destroyed
+      // sandbox's URLs are not resurrected after a new container
+      // takes the same DO id.
+      await this.ctx.storage.delete('tunnels');
 
       // Disconnect transport after all cleanup commands have completed
       this.client.disconnect();
@@ -1838,6 +1852,22 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     } catch (error) {
       this.logger.error(
         'Failed to restore exposed ports after container start',
+        error instanceof Error ? error : new Error(String(error))
+      );
+    }
+
+    // Tunnels are NOT restored across container restart. Every
+    // cloudflared process the container was running died with it, so
+    // every stored *.trycloudflare.com URL is dead. Clearing storage
+    // here means the next get(port) call takes the miss branch and
+    // spawns a fresh tunnel with a new URL. We do this inside onStart's
+    // blockConcurrencyWhile gate so any get() that arrived during the
+    // startup window sees the empty cache by the time it runs.
+    try {
+      await this.ctx.storage.delete('tunnels');
+    } catch (error) {
+      this.logger.error(
+        'Failed to clear tunnel storage after container start',
         error instanceof Error ? error : new Error(String(error))
       );
     }
@@ -3873,14 +3903,20 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   /**
-   * Namespaced tunnel API. Currently supports zero-config *quick tunnels*
-   * (Cloudflare's trycloudflare service):
+   * Namespaced tunnel API. Quick tunnels are zero-config preview URLs
+   * backed by Cloudflare's trycloudflare service.
    *
-   * - `tunnels.create(port)` — spawn cloudflared, return a
-   *   `https://<words>.trycloudflare.com` URL pointing at `localhost:<port>`.
-   * - `tunnels.list()` — tunnels currently running in the container.
-   * - `tunnels.destroy(idOrInfo)` — tear down by id or by the record
-   *   returned from `create()`.
+   * - `tunnels.get(port)` — idempotent. Returns the cached tunnel for
+   *   `port` if one exists in DO storage, otherwise spawns a fresh
+   *   cloudflared process and persists the record.
+   * - `tunnels.list()` — records currently known to this sandbox, from
+   *   DO storage.
+   * - `tunnels.destroy(portOrInfo)` — tear down by port number or by
+   *   the record returned from `get()`.
+   *
+   * Storage is cleared on container restart (`onStart`), so URLs do
+   * not survive a container restart — the next `get(port)` call will
+   * spawn a fresh tunnel with a new URL.
    *
    * Requires the RPC transport. Calling this on a route-based transport
    * throws "RPC transport required".
@@ -3889,6 +3925,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     if (!this.tunnelsHandler) {
       this.tunnelsHandler = createTunnelsHandler({
         client: this.client,
+        storage: this.ctx.storage,
         logger: this.logger
       });
     }

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -98,6 +98,10 @@ import type {
   LocalSyncMountInfo,
   MountInfo
 } from './storage-mount/types';
+import {
+  createTunnelsHandler,
+  type TunnelsHandler
+} from './tunnels/tunnels-handler';
 import { SDK_VERSION } from './version';
 
 /**
@@ -533,6 +537,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
   private codeInterpreter: CodeInterpreter;
   private sandboxName: string | null = null;
+  // Tunnels namespace handler. Lazily constructed on first access via the
+  // `tunnels` getter; holds an in-memory map of tunnels created through
+  // this Sandbox instance.
+  private tunnelsHandler: TunnelsHandler | null = null;
   private normalizeId: boolean = false;
   private defaultSession: string | null = null;
   // Incremented whenever the container stops. Used to invalidate
@@ -3862,6 +3870,29 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         }
       ];
     });
+  }
+
+  /**
+   * Namespaced tunnel API. Currently supports zero-config *quick tunnels*
+   * (Cloudflare's trycloudflare service):
+   *
+   * - `tunnels.create(port)` — spawn cloudflared, return a
+   *   `https://<words>.trycloudflare.com` URL pointing at `localhost:<port>`.
+   * - `tunnels.list()` — tunnels currently running in the container.
+   * - `tunnels.destroy(idOrInfo)` — tear down by id or by the record
+   *   returned from `create()`.
+   *
+   * Requires the RPC transport. Calling this on a route-based transport
+   * throws "RPC transport required".
+   */
+  get tunnels(): TunnelsHandler {
+    if (!this.tunnelsHandler) {
+      this.tunnelsHandler = createTunnelsHandler({
+        client: this.client,
+        logger: this.logger
+      });
+    }
+    return this.tunnelsHandler;
   }
 
   async isPortExposed(port: number): Promise<boolean> {

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -98,8 +98,10 @@ import type {
   LocalSyncMountInfo,
   MountInfo
 } from './storage-mount/types';
+import { SandboxControlCallbackImpl } from './tunnels/sandbox-control-callback';
 import {
   createTunnelsHandler,
+  type TunnelExitHandler,
   type TunnelsHandler
 } from './tunnels/tunnels-handler';
 import { SDK_VERSION } from './version';
@@ -539,8 +541,18 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   private sandboxName: string | null = null;
   // Tunnels namespace handler. Lazily constructed on first access via the
   // `tunnels` getter; holds an in-memory map of tunnels created through
-  // this Sandbox instance.
+  // this Sandbox instance. The sibling `tunnelExitHandler` is the
+  // control-plane exit hook invoked by the capnweb session's
+  // SandboxControlCallback when the container reports cloudflared has
+  // died; both fields are reset together on transport swap.
   private tunnelsHandler: TunnelsHandler | null = null;
+  private tunnelExitHandler: TunnelExitHandler | null = null;
+  // capnweb localMain exposed to the container side of the RPC
+  // session. Constructed once in the constructor (the lazy accessor
+  // keeps it pointing at the current `tunnelExitHandler` even as
+  // transports swap), so the container can call back into the DO
+  // without us re-binding the session.
+  private readonly controlCallback: SandboxControlCallbackImpl;
   private normalizeId: boolean = false;
   private defaultSession: string | null = null;
   // Incremented whenever the container stops. Used to invalidate
@@ -732,6 +744,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         port: 3000,
         logger: this.logger,
         retryTimeoutMs: this.computeRetryTimeoutMs(),
+        // localMain exposes the DO-side control callback (tunnel-exit
+        // notifications, etc.) to the container side of the session.
+        localMain: this.controlCallback,
         // Mirrors containerFetch()'s request lifecycle for the RPC transport.
         //
         // The HTTP transport bumps inflightRequests at the top of each
@@ -823,6 +838,14 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       });
     }
 
+    // Construct the control callback BEFORE the client — RPC clients
+    // capture it as `localMain` on the capnweb session, and the
+    // session is created eagerly in the connection's constructor.
+    this.controlCallback = new SandboxControlCallbackImpl(
+      () => this.tunnelExitHandler,
+      this.logger
+    );
+
     this.client = this.createClientForTransport(this.transport);
 
     this.codeInterpreter = new CodeInterpreter(() => this.client.interpreter);
@@ -874,6 +897,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         // Drop the tunnels handler; the lazy getter rebinds it to the
         // new client on next access. Same rationale as codeInterpreter.
         this.tunnelsHandler = null;
+        this.tunnelExitHandler = null;
         previousClient.disconnect();
       }
       if (storedTransport) {
@@ -1097,6 +1121,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     // tunnels are still backed by their cloudflared processes since the
     // container did not restart.
     this.tunnelsHandler = null;
+    this.tunnelExitHandler = null;
     previousClient.disconnect();
     this.renewActivityTimeout();
     this.logger.debug('Transport updated', { transport });
@@ -3922,14 +3947,26 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    * throws "RPC transport required".
    */
   get tunnels(): TunnelsHandler {
-    if (!this.tunnelsHandler) {
-      this.tunnelsHandler = createTunnelsHandler({
-        client: this.client,
-        storage: this.ctx.storage,
-        logger: this.logger
-      });
-    }
-    return this.tunnelsHandler;
+    this.ensureTunnelsBuilt();
+    // Non-null after ensureTunnelsBuilt(); cast for the type system.
+    return this.tunnelsHandler as TunnelsHandler;
+  }
+
+  /**
+   * Lazily construct both the public tunnels handler and its sibling
+   * exit-handler callback. Called from the `tunnels` getter on first
+   * access and on every access after a transport swap clears both
+   * fields.
+   */
+  private ensureTunnelsBuilt(): void {
+    if (this.tunnelsHandler) return;
+    const built = createTunnelsHandler({
+      client: this.client,
+      storage: this.ctx.storage,
+      logger: this.logger
+    });
+    this.tunnelsHandler = built.tunnels;
+    this.tunnelExitHandler = built.handleTunnelExit;
   }
 
   async isPortExposed(port: number): Promise<boolean> {

--- a/packages/sandbox/src/tunnels/sandbox-control-callback.ts
+++ b/packages/sandbox/src/tunnels/sandbox-control-callback.ts
@@ -1,0 +1,48 @@
+/**
+ * `SandboxControlCallbackImpl` — capnweb `RpcTarget` the DO exposes as
+ * `localMain` on the container-control session. The container reaches
+ * it via `session.getRemoteMain<SandboxControlCallback>()` to push
+ * control-plane events back to the DO.
+ */
+
+import type { Logger, SandboxControlCallback } from '@repo/shared';
+import { RpcTarget } from 'capnweb';
+import type { TunnelExitHandler } from './tunnels-handler';
+
+export class SandboxControlCallbackImpl
+  extends RpcTarget
+  implements SandboxControlCallback
+{
+  constructor(
+    /**
+     * Accessor (not a direct reference) so that `setTransport` /
+     * eviction can swap the handler without re-binding the capnweb
+     * session. Returns `null` if the handler hasn't been constructed
+     * yet — the callback no-ops in that case, which is fine because
+     * the container only reaches us via a live session and a live
+     * session implies a sandbox that is about to construct (or has
+     * just constructed) its handler on the next access.
+     */
+    private readonly getHandler: () => TunnelExitHandler | null,
+    private readonly logger: Logger
+  ) {
+    super();
+  }
+
+  async onTunnelExit(
+    id: string,
+    port: number,
+    exitCode: number | null
+  ): Promise<void> {
+    const handler = this.getHandler();
+    if (!handler) {
+      this.logger.debug('onTunnelExit: no handler bound; ignoring', {
+        id,
+        port,
+        exitCode
+      });
+      return;
+    }
+    await handler(id, port, exitCode);
+  }
+}

--- a/packages/sandbox/src/tunnels/tunnels-handler.ts
+++ b/packages/sandbox/src/tunnels/tunnels-handler.ts
@@ -82,14 +82,38 @@ function isTunnelNotFoundError(error: unknown): boolean {
 }
 
 export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandler {
-  // Per-port inflight coalescing. Two simultaneous get(8080) calls on a
-  // cold cache would otherwise mint two ids and spawn two cloudflared
-  // processes. The slot is cleared in a `finally` so a failed spawn
-  // doesn't poison subsequent calls for the same port.
-  const inflight = new Map<number, Promise<TunnelInfo>>();
+  // Per-port serialization lock. Any operation that mutates the tunnel
+  // for a given port — get() on a cache miss, destroy() — queues behind
+  // the previous operation on the same port. Two consequences:
+  //
+  //   - get(8080) followed by destroy(8080) is well-ordered: the destroy
+  //     observes whatever the get just wrote, even though both yield to
+  //     external RPCs in the middle.
+  //   - Two concurrent get(8080) calls share the first call's record:
+  //     the second runs after the first writes storage and takes the
+  //     hit branch (so no double cloudflared spawn).
+  //
+  // The lock is a plain Promise chain keyed by port. `transaction()` on
+  // the storage write still matters for *cross-port* writes — a
+  // get(8080) and get(8081) running in parallel are independent here.
+  const portLocks = new Map<number, Promise<unknown>>();
 
-  async function readMap(): Promise<TunnelMap> {
-    return (await host.storage.get<TunnelMap>(STORAGE_KEY)) ?? {};
+  function withPortLock<T>(port: number, fn: () => Promise<T>): Promise<T> {
+    const previous = portLocks.get(port) ?? Promise.resolve();
+    const next = previous.then(fn, fn);
+    // Swallow rejections on the chain so a failed op doesn't poison
+    // subsequent ones; the original promise still rejects to the caller.
+    portLocks.set(
+      port,
+      next.catch(() => undefined)
+    );
+    return next;
+  }
+
+  async function readMap(
+    storage: TunnelsStorageTxn = host.storage
+  ): Promise<TunnelMap> {
+    return (await storage.get<TunnelMap>(STORAGE_KEY)) ?? {};
   }
 
   async function get(port: number): Promise<TunnelInfo> {
@@ -100,18 +124,7 @@ export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandler {
     try {
       validateTunnelPort(port);
 
-      // Coalescing has to start synchronously: two concurrent get()
-      // calls both need to observe each other's inflight slot before
-      // doing the storage read, otherwise they each mint an id and
-      // spawn a duplicate cloudflared process.
-      const inflightExisting = inflight.get(port);
-      if (inflightExisting) {
-        const info = await inflightExisting;
-        outcome = 'success';
-        return info;
-      }
-
-      const work = (async (): Promise<TunnelInfo> => {
+      const info = await withPortLock(port, async () => {
         const map = await readMap();
         const existing = map[port.toString()];
         if (existing) {
@@ -119,27 +132,20 @@ export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandler {
           return existing;
         }
         const id = `quick-${shortId()}`;
-        const info = await host.client.tunnels.runQuickTunnel(id, port);
-        // Atomic re-read and write. The cloudflared await above yields,
-        // so a concurrent get(otherPort) may have written between our
-        // first readMap() and now; transaction() retries on conflict.
+        const spawned = await host.client.tunnels.runQuickTunnel(id, port);
+        // Atomic re-read + write. The lock orders same-port ops, but
+        // a concurrent get(otherPort) can still write the `tunnels` key
+        // between the cloudflared await above and here. transaction()
+        // retries on conflict so the cross-port write doesn't clobber.
         await host.storage.transaction(async (txn) => {
-          const nextMap = (await txn.get<TunnelMap>(STORAGE_KEY)) ?? {};
-          nextMap[port.toString()] = info;
+          const nextMap = await readMap(txn);
+          nextMap[port.toString()] = spawned;
           await txn.put(STORAGE_KEY, nextMap);
         });
-        return info;
-      })();
-      inflight.set(port, work);
-      try {
-        const info = await work;
-        outcome = 'success';
-        return info;
-      } finally {
-        // Always clear the slot — including on failure — so the next
-        // caller retries instead of awaiting a rejected promise.
-        if (inflight.get(port) === work) inflight.delete(port);
-      }
+        return spawned;
+      });
+      outcome = 'success';
+      return info;
     } catch (error) {
       caughtError = error instanceof Error ? error : new Error(String(error));
       throw error;
@@ -162,35 +168,35 @@ export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandler {
     let caughtError: Error | undefined;
     let tunnelId: string | undefined;
     try {
-      const map = await readMap();
-      const existing = map[port.toString()];
-      if (!existing) {
-        // Idempotent — destroying an unknown port resolves successfully.
-        outcome = 'success';
-        return;
-      }
-      tunnelId = existing.id;
+      await withPortLock(port, async () => {
+        const map = await readMap();
+        const existing = map[port.toString()];
+        if (!existing) {
+          // Idempotent — destroying an unknown port resolves successfully.
+          return;
+        }
+        tunnelId = existing.id;
 
-      // Atomic clear: same race window as get(), since destroyTunnel()
-      // also yields. Wrap the read-modify-write so a concurrent
-      // get(otherPort) write doesn't resurrect this entry. Storage is
-      // cleared *before* the container RPC for the same reason as
-      // portTokens (sandbox.ts:1795): a get(port) that races our destroy
-      // should see a cache miss and spawn fresh rather than reuse the
-      // record we're tearing down.
-      await host.storage.transaction(async (txn) => {
-        const current = (await txn.get<TunnelMap>(STORAGE_KEY)) ?? {};
-        delete current[port.toString()];
-        await txn.put(STORAGE_KEY, current);
+        // Clear storage first. Same ordering as portTokens (sandbox.ts):
+        // a hypothetical reader that observes storage between the put
+        // below and the destroyTunnel RPC sees a cache miss — the right
+        // answer, since the tunnel is on its way out. The port lock
+        // means no in-process get(port) is racing with us, but Workers
+        // / external readers don't go through this handler.
+        await host.storage.transaction(async (txn) => {
+          const current = await readMap(txn);
+          delete current[port.toString()];
+          await txn.put(STORAGE_KEY, current);
+        });
+
+        try {
+          await host.client.tunnels.destroyTunnel(existing.id);
+        } catch (error) {
+          if (!isTunnelNotFoundError(error)) throw error;
+          // Container already forgot — treat as success. Storage is
+          // already cleared above, so we're done.
+        }
       });
-
-      try {
-        await host.client.tunnels.destroyTunnel(existing.id);
-      } catch (error) {
-        if (!isTunnelNotFoundError(error)) throw error;
-        // Container already forgot — treat as success. Storage is
-        // already cleared above, so we're done.
-      }
       outcome = 'success';
     } catch (error) {
       caughtError = error instanceof Error ? error : new Error(String(error));

--- a/packages/sandbox/src/tunnels/tunnels-handler.ts
+++ b/packages/sandbox/src/tunnels/tunnels-handler.ts
@@ -54,6 +54,24 @@ export interface TunnelsHandler {
   destroy(portOrInfo: number | TunnelInfo): Promise<void>;
 }
 
+/**
+ * Container-driven exit hook. Invoked by `SandboxControlCallbackImpl`
+ * when the container reports that a `cloudflared` process has
+ * exited. NOT part of the public `TunnelsHandler` interface —
+ * exposed only through the factory's return shape so the public
+ * `sandbox.tunnels` API stays narrow.
+ */
+export type TunnelExitHandler = (
+  id: string,
+  port: number,
+  exitCode: number | null
+) => Promise<void>;
+
+export interface TunnelsHandle {
+  tunnels: TunnelsHandler;
+  handleTunnelExit: TunnelExitHandler;
+}
+
 /** DO storage key for the `port → TunnelInfo` map. */
 const STORAGE_KEY = 'tunnels';
 
@@ -81,7 +99,7 @@ function isTunnelNotFoundError(error: unknown): boolean {
   return message.includes('TUNNEL_NOT_FOUND');
 }
 
-export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandler {
+export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandle {
   // Per-port serialization lock. Any operation that mutates the tunnel
   // for a given port — get() on a cache miss, destroy() — queues behind
   // the previous operation on the same port. Two consequences:
@@ -218,5 +236,34 @@ export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandler {
     return Object.values(map);
   }
 
-  return { get, list, destroy };
+  const handleTunnelExit: TunnelExitHandler = async (id, port, exitCode) => {
+    const startTime = Date.now();
+    await withPortLock(port, async () => {
+      await host.storage.transaction(async (txn) => {
+        const map = await readMap(txn);
+        const existing = map[port.toString()];
+        // Defensive: only clear if storage still references this exact
+        // tunnel id. Without this check, a sequence like "old
+        // cloudflared dies → new get() spawns fresh → old callback
+        // fires" would clobber the new record.
+        if (existing?.id === id) {
+          delete map[port.toString()];
+          await txn.put(STORAGE_KEY, map);
+        }
+      });
+      logCanonicalEvent(host.logger, {
+        event: 'tunnel.exit',
+        outcome: 'success',
+        port,
+        tunnelId: id,
+        exitCode: exitCode ?? undefined,
+        durationMs: Date.now() - startTime
+      });
+    });
+  };
+
+  return {
+    tunnels: { get, list, destroy },
+    handleTunnelExit
+  };
 }

--- a/packages/sandbox/src/tunnels/tunnels-handler.ts
+++ b/packages/sandbox/src/tunnels/tunnels-handler.ts
@@ -1,6 +1,12 @@
 /**
  * Tunnels namespace handler. Created once per Sandbox DO instance via
  * `createTunnelsHandler(host)` and exposed as `sandbox.tunnels`.
+ *
+ * Storage is the source of truth. The DO holds a `Record<portString, TunnelInfo>`
+ * under the `tunnels` storage key. `Sandbox.onStart()` clears the key on every
+ * container restart so any record in storage is by construction backed by a
+ * running `cloudflared` process; the handler never needs to verify that
+ * separately against the container.
  */
 
 import type { Logger, SandboxTunnelsAPI, TunnelInfo } from '@repo/shared';
@@ -12,17 +18,46 @@ interface TunnelsRPCClient {
   tunnels: SandboxTunnelsAPI;
 }
 
+/**
+ * Subset of `DurableObjectTransaction` (and `DurableObjectStorage`) used
+ * inside a transaction closure — no nested `transaction()`.
+ */
+export interface TunnelsStorageTxn {
+  get<T>(key: string): Promise<T | undefined>;
+  put<T>(key: string, value: T): Promise<void>;
+  delete(key: string): Promise<boolean>;
+}
+
+/**
+ * Subset of `DurableObjectStorage` the handler uses.
+ *
+ * `transaction` gives optimistic concurrency for the read-modify-write
+ * paths in `get()` and `destroy()`: while we await the container RPC,
+ * another request to the same DO can land and rewrite the `tunnels`
+ * key. Wrapping the write in `transaction()` makes the runtime retry
+ * on conflict instead of clobbering the concurrent write.
+ */
+export interface TunnelsStorage extends TunnelsStorageTxn {
+  transaction<T>(closure: (txn: TunnelsStorageTxn) => Promise<T>): Promise<T>;
+}
+
 /** Subset of the Sandbox DO the handler reads from. */
 export interface TunnelsHandlerHost {
   client: TunnelsRPCClient;
+  storage: TunnelsStorage;
   logger: Logger;
 }
 
 export interface TunnelsHandler {
-  create(port: number): Promise<TunnelInfo>;
+  get(port: number): Promise<TunnelInfo>;
   list(): Promise<TunnelInfo[]>;
-  destroy(idOrInfo: string | TunnelInfo): Promise<void>;
+  destroy(portOrInfo: number | TunnelInfo): Promise<void>;
 }
+
+/** DO storage key for the `port → TunnelInfo` map. */
+const STORAGE_KEY = 'tunnels';
+
+type TunnelMap = Record<string, TunnelInfo>;
 
 function validateTunnelPort(port: number): void {
   if (!validatePort(port)) {
@@ -32,7 +67,7 @@ function validateTunnelPort(port: number): void {
   }
 }
 
-/** 8-char hex id derived from `crypto.getRandomValues`. */
+/** 8-char hex id derived from `crypto.getRandomValues`. Unique per sandbox. */
 function shortId(): string {
   const buf = new Uint8Array(4);
   crypto.getRandomValues(buf);
@@ -41,39 +76,121 @@ function shortId(): string {
     .join('');
 }
 
+function isTunnelNotFoundError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes('TUNNEL_NOT_FOUND');
+}
+
 export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandler {
-  async function create(port: number): Promise<TunnelInfo> {
+  // Per-port inflight coalescing. Two simultaneous get(8080) calls on a
+  // cold cache would otherwise mint two ids and spawn two cloudflared
+  // processes. The slot is cleared in a `finally` so a failed spawn
+  // doesn't poison subsequent calls for the same port.
+  const inflight = new Map<number, Promise<TunnelInfo>>();
+
+  async function readMap(): Promise<TunnelMap> {
+    return (await host.storage.get<TunnelMap>(STORAGE_KEY)) ?? {};
+  }
+
+  async function get(port: number): Promise<TunnelInfo> {
     const startTime = Date.now();
     let outcome: 'success' | 'error' = 'error';
+    let cacheState: 'hit' | 'miss' = 'miss';
     let caughtError: Error | undefined;
     try {
       validateTunnelPort(port);
 
-      const id = `quick-${shortId()}`;
-      const info = await host.client.tunnels.runQuickTunnel(id, port);
-      outcome = 'success';
-      return info;
+      // Coalescing has to start synchronously: two concurrent get()
+      // calls both need to observe each other's inflight slot before
+      // doing the storage read, otherwise they each mint an id and
+      // spawn a duplicate cloudflared process.
+      const inflightExisting = inflight.get(port);
+      if (inflightExisting) {
+        const info = await inflightExisting;
+        outcome = 'success';
+        return info;
+      }
+
+      const work = (async (): Promise<TunnelInfo> => {
+        const map = await readMap();
+        const existing = map[port.toString()];
+        if (existing) {
+          cacheState = 'hit';
+          return existing;
+        }
+        const id = `quick-${shortId()}`;
+        const info = await host.client.tunnels.runQuickTunnel(id, port);
+        // Atomic re-read and write. The cloudflared await above yields,
+        // so a concurrent get(otherPort) may have written between our
+        // first readMap() and now; transaction() retries on conflict.
+        await host.storage.transaction(async (txn) => {
+          const nextMap = (await txn.get<TunnelMap>(STORAGE_KEY)) ?? {};
+          nextMap[port.toString()] = info;
+          await txn.put(STORAGE_KEY, nextMap);
+        });
+        return info;
+      })();
+      inflight.set(port, work);
+      try {
+        const info = await work;
+        outcome = 'success';
+        return info;
+      } finally {
+        // Always clear the slot — including on failure — so the next
+        // caller retries instead of awaiting a rejected promise.
+        if (inflight.get(port) === work) inflight.delete(port);
+      }
     } catch (error) {
       caughtError = error instanceof Error ? error : new Error(String(error));
       throw error;
     } finally {
       logCanonicalEvent(host.logger, {
-        event: 'tunnel.create',
+        event: 'tunnel.get',
         outcome,
         port,
+        cacheState,
         durationMs: Date.now() - startTime,
         error: caughtError
       });
     }
   }
 
-  async function destroy(idOrInfo: string | TunnelInfo): Promise<void> {
-    const id = typeof idOrInfo === 'string' ? idOrInfo : idOrInfo.id;
+  async function destroy(portOrInfo: number | TunnelInfo): Promise<void> {
+    const port = typeof portOrInfo === 'number' ? portOrInfo : portOrInfo.port;
     const startTime = Date.now();
     let outcome: 'success' | 'error' = 'error';
     let caughtError: Error | undefined;
+    let tunnelId: string | undefined;
     try {
-      await host.client.tunnels.destroyTunnel(id);
+      const map = await readMap();
+      const existing = map[port.toString()];
+      if (!existing) {
+        // Idempotent — destroying an unknown port resolves successfully.
+        outcome = 'success';
+        return;
+      }
+      tunnelId = existing.id;
+
+      // Atomic clear: same race window as get(), since destroyTunnel()
+      // also yields. Wrap the read-modify-write so a concurrent
+      // get(otherPort) write doesn't resurrect this entry. Storage is
+      // cleared *before* the container RPC for the same reason as
+      // portTokens (sandbox.ts:1795): a get(port) that races our destroy
+      // should see a cache miss and spawn fresh rather than reuse the
+      // record we're tearing down.
+      await host.storage.transaction(async (txn) => {
+        const current = (await txn.get<TunnelMap>(STORAGE_KEY)) ?? {};
+        delete current[port.toString()];
+        await txn.put(STORAGE_KEY, current);
+      });
+
+      try {
+        await host.client.tunnels.destroyTunnel(existing.id);
+      } catch (error) {
+        if (!isTunnelNotFoundError(error)) throw error;
+        // Container already forgot — treat as success. Storage is
+        // already cleared above, so we're done.
+      }
       outcome = 'success';
     } catch (error) {
       caughtError = error instanceof Error ? error : new Error(String(error));
@@ -82,7 +199,8 @@ export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandler {
       logCanonicalEvent(host.logger, {
         event: 'tunnel.destroy',
         outcome,
-        tunnelId: id,
+        port,
+        tunnelId,
         durationMs: Date.now() - startTime,
         error: caughtError
       });
@@ -90,8 +208,9 @@ export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandler {
   }
 
   async function list(): Promise<TunnelInfo[]> {
-    return host.client.tunnels.listTunnels();
+    const map = await readMap();
+    return Object.values(map);
   }
 
-  return { create, list, destroy };
+  return { get, list, destroy };
 }

--- a/packages/sandbox/src/tunnels/tunnels-handler.ts
+++ b/packages/sandbox/src/tunnels/tunnels-handler.ts
@@ -1,0 +1,97 @@
+/**
+ * Tunnels namespace handler. Created once per Sandbox DO instance via
+ * `createTunnelsHandler(host)` and exposed as `sandbox.tunnels`.
+ */
+
+import type { Logger, SandboxTunnelsAPI, TunnelInfo } from '@repo/shared';
+import { logCanonicalEvent } from '@repo/shared';
+import { SandboxSecurityError, validatePort } from '../security';
+
+/** Subset of the RPC client this handler depends on. */
+interface TunnelsRPCClient {
+  tunnels: SandboxTunnelsAPI;
+}
+
+/** Subset of the Sandbox DO the handler reads from. */
+export interface TunnelsHandlerHost {
+  client: TunnelsRPCClient;
+  logger: Logger;
+}
+
+export interface TunnelsHandler {
+  create(port: number): Promise<TunnelInfo>;
+  list(): Promise<TunnelInfo[]>;
+  destroy(idOrInfo: string | TunnelInfo): Promise<void>;
+}
+
+function validateTunnelPort(port: number): void {
+  if (!validatePort(port)) {
+    throw new SandboxSecurityError(
+      `Invalid port number: ${port}. Must be 1024-65535, excluding reserved ports.`
+    );
+  }
+}
+
+/** 8-char hex id derived from `crypto.getRandomValues`. */
+function shortId(): string {
+  const buf = new Uint8Array(4);
+  crypto.getRandomValues(buf);
+  return Array.from(buf)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandler {
+  async function create(port: number): Promise<TunnelInfo> {
+    const startTime = Date.now();
+    let outcome: 'success' | 'error' = 'error';
+    let caughtError: Error | undefined;
+    try {
+      validateTunnelPort(port);
+
+      const id = `quick-${shortId()}`;
+      const info = await host.client.tunnels.runQuickTunnel(id, port);
+      outcome = 'success';
+      return info;
+    } catch (error) {
+      caughtError = error instanceof Error ? error : new Error(String(error));
+      throw error;
+    } finally {
+      logCanonicalEvent(host.logger, {
+        event: 'tunnel.create',
+        outcome,
+        port,
+        durationMs: Date.now() - startTime,
+        error: caughtError
+      });
+    }
+  }
+
+  async function destroy(idOrInfo: string | TunnelInfo): Promise<void> {
+    const id = typeof idOrInfo === 'string' ? idOrInfo : idOrInfo.id;
+    const startTime = Date.now();
+    let outcome: 'success' | 'error' = 'error';
+    let caughtError: Error | undefined;
+    try {
+      await host.client.tunnels.destroyTunnel(id);
+      outcome = 'success';
+    } catch (error) {
+      caughtError = error instanceof Error ? error : new Error(String(error));
+      throw error;
+    } finally {
+      logCanonicalEvent(host.logger, {
+        event: 'tunnel.destroy',
+        outcome,
+        tunnelId: id,
+        durationMs: Date.now() - startTime,
+        error: caughtError
+      });
+    }
+  }
+
+  async function list(): Promise<TunnelInfo[]> {
+    return host.client.tunnels.listTunnels();
+  }
+
+  return { create, list, destroy };
+}

--- a/packages/sandbox/tests/sandbox-control-callback.test.ts
+++ b/packages/sandbox/tests/sandbox-control-callback.test.ts
@@ -1,0 +1,87 @@
+/**
+ * SandboxControlCallbackImpl unit tests.
+ *
+ * The class is the capnweb-facing RpcTarget the DO exposes via
+ * `localMain`. It does almost nothing on its own — just routes
+ * `onTunnelExit` through to the `TunnelExitHandler` it was given.
+ * Most of the interesting behaviour lives in `tunnels-handler.ts`.
+ */
+
+import type { Logger } from '@repo/shared';
+import { describe, expect, it, vi } from 'vitest';
+import { SandboxControlCallbackImpl } from '../src/tunnels/sandbox-control-callback';
+import type { TunnelExitHandler } from '../src/tunnels/tunnels-handler';
+
+function makeLogger(): Logger {
+  const log: Logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(() => log)
+  } as unknown as Logger;
+  return log;
+}
+
+describe('SandboxControlCallbackImpl', () => {
+  it('routes onTunnelExit through to the bound handler', async () => {
+    const handler = vi.fn<TunnelExitHandler>().mockResolvedValue(undefined);
+    const cb = new SandboxControlCallbackImpl(() => handler, makeLogger());
+
+    await cb.onTunnelExit('quick-a', 8080, 0);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith('quick-a', 8080, 0);
+  });
+
+  it('passes through a null exitCode (signalled process)', async () => {
+    const handler = vi.fn<TunnelExitHandler>().mockResolvedValue(undefined);
+    const cb = new SandboxControlCallbackImpl(() => handler, makeLogger());
+
+    await cb.onTunnelExit('quick-b', 8081, null);
+
+    expect(handler).toHaveBeenCalledWith('quick-b', 8081, null);
+  });
+
+  it('is a no-op when the accessor returns null', async () => {
+    const cb = new SandboxControlCallbackImpl(() => null, makeLogger());
+
+    // Must not throw — the accessor returning null models the brief
+    // post-setTransport window before the lazy getter rebuilds the
+    // tunnels handler.
+    await expect(cb.onTunnelExit('quick-c', 8082, 0)).resolves.toBeUndefined();
+  });
+
+  it('reads the handler accessor every call (does not cache)', async () => {
+    let current: TunnelExitHandler | null = null;
+    const cb = new SandboxControlCallbackImpl(() => current, makeLogger());
+
+    // First call: no handler bound. No-op.
+    await cb.onTunnelExit('quick-d', 8083, 0);
+
+    // Bind a handler, fire again. Must invoke the newly bound handler.
+    const handler = vi.fn<TunnelExitHandler>().mockResolvedValue(undefined);
+    current = handler;
+    await cb.onTunnelExit('quick-d', 8083, 0);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Swap to a different handler (simulating a transport rebind).
+    const newer = vi.fn<TunnelExitHandler>().mockResolvedValue(undefined);
+    current = newer;
+    await cb.onTunnelExit('quick-d', 8083, 0);
+    expect(newer).toHaveBeenCalledTimes(1);
+    // The original handler was not called again.
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates handler errors to the caller', async () => {
+    const handler = vi
+      .fn<TunnelExitHandler>()
+      .mockRejectedValue(new Error('storage boom'));
+    const cb = new SandboxControlCallbackImpl(() => handler, makeLogger());
+
+    await expect(cb.onTunnelExit('quick-e', 8084, 0)).rejects.toThrow(
+      'storage boom'
+    );
+  });
+});

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1440,6 +1440,38 @@ describe('Sandbox - Automatic Session Management', () => {
     });
   });
 
+  describe('tunnels lifecycle storage', () => {
+    it('onStart() clears the tunnels storage key', async () => {
+      const deletedKeys: string[] = [];
+      vi.mocked(mockCtx.storage!.delete).mockImplementation(async (key) => {
+        deletedKeys.push(String(key));
+        return true;
+      });
+      // restoreExposedPorts reads portTokens; make it a no-op so the
+      // tunnels-clear branch is reachable.
+      vi.mocked(mockCtx.storage!.get).mockResolvedValue(undefined as any);
+
+      await (sandbox as any).onStart();
+
+      expect(deletedKeys).toContain('tunnels');
+    });
+
+    it('destroy() deletes the tunnels storage key', async () => {
+      const deletedKeys: string[] = [];
+      vi.mocked(mockCtx.storage!.delete).mockImplementation(async (key) => {
+        deletedKeys.push(String(key));
+        return true;
+      });
+      vi.spyOn(Container.prototype, 'destroy').mockImplementation(
+        async () => {}
+      );
+
+      await sandbox.destroy();
+
+      expect(deletedKeys).toContain('tunnels');
+    });
+  });
+
   describe('validatePortToken', () => {
     beforeEach(() => {
       // Spy on getExposedPorts so a regression that reintroduces the

--- a/packages/sandbox/tests/tunnels-handler.test.ts
+++ b/packages/sandbox/tests/tunnels-handler.test.ts
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SandboxSecurityError } from '../src/security';
 import {
   createTunnelsHandler,
+  type TunnelsHandler,
   type TunnelsStorage
 } from '../src/tunnels/tunnels-handler';
 
@@ -90,14 +91,22 @@ function makeRecord(overrides: Partial<TunnelInfo> = {}): TunnelInfo {
 function makeHandler() {
   const { client } = makeClient();
   const storage = makeStorage();
-  const handler = createTunnelsHandler({
+  const { tunnels, handleTunnelExit } = createTunnelsHandler({
     client: client as unknown as Parameters<
       typeof createTunnelsHandler
     >[0]['client'],
     storage,
     logger: makeLogger()
   });
-  return { client, storage, handler };
+  // `handler` alias kept for legacy test bodies; new tests should
+  // reach for `tunnels` and `handleTunnelExit` directly.
+  return {
+    client,
+    storage,
+    handler: tunnels,
+    tunnels,
+    handleTunnelExit
+  };
 }
 
 describe('tunnels handler > get', () => {
@@ -134,7 +143,7 @@ describe('tunnels handler > get', () => {
     const record = makeRecord({ id: 'quick-cached0000cached', port: 8080 });
     const { client } = makeClient();
     const storage = makeStorage({ '8080': record });
-    const handler = createTunnelsHandler({
+    const { tunnels: handler } = createTunnelsHandler({
       client: client as unknown as Parameters<
         typeof createTunnelsHandler
       >[0]['client'],
@@ -155,7 +164,7 @@ describe('tunnels handler > get', () => {
     const record = makeRecord({ id: 'quick-stale00000000stale', port: 8080 });
     const { client } = makeClient();
     const storage = makeStorage({ '8080': record });
-    const handler = createTunnelsHandler({
+    const { tunnels: handler } = createTunnelsHandler({
       client: client as unknown as Parameters<
         typeof createTunnelsHandler
       >[0]['client'],
@@ -282,7 +291,7 @@ describe('tunnels handler > destroy', () => {
     const record = makeRecord({ id: 'quick-known0000known00', port: 8080 });
     const { client } = makeClient();
     const storage = makeStorage({ '8080': record });
-    const handler = createTunnelsHandler({
+    const { tunnels: handler } = createTunnelsHandler({
       client: client as unknown as Parameters<
         typeof createTunnelsHandler
       >[0]['client'],
@@ -307,7 +316,7 @@ describe('tunnels handler > destroy', () => {
     const record = makeRecord({ id: 'quick-tx0000tx0000tx', port: 8080 });
     const { client } = makeClient();
     const storage = makeStorage({ '8080': record });
-    const handler = createTunnelsHandler({
+    const { tunnels: handler } = createTunnelsHandler({
       client: client as unknown as Parameters<
         typeof createTunnelsHandler
       >[0]['client'],
@@ -330,7 +339,7 @@ describe('tunnels handler > destroy', () => {
     const record = makeRecord({ id: 'quick-info0000info00', port: 8080 });
     const { client } = makeClient();
     const storage = makeStorage({ '8080': record });
-    const handler = createTunnelsHandler({
+    const { tunnels: handler } = createTunnelsHandler({
       client: client as unknown as Parameters<
         typeof createTunnelsHandler
       >[0]['client'],
@@ -360,7 +369,7 @@ describe('tunnels handler > destroy', () => {
     const record = makeRecord({ id: 'quick-gone0000gone00', port: 8080 });
     const { client } = makeClient();
     const storage = makeStorage({ '8080': record });
-    const handler = createTunnelsHandler({
+    const { tunnels: handler } = createTunnelsHandler({
       client: client as unknown as Parameters<
         typeof createTunnelsHandler
       >[0]['client'],
@@ -382,7 +391,7 @@ describe('tunnels handler > destroy', () => {
     const record = makeRecord({ id: 'quick-err000000err000', port: 8080 });
     const { client } = makeClient();
     const storage = makeStorage({ '8080': record });
-    const handler = createTunnelsHandler({
+    const { tunnels: handler } = createTunnelsHandler({
       client: client as unknown as Parameters<
         typeof createTunnelsHandler
       >[0]['client'],
@@ -410,7 +419,7 @@ describe('tunnels handler > list', () => {
     });
     const { client } = makeClient();
     const storage = makeStorage({ '8080': a, '8081': b });
-    const handler = createTunnelsHandler({
+    const { tunnels: handler } = createTunnelsHandler({
       client: client as unknown as Parameters<
         typeof createTunnelsHandler
       >[0]['client'],
@@ -482,7 +491,7 @@ describe('tunnels handler > per-port serialization', () => {
     const record = makeRecord({ id: 'quick-pre000pre000pre0', port: 8080 });
     const { client } = makeClient();
     const storage = makeStorage({ '8080': record });
-    const handler = createTunnelsHandler({
+    const { tunnels: handler } = createTunnelsHandler({
       client: client as unknown as Parameters<
         typeof createTunnelsHandler
       >[0]['client'],
@@ -522,6 +531,125 @@ describe('tunnels handler > per-port serialization', () => {
     // resurrected the old record.
     expect(client.tunnels.runQuickTunnel).toHaveBeenCalledTimes(1);
     expect(info.id).not.toBe(record.id);
+  });
+});
+
+describe('tunnels handler > handleTunnelExit', () => {
+  it('clears the matching port from storage when the stored id matches', async () => {
+    const record = makeRecord({ id: 'quick-exit0000exit0000', port: 8080 });
+    const { client } = makeClient();
+    const storage = makeStorage({ '8080': record });
+    const { tunnels, handleTunnelExit } = createTunnelsHandler({
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage,
+      logger: makeLogger()
+    });
+
+    await handleTunnelExit(record.id, 8080, 0);
+
+    const final = await storage.get<Record<string, TunnelInfo>>('tunnels');
+    expect(final ?? {}).toEqual({});
+    // No container RPCs were issued — the exit hook is pure storage.
+    expect(client.tunnels.destroyTunnel).not.toHaveBeenCalled();
+    // `tunnels.list()` reflects the cleared storage.
+    await expect(tunnels.list()).resolves.toEqual([]);
+  });
+
+  it('is a no-op when the stored id has been replaced (id-mismatch safety net)', async () => {
+    const newer = makeRecord({ id: 'quick-newer000newer00', port: 8080 });
+    const { client } = makeClient();
+    const storage = makeStorage({ '8080': newer });
+    const { handleTunnelExit } = createTunnelsHandler({
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage,
+      logger: makeLogger()
+    });
+
+    // Callback fires for an OLDER tunnel id that's no longer in storage.
+    await handleTunnelExit('quick-stale0000stale00', 8080, null);
+
+    // Storage is untouched.
+    const final = await storage.get<Record<string, TunnelInfo>>('tunnels');
+    expect(final).toEqual({ '8080': newer });
+  });
+
+  it('is a no-op when storage is empty (already destroyed)', async () => {
+    const { client } = makeClient();
+    const storage = makeStorage();
+    const { handleTunnelExit } = createTunnelsHandler({
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage,
+      logger: makeLogger()
+    });
+
+    await expect(
+      handleTunnelExit('quick-anything00000ok', 8080, null)
+    ).resolves.toBeUndefined();
+    // No write happened.
+    expect((storage.put as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+
+  it('runs under the port lock — waits for a concurrent get(port) to complete', async () => {
+    const { client, storage, tunnels, handleTunnelExit } = makeHandler();
+    let resolveSpawn: (info: TunnelInfo) => void = () => {};
+    client.tunnels.runQuickTunnel.mockImplementation(
+      (id: string, port: number) =>
+        new Promise<TunnelInfo>((resolve) => {
+          resolveSpawn = () => resolve(makeRecord({ id, port }));
+        })
+    );
+
+    // Kick off a slow get(8080). Holds the port lock past the spawn.
+    const getPromise = tunnels.get(8080);
+    for (let i = 0; i < 50; i++) {
+      if (client.tunnels.runQuickTunnel.mock.calls.length > 0) break;
+      await new Promise((r) => setTimeout(r, 1));
+    }
+
+    // Fire an exit callback for some arbitrary id while get() is
+    // blocked. Without the lock, the callback would read the empty
+    // storage now (before get() writes) and observe nothing to clean
+    // up. With the lock, it must wait until get() releases.
+    const exitPromise = handleTunnelExit('quick-old', 8080, 0);
+    await new Promise((r) => setTimeout(r, 5));
+
+    // The exit hook has not yet read storage — storage is empty so
+    // there's nothing visible to assert directly, but we *can* assert
+    // it hasn't completed.
+    let exitResolved = false;
+    void exitPromise.then(() => {
+      exitResolved = true;
+    });
+    expect(exitResolved).toBe(false);
+
+    // Let get() finish.
+    resolveSpawn(makeRecord({ id: 'unused', port: 8080 }));
+    const info = await getPromise;
+    await exitPromise;
+
+    // The exit callback ran after the get() wrote storage, saw a
+    // different id ('quick-old' vs the spawned id), and no-op'd —
+    // the spawned record is still there.
+    const final = await storage.get<Record<string, TunnelInfo>>('tunnels');
+    expect(final).toEqual({ '8080': info });
+  });
+});
+
+describe('TunnelsHandler public surface', () => {
+  it('does not expose any exit hook on the public interface', () => {
+    // Compile-time guard: if a future change adds a method to
+    // TunnelsHandler beyond get/list/destroy, this assertion fails
+    // and the developer has to consciously update the allowlist.
+    type AllowedKeys = 'get' | 'list' | 'destroy';
+    type _Check = keyof TunnelsHandler extends AllowedKeys ? true : false;
+    const ok: _Check = true;
+    expect(ok).toBe(true);
   });
 });
 

--- a/packages/sandbox/tests/tunnels-handler.test.ts
+++ b/packages/sandbox/tests/tunnels-handler.test.ts
@@ -430,6 +430,101 @@ describe('tunnels handler > list', () => {
   });
 });
 
+describe('tunnels handler > per-port serialization', () => {
+  it('queues destroy(port) behind an in-flight get(port) so the destroy sees the new record', async () => {
+    const { client, storage, handler } = makeHandler();
+    let resolveSpawn: (info: TunnelInfo) => void = () => {};
+    client.tunnels.runQuickTunnel.mockImplementation(
+      (id: string, port: number) =>
+        new Promise<TunnelInfo>((resolve) => {
+          resolveSpawn = () => resolve(makeRecord({ id, port }));
+        })
+    );
+    client.tunnels.destroyTunnel.mockResolvedValue({
+      success: true,
+      id: ''
+    });
+
+    // Kick off get() but don't await yet — it's blocked on runQuickTunnel.
+    const getPromise = handler.get(8080);
+    // Wait until the spawn is in flight so we know get() holds the lock.
+    for (let i = 0; i < 50; i++) {
+      if (client.tunnels.runQuickTunnel.mock.calls.length > 0) break;
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    expect(client.tunnels.runQuickTunnel).toHaveBeenCalledTimes(1);
+
+    // Now race a destroy(8080) against the unfinished get(). Without
+    // serialization, the destroy would observe an empty map and return
+    // a no-op success, then get() would write its record into storage
+    // — leaking a cloudflared process the user thinks is gone.
+    const destroyPromise = handler.destroy(8080);
+    // Give the destroy a tick to attempt entering the critical section.
+    await new Promise((r) => setTimeout(r, 5));
+    // The destroy must NOT have called destroyTunnel yet (no record to destroy).
+    expect(client.tunnels.destroyTunnel).not.toHaveBeenCalled();
+
+    // Let get() complete.
+    resolveSpawn(makeRecord({ id: 'unused', port: 8080 }));
+    const info = await getPromise;
+    await destroyPromise;
+
+    // The destroy ran *after* the get wrote, so it tore down the right tunnel.
+    expect(client.tunnels.destroyTunnel).toHaveBeenCalledTimes(1);
+    expect(client.tunnels.destroyTunnel).toHaveBeenCalledWith(info.id);
+    // Storage is empty at the end — the get's write and the destroy's
+    // clear both happened, in that order.
+    const final = await storage.get<Record<string, TunnelInfo>>('tunnels');
+    expect(final ?? {}).toEqual({});
+  });
+
+  it('queues get(port) behind an in-flight destroy(port)', async () => {
+    const record = makeRecord({ id: 'quick-pre000pre000pre0', port: 8080 });
+    const { client } = makeClient();
+    const storage = makeStorage({ '8080': record });
+    const handler = createTunnelsHandler({
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage,
+      logger: makeLogger()
+    });
+    let resolveDestroy: () => void = () => {};
+    client.tunnels.destroyTunnel.mockImplementation(
+      () =>
+        new Promise<{ success: true; id: string }>((resolve) => {
+          resolveDestroy = () => resolve({ success: true, id: record.id });
+        })
+    );
+    client.tunnels.runQuickTunnel.mockImplementation(
+      async (id: string, port: number) => makeRecord({ id, port })
+    );
+
+    const destroyPromise = handler.destroy(8080);
+    // Wait until the destroy is in flight (has called destroyTunnel).
+    for (let i = 0; i < 50; i++) {
+      if (client.tunnels.destroyTunnel.mock.calls.length > 0) break;
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    expect(client.tunnels.destroyTunnel).toHaveBeenCalledTimes(1);
+
+    // get() must wait — if it ran now it would see the empty map and
+    // try to spawn while destroy() is still tearing down the old one.
+    const getPromise = handler.get(8080);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(client.tunnels.runQuickTunnel).not.toHaveBeenCalled();
+
+    resolveDestroy();
+    await destroyPromise;
+    const info = await getPromise;
+
+    // After the destroy completes, get() spawned a fresh tunnel — not
+    // resurrected the old record.
+    expect(client.tunnels.runQuickTunnel).toHaveBeenCalledTimes(1);
+    expect(info.id).not.toBe(record.id);
+  });
+});
+
 describe('route-based SandboxClient.tunnels placeholder', () => {
   it('throws "RPC transport required" from any method on the proxy', async () => {
     const { SandboxClient } = await import('../src/clients/sandbox-client');

--- a/packages/sandbox/tests/tunnels-handler.test.ts
+++ b/packages/sandbox/tests/tunnels-handler.test.ts
@@ -1,15 +1,18 @@
 /**
  * SDK tunnels handler unit tests.
  *
- * Mocks the container RPC client so we exercise the handler's validation,
- * id minting, registry, and log-event paths without standing up a real
- * container.
+ * Exercises validation, id minting, DO-storage caching, inflight
+ * coalescing, and log-event paths against a mocked RPC client and a
+ * lightweight in-memory `ctx.storage` shim.
  */
 
 import type { Logger, TunnelInfo } from '@repo/shared';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SandboxSecurityError } from '../src/security';
-import { createTunnelsHandler } from '../src/tunnels/tunnels-handler';
+import {
+  createTunnelsHandler,
+  type TunnelsStorage
+} from '../src/tunnels/tunnels-handler';
 
 function makeLogger(): Logger {
   const log: Logger = {
@@ -40,9 +43,42 @@ function makeClient(): { client: { tunnels: MockTunnelsClient } } {
   };
 }
 
+/**
+ * Minimal in-memory shim covering only the storage subset the handler
+ * uses. `transaction()` serializes closures via a chained promise so
+ * concurrent read-modify-write callers observe a consistent map —
+ * mirrors the real DO's optimistic-concurrency contract from the
+ * caller's perspective.
+ */
+function makeStorage(initial?: Record<string, TunnelInfo>): TunnelsStorage {
+  let value: Record<string, TunnelInfo> | undefined = initial
+    ? { ...initial }
+    : undefined;
+  let txQueue: Promise<unknown> = Promise.resolve();
+  const storage = {
+    get: vi.fn(async () => value),
+    put: vi.fn(async (_key: string, next: Record<string, TunnelInfo>) => {
+      value = { ...next };
+    }),
+    delete: vi.fn(async () => {
+      value = undefined;
+      return true;
+    }),
+    transaction: vi.fn((closure: (txn: unknown) => Promise<unknown>) => {
+      const next = txQueue.then(() => closure(storage));
+      // Swallow rejection on the chain so a failed closure doesn't
+      // poison subsequent transactions; the original promise still
+      // rejects to the caller.
+      txQueue = next.catch(() => undefined);
+      return next;
+    })
+  } as unknown as TunnelsStorage;
+  return storage;
+}
+
 function makeRecord(overrides: Partial<TunnelInfo> = {}): TunnelInfo {
   return {
-    id: 'quick-abcdef01',
+    id: 'quick-0123456789abcdef',
     port: 8080,
     url: 'https://stub.trycloudflare.com',
     hostname: 'stub.trycloudflare.com',
@@ -51,7 +87,20 @@ function makeRecord(overrides: Partial<TunnelInfo> = {}): TunnelInfo {
   };
 }
 
-describe('tunnels handler > create', () => {
+function makeHandler() {
+  const { client } = makeClient();
+  const storage = makeStorage();
+  const handler = createTunnelsHandler({
+    client: client as unknown as Parameters<
+      typeof createTunnelsHandler
+    >[0]['client'],
+    storage,
+    logger: makeLogger()
+  });
+  return { client, storage, handler };
+}
+
+describe('tunnels handler > get', () => {
   let warn: ReturnType<typeof vi.spyOn>;
   beforeEach(() => {
     warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -60,17 +109,13 @@ describe('tunnels handler > create', () => {
     warn.mockRestore();
   });
 
-  it('mints a `quick-<8 hex>` id and forwards it to the RPC client', async () => {
-    const { client } = makeClient();
+  it('mints a `quick-<8 hex>` id and forwards it to the RPC client on cache miss', async () => {
+    const { client, storage, handler } = makeHandler();
     client.tunnels.runQuickTunnel.mockImplementation(
       async (id: string, port: number) => makeRecord({ id, port })
     );
-    const handler = createTunnelsHandler({
-      client: client as any,
-      logger: makeLogger()
-    });
 
-    const info = await handler.create(8080);
+    const info = await handler.get(8080);
 
     expect(client.tunnels.runQuickTunnel).toHaveBeenCalledTimes(1);
     const [id, port] = client.tunnels.runQuickTunnel.mock.calls[0];
@@ -78,37 +123,154 @@ describe('tunnels handler > create', () => {
     expect(id).toMatch(/^quick-[0-9a-f]{8}$/);
     expect(info.id).toBe(id);
     expect(info.name).toBeUndefined();
-    expect(info.url).toBe('https://stub.trycloudflare.com');
-    expect(info.hostname).toBe('stub.trycloudflare.com');
+
+    // Storage is written under the port key.
+    expect(storage.put).toHaveBeenCalledTimes(1);
+    const [, stored] = (storage.put as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(stored).toEqual({ '8080': info });
   });
 
-  it('rejects out-of-range ports with SandboxSecurityError', async () => {
+  it('cache hit: returns the stored record without any container RPC', async () => {
+    const record = makeRecord({ id: 'quick-cached0000cached', port: 8080 });
     const { client } = makeClient();
+    const storage = makeStorage({ '8080': record });
     const handler = createTunnelsHandler({
-      client: client as any,
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage,
       logger: makeLogger()
     });
 
-    await expect(handler.create(80)).rejects.toBeInstanceOf(
+    const info = await handler.get(8080);
+
+    expect(info).toEqual(record);
+    expect(client.tunnels.runQuickTunnel).not.toHaveBeenCalled();
+    expect(client.tunnels.listTunnels).not.toHaveBeenCalled();
+    expect(client.tunnels.destroyTunnel).not.toHaveBeenCalled();
+    expect(storage.put).not.toHaveBeenCalled();
+  });
+
+  it('after storage is cleared (simulating container restart), behaves like cache miss', async () => {
+    const record = makeRecord({ id: 'quick-stale00000000stale', port: 8080 });
+    const { client } = makeClient();
+    const storage = makeStorage({ '8080': record });
+    const handler = createTunnelsHandler({
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage,
+      logger: makeLogger()
+    });
+
+    // Simulate the onStart() clear.
+    await storage.delete('tunnels');
+
+    client.tunnels.runQuickTunnel.mockImplementation(
+      async (id: string, port: number) =>
+        makeRecord({
+          id,
+          port,
+          url: 'https://fresh.trycloudflare.com',
+          hostname: 'fresh.trycloudflare.com'
+        })
+    );
+
+    const info = await handler.get(8080);
+    expect(client.tunnels.runQuickTunnel).toHaveBeenCalledTimes(1);
+    const [id] = client.tunnels.runQuickTunnel.mock.calls[0];
+    expect(id).not.toBe(record.id); // fresh id
+    expect(info.url).toBe('https://fresh.trycloudflare.com');
+  });
+
+  it('coalesces concurrent get() calls for the same port', async () => {
+    const { client, handler } = makeHandler();
+    let resolveRun: (info: TunnelInfo) => void = () => {};
+    client.tunnels.runQuickTunnel.mockImplementation(
+      (id: string, port: number) =>
+        new Promise<TunnelInfo>((resolve) => {
+          resolveRun = () => resolve(makeRecord({ id, port }));
+        })
+    );
+
+    const a = handler.get(8080);
+    const b = handler.get(8080);
+    // Wait until runQuickTunnel is invoked so we know the work promise
+    // is past the storage-read await and ready to resolve.
+    for (let i = 0; i < 50; i++) {
+      if (client.tunnels.runQuickTunnel.mock.calls.length > 0) break;
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    expect(client.tunnels.runQuickTunnel).toHaveBeenCalledTimes(1);
+    resolveRun(makeRecord({ id: 'ignored', port: 8080 }));
+    const [resolvedA, resolvedB] = await Promise.all([a, b]);
+
+    expect(client.tunnels.runQuickTunnel).toHaveBeenCalledTimes(1);
+    expect(resolvedA).toEqual(resolvedB);
+  });
+
+  it('does not coalesce different ports', async () => {
+    const { client, handler } = makeHandler();
+    client.tunnels.runQuickTunnel.mockImplementation(
+      async (id: string, port: number) => makeRecord({ id, port })
+    );
+
+    const [a, b] = await Promise.all([handler.get(8080), handler.get(8081)]);
+    expect(client.tunnels.runQuickTunnel).toHaveBeenCalledTimes(2);
+    expect(a.port).toBe(8080);
+    expect(b.port).toBe(8081);
+  });
+
+  it('writes through storage.transaction() so concurrent miss-path writes do not clobber each other', async () => {
+    const { client, storage, handler } = makeHandler();
+    client.tunnels.runQuickTunnel.mockImplementation(
+      async (id: string, port: number) => makeRecord({ id, port })
+    );
+
+    await Promise.all([handler.get(8080), handler.get(8081)]);
+
+    // One transaction per miss-path write.
+    expect(
+      (storage.transaction as ReturnType<typeof vi.fn>).mock.calls.length
+    ).toBe(2);
+    // Both entries land in storage — the second writer did not clobber
+    // the first.
+    const final = await storage.get<Record<string, TunnelInfo>>('tunnels');
+    expect(Object.keys(final ?? {})).toEqual(
+      expect.arrayContaining(['8080', '8081'])
+    );
+  });
+
+  it('clears the inflight slot when the spawn fails', async () => {
+    const { client, handler } = makeHandler();
+    client.tunnels.runQuickTunnel.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(handler.get(8080)).rejects.toThrow('boom');
+
+    // Subsequent calls retry rather than re-resolving the failed promise.
+    client.tunnels.runQuickTunnel.mockImplementationOnce(
+      async (id: string, port: number) => makeRecord({ id, port })
+    );
+    const info = await handler.get(8080);
+    expect(client.tunnels.runQuickTunnel).toHaveBeenCalledTimes(2);
+    expect(info.port).toBe(8080);
+  });
+
+  it('rejects out-of-range ports with SandboxSecurityError', async () => {
+    const { client, handler } = makeHandler();
+
+    await expect(handler.get(80)).rejects.toBeInstanceOf(SandboxSecurityError);
+    await expect(handler.get(100000)).rejects.toBeInstanceOf(
       SandboxSecurityError
     );
-    await expect(handler.create(100000)).rejects.toBeInstanceOf(
-      SandboxSecurityError
-    );
-    await expect(handler.create(1.5)).rejects.toBeInstanceOf(
-      SandboxSecurityError
-    );
+    await expect(handler.get(1.5)).rejects.toBeInstanceOf(SandboxSecurityError);
     expect(client.tunnels.runQuickTunnel).not.toHaveBeenCalled();
   });
 
   it('rejects the reserved control-plane port 3000', async () => {
-    const { client } = makeClient();
-    const handler = createTunnelsHandler({
-      client: client as any,
-      logger: makeLogger()
-    });
+    const { client, handler } = makeHandler();
 
-    await expect(handler.create(3000)).rejects.toBeInstanceOf(
+    await expect(handler.get(3000)).rejects.toBeInstanceOf(
       SandboxSecurityError
     );
     expect(client.tunnels.runQuickTunnel).not.toHaveBeenCalled();
@@ -116,83 +278,164 @@ describe('tunnels handler > create', () => {
 });
 
 describe('tunnels handler > destroy', () => {
-  it('forwards the id from a string argument to the RPC client', async () => {
+  it('clears storage and calls destroyTunnel(id) for a known port', async () => {
+    const record = makeRecord({ id: 'quick-known0000known00', port: 8080 });
     const { client } = makeClient();
-    client.tunnels.runQuickTunnel.mockImplementation(
-      async (id: string, port: number) => makeRecord({ id, port })
-    );
+    const storage = makeStorage({ '8080': record });
+    const handler = createTunnelsHandler({
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage,
+      logger: makeLogger()
+    });
     client.tunnels.destroyTunnel.mockResolvedValue({
       success: true,
-      id: 'quick-abcdef01'
+      id: record.id
     });
-    const handler = createTunnelsHandler({
-      client: client as any,
-      logger: makeLogger()
-    });
-    const info = await handler.create(8080);
 
-    await handler.destroy(info.id);
+    await handler.destroy(8080);
 
-    expect(client.tunnels.destroyTunnel).toHaveBeenCalledWith(info.id);
+    expect(client.tunnels.destroyTunnel).toHaveBeenCalledWith(record.id);
+    // Storage entry is removed before the RPC.
+    const putCalls = (storage.put as ReturnType<typeof vi.fn>).mock.calls;
+    expect(putCalls).toHaveLength(1);
+    expect(putCalls[0][1]).toEqual({});
   });
 
-  it('accepts a TunnelInfo object and resolves the id from it', async () => {
+  it('wraps the read-modify-write in storage.transaction()', async () => {
+    const record = makeRecord({ id: 'quick-tx0000tx0000tx', port: 8080 });
     const { client } = makeClient();
-    client.tunnels.runQuickTunnel.mockImplementation(
-      async (id: string, port: number) => makeRecord({ id, port })
-    );
-    client.tunnels.destroyTunnel.mockResolvedValue({ success: true, id: '' });
+    const storage = makeStorage({ '8080': record });
     const handler = createTunnelsHandler({
-      client: client as any,
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage,
       logger: makeLogger()
     });
-    const info = await handler.create(8080);
+    client.tunnels.destroyTunnel.mockResolvedValue({
+      success: true,
+      id: record.id
+    });
 
-    await handler.destroy(info);
+    await handler.destroy(8080);
 
-    expect(client.tunnels.destroyTunnel).toHaveBeenCalledWith(info.id);
+    expect(
+      (storage.transaction as ReturnType<typeof vi.fn>).mock.calls.length
+    ).toBe(1);
   });
 
-  it('propagates TUNNEL_NOT_FOUND from the RPC client', async () => {
+  it('accepts a TunnelInfo object and resolves the port from it', async () => {
+    const record = makeRecord({ id: 'quick-info0000info00', port: 8080 });
     const { client } = makeClient();
+    const storage = makeStorage({ '8080': record });
+    const handler = createTunnelsHandler({
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage,
+      logger: makeLogger()
+    });
+    client.tunnels.destroyTunnel.mockResolvedValue({
+      success: true,
+      id: record.id
+    });
+
+    await handler.destroy(record);
+
+    expect(client.tunnels.destroyTunnel).toHaveBeenCalledWith(record.id);
+  });
+
+  it('is a no-op success on unknown port', async () => {
+    const { client, storage, handler } = makeHandler();
+
+    await expect(handler.destroy(9999)).resolves.toBeUndefined();
+    expect(client.tunnels.destroyTunnel).not.toHaveBeenCalled();
+    expect(storage.put).not.toHaveBeenCalled();
+    expect(storage.delete).not.toHaveBeenCalled();
+  });
+
+  it('swallows TUNNEL_NOT_FOUND from the container (already gone)', async () => {
+    const record = makeRecord({ id: 'quick-gone0000gone00', port: 8080 });
+    const { client } = makeClient();
+    const storage = makeStorage({ '8080': record });
+    const handler = createTunnelsHandler({
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage,
+      logger: makeLogger()
+    });
     client.tunnels.destroyTunnel.mockRejectedValue(
-      new Error('TUNNEL_NOT_FOUND: tunnel ghost is not running')
+      new Error('TUNNEL_NOT_FOUND: tunnel quick-gone is not running')
     );
+
+    await expect(handler.destroy(8080)).resolves.toBeUndefined();
+    // Storage is still cleared.
+    const putCalls = (storage.put as ReturnType<typeof vi.fn>).mock.calls;
+    expect(putCalls).toHaveLength(1);
+    expect(putCalls[0][1]).toEqual({});
+  });
+
+  it('does not roll back storage when the container call fails with a non-NOT_FOUND error', async () => {
+    const record = makeRecord({ id: 'quick-err000000err000', port: 8080 });
+    const { client } = makeClient();
+    const storage = makeStorage({ '8080': record });
     const handler = createTunnelsHandler({
-      client: client as any,
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage,
       logger: makeLogger()
     });
+    client.tunnels.destroyTunnel.mockRejectedValue(new Error('boom'));
 
-    await expect(handler.destroy('ghost')).rejects.toThrow(/TUNNEL_NOT_FOUND/);
+    await expect(handler.destroy(8080)).rejects.toThrow('boom');
+    const putCalls = (storage.put as ReturnType<typeof vi.fn>).mock.calls;
+    // Storage was cleared before the RPC and is not restored on failure.
+    expect(putCalls).toHaveLength(1);
+    expect(putCalls[0][1]).toEqual({});
   });
 });
 
 describe('tunnels handler > list', () => {
-  it('returns the records as the RPC client surfaces them', async () => {
+  it('returns the values from storage (no container round-trip)', async () => {
+    const a = makeRecord({ id: 'quick-aaaa1111aaaa1111', port: 8080 });
+    const b = makeRecord({
+      id: 'quick-bbbb2222bbbb2222',
+      port: 8081,
+      url: 'https://b.trycloudflare.com',
+      hostname: 'b.trycloudflare.com'
+    });
     const { client } = makeClient();
-    const records: TunnelInfo[] = [
-      makeRecord({ id: 'quick-aaaaaaaa', port: 8080 }),
-      makeRecord({ id: 'quick-bbbbbbbb', port: 8081 })
-    ];
-    client.tunnels.listTunnels.mockResolvedValue(records);
+    const storage = makeStorage({ '8080': a, '8081': b });
     const handler = createTunnelsHandler({
-      client: client as any,
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage,
       logger: makeLogger()
     });
 
     const tunnels = await handler.list();
+    expect(tunnels).toEqual(expect.arrayContaining([a, b]));
+    expect(tunnels).toHaveLength(2);
+    expect(client.tunnels.listTunnels).not.toHaveBeenCalled();
+  });
 
-    expect(tunnels).toEqual(records);
+  it('returns an empty array when storage is empty', async () => {
+    const { handler } = makeHandler();
+    await expect(handler.list()).resolves.toEqual([]);
   });
 });
 
 describe('route-based SandboxClient.tunnels placeholder', () => {
   it('throws "RPC transport required" from any method on the proxy', async () => {
-    // Late import so this only loads when the test runs.
     const { SandboxClient } = await import('../src/clients/sandbox-client');
     const client = new SandboxClient({ baseUrl: 'http://test.invalid' });
     expect(() =>
-      (client.tunnels as unknown as { create: () => void }).create()
+      (client.tunnels as unknown as { get: () => void }).get()
     ).toThrow(/RPC transport/);
     expect(() =>
       (client.tunnels as unknown as { list: () => void }).list()

--- a/packages/sandbox/tests/tunnels-handler.test.ts
+++ b/packages/sandbox/tests/tunnels-handler.test.ts
@@ -1,0 +1,204 @@
+/**
+ * SDK tunnels handler unit tests.
+ *
+ * Mocks the container RPC client so we exercise the handler's validation,
+ * id minting, registry, and log-event paths without standing up a real
+ * container.
+ */
+
+import type { Logger, TunnelInfo } from '@repo/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SandboxSecurityError } from '../src/security';
+import { createTunnelsHandler } from '../src/tunnels/tunnels-handler';
+
+function makeLogger(): Logger {
+  const log: Logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(() => log)
+  } as unknown as Logger;
+  return log;
+}
+
+interface MockTunnelsClient {
+  runQuickTunnel: ReturnType<typeof vi.fn>;
+  destroyTunnel: ReturnType<typeof vi.fn>;
+  listTunnels: ReturnType<typeof vi.fn>;
+}
+
+function makeClient(): { client: { tunnels: MockTunnelsClient } } {
+  return {
+    client: {
+      tunnels: {
+        runQuickTunnel: vi.fn(),
+        destroyTunnel: vi.fn(),
+        listTunnels: vi.fn()
+      }
+    }
+  };
+}
+
+function makeRecord(overrides: Partial<TunnelInfo> = {}): TunnelInfo {
+  return {
+    id: 'quick-abcdef01',
+    port: 8080,
+    url: 'https://stub.trycloudflare.com',
+    hostname: 'stub.trycloudflare.com',
+    createdAt: '2026-05-13T00:00:00.000Z',
+    ...overrides
+  };
+}
+
+describe('tunnels handler > create', () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('mints a `quick-<8 hex>` id and forwards it to the RPC client', async () => {
+    const { client } = makeClient();
+    client.tunnels.runQuickTunnel.mockImplementation(
+      async (id: string, port: number) => makeRecord({ id, port })
+    );
+    const handler = createTunnelsHandler({
+      client: client as any,
+      logger: makeLogger()
+    });
+
+    const info = await handler.create(8080);
+
+    expect(client.tunnels.runQuickTunnel).toHaveBeenCalledTimes(1);
+    const [id, port] = client.tunnels.runQuickTunnel.mock.calls[0];
+    expect(port).toBe(8080);
+    expect(id).toMatch(/^quick-[0-9a-f]{8}$/);
+    expect(info.id).toBe(id);
+    expect(info.name).toBeUndefined();
+    expect(info.url).toBe('https://stub.trycloudflare.com');
+    expect(info.hostname).toBe('stub.trycloudflare.com');
+  });
+
+  it('rejects out-of-range ports with SandboxSecurityError', async () => {
+    const { client } = makeClient();
+    const handler = createTunnelsHandler({
+      client: client as any,
+      logger: makeLogger()
+    });
+
+    await expect(handler.create(80)).rejects.toBeInstanceOf(
+      SandboxSecurityError
+    );
+    await expect(handler.create(100000)).rejects.toBeInstanceOf(
+      SandboxSecurityError
+    );
+    await expect(handler.create(1.5)).rejects.toBeInstanceOf(
+      SandboxSecurityError
+    );
+    expect(client.tunnels.runQuickTunnel).not.toHaveBeenCalled();
+  });
+
+  it('rejects the reserved control-plane port 3000', async () => {
+    const { client } = makeClient();
+    const handler = createTunnelsHandler({
+      client: client as any,
+      logger: makeLogger()
+    });
+
+    await expect(handler.create(3000)).rejects.toBeInstanceOf(
+      SandboxSecurityError
+    );
+    expect(client.tunnels.runQuickTunnel).not.toHaveBeenCalled();
+  });
+});
+
+describe('tunnels handler > destroy', () => {
+  it('forwards the id from a string argument to the RPC client', async () => {
+    const { client } = makeClient();
+    client.tunnels.runQuickTunnel.mockImplementation(
+      async (id: string, port: number) => makeRecord({ id, port })
+    );
+    client.tunnels.destroyTunnel.mockResolvedValue({
+      success: true,
+      id: 'quick-abcdef01'
+    });
+    const handler = createTunnelsHandler({
+      client: client as any,
+      logger: makeLogger()
+    });
+    const info = await handler.create(8080);
+
+    await handler.destroy(info.id);
+
+    expect(client.tunnels.destroyTunnel).toHaveBeenCalledWith(info.id);
+  });
+
+  it('accepts a TunnelInfo object and resolves the id from it', async () => {
+    const { client } = makeClient();
+    client.tunnels.runQuickTunnel.mockImplementation(
+      async (id: string, port: number) => makeRecord({ id, port })
+    );
+    client.tunnels.destroyTunnel.mockResolvedValue({ success: true, id: '' });
+    const handler = createTunnelsHandler({
+      client: client as any,
+      logger: makeLogger()
+    });
+    const info = await handler.create(8080);
+
+    await handler.destroy(info);
+
+    expect(client.tunnels.destroyTunnel).toHaveBeenCalledWith(info.id);
+  });
+
+  it('propagates TUNNEL_NOT_FOUND from the RPC client', async () => {
+    const { client } = makeClient();
+    client.tunnels.destroyTunnel.mockRejectedValue(
+      new Error('TUNNEL_NOT_FOUND: tunnel ghost is not running')
+    );
+    const handler = createTunnelsHandler({
+      client: client as any,
+      logger: makeLogger()
+    });
+
+    await expect(handler.destroy('ghost')).rejects.toThrow(/TUNNEL_NOT_FOUND/);
+  });
+});
+
+describe('tunnels handler > list', () => {
+  it('returns the records as the RPC client surfaces them', async () => {
+    const { client } = makeClient();
+    const records: TunnelInfo[] = [
+      makeRecord({ id: 'quick-aaaaaaaa', port: 8080 }),
+      makeRecord({ id: 'quick-bbbbbbbb', port: 8081 })
+    ];
+    client.tunnels.listTunnels.mockResolvedValue(records);
+    const handler = createTunnelsHandler({
+      client: client as any,
+      logger: makeLogger()
+    });
+
+    const tunnels = await handler.list();
+
+    expect(tunnels).toEqual(records);
+  });
+});
+
+describe('route-based SandboxClient.tunnels placeholder', () => {
+  it('throws "RPC transport required" from any method on the proxy', async () => {
+    // Late import so this only loads when the test runs.
+    const { SandboxClient } = await import('../src/clients/sandbox-client');
+    const client = new SandboxClient({ baseUrl: 'http://test.invalid' });
+    expect(() =>
+      (client.tunnels as unknown as { create: () => void }).create()
+    ).toThrow(/RPC transport/);
+    expect(() =>
+      (client.tunnels as unknown as { list: () => void }).list()
+    ).toThrow(/RPC transport/);
+    expect(() =>
+      (client.tunnels as unknown as { destroy: () => void }).destroy()
+    ).toThrow(/RPC transport/);
+  });
+});

--- a/packages/shared/src/errors/suggestions.ts
+++ b/packages/shared/src/errors/suggestions.ts
@@ -128,7 +128,7 @@ export function getSuggestion(
         case 'invalid_frame':
           return 'The container sent a frame the RPC transport cannot handle. This usually indicates a version mismatch between the SDK and the container image.';
         case 'protocol_error':
-          return 'The peer sent a malformed RPC message (capnweb could not parse the wire format). This usually indicates a version mismatch between the SDK and the container image.';
+          return 'The peer sent a malformed RPC message (could not parse the wire format). This usually indicates a version mismatch between the SDK and the container image.';
         case 'session_disposed':
           return 'The RPC session was disposed while a call was in flight. Avoid reusing stubs after disconnect(); the next method call will reconnect automatically.';
         default:

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -122,8 +122,10 @@ export type {
   SandboxInterpreterAPI,
   SandboxPortsAPI,
   SandboxProcessesAPI,
+  SandboxTunnelsAPI,
   SandboxUtilsAPI,
-  SandboxWatchAPI
+  SandboxWatchAPI,
+  TunnelInfo
 } from './rpc-types.js';
 // Export shell utilities
 export { shellEscape } from './shell-escape.js';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -116,6 +116,7 @@ export type {
   SandboxAPI,
   SandboxBackupAPI,
   SandboxCommandsAPI,
+  SandboxControlCallback,
   SandboxDesktopAPI,
   SandboxFilesAPI,
   SandboxGitAPI,

--- a/packages/shared/src/rpc-types.ts
+++ b/packages/shared/src/rpc-types.ts
@@ -70,6 +70,7 @@ export interface SandboxAPI {
   backup: SandboxBackupAPI;
   desktop: SandboxDesktopAPI;
   watch: SandboxWatchAPI;
+  tunnels: SandboxTunnelsAPI;
 }
 
 export interface SandboxCommandsAPI {
@@ -325,4 +326,32 @@ export interface SandboxDesktopAPI {
 export interface SandboxWatchAPI {
   watch(request: WatchRequest): Promise<ReadableStream<Uint8Array>>;
   checkChanges(request: CheckChangesRequest): Promise<CheckChangesResult>;
+}
+
+/**
+ * Public-facing tunnel record.
+ *
+ * Today only quick tunnels (`*.trycloudflare.com`) are supported. Future
+ * PRs will add named tunnels, which will carry a `name: string` field;
+ * `TunnelInfo` will then become a discriminated union keyed on the
+ * presence of `name`. The quick variant declares `name?: never` so the
+ * narrowing works without a breaking change here.
+ */
+export interface TunnelInfo {
+  id: string;
+  port: number;
+  url: string;
+  hostname: string;
+  createdAt: string;
+  /** Reserved for the named-tunnel variant in a future PR. */
+  name?: never;
+}
+
+export interface SandboxTunnelsAPI {
+  /** Spawn `cloudflared tunnel --url`. No credentials required. */
+  runQuickTunnel(id: string, port: number): Promise<TunnelInfo>;
+  /** Stop the cloudflared process for the given tunnel id. */
+  destroyTunnel(id: string): Promise<{ success: true; id: string }>;
+  /** List tunnels currently running inside the container. */
+  listTunnels(): Promise<TunnelInfo[]>;
 }

--- a/packages/shared/src/rpc-types.ts
+++ b/packages/shared/src/rpc-types.ts
@@ -355,3 +355,26 @@ export interface SandboxTunnelsAPI {
   /** List tunnels currently running inside the container. */
   listTunnels(): Promise<TunnelInfo[]>;
 }
+
+/**
+ * RPC surface the Sandbox DO exposes to the container over the existing
+ * capnweb session. The container reaches it via
+ * `session.getRemoteMain<SandboxControlCallback>()` and invokes methods
+ * to push control-plane events (today: tunnel exits) back to the DO.
+ *
+ * One stable target per sandbox; not per-tunnel. Reusable seam for
+ * future container→DO events.
+ */
+export interface SandboxControlCallback {
+  /**
+   * Called by the container when a `cloudflared` process exits for any
+   * reason — SIGTERM from `destroyTunnel`, container-initiated SIGKILL,
+   * network failure, segfault. `exitCode` is `null` if the process was
+   * signalled rather than exited cleanly.
+   */
+  onTunnelExit(
+    id: string,
+    port: number,
+    exitCode: number | null
+  ): Promise<void>;
+}

--- a/tests/e2e/test-worker/index.ts
+++ b/tests/e2e/test-worker/index.ts
@@ -988,14 +988,14 @@ console.log('Terminal server on port ' + port);
       }
 
       // Tunnels (RPC-only)
-      if (url.pathname === '/api/tunnel/create' && request.method === 'POST') {
+      if (url.pathname === '/api/tunnel/get' && request.method === 'POST') {
         if (transport !== 'rpc') {
           return new Response(
             JSON.stringify({ error: 'Tunnels require transport=rpc' }),
             { status: 400, headers: { 'Content-Type': 'application/json' } }
           );
         }
-        const info = await sandbox.tunnels.create(body.port);
+        const info = await sandbox.tunnels.get(body.port);
         return new Response(JSON.stringify(info), {
           headers: { 'Content-Type': 'application/json' }
         });
@@ -1024,11 +1024,16 @@ console.log('Terminal server on port ' + port);
             { status: 400, headers: { 'Content-Type': 'application/json' } }
           );
         }
-        const id = decodeURIComponent(
-          url.pathname.slice('/api/tunnel/'.length)
-        );
-        await sandbox.tunnels.destroy(id);
-        return new Response(JSON.stringify({ success: true, id }), {
+        const portStr = url.pathname.slice('/api/tunnel/'.length);
+        const port = Number.parseInt(portStr, 10);
+        if (!Number.isFinite(port)) {
+          return new Response(
+            JSON.stringify({ error: `Invalid port: ${portStr}` }),
+            { status: 400, headers: { 'Content-Type': 'application/json' } }
+          );
+        }
+        await sandbox.tunnels.destroy(port);
+        return new Response(JSON.stringify({ success: true, port }), {
           headers: { 'Content-Type': 'application/json' }
         });
       }

--- a/tests/e2e/test-worker/index.ts
+++ b/tests/e2e/test-worker/index.ts
@@ -987,6 +987,52 @@ console.log('Terminal server on port ' + port);
         }
       }
 
+      // Tunnels (RPC-only)
+      if (url.pathname === '/api/tunnel/create' && request.method === 'POST') {
+        if (transport !== 'rpc') {
+          return new Response(
+            JSON.stringify({ error: 'Tunnels require transport=rpc' }),
+            { status: 400, headers: { 'Content-Type': 'application/json' } }
+          );
+        }
+        const info = await sandbox.tunnels.create(body.port);
+        return new Response(JSON.stringify(info), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      if (url.pathname === '/api/tunnel/list' && request.method === 'GET') {
+        if (transport !== 'rpc') {
+          return new Response(
+            JSON.stringify({ error: 'Tunnels require transport=rpc' }),
+            { status: 400, headers: { 'Content-Type': 'application/json' } }
+          );
+        }
+        const tunnels = await sandbox.tunnels.list();
+        return new Response(JSON.stringify({ tunnels }), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      if (
+        url.pathname.startsWith('/api/tunnel/') &&
+        request.method === 'DELETE'
+      ) {
+        if (transport !== 'rpc') {
+          return new Response(
+            JSON.stringify({ error: 'Tunnels require transport=rpc' }),
+            { status: 400, headers: { 'Content-Type': 'application/json' } }
+          );
+        }
+        const id = decodeURIComponent(
+          url.pathname.slice('/api/tunnel/'.length)
+        );
+        await sandbox.tunnels.destroy(id);
+        return new Response(JSON.stringify({ success: true, id }), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
       // Environment variables
       if (url.pathname === '/api/env/set' && request.method === 'POST') {
         await executor.setEnvVars(body.envVars);

--- a/tests/e2e/tunnel-quick-workflow.test.ts
+++ b/tests/e2e/tunnel-quick-workflow.test.ts
@@ -1,0 +1,299 @@
+import type { Process } from '@repo/shared';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import {
+  cleanupTestSandbox,
+  createTestSandbox,
+  type TestSandbox
+} from './helpers/global-sandbox';
+
+/**
+ * Quick tunnel round-trip.
+ *
+ * Spawns a tiny Bun HTTP server inside the sandbox, calls
+ * `sandbox.tunnels.create(port)`, then `fetch()`s the returned
+ * `*.trycloudflare.com` URL from outside the container and asserts the
+ * body matches.
+ *
+ * Quick tunnels need no Cloudflare credentials, so this is the cheapest
+ * end-to-end check that the cloudflared binary, the TunnelManager
+ * spawn/ready logic, and the RPC plumbing all work.
+ *
+ * Skipped unless `TEST_TRANSPORT=rpc` — the route-based transport's
+ * `tunnels` stub is intentionally a "not implemented" placeholder.
+ */
+
+const TUNNEL_TEST_PORT = 9871;
+
+const skipQuickTunnel = (process.env.TEST_TRANSPORT ?? 'http') !== 'rpc';
+
+interface QuickTunnelInfo {
+  id: string;
+  port: number;
+  url: string;
+  hostname: string;
+  createdAt: string;
+  name?: never;
+}
+
+describe('Quick tunnel round-trip', () => {
+  let workerUrl: string;
+  let headers: Record<string, string>;
+  let sandbox: TestSandbox | null = null;
+
+  beforeAll(async () => {
+    sandbox = await createTestSandbox();
+    workerUrl = sandbox.workerUrl;
+    headers = sandbox.headers();
+  }, 120_000);
+
+  afterAll(async () => {
+    await cleanupTestSandbox(sandbox);
+  }, 120_000);
+
+  test.skipIf(skipQuickTunnel)(
+    'creates a *.trycloudflare.com URL that proxies to a server inside the sandbox',
+    async () => {
+      // 1. Boot a Bun server inside the sandbox.
+      const marker = `quick-tunnel-${Math.random().toString(36).slice(2, 10)}`;
+      const serverCode = `
+const server = Bun.serve({
+  hostname: "0.0.0.0",
+  port: ${TUNNEL_TEST_PORT},
+  fetch(req) {
+    const url = new URL(req.url);
+    if (url.pathname === "/marker") {
+      return new Response("${marker}", { status: 200 });
+    }
+    return new Response("not found", { status: 404 });
+  },
+});
+console.log("Server listening on port " + server.port);
+      `.trim();
+
+      const writeResponse = await fetch(`${workerUrl}/api/file/write`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          path: '/workspace/quick-tunnel-server.ts',
+          content: serverCode
+        })
+      });
+      expect(writeResponse.status).toBe(200);
+
+      const startResponse = await fetch(`${workerUrl}/api/process/start`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          command: 'bun run /workspace/quick-tunnel-server.ts'
+        })
+      });
+      expect(startResponse.status).toBe(200);
+      const { id: processId } = (await startResponse.json()) as Process;
+
+      const waitPortResponse = await fetch(
+        `${workerUrl}/api/process/${processId}/waitForPort`,
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            port: TUNNEL_TEST_PORT,
+            timeout: 15_000,
+            mode: 'tcp'
+          })
+        }
+      );
+      expect(waitPortResponse.status).toBe(200);
+
+      // 2. Create the quick tunnel.
+      const createResponse = await fetch(`${workerUrl}/api/tunnel/create`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ port: TUNNEL_TEST_PORT })
+      });
+      expect(createResponse.status).toBe(200);
+      const tunnel = (await createResponse.json()) as QuickTunnelInfo;
+      expect(tunnel.name).toBeUndefined();
+      expect(tunnel.port).toBe(TUNNEL_TEST_PORT);
+      expect(tunnel.url).toMatch(/^https:\/\/[a-z0-9-]+\.trycloudflare\.com$/);
+      expect(tunnel.hostname).toMatch(/\.trycloudflare\.com$/);
+      expect(tunnel.id).toMatch(/^quick-[0-9a-f]{16}$/);
+
+      try {
+        // 3. Confirm list() round-trips the tunnel.
+        const listResponse = await fetch(`${workerUrl}/api/tunnel/list`, {
+          headers
+        });
+        expect(listResponse.status).toBe(200);
+        const { tunnels } = (await listResponse.json()) as {
+          tunnels: QuickTunnelInfo[];
+        };
+        expect(tunnels.map((t) => t.id)).toContain(tunnel.id);
+
+        // 4. Fetch the marker from the public URL. The Cloudflare edge can
+        //    take a couple of seconds to fully propagate even after
+        //    cloudflared reports `/ready`, so retry briefly.
+        const fetchedBody = await fetchWithRetry(
+          `${tunnel.url}/marker`,
+          marker,
+          { tries: 10, delayMs: 1000 }
+        );
+        expect(fetchedBody).toBe(marker);
+      } finally {
+        // 5. Clean up — the tunnel and the user process.
+        await fetch(
+          `${workerUrl}/api/tunnel/${encodeURIComponent(tunnel.id)}`,
+          { method: 'DELETE', headers }
+        );
+        await fetch(`${workerUrl}/api/process/${processId}/kill`, {
+          method: 'POST',
+          headers
+        }).catch(() => {});
+      }
+
+      // 6. After destroy, the tunnel is no longer in list().
+      const listAfter = await fetch(`${workerUrl}/api/tunnel/list`, {
+        headers
+      });
+      const { tunnels: tunnelsAfter } = (await listAfter.json()) as {
+        tunnels: QuickTunnelInfo[];
+      };
+      expect(tunnelsAfter.map((t) => t.id)).not.toContain(tunnel.id);
+    },
+    180_000
+  );
+
+  test.skipIf(skipQuickTunnel)(
+    'runs two tunnels on two different ports side by side',
+    async () => {
+      const portA = TUNNEL_TEST_PORT + 1;
+      const portB = TUNNEL_TEST_PORT + 2;
+      const markerA = `multi-a-${Math.random().toString(36).slice(2, 8)}`;
+      const markerB = `multi-b-${Math.random().toString(36).slice(2, 8)}`;
+
+      const startServer = async (port: number, marker: string) => {
+        const code = `
+Bun.serve({
+  hostname: "0.0.0.0",
+  port: ${port},
+  fetch() { return new Response("${marker}"); }
+});
+        `.trim();
+        const filePath = `/workspace/multi-tunnel-${port}.ts`;
+        await fetch(`${workerUrl}/api/file/write`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ path: filePath, content: code })
+        });
+        const start = await fetch(`${workerUrl}/api/process/start`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ command: `bun run ${filePath}` })
+        });
+        const { id: processId } = (await start.json()) as Process;
+        await fetch(
+          `${workerUrl}/api/process/${processId}/waitForPort`,
+          {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({ port, timeout: 15_000, mode: 'tcp' })
+          }
+        );
+        return processId;
+      };
+
+      const createTunnel = async (port: number) => {
+        const r = await fetch(`${workerUrl}/api/tunnel/create`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ port })
+        });
+        expect(r.status).toBe(200);
+        return (await r.json()) as QuickTunnelInfo;
+      };
+
+      const processA = await startServer(portA, markerA);
+      const processB = await startServer(portB, markerB);
+      const tunnelA = await createTunnel(portA);
+      const tunnelB = await createTunnel(portB);
+
+      try {
+        expect(tunnelA.id).not.toBe(tunnelB.id);
+        expect(tunnelA.url).not.toBe(tunnelB.url);
+        expect(tunnelA.port).toBe(portA);
+        expect(tunnelB.port).toBe(portB);
+
+        const listResponse = await fetch(`${workerUrl}/api/tunnel/list`, {
+          headers
+        });
+        const { tunnels } = (await listResponse.json()) as {
+          tunnels: QuickTunnelInfo[];
+        };
+        const ids = tunnels.map((t) => t.id);
+        expect(ids).toContain(tunnelA.id);
+        expect(ids).toContain(tunnelB.id);
+
+        // Each tunnel routes to its own backing port.
+        const [bodyA, bodyB] = await Promise.all([
+          fetchWithRetry(tunnelA.url, markerA, { tries: 10, delayMs: 1000 }),
+          fetchWithRetry(tunnelB.url, markerB, { tries: 10, delayMs: 1000 })
+        ]);
+        expect(bodyA).toBe(markerA);
+        expect(bodyB).toBe(markerB);
+      } finally {
+        await Promise.all([
+          fetch(
+            `${workerUrl}/api/tunnel/${encodeURIComponent(tunnelA.id)}`,
+            { method: 'DELETE', headers }
+          ),
+          fetch(
+            `${workerUrl}/api/tunnel/${encodeURIComponent(tunnelB.id)}`,
+            { method: 'DELETE', headers }
+          )
+        ]);
+        await Promise.all([
+          fetch(`${workerUrl}/api/process/${processA}/kill`, {
+            method: 'POST',
+            headers
+          }).catch(() => {}),
+          fetch(`${workerUrl}/api/process/${processB}/kill`, {
+            method: 'POST',
+            headers
+          }).catch(() => {})
+        ]);
+      }
+    },
+    240_000
+  );
+});
+
+async function fetchWithRetry(
+  url: string,
+  expectedBody: string,
+  opts: { tries: number; delayMs: number }
+): Promise<string> {
+  let lastError: unknown;
+  for (let i = 0; i < opts.tries; i++) {
+    try {
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(10_000)
+      });
+      if (response.ok) {
+        const body = await response.text();
+        if (body === expectedBody) return body;
+        lastError = new Error(
+          `Unexpected body (status ${response.status}): ${body.slice(0, 80)}`
+        );
+      } else {
+        lastError = new Error(`HTTP ${response.status}`);
+      }
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((r) => setTimeout(r, opts.delayMs));
+  }
+  throw new Error(
+    `fetchWithRetry failed for ${url}: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`
+  );
+}

--- a/tests/e2e/tunnel-quick-workflow.test.ts
+++ b/tests/e2e/tunnel-quick-workflow.test.ts
@@ -10,9 +10,13 @@ import {
  * Quick tunnel round-trip.
  *
  * Spawns a tiny Bun HTTP server inside the sandbox, calls
- * `sandbox.tunnels.create(port)`, then `fetch()`s the returned
+ * `sandbox.tunnels.get(port)`, then `fetch()`s the returned
  * `*.trycloudflare.com` URL from outside the container and asserts the
- * body matches.
+ * body matches. Then verifies the DO-storage caching contract:
+ *
+ *   - A second `get(port)` for the same port returns the same record.
+ *   - `destroy(port)` then `get(port)` yields a new record.
+ *   - `list()` reflects the storage view across the lifecycle.
  *
  * Quick tunnels need no Cloudflare credentials, so this is the cheapest
  * end-to-end check that the cloudflared binary, the TunnelManager
@@ -51,7 +55,7 @@ describe('Quick tunnel round-trip', () => {
   }, 120_000);
 
   test.skipIf(skipQuickTunnel)(
-    'creates a *.trycloudflare.com URL that proxies to a server inside the sandbox',
+    'get() creates a *.trycloudflare.com URL that proxies to a server inside the sandbox',
     async () => {
       // 1. Boot a Bun server inside the sandbox.
       const marker = `quick-tunnel-${Math.random().toString(36).slice(2, 10)}`;
@@ -105,13 +109,7 @@ console.log("Server listening on port " + server.port);
       expect(waitPortResponse.status).toBe(200);
 
       // 2. Create the quick tunnel.
-      const createResponse = await fetch(`${workerUrl}/api/tunnel/create`, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({ port: TUNNEL_TEST_PORT })
-      });
-      expect(createResponse.status).toBe(200);
-      const tunnel = (await createResponse.json()) as QuickTunnelInfo;
+      const tunnel = await getTunnel(TUNNEL_TEST_PORT);
       expect(tunnel.name).toBeUndefined();
       expect(tunnel.port).toBe(TUNNEL_TEST_PORT);
       expect(tunnel.url).toMatch(/^https:\/\/[a-z0-9-]+\.trycloudflare\.com$/);
@@ -119,19 +117,19 @@ console.log("Server listening on port " + server.port);
       expect(tunnel.id).toMatch(/^quick-[0-9a-f]{8}$/);
 
       try {
-        // 3. Confirm list() round-trips the tunnel.
-        const listResponse = await fetch(`${workerUrl}/api/tunnel/list`, {
-          headers
-        });
-        expect(listResponse.status).toBe(200);
-        const { tunnels } = (await listResponse.json()) as {
-          tunnels: QuickTunnelInfo[];
-        };
-        expect(tunnels.map((t) => t.id)).toContain(tunnel.id);
+        // 3. Idempotency: a second get() for the same port returns the
+        //    identical record. No new cloudflared spawn, same URL.
+        const second = await getTunnel(TUNNEL_TEST_PORT);
+        expect(second.id).toBe(tunnel.id);
+        expect(second.url).toBe(tunnel.url);
 
-        // 4. Fetch the marker from the public URL. The Cloudflare edge can
-        //    take a couple of seconds to fully propagate even after
-        //    cloudflared reports `/ready`, so retry briefly.
+        // 4. list() reflects the cached tunnel.
+        const listed = await listTunnels();
+        expect(listed.map((t) => t.id)).toContain(tunnel.id);
+
+        // 5. Fetch the marker through the public URL. The Cloudflare edge
+        //    can take a couple of seconds to propagate even after
+        //    cloudflared reports /ready, so retry briefly.
         const fetchedBody = await fetchWithRetry(
           `${tunnel.url}/marker`,
           marker,
@@ -139,25 +137,61 @@ console.log("Server listening on port " + server.port);
         );
         expect(fetchedBody).toBe(marker);
       } finally {
-        // 5. Clean up — the tunnel and the user process.
-        await fetch(
-          `${workerUrl}/api/tunnel/${encodeURIComponent(tunnel.id)}`,
-          { method: 'DELETE', headers }
-        );
+        // 6. Clean up — the tunnel and the user process.
+        await destroyTunnel(TUNNEL_TEST_PORT);
         await fetch(`${workerUrl}/api/process/${processId}/kill`, {
           method: 'POST',
           headers
         }).catch(() => {});
       }
 
-      // 6. After destroy, the tunnel is no longer in list().
-      const listAfter = await fetch(`${workerUrl}/api/tunnel/list`, {
-        headers
+      // 7. After destroy, the tunnel is no longer in list().
+      const after = await listTunnels();
+      expect(after.map((t) => t.id)).not.toContain(tunnel.id);
+    },
+    180_000
+  );
+
+  test.skipIf(skipQuickTunnel)(
+    'destroy() then get() returns a fresh record (new id, new URL)',
+    async () => {
+      // Boot a tiny server so the tunnel has something to point at.
+      const port = TUNNEL_TEST_PORT + 10;
+      const filePath = `/workspace/quick-tunnel-refresh-${port}.ts`;
+      await fetch(`${workerUrl}/api/file/write`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          path: filePath,
+          content: `Bun.serve({ hostname: "0.0.0.0", port: ${port}, fetch() { return new Response("ok"); } });`
+        })
       });
-      const { tunnels: tunnelsAfter } = (await listAfter.json()) as {
-        tunnels: QuickTunnelInfo[];
-      };
-      expect(tunnelsAfter.map((t) => t.id)).not.toContain(tunnel.id);
+      const startResponse = await fetch(`${workerUrl}/api/process/start`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ command: `bun run ${filePath}` })
+      });
+      const { id: processId } = (await startResponse.json()) as Process;
+      await fetch(`${workerUrl}/api/process/${processId}/waitForPort`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ port, timeout: 15_000, mode: 'tcp' })
+      });
+
+      try {
+        const first = await getTunnel(port);
+        await destroyTunnel(port);
+        const second = await getTunnel(port);
+        expect(second.id).not.toBe(first.id);
+        expect(second.url).not.toBe(first.url);
+        expect(second.port).toBe(port);
+      } finally {
+        await destroyTunnel(port).catch(() => {});
+        await fetch(`${workerUrl}/api/process/${processId}/kill`, {
+          method: 'POST',
+          headers
+        }).catch(() => {});
+      }
     },
     180_000
   );
@@ -190,31 +224,18 @@ Bun.serve({
           body: JSON.stringify({ command: `bun run ${filePath}` })
         });
         const { id: processId } = (await start.json()) as Process;
-        await fetch(
-          `${workerUrl}/api/process/${processId}/waitForPort`,
-          {
-            method: 'POST',
-            headers,
-            body: JSON.stringify({ port, timeout: 15_000, mode: 'tcp' })
-          }
-        );
-        return processId;
-      };
-
-      const createTunnel = async (port: number) => {
-        const r = await fetch(`${workerUrl}/api/tunnel/create`, {
+        await fetch(`${workerUrl}/api/process/${processId}/waitForPort`, {
           method: 'POST',
           headers,
-          body: JSON.stringify({ port })
+          body: JSON.stringify({ port, timeout: 15_000, mode: 'tcp' })
         });
-        expect(r.status).toBe(200);
-        return (await r.json()) as QuickTunnelInfo;
+        return processId;
       };
 
       const processA = await startServer(portA, markerA);
       const processB = await startServer(portB, markerB);
-      const tunnelA = await createTunnel(portA);
-      const tunnelB = await createTunnel(portB);
+      const tunnelA = await getTunnel(portA);
+      const tunnelB = await getTunnel(portB);
 
       try {
         expect(tunnelA.id).not.toBe(tunnelB.id);
@@ -222,13 +243,8 @@ Bun.serve({
         expect(tunnelA.port).toBe(portA);
         expect(tunnelB.port).toBe(portB);
 
-        const listResponse = await fetch(`${workerUrl}/api/tunnel/list`, {
-          headers
-        });
-        const { tunnels } = (await listResponse.json()) as {
-          tunnels: QuickTunnelInfo[];
-        };
-        const ids = tunnels.map((t) => t.id);
+        const listed = await listTunnels();
+        const ids = listed.map((t) => t.id);
         expect(ids).toContain(tunnelA.id);
         expect(ids).toContain(tunnelB.id);
 
@@ -240,16 +256,7 @@ Bun.serve({
         expect(bodyA).toBe(markerA);
         expect(bodyB).toBe(markerB);
       } finally {
-        await Promise.all([
-          fetch(
-            `${workerUrl}/api/tunnel/${encodeURIComponent(tunnelA.id)}`,
-            { method: 'DELETE', headers }
-          ),
-          fetch(
-            `${workerUrl}/api/tunnel/${encodeURIComponent(tunnelB.id)}`,
-            { method: 'DELETE', headers }
-          )
-        ]);
+        await Promise.all([destroyTunnel(portA), destroyTunnel(portB)]);
         await Promise.all([
           fetch(`${workerUrl}/api/process/${processA}/kill`, {
             method: 'POST',
@@ -264,6 +271,32 @@ Bun.serve({
     },
     240_000
   );
+
+  // ---- helpers --------------------------------------------------------
+
+  async function getTunnel(port: number): Promise<QuickTunnelInfo> {
+    const r = await fetch(`${workerUrl}/api/tunnel/get`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ port })
+    });
+    expect(r.status).toBe(200);
+    return (await r.json()) as QuickTunnelInfo;
+  }
+
+  async function listTunnels(): Promise<QuickTunnelInfo[]> {
+    const r = await fetch(`${workerUrl}/api/tunnel/list`, { headers });
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as { tunnels: QuickTunnelInfo[] };
+    return body.tunnels;
+  }
+
+  async function destroyTunnel(port: number): Promise<void> {
+    await fetch(`${workerUrl}/api/tunnel/${port}`, {
+      method: 'DELETE',
+      headers
+    });
+  }
 });
 
 async function fetchWithRetry(

--- a/tests/e2e/tunnel-quick-workflow.test.ts
+++ b/tests/e2e/tunnel-quick-workflow.test.ts
@@ -197,6 +197,80 @@ console.log("Server listening on port " + server.port);
   );
 
   test.skipIf(skipQuickTunnel)(
+    'auto-clears the storage entry when cloudflared exits unexpectedly',
+    async () => {
+      const port = TUNNEL_TEST_PORT + 20;
+      const filePath = `/workspace/quick-tunnel-crash-${port}.ts`;
+      // Boot a tiny server so cloudflared has something to point at.
+      await fetch(`${workerUrl}/api/file/write`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          path: filePath,
+          content: `Bun.serve({ hostname: "0.0.0.0", port: ${port}, fetch() { return new Response("ok"); } });`
+        })
+      });
+      const startResponse = await fetch(`${workerUrl}/api/process/start`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ command: `bun run ${filePath}` })
+      });
+      const { id: processId } = (await startResponse.json()) as Process;
+      await fetch(`${workerUrl}/api/process/${processId}/waitForPort`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ port, timeout: 15_000, mode: 'tcp' })
+      });
+
+      try {
+        const tunnel = await getTunnel(port);
+        // Tunnel is in the cache.
+        expect((await listTunnels()).map((t) => t.id)).toContain(tunnel.id);
+
+        // Kill the cloudflared process from inside the sandbox.
+        // pgrep / pkill are part of procps which ships in the base
+        // image; cloudflared was started by the container's
+        // TunnelManager so it's a child of pid 1.
+        const killResponse = await fetch(`${workerUrl}/api/execute`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ command: 'pkill -9 -f cloudflared' })
+        });
+        expect(killResponse.status).toBe(200);
+
+        // Poll list() until the dead tunnel is evicted. The exit
+        // callback fires inside the container's proc.exited handler,
+        // crosses the capnweb session, and clears storage — a
+        // handful of milliseconds in the happy case, but allow a few
+        // seconds for the round-trip.
+        let cleared = false;
+        for (let i = 0; i < 20; i++) {
+          await new Promise((r) => setTimeout(r, 500));
+          const ids = (await listTunnels()).map((t) => t.id);
+          if (!ids.includes(tunnel.id)) {
+            cleared = true;
+            break;
+          }
+        }
+        expect(cleared).toBe(true);
+
+        // A subsequent get(port) is now a clean cache miss — spawns
+        // a fresh tunnel with a new id and URL.
+        const fresh = await getTunnel(port);
+        expect(fresh.id).not.toBe(tunnel.id);
+        expect(fresh.url).not.toBe(tunnel.url);
+      } finally {
+        await destroyTunnel(port).catch(() => {});
+        await fetch(`${workerUrl}/api/process/${processId}/kill`, {
+          method: 'POST',
+          headers
+        }).catch(() => {});
+      }
+    },
+    180_000
+  );
+
+  test.skipIf(skipQuickTunnel)(
     'runs two tunnels on two different ports side by side',
     async () => {
       const portA = TUNNEL_TEST_PORT + 1;

--- a/tests/e2e/tunnel-quick-workflow.test.ts
+++ b/tests/e2e/tunnel-quick-workflow.test.ts
@@ -116,7 +116,7 @@ console.log("Server listening on port " + server.port);
       expect(tunnel.port).toBe(TUNNEL_TEST_PORT);
       expect(tunnel.url).toMatch(/^https:\/\/[a-z0-9-]+\.trycloudflare\.com$/);
       expect(tunnel.hostname).toMatch(/\.trycloudflare\.com$/);
-      expect(tunnel.id).toMatch(/^quick-[0-9a-f]{16}$/);
+      expect(tunnel.id).toMatch(/^quick-[0-9a-f]{8}$/);
 
       try {
         // 3. Confirm list() round-trips the tunnel.


### PR DESCRIPTION
Add `sandbox.tunnels` namespace with quick-tunnel support. Call `sandbox.tunnels.create(port)` to spawn a `cloudflared` quick tunnel inside the sandbox and get back a `https://<words>.trycloudflare.com` URL that proxies to `localhost:<port>` inside the container. No Cloudflare account or DNS setup required.

```ts
const tunnel = await sandbox.tunnels.create(8080);
console.log(tunnel.url);
// → https://random-words-here.trycloudflare.com

await sandbox.tunnels.list();
await sandbox.tunnels.destroy(tunnel);
```

This PR supercedes #674 which has a fuller implementation. The plan is to ship the tunnels interface in smaller chunks, starting with the basic "quick" tunnels that provide ephemeral URLs to single ports running inside the container.

> [!NOTE]
> Quick tunnels require the RPC transport and the glibc sandbox image variants (default, python, opencode, desktop) — the musl/Alpine variant does not include cloudflared.

**Limitations**

- **No SSE.** The trycloudflare edge buffers `text/event-stream` responses, so server-sent events don't reach the client. WebSockets work fine. Named tunnels don't have this issue.
- **No uptime guarantee.** Cloudflare positions trycloudflare as a debug aid, not a production target.
- **No persistent hostname.** Every restart picks a new `<words>.trycloudflare.com`.

**Background**

Today's `exposePort()` uses a Worker-fronted preview URL: traffic hits the Worker, the Worker calls into the Durable Object, the DO routes to the container. That's a great fit for HTTP request/response, but it has real ceilings for streaming / long-lived workloads:

- **Wildcard DNS.** Preview URLs encode the port + sandbox + token in the subdomain (`8080-sandbox-id-token.example.com`), which requires a wildcard CNAME *and* a custom domain (no `.workers.dev`).
- **Local Dev** The shared origin in local development means that tools like vite often accidentally intercept traffic intended for the sandbox.
- **CPU time per request.** A Worker invocation is bounded by your plan's CPU limit. A long-lived WebSocket or a multi-minute SSE stream can run into that ceiling well before the workload would naturally end.
- **Subrequest count.** Each Worker invocation has a hard subrequest cap. Anything that fans out (one request → many container calls) hits it.
- **Token-based auth on every request.** Adds latency on the hot path.

A Cloudflare Tunnel sidesteps all of those. Traffic terminates at the CF edge, gets routed straight into a `cloudflared` process inside the container over a persistent QUIC/HTTP2 connection, and never hits your Worker. Your Worker's CPU and subrequest budgets aren't touched. The hostname is whatever you point at the tunnel — no wildcard required.

**Overview**

This PR is broken into a couple of core pieces:

 1. We now install `cloudflared` in all non-musl images. There are currently no pre-built Alpine/musl binaries so this will be supported in a follow-up PR.
 2. The sandbox app in the container gained a `TunnelService` that handles spawning the `cloudflared` process and extracting the URL.
 3. The `Sandbox` interface now has a `tunnels` object with `create()/list()/destroy()` methods.

**API**

```ts
const tunnel = await sandbox.tunnels.create(8080);
// → https://<random-words>.trycloudflare.com

await sandbox.tunnels.list();
await sandbox.tunnels.destroy(tunnel);
```

**Testing**

There are unit tests for the TunnelService and E2E tests covering creating one & multiple tunnels.
