### PR TITLE
Recover RPC stream after OOM error

### DIFF
--- a/packages/sandbox/src/container-control/client.ts
+++ b/packages/sandbox/src/container-control/client.ts
@@ -394,9 +394,19 @@ export class ContainerControlClient {
     this.connOptions = {
       stub: options.stub,
       port: options.port,
+      localMain: options.localMain,
       logger: options.logger,
       retryTimeoutMs: options.retryTimeoutMs,
-      localMain: options.localMain
+      // Event-driven failure recovery: when the live WebSocket closes
+      // or errors, tear the connection down inside the same turn of
+      // the event loop so the next RPC call builds a fresh one. The
+      // 1Hz busy-poll fallback can't be relied on here — `setInterval`
+      // callbacks don't fire while the DO isolate sits idle between
+      // requests, which is exactly the state the isolate enters after
+      // every in-flight RPC rejects with a peer-closed error.
+      onClose: () => {
+        if (this.conn) this.destroyConnection();
+      }
     };
     this.idleDisconnectMs =
       options.idleDisconnectMs ?? DEFAULT_IDLE_DISCONNECT_MS;

--- a/packages/sandbox/src/container-control/client.ts
+++ b/packages/sandbox/src/container-control/client.ts
@@ -382,13 +382,6 @@ export class ContainerControlClient {
   private busyPollTimer: ReturnType<typeof setInterval> | null = null;
   /** Tracks whether we currently believe the session is busy. */
   private busy = false;
-  /**
-   * Set the first time the poller observes `conn.isConnected() === true`,
-   * cleared in `destroyConnection()`. Lets us distinguish "the WebSocket
-   * upgrade is still in progress" (don't tear down) from "we were
-   * connected and the peer went away" (do tear down).
-   */
-  private wasEverConnected = false;
 
   constructor(options: ContainerControlClientOptions) {
     this.connOptions = {
@@ -462,23 +455,17 @@ export class ContainerControlClient {
     const conn = this.conn;
     if (!conn) return;
     if (!conn.isConnected()) {
-      // Two distinct cases share the same `isConnected() === false`
-      // signal:
-      //   1. The WebSocket upgrade is still in progress — we constructed
-      //      the connection in getConnection() but doConnect() hasn't
-      //      resolved yet. Sends are queued in the deferred transport.
-      //      Tearing down here would drop those queued calls on the floor.
-      //   2. We were connected and the peer went away (container crash,
-      //      network blip). The session is dead, we must release
-      //      inflight and stop polling.
-      // `wasEverConnected` distinguishes them: it flips to true the first
-      // time we observe a live connection below.
-      if (this.wasEverConnected) {
-        this.destroyConnection();
-      }
+      // The WebSocket upgrade is still in progress (or a freshly
+      // recreated connection hasn't finished doConnect() yet). Sends
+      // are queued in the deferred transport and will flush once the
+      // upgrade resolves — don't tear down here.
+      //
+      // Failure recovery (a peer that disconnected after we connected)
+      // is handled synchronously by `ContainerControlConnection`'s
+      // `onClose` callback firing `destroyConnection()`, which nulls
+      // `this.conn` before the poller could observe it.
       return;
     }
-    this.wasEverConnected = true;
 
     const { imports, exports } = conn.getStats();
     const isBusy =
@@ -559,7 +546,6 @@ export class ContainerControlClient {
       this.conn.disconnect();
       this.conn = null;
     }
-    this.wasEverConnected = false;
   }
 
   // -------------------------------------------------------------------------

--- a/packages/sandbox/src/container-control/connection.ts
+++ b/packages/sandbox/src/container-control/connection.ts
@@ -55,6 +55,17 @@ export interface ContainerControlConnectionOptions {
    * exited). When omitted, the container sees an empty remote main.
    */
   localMain?: any;
+  /**
+   * Invoked when an active WebSocket transitions to closed/errored.
+   * Fired at most once per successful connection from the WS event
+   * handlers in `doConnect`. Gives owners a synchronous teardown
+   * signal so recovery doesn't depend on a periodic poller running
+   * inside what may be an idle isolate.
+   *
+   * Not fired for `doConnect` failures (the rejected `connect()`
+   * promise is the signal in that case) nor for `disconnect()`.
+   */
+  onClose?: () => void;
 }
 
 /**
@@ -75,12 +86,14 @@ export class ContainerControlConnection {
   private readonly port: number;
   private readonly logger: Logger;
   private retryTimeoutMs: number;
+  private readonly onClose: (() => void) | undefined;
 
   constructor(options: ContainerControlConnectionOptions) {
     this.containerStub = options.stub;
     this.port = options.port ?? 3000;
     this.logger = options.logger ?? createNoOpLogger();
     this.retryTimeoutMs = options.retryTimeoutMs ?? DEFAULT_RETRY_TIMEOUT_MS;
+    this.onClose = options.onClose;
 
     this.transport = new DeferredTransport();
     this.session = new RpcSession<SandboxAPI>(
@@ -163,6 +176,22 @@ export class ContainerControlConnection {
   // Internal
   // -----------------------------------------------------------------------
 
+  /**
+   * Run the owner-provided `onClose` callback exactly once per call,
+   * swallowing any errors so a buggy listener can't keep the connection
+   * object in a half-torn-down state.
+   */
+  private fireOnClose(): void {
+    if (!this.onClose) return;
+    try {
+      this.onClose();
+    } catch (err) {
+      this.logger.warn('ContainerControlConnection onClose handler threw', {
+        error: err instanceof Error ? err.message : String(err)
+      });
+    }
+  }
+
   private async doConnect(): Promise<void> {
     try {
       const response = await this.fetchUpgradeWithRetry();
@@ -184,14 +213,18 @@ export class ContainerControlConnection {
       (ws as unknown as { accept: () => void }).accept();
 
       ws.addEventListener('close', () => {
+        const wasConnected = this.connected;
         this.connected = false;
         this.ws = null;
         this.logger.debug('ContainerControlConnection WebSocket closed');
+        if (wasConnected) this.fireOnClose();
       });
 
       ws.addEventListener('error', () => {
+        const wasConnected = this.connected;
         this.connected = false;
         this.ws = null;
+        if (wasConnected) this.fireOnClose();
       });
 
       this.ws = ws;

--- a/packages/sandbox/src/container-control/connection.ts
+++ b/packages/sandbox/src/container-control/connection.ts
@@ -152,6 +152,13 @@ export class ContainerControlConnection {
       // Stub may already be disposed
     }
     if (this.ws) {
+      // Unbind first so a late `close` / `error` event dispatched by
+      // the runtime after we've decided this connection is dead can't
+      // reach a successor that the owner installed in our place — see
+      // the WebSocket-listener-unbinding tests in container-connection
+      // for the race this prevents.
+      this.ws.removeEventListener('close', this.onWebSocketClose);
+      this.ws.removeEventListener('error', this.onWebSocketError);
       try {
         this.ws.close();
       } catch {
@@ -192,6 +199,31 @@ export class ContainerControlConnection {
     }
   }
 
+  /**
+   * WebSocket `close` listener. Defined as a bound arrow field so the
+   * same reference can be passed to both `addEventListener` and
+   * `removeEventListener` — a fresh anonymous lambda would silently
+   * fail to unbind.
+   */
+  private onWebSocketClose = (): void => {
+    const wasConnected = this.connected;
+    this.connected = false;
+    this.ws = null;
+    this.logger.debug('ContainerControlConnection WebSocket closed');
+    if (wasConnected) this.fireOnClose();
+  };
+
+  /**
+   * WebSocket `error` listener. Same field-form rationale as
+   * {@link onWebSocketClose}.
+   */
+  private onWebSocketError = (): void => {
+    const wasConnected = this.connected;
+    this.connected = false;
+    this.ws = null;
+    if (wasConnected) this.fireOnClose();
+  };
+
   private async doConnect(): Promise<void> {
     try {
       const response = await this.fetchUpgradeWithRetry();
@@ -212,20 +244,8 @@ export class ContainerControlConnection {
       // Workers WebSockets require explicit accept() before use
       (ws as unknown as { accept: () => void }).accept();
 
-      ws.addEventListener('close', () => {
-        const wasConnected = this.connected;
-        this.connected = false;
-        this.ws = null;
-        this.logger.debug('ContainerControlConnection WebSocket closed');
-        if (wasConnected) this.fireOnClose();
-      });
-
-      ws.addEventListener('error', () => {
-        const wasConnected = this.connected;
-        this.connected = false;
-        this.ws = null;
-        if (wasConnected) this.fireOnClose();
-      });
+      ws.addEventListener('close', this.onWebSocketClose);
+      ws.addEventListener('error', this.onWebSocketError);
 
       this.ws = ws;
       this.transport.activate(ws);

--- a/packages/sandbox/tests/container-connection.test.ts
+++ b/packages/sandbox/tests/container-connection.test.ts
@@ -513,4 +513,130 @@ describe('ContainerControlConnection', () => {
       }
     });
   });
+
+  /**
+   * When a peer-closed WebSocket triggers an `onClose` callback that
+   * destroys the connection and creates a new one, we must not let a
+   * stale `close` / `error` event from the old WebSocket arrive later
+   * and clobber the successor connection. The connection guards against
+   * this by unbinding its own listeners from the underlying WebSocket
+   * inside `disconnect()`, so any event the runtime dispatches after we
+   * decide the connection is dead becomes a no-op.
+   */
+  describe('WebSocket listener unbinding', () => {
+    /**
+     * Fake WebSocket that records every (un)bind so we can assert
+     * `disconnect()` cleans up the listeners it registered in
+     * `doConnect()`.
+     */
+    function createTrackedWebSocket(): {
+      ws: WebSocket;
+      listenerCount: (type: string) => number;
+      emitClose: (code: number, reason: string) => void;
+      emitError: () => void;
+    } {
+      const target = new EventTarget();
+      const counts: Record<string, number> = {};
+
+      const addListener = (type: string, listener: EventListener): void => {
+        counts[type] = (counts[type] ?? 0) + 1;
+        target.addEventListener(type, listener);
+      };
+      const removeListener = (type: string, listener: EventListener): void => {
+        counts[type] = Math.max(0, (counts[type] ?? 0) - 1);
+        target.removeEventListener(type, listener);
+      };
+
+      const ws = {
+        addEventListener: addListener,
+        removeEventListener: removeListener,
+        send: () => {},
+        close: () => {},
+        accept: () => {}
+      } as unknown as WebSocket;
+
+      return {
+        ws,
+        listenerCount: (type) => counts[type] ?? 0,
+        emitClose: (code, reason) =>
+          target.dispatchEvent(
+            Object.assign(new Event('close'), { code, reason }) as CloseEvent
+          ),
+        emitError: () => target.dispatchEvent(new Event('error'))
+      };
+    }
+
+    function makeUpgradeResponseFor(ws: WebSocket): Response {
+      return {
+        status: 101,
+        statusText: 'Switching Protocols',
+        webSocket: ws
+      } as unknown as Response;
+    }
+
+    it('unbinds its close and error listeners from the WebSocket on disconnect', async () => {
+      const tracked = createTrackedWebSocket();
+      const conn = new ContainerControlConnection({
+        stub: {
+          fetch: vi.fn().mockResolvedValue(makeUpgradeResponseFor(tracked.ws))
+        }
+      });
+
+      await conn.connect();
+      expect(tracked.listenerCount('close')).toBeGreaterThan(0);
+      expect(tracked.listenerCount('error')).toBeGreaterThan(0);
+
+      const closeBeforeDisconnect = tracked.listenerCount('close');
+      const errorBeforeDisconnect = tracked.listenerCount('error');
+
+      conn.disconnect();
+
+      // The connection's own close/error listeners must be gone. The
+      // DeferredTransport's listeners on the same WebSocket are out of
+      // scope here — we only assert that the connection removed exactly
+      // the listeners it added in doConnect().
+      expect(tracked.listenerCount('close')).toBe(closeBeforeDisconnect - 1);
+      expect(tracked.listenerCount('error')).toBe(errorBeforeDisconnect - 1);
+    });
+
+    it('does not fire onClose for a close event dispatched after disconnect()', async () => {
+      const tracked = createTrackedWebSocket();
+      const onClose = vi.fn();
+      const conn = new ContainerControlConnection({
+        stub: {
+          fetch: vi.fn().mockResolvedValue(makeUpgradeResponseFor(tracked.ws))
+        },
+        onClose
+      });
+
+      await conn.connect();
+      conn.disconnect();
+
+      // Runtime dispatches a delayed close after we've already torn down.
+      // This simulates the race where a successor connection has been
+      // installed on the client and we don't want its stale predecessor's
+      // close event to reach the client's onClose handler.
+      tracked.emitClose(1011, 'Container WebSocket error');
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('does not fire onClose for an error event dispatched after disconnect()', async () => {
+      const tracked = createTrackedWebSocket();
+      const onClose = vi.fn();
+      const conn = new ContainerControlConnection({
+        stub: {
+          fetch: vi.fn().mockResolvedValue(makeUpgradeResponseFor(tracked.ws))
+        },
+        onClose
+      });
+
+      await conn.connect();
+      conn.disconnect();
+
+      tracked.emitError();
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/sandbox/tests/container-connection.test.ts
+++ b/packages/sandbox/tests/container-connection.test.ts
@@ -113,7 +113,7 @@ describe('ContainerControlConnection', () => {
 
       vi.spyOn(internals, 'doConnect').mockImplementation(async () => {
         internals.connected = true;
-        internals.ws = { close: vi.fn() };
+        internals.ws = { close: vi.fn(), removeEventListener: vi.fn() };
       });
 
       await conn.connect();
@@ -132,7 +132,7 @@ describe('ContainerControlConnection', () => {
 
       vi.spyOn(internals, 'doConnect').mockImplementation(async () => {
         internals.connected = true;
-        internals.ws = { close: vi.fn() };
+        internals.ws = { close: vi.fn(), removeEventListener: vi.fn() };
       });
 
       // rpc() returns the stub immediately — same reference before and after connect
@@ -156,7 +156,7 @@ describe('ContainerControlConnection', () => {
         .spyOn(internals, 'doConnect')
         .mockImplementation(async () => {
           internals.connected = true;
-          internals.ws = { close: vi.fn() };
+          internals.ws = { close: vi.fn(), removeEventListener: vi.fn() };
         });
 
       await conn.connect();
@@ -183,7 +183,7 @@ describe('ContainerControlConnection', () => {
         .spyOn(internals, 'doConnect')
         .mockImplementation(async () => {
           internals.connected = true;
-          internals.ws = { close: vi.fn() };
+          internals.ws = { close: vi.fn(), removeEventListener: vi.fn() };
         });
 
       await Promise.all([conn.connect(), conn.connect()]);

--- a/packages/sandbox/tests/rpc-sandbox-client.test.ts
+++ b/packages/sandbox/tests/rpc-sandbox-client.test.ts
@@ -13,9 +13,34 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 let stats = { imports: 1, exports: 1 };
 let connected = true;
 const disconnects: number[] = [];
+/**
+ * onClose callbacks installed by `ContainerControlClient` on the active
+ * mock connection. The client's `getConnection()` wires this so the WS
+ * close/error listeners can fire teardown synchronously — in tests we
+ * invoke it directly via {@link triggerPeerClose} to simulate the
+ * runtime dispatching that event.
+ */
+const onCloseHandlers: Array<() => void> = [];
+
+/**
+ * Simulate the runtime firing a `close` / `error` event on the live
+ * WebSocket: flip the mock's `connected` flag and fire whichever
+ * `onClose` the client most recently installed. Returns whether a
+ * handler was actually invoked.
+ */
+function triggerPeerClose(): boolean {
+  connected = false;
+  const handler = onCloseHandlers.pop();
+  if (!handler) return false;
+  handler();
+  return true;
+}
 
 vi.mock('../src/container-control/connection', () => ({
   ContainerControlConnection: class {
+    constructor(options: { onClose?: () => void } = {}) {
+      if (options.onClose) onCloseHandlers.push(options.onClose);
+    }
     isConnected() {
       return connected;
     }
@@ -46,6 +71,7 @@ describe('ContainerControlClient busy/idle tracking', () => {
     stats = { imports: 1, exports: 1 };
     connected = true;
     disconnects.length = 0;
+    onCloseHandlers.length = 0;
   });
 
   afterEach(() => {
@@ -142,19 +168,19 @@ describe('ContainerControlClient busy/idle tracking', () => {
     vi.advanceTimersByTime(1_000);
     expect(onSessionBusy).toHaveBeenCalledTimes(1);
 
-    // Container crash / WebSocket peer-close: connection reports
-    // disconnected on the next poll.
-    connected = false;
-    vi.advanceTimersByTime(1_000);
-
-    // The poller must observe the dead connection, fire onSessionIdle so
-    // the DO's inflight counter unwinds, and tear down so it isn't
-    // looping over a corpse forever.
+    // Container crash / WebSocket peer-close: the connection's WS
+    // close listener fires synchronously via the `onClose` callback
+    // the client installed in `getConnection()`. This must release
+    // the inflight slot and tear the connection down inside the same
+    // turn of the event loop — no waiting on a poll tick.
+    const fired = triggerPeerClose();
+    expect(fired).toBe(true);
     expect(onSessionIdle).toHaveBeenCalledTimes(1);
     expect(disconnects).toHaveLength(1);
 
-    // Subsequent ticks must be a no-op — if the poller fired again it
-    // would attempt destroyConnection() repeatedly.
+    // Subsequent poll ticks must be a no-op — `this.conn` has already
+    // been nulled by `destroyConnection()`, so there's nothing left to
+    // observe.
     vi.advanceTimersByTime(5_000);
     expect(onSessionIdle).toHaveBeenCalledTimes(1);
     expect(disconnects).toHaveLength(1);
@@ -179,18 +205,22 @@ describe('ContainerControlClient busy/idle tracking', () => {
     // Several poll ticks while the upgrade is still pending. Must not
     // dispose the connection — the deferred transport's queue is the
     // only thing standing between the user's RPC call and the wire.
+    // The poller now treats `!isConnected()` as 'upgrade in progress'
+    // unconditionally; peer-disconnect teardown comes through onClose.
     vi.advanceTimersByTime(5_000);
     expect(disconnects).toHaveLength(0);
     expect(onSessionIdle).not.toHaveBeenCalled();
 
-    // Upgrade completes. From here on the poller treats subsequent
-    // disconnections as real peer-gone events.
+    // Upgrade completes; the session goes busy.
     connected = true;
     stats = { imports: 1, exports: 2 };
     vi.advanceTimersByTime(1_000); // observed busy
 
-    connected = false;
-    vi.advanceTimersByTime(1_000); // peer-gone — now we tear down
+    // Peer goes away. The WS close listener fires `onClose`, which
+    // tears the connection down synchronously without depending on
+    // the poller observing anything.
+    const fired = triggerPeerClose();
+    expect(fired).toBe(true);
     expect(disconnects).toHaveLength(1);
     expect(onSessionIdle).toHaveBeenCalledTimes(1);
   });

--- a/tests/e2e/rpc-recovery-after-ws-close.test.ts
+++ b/tests/e2e/rpc-recovery-after-ws-close.test.ts
@@ -1,0 +1,129 @@
+/**
+ * RPC transport — recovery after WebSocket failure.
+ *
+ * When several large writeFile calls land concurrently on the RPC
+ * transport, the container-side proxy WebSocket inside containerFetch
+ * fails and closes the proxied connection with code 1011 ("Container
+ * WebSocket error"). Every in-flight RPC rejects with
+ * `RPCTransportError: Peer closed WebSocket: 1011 ...`. That part is
+ * fine — the calls are expected to fail.
+ *
+ * What is NOT fine: after that failure, every subsequent RPC on the
+ * same Durable Object isolate also rejects with the same cached error
+ * in <5 ms, because `DeferredTransport.#error` is sticky and recovery
+ * is gated on a `setInterval` poller that doesn't fire while the
+ * isolate is idle. The DO stays wedged until the runtime evicts it.
+ *
+ * This test reproduces the wedge: it fires a concurrent batch of
+ * large writeFile calls, ignores their (expected) failures, then
+ * issues a tiny `exec` and asserts it succeeds. On a healthy SDK the
+ * DO recovers within a request or two; on the broken SDK every retry
+ * returns the same 1011 error indefinitely.
+ */
+
+import type { ExecResult } from '@repo/shared';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import {
+  cleanupTestSandbox,
+  createTestSandbox,
+  createUniqueSession,
+  type TestSandbox
+} from './helpers/global-sandbox';
+
+const isRPCTransport = process.env.TEST_TRANSPORT === 'rpc';
+
+// Payload sized just under the 32 MiB JSRPC argument limit so the
+// Worker → DO hop survives serialization and the pressure lands on the
+// capnweb WebSocket between the DO and the container.
+const PAYLOAD_SIZE_BYTES = 31 * 1024 * 1024;
+const CONCURRENT_WRITES = 5;
+const RECOVERY_ATTEMPTS = 5;
+const RECOVERY_DELAY_MS = 500;
+
+describe.skipIf(!isRPCTransport)(
+  'RPC transport recovery after WebSocket failure',
+  () => {
+    let sandbox: TestSandbox | null = null;
+    let workerUrl: string;
+    let headers: Record<string, string>;
+
+    beforeAll(async () => {
+      sandbox = await createTestSandbox();
+      workerUrl = sandbox.workerUrl;
+      headers = sandbox.headers(createUniqueSession());
+    }, 120000);
+
+    afterAll(async () => {
+      await cleanupTestSandbox(sandbox);
+      sandbox = null;
+    }, 120000);
+
+    test(
+      'DO recovers and serves subsequent requests after a concurrent writeFile batch closes the capnweb WebSocket with 1011',
+      async () => {
+        // Confirm baseline health before stressing the connection.
+        const baseline = await fetch(`${workerUrl}/api/execute`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ command: 'echo baseline' })
+        });
+        expect(baseline.status).toBe(200);
+        const baselineResult = (await baseline.json()) as ExecResult;
+        expect(baselineResult.stdout.trim()).toBe('baseline');
+
+        // Build the payload once and reuse it across all concurrent
+        // writes. Each request still serialises its own copy across
+        // the Worker → DO RPC boundary, which is what we want.
+        const payload = 'A'.repeat(PAYLOAD_SIZE_BYTES);
+
+        // Fire the batch. We do NOT assert on individual outcomes —
+        // any combination of success/failure is acceptable here.
+        // The bug we're guarding against is that the *next* call
+        // after the batch stays broken forever.
+        const writes = Array.from({ length: CONCURRENT_WRITES }, (_, i) =>
+          fetch(`${workerUrl}/api/file/write`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({
+              path: sandbox!.uniquePath(`stress-${i}.bin`),
+              content: payload
+            })
+          }).catch(() => undefined)
+        );
+        await Promise.all(writes);
+
+        // Now probe with a tiny exec. The SDK should recover and
+        // return a 200 within a handful of attempts. Pre-fix, every
+        // attempt fails in ~1 ms with the cached 1011 error.
+        let recoveredOn = -1;
+        let lastStatus = 0;
+        let lastBody = '';
+        for (let attempt = 0; attempt < RECOVERY_ATTEMPTS; attempt++) {
+          const probe = await fetch(`${workerUrl}/api/execute`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({ command: 'echo recovered' })
+          });
+          lastStatus = probe.status;
+          lastBody = await probe.text();
+          if (probe.status === 200) {
+            const result = JSON.parse(lastBody) as ExecResult;
+            if (result.stdout.trim() === 'recovered') {
+              recoveredOn = attempt;
+              break;
+            }
+          }
+          await new Promise((resolve) =>
+            setTimeout(resolve, RECOVERY_DELAY_MS)
+          );
+        }
+
+        expect(
+          recoveredOn,
+          `DO did not recover within ${RECOVERY_ATTEMPTS} attempts. Last status: ${lastStatus}, last body: ${lastBody.slice(0, 500)}`
+        ).toBeGreaterThanOrEqual(0);
+      },
+      120000
+    );
+  }
+);


### PR DESCRIPTION
When several RPC calls land concurrently on the `rpc` transport and the proxied container WebSocket fails — for example, under load from a few large `writeFile` payloads — every in-flight RPC rejects with `RPCTransportError: Peer closed WebSocket: 1011 ...`.

The Durable Object isolate stays wedged after that failure. Every subsequent RPC on the same isolate rejects with the same cached error, and only runtime eviction (idle or otherwise) recovers it.

## Root cause

Recovery in `ContainerControlClient` is driven by `setInterval(pollBusyState, 1000)`. The poller is the only path that calls `destroyConnection()` to null out the broken `ContainerControlConnection` (and with it the broken `DeferredTransport` / `RpcSession`) so the next `getConnection()` builds a fresh one. 

In a DO, `setInterval` callbacks don't fire while the isolate sits idle between requests — which is exactly the state the isolate enters the instant the failing batch returns its 500s. The poller never ticks again, `this.conn` keeps pointing at the dead connection, and `DeferredTransport.#error` is sticky for the lifetime of the transport, so every reuse of the cached stub throws synchronously without doing any I/O.

The wedge reproduces locally with `wrangler dev --var SANDBOX_TRANSPORT:rpc` and five concurrent `writeFile` calls sized just under the 32 MiB JSRPC argument limit. The Docker container itself stays healthy throughout; the failure is purely in-isolate state.

## Fix

Make failure recovery event-driven instead of polled. `ContainerControlConnection` now accepts an `onClose` option that fires from the WebSocket `close` and `error` listeners installed in `doConnect`, but only when an already-active connection transitions to disconnected. 

`ContainerControlClient` passes `onClose: () => this.destroyConnection()`, so the broken connection is torn down inside the same turn of the event loop as the WS close. The very next call to `getConnection()` builds a fresh `ContainerControlConnection` and the isolate recovers without depending on a timer firing. The existing busy-poll path is unchanged for idle-disconnect; only the failure-recovery branch moved.

The `wasEverConnected` flag in `ContainerControlClient` existed solely to distinguish "WS upgrade still in progress" from "peer disconnected mid-session" inside `pollBusyState`. Now that the disconnected case is handled synchronously via `onClose`, the flag is dead state: by the time the poller could observe `!isConnected()`, `this.conn` has already been nulled. So the field has now been removed.

## Verification

A new `tests/e2e/rpc-recovery-after-ws-close.test.ts` adds a regression test that reproduces the issue against main. The new code demonstrates the fix.
