### PR TITLE
Fix inconsistent interfaces between HTTP and RPC clients

### DIFF
--- a/.changeset/desktop-type-delay-mapping.md
+++ b/.changeset/desktop-type-delay-mapping.md
@@ -1,5 +1,0 @@
----
-'@cloudflare/sandbox': patch
----
-
-Fix `desktop.type()` `delayMs` option being silently dropped over the RPC transport. The option is now correctly forwarded for both HTTP and RPC clients, with the user-facing `{ delayMs }` shape consistent across both.

--- a/.changeset/desktop-type-delay-mapping.md
+++ b/.changeset/desktop-type-delay-mapping.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Fix `desktop.type()` `delayMs` option being silently dropped over the RPC transport. The option is now correctly forwarded for both HTTP and RPC clients, with the user-facing `{ delayMs }` shape consistent across both.

--- a/.changeset/rpc-desktop-interface.md
+++ b/.changeset/rpc-desktop-interface.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Fix inconsistencies in the sandbox.desktop interface between RPC and HTTP transports

--- a/packages/sandbox-container/src/control-plane/api.ts
+++ b/packages/sandbox-container/src/control-plane/api.ts
@@ -139,10 +139,17 @@ export class SandboxControlAPI extends RpcTarget implements SandboxAPI {
     return new BackupRPCAPI(this.#deps.backupService);
   }
   get desktop(): SandboxDesktopAPI {
-    // DesktopRPCAPI.type declares the capnweb wire shape `{ delay }` while
-    // SandboxDesktopAPI exposes the user-facing `{ delayMs }`. The client
-    // wrapper translates `delayMs` -> `delay` before the call reaches us,
-    // and DesktopRPCAPI.type translates back to `delayMs` for the service.
+    // DesktopRPCAPI exposes the capnweb wire shape used by the container:
+    //   - `type` takes `{ delay }` (HTTP/service use `delayMs`)
+    //   - `screenshot` / `screenshotRegion` always return base64
+    //   - `screenshotRegion` takes a single `{ region, ...options }` request
+    //
+    // SandboxDesktopAPI exposes the user-facing surface shared with the
+    // HTTP DesktopClient (overloaded `format: 'bytes'`, positional
+    // `screenshotRegion(region, options?)`, `{ delayMs }` for type). The
+    // client-side RPC wrapper in container-control/client.ts translates
+    // user calls down to this wire shape; DesktopRPCAPI.type translates
+    // `delay` back to `delayMs` for the service.
     return new DesktopRPCAPI(
       this.#deps.desktopService
     ) as unknown as SandboxDesktopAPI;

--- a/packages/sandbox-container/src/control-plane/api.ts
+++ b/packages/sandbox-container/src/control-plane/api.ts
@@ -26,6 +26,7 @@ import type {
   OutputMessage,
   Result,
   SandboxAPI,
+  SandboxDesktopAPI,
   TunnelInfo,
   WatchRequest
 } from '@repo/shared';
@@ -137,8 +138,14 @@ export class SandboxControlAPI extends RpcTarget implements SandboxAPI {
   get backup() {
     return new BackupRPCAPI(this.#deps.backupService);
   }
-  get desktop() {
-    return new DesktopRPCAPI(this.#deps.desktopService);
+  get desktop(): SandboxDesktopAPI {
+    // DesktopRPCAPI.type declares the capnweb wire shape `{ delay }` while
+    // SandboxDesktopAPI exposes the user-facing `{ delayMs }`. The client
+    // wrapper translates `delayMs` -> `delay` before the call reaches us,
+    // and DesktopRPCAPI.type translates back to `delayMs` for the service.
+    return new DesktopRPCAPI(
+      this.#deps.desktopService
+    ) as unknown as SandboxDesktopAPI;
   }
   get watch() {
     return new WatchRPCAPI(this.#deps.watchService);
@@ -1242,7 +1249,15 @@ class DesktopRPCAPI extends RpcTarget {
     );
   }
   async type(text: string, options?: { delay?: number }): Promise<void> {
-    throwIfError(await this.#svc.typeText({ text, ...options }));
+    // RPC wire uses `delay` (see SandboxDesktopAPI capnweb signature in
+    // the client wrapper); the service layer and HTTP wire use `delayMs`.
+    // Translate here so the field name is consistent with DesktopTypeRequest.
+    throwIfError(
+      await this.#svc.typeText({
+        text,
+        ...(options?.delay !== undefined && { delayMs: options.delay })
+      })
+    );
   }
   async press(key: string): Promise<void> {
     throwIfError(await this.#svc.keyPress({ key }));

--- a/packages/sandbox-container/src/control-plane/api.ts
+++ b/packages/sandbox-container/src/control-plane/api.ts
@@ -8,6 +8,7 @@ import type {
   DesktopMouseDragRequest,
   DesktopMouseScrollRequest,
   DesktopMouseUpRequest,
+  DesktopProcessHealth,
   DesktopScreenSize,
   DesktopScreenshotRegionRequest,
   DesktopScreenshotRequest,
@@ -1255,8 +1256,10 @@ class DesktopRPCAPI extends RpcTarget {
   async getScreenSize(): Promise<DesktopScreenSize> {
     return extractData<DesktopScreenSize>(await this.#svc.getScreenSize());
   }
-  async getProcessStatus(_name: string): Promise<DesktopStatusResult> {
-    return this.status();
+  async getProcessStatus(name: string): Promise<DesktopProcessHealth> {
+    return extractData<DesktopProcessHealth>(
+      await this.#svc.getProcessStatus(name)
+    );
   }
 }
 

--- a/packages/sandbox-container/src/control-plane/api.ts
+++ b/packages/sandbox-container/src/control-plane/api.ts
@@ -140,16 +140,14 @@ export class SandboxControlAPI extends RpcTarget implements SandboxAPI {
   }
   get desktop(): SandboxDesktopAPI {
     // DesktopRPCAPI exposes the capnweb wire shape used by the container:
-    //   - `type` takes `{ delay }` (HTTP/service use `delayMs`)
     //   - `screenshot` / `screenshotRegion` always return base64
     //   - `screenshotRegion` takes a single `{ region, ...options }` request
     //
     // SandboxDesktopAPI exposes the user-facing surface shared with the
-    // HTTP DesktopClient (overloaded `format: 'bytes'`, positional
-    // `screenshotRegion(region, options?)`, `{ delayMs }` for type). The
+    // HTTP DesktopClient (overloaded `format: 'bytes'` returning a
+    // Uint8Array, positional `screenshotRegion(region, options?)`). The
     // client-side RPC wrapper in container-control/client.ts translates
-    // user calls down to this wire shape; DesktopRPCAPI.type translates
-    // `delay` back to `delayMs` for the service.
+    // user calls down to this wire shape.
     return new DesktopRPCAPI(
       this.#deps.desktopService
     ) as unknown as SandboxDesktopAPI;
@@ -1255,16 +1253,8 @@ class DesktopRPCAPI extends RpcTarget {
       await this.#svc.getCursorPosition()
     );
   }
-  async type(text: string, options?: { delay?: number }): Promise<void> {
-    // RPC wire uses `delay` (see SandboxDesktopAPI capnweb signature in
-    // the client wrapper); the service layer and HTTP wire use `delayMs`.
-    // Translate here so the field name is consistent with DesktopTypeRequest.
-    throwIfError(
-      await this.#svc.typeText({
-        text,
-        ...(options?.delay !== undefined && { delayMs: options.delay })
-      })
-    );
+  async type(text: string, options?: { delayMs?: number }): Promise<void> {
+    throwIfError(await this.#svc.typeText({ text, ...options }));
   }
   async press(key: string): Promise<void> {
     throwIfError(await this.#svc.keyPress({ key }));

--- a/packages/sandbox/src/clients/backup-client.ts
+++ b/packages/sandbox/src/clients/backup-client.ts
@@ -3,6 +3,7 @@ import type {
   CreateBackupResponse,
   RestoreBackupRequest,
   RestoreBackupResponse,
+  SandboxBackupAPI,
   UploadPartsRequest,
   UploadPartsResponse
 } from '@repo/shared';
@@ -15,7 +16,7 @@ import { BaseHttpClient } from './base-client';
  * The container creates/extracts squashfs archives locally.
  * R2 upload/download is handled by the Sandbox DO, not by this client.
  */
-export class BackupClient extends BaseHttpClient {
+export class BackupClient extends BaseHttpClient implements SandboxBackupAPI {
   /**
    * Tell the container to create a squashfs archive from a directory.
    * @param dir - Directory to back up

--- a/packages/sandbox/src/clients/command-client.ts
+++ b/packages/sandbox/src/clients/command-client.ts
@@ -1,4 +1,4 @@
-import type { ExecuteRequest } from '@repo/shared';
+import type { ExecuteRequest, SandboxCommandsAPI } from '@repo/shared';
 import { BaseHttpClient } from './base-client';
 import type { BaseApiResponse } from './types';
 
@@ -20,7 +20,10 @@ export interface ExecuteResponse extends BaseApiResponse {
 /**
  * Client for command execution operations
  */
-export class CommandClient extends BaseHttpClient {
+export class CommandClient
+  extends BaseHttpClient
+  implements SandboxCommandsAPI
+{
   /**
    * Execute a command and return the complete result
    * @param command - The command to execute

--- a/packages/sandbox/src/clients/desktop-client.ts
+++ b/packages/sandbox/src/clients/desktop-client.ts
@@ -1,4 +1,5 @@
 import type {
+  DesktopProcessHealth,
   DesktopScreenshotRegionRequest,
   DesktopScreenshotRequest,
   SandboxDesktopAPI
@@ -117,11 +118,7 @@ export interface Desktop {
   keyDown(key: KeyInput): Promise<void>;
   keyUp(key: KeyInput): Promise<void>;
   getScreenSize(): Promise<ScreenSizeResponse>;
-  getProcessStatus(
-    name: string
-  ): Promise<
-    BaseApiResponse & { running: boolean; pid?: number; uptime?: number }
-  >;
+  getProcessStatus(name: string): Promise<DesktopProcessHealth>;
 }
 
 /**
@@ -416,15 +413,9 @@ export class DesktopClient extends BaseHttpClient implements SandboxDesktopAPI {
   /**
    * Get health status for a specific desktop process.
    */
-  async getProcessStatus(
-    name: string
-  ): Promise<
-    BaseApiResponse & { running: boolean; pid?: number; uptime?: number }
-  > {
-    const response = await this.get<
-      BaseApiResponse & { running: boolean; pid?: number; uptime?: number }
-    >(`/api/desktop/process/${encodeURIComponent(name)}/status`);
-
-    return response;
+  async getProcessStatus(name: string): Promise<DesktopProcessHealth> {
+    return this.get<DesktopProcessHealth>(
+      `/api/desktop/process/${encodeURIComponent(name)}/status`
+    );
   }
 }

--- a/packages/sandbox/src/clients/desktop-client.ts
+++ b/packages/sandbox/src/clients/desktop-client.ts
@@ -34,7 +34,7 @@ export type ScrollDirection = 'up' | 'down' | 'left' | 'right';
 export type KeyInput = string;
 
 export interface TypeOptions {
-  delay?: number;
+  delayMs?: number;
 }
 
 export interface DesktopStartResponse extends BaseApiResponse {
@@ -375,7 +375,7 @@ export class DesktopClient extends BaseHttpClient implements SandboxDesktopAPI {
   async type(text: string, options?: TypeOptions): Promise<void> {
     await this.post<BaseApiResponse>('/api/desktop/keyboard/type', {
       text,
-      ...(options?.delay !== undefined && { delay: options.delay })
+      ...(options?.delayMs !== undefined && { delayMs: options.delayMs })
     });
   }
 

--- a/packages/sandbox/src/clients/desktop-client.ts
+++ b/packages/sandbox/src/clients/desktop-client.ts
@@ -1,4 +1,8 @@
-import type { SandboxDesktopAPI } from '@repo/shared';
+import type {
+  DesktopScreenshotRegionRequest,
+  DesktopScreenshotRequest,
+  SandboxDesktopAPI
+} from '@repo/shared';
 import { BaseHttpClient } from './base-client';
 import type { BaseApiResponse } from './types';
 
@@ -82,27 +86,10 @@ export interface Desktop {
   start(options?: DesktopStartOptions): Promise<DesktopStartResponse>;
   stop(): Promise<DesktopStopResponse>;
   status(): Promise<DesktopStatusResponse>;
-  screenshot(
-    options?: ScreenshotOptions & { format?: 'base64' }
+  screenshot(options?: DesktopScreenshotRequest): Promise<ScreenshotResponse>;
+  screenshotRegion(
+    request: DesktopScreenshotRegionRequest
   ): Promise<ScreenshotResponse>;
-  screenshot(
-    options: ScreenshotOptions & { format: 'bytes' }
-  ): Promise<ScreenshotBytesResponse>;
-  screenshot(
-    options?: ScreenshotOptions
-  ): Promise<ScreenshotResponse | ScreenshotBytesResponse>;
-  screenshotRegion(
-    region: ScreenshotRegion,
-    options?: ScreenshotOptions & { format?: 'base64' }
-  ): Promise<ScreenshotResponse>;
-  screenshotRegion(
-    region: ScreenshotRegion,
-    options: ScreenshotOptions & { format: 'bytes' }
-  ): Promise<ScreenshotBytesResponse>;
-  screenshotRegion(
-    region: ScreenshotRegion,
-    options?: ScreenshotOptions
-  ): Promise<ScreenshotResponse | ScreenshotBytesResponse>;
   click(x: number, y: number, options?: ClickOptions): Promise<void>;
   doubleClick(x: number, y: number, options?: ClickOptions): Promise<void>;
   tripleClick(x: number, y: number, options?: ClickOptions): Promise<void>;
@@ -199,18 +186,8 @@ export class DesktopClient extends BaseHttpClient implements SandboxDesktopAPI {
    * Capture a full-screen screenshot as base64 (default).
    */
   async screenshot(
-    options?: ScreenshotOptions & { format?: 'base64' }
-  ): Promise<ScreenshotResponse>;
-  /**
-   * Capture a full-screen screenshot as bytes.
-   */
-  async screenshot(
-    options: ScreenshotOptions & { format: 'bytes' }
-  ): Promise<ScreenshotBytesResponse>;
-  async screenshot(
-    options?: ScreenshotOptions
-  ): Promise<ScreenshotResponse | ScreenshotBytesResponse> {
-    const wantsBytes = options?.format === 'bytes';
+    options?: DesktopScreenshotRequest
+  ): Promise<ScreenshotResponse> {
     const data = {
       format: 'base64',
       ...(options?.imageFormat !== undefined && {
@@ -221,78 +198,31 @@ export class DesktopClient extends BaseHttpClient implements SandboxDesktopAPI {
         showCursor: options.showCursor
       })
     };
-
-    const response = await this.post<ScreenshotResponse>(
-      '/api/desktop/screenshot',
-      data
-    );
-
-    if (wantsBytes) {
-      const binaryString = atob(response.data);
-      const bytes = new Uint8Array(binaryString.length);
-      for (let i = 0; i < binaryString.length; i++) {
-        bytes[i] = binaryString.charCodeAt(i);
-      }
-
-      return {
-        ...response,
-        data: bytes
-      } as ScreenshotBytesResponse;
-    }
-
-    return response;
+    return this.post<ScreenshotResponse>('/api/desktop/screenshot', data);
   }
 
   /**
-   * Capture a region screenshot as base64 (default).
+   * Capture a region screenshot as base64.
    */
   async screenshotRegion(
-    region: ScreenshotRegion,
-    options?: ScreenshotOptions & { format?: 'base64' }
-  ): Promise<ScreenshotResponse>;
-  /**
-   * Capture a region screenshot as bytes.
-   */
-  async screenshotRegion(
-    region: ScreenshotRegion,
-    options: ScreenshotOptions & { format: 'bytes' }
-  ): Promise<ScreenshotBytesResponse>;
-  async screenshotRegion(
-    region: ScreenshotRegion,
-    options?: ScreenshotOptions
-  ): Promise<ScreenshotResponse | ScreenshotBytesResponse> {
-    const wantsBytes = options?.format === 'bytes';
+    request: DesktopScreenshotRegionRequest
+  ): Promise<ScreenshotResponse> {
+    const { region, ...options } = request;
     const data = {
       region,
       format: 'base64',
-      ...(options?.imageFormat !== undefined && {
+      ...(options.imageFormat !== undefined && {
         imageFormat: options.imageFormat
       }),
-      ...(options?.quality !== undefined && { quality: options.quality }),
-      ...(options?.showCursor !== undefined && {
+      ...(options.quality !== undefined && { quality: options.quality }),
+      ...(options.showCursor !== undefined && {
         showCursor: options.showCursor
       })
     };
-
-    const response = await this.post<ScreenshotResponse>(
+    return this.post<ScreenshotResponse>(
       '/api/desktop/screenshot/region',
       data
     );
-
-    if (wantsBytes) {
-      const binaryString = atob(response.data);
-      const bytes = new Uint8Array(binaryString.length);
-      for (let i = 0; i < binaryString.length; i++) {
-        bytes[i] = binaryString.charCodeAt(i);
-      }
-
-      return {
-        ...response,
-        data: bytes
-      } as ScreenshotBytesResponse;
-    }
-
-    return response;
   }
 
   /**

--- a/packages/sandbox/src/clients/desktop-client.ts
+++ b/packages/sandbox/src/clients/desktop-client.ts
@@ -33,7 +33,7 @@ export type ScrollDirection = 'up' | 'down' | 'left' | 'right';
 export type KeyInput = string;
 
 export interface TypeOptions {
-  delayMs?: number;
+  delay?: number;
 }
 
 export interface DesktopStartResponse extends BaseApiResponse {
@@ -378,7 +378,7 @@ export class DesktopClient extends BaseHttpClient implements SandboxDesktopAPI {
   async type(text: string, options?: TypeOptions): Promise<void> {
     await this.post<BaseApiResponse>('/api/desktop/keyboard/type', {
       text,
-      ...(options?.delayMs !== undefined && { delayMs: options.delayMs })
+      ...(options?.delay !== undefined && { delay: options.delay })
     });
   }
 

--- a/packages/sandbox/src/clients/desktop-client.ts
+++ b/packages/sandbox/src/clients/desktop-client.ts
@@ -1,3 +1,4 @@
+import type { SandboxDesktopAPI } from '@repo/shared';
 import { BaseHttpClient } from './base-client';
 import type { BaseApiResponse } from './types';
 
@@ -139,7 +140,7 @@ export interface Desktop {
 /**
  * Client for desktop environment lifecycle, input, and screen operations
  */
-export class DesktopClient extends BaseHttpClient {
+export class DesktopClient extends BaseHttpClient implements SandboxDesktopAPI {
   /**
    * Start the desktop environment with optional resolution and DPI.
    */

--- a/packages/sandbox/src/clients/desktop-client.ts
+++ b/packages/sandbox/src/clients/desktop-client.ts
@@ -1,9 +1,4 @@
-import type {
-  DesktopProcessHealth,
-  DesktopScreenshotRegionRequest,
-  DesktopScreenshotRequest,
-  SandboxDesktopAPI
-} from '@repo/shared';
+import type { DesktopProcessHealth, SandboxDesktopAPI } from '@repo/shared';
 import { BaseHttpClient } from './base-client';
 import type { BaseApiResponse } from './types';
 
@@ -87,10 +82,27 @@ export interface Desktop {
   start(options?: DesktopStartOptions): Promise<DesktopStartResponse>;
   stop(): Promise<DesktopStopResponse>;
   status(): Promise<DesktopStatusResponse>;
-  screenshot(options?: DesktopScreenshotRequest): Promise<ScreenshotResponse>;
-  screenshotRegion(
-    request: DesktopScreenshotRegionRequest
+  screenshot(
+    options?: ScreenshotOptions & { format?: 'base64' }
   ): Promise<ScreenshotResponse>;
+  screenshot(
+    options: ScreenshotOptions & { format: 'bytes' }
+  ): Promise<ScreenshotBytesResponse>;
+  screenshot(
+    options?: ScreenshotOptions
+  ): Promise<ScreenshotResponse | ScreenshotBytesResponse>;
+  screenshotRegion(
+    region: ScreenshotRegion,
+    options?: ScreenshotOptions & { format?: 'base64' }
+  ): Promise<ScreenshotResponse>;
+  screenshotRegion(
+    region: ScreenshotRegion,
+    options: ScreenshotOptions & { format: 'bytes' }
+  ): Promise<ScreenshotBytesResponse>;
+  screenshotRegion(
+    region: ScreenshotRegion,
+    options?: ScreenshotOptions
+  ): Promise<ScreenshotResponse | ScreenshotBytesResponse>;
   click(x: number, y: number, options?: ClickOptions): Promise<void>;
   doubleClick(x: number, y: number, options?: ClickOptions): Promise<void>;
   tripleClick(x: number, y: number, options?: ClickOptions): Promise<void>;
@@ -119,6 +131,20 @@ export interface Desktop {
   keyUp(key: KeyInput): Promise<void>;
   getScreenSize(): Promise<ScreenSizeResponse>;
   getProcessStatus(name: string): Promise<DesktopProcessHealth>;
+}
+
+/**
+ * Decode a base64-encoded screenshot payload into a Uint8Array.
+ * Shared with the RPC client wrapper, which receives base64 over the
+ * wire and needs the same `format: 'bytes'` convenience.
+ */
+export function base64ToBytes(data: string): Uint8Array {
+  const binaryString = atob(data);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes;
 }
 
 /**
@@ -183,8 +209,18 @@ export class DesktopClient extends BaseHttpClient implements SandboxDesktopAPI {
    * Capture a full-screen screenshot as base64 (default).
    */
   async screenshot(
-    options?: DesktopScreenshotRequest
-  ): Promise<ScreenshotResponse> {
+    options?: ScreenshotOptions & { format?: 'base64' }
+  ): Promise<ScreenshotResponse>;
+  /**
+   * Capture a full-screen screenshot as bytes.
+   */
+  async screenshot(
+    options: ScreenshotOptions & { format: 'bytes' }
+  ): Promise<ScreenshotBytesResponse>;
+  async screenshot(
+    options?: ScreenshotOptions
+  ): Promise<ScreenshotResponse | ScreenshotBytesResponse> {
+    const wantsBytes = options?.format === 'bytes';
     const data = {
       format: 'base64',
       ...(options?.imageFormat !== undefined && {
@@ -195,31 +231,66 @@ export class DesktopClient extends BaseHttpClient implements SandboxDesktopAPI {
         showCursor: options.showCursor
       })
     };
-    return this.post<ScreenshotResponse>('/api/desktop/screenshot', data);
+
+    const response = await this.post<ScreenshotResponse>(
+      '/api/desktop/screenshot',
+      data
+    );
+
+    if (wantsBytes) {
+      return {
+        ...response,
+        data: base64ToBytes(response.data)
+      } as ScreenshotBytesResponse;
+    }
+
+    return response;
   }
 
   /**
-   * Capture a region screenshot as base64.
+   * Capture a region screenshot as base64 (default).
    */
   async screenshotRegion(
-    request: DesktopScreenshotRegionRequest
-  ): Promise<ScreenshotResponse> {
-    const { region, ...options } = request;
+    region: ScreenshotRegion,
+    options?: ScreenshotOptions & { format?: 'base64' }
+  ): Promise<ScreenshotResponse>;
+  /**
+   * Capture a region screenshot as bytes.
+   */
+  async screenshotRegion(
+    region: ScreenshotRegion,
+    options: ScreenshotOptions & { format: 'bytes' }
+  ): Promise<ScreenshotBytesResponse>;
+  async screenshotRegion(
+    region: ScreenshotRegion,
+    options?: ScreenshotOptions
+  ): Promise<ScreenshotResponse | ScreenshotBytesResponse> {
+    const wantsBytes = options?.format === 'bytes';
     const data = {
       region,
       format: 'base64',
-      ...(options.imageFormat !== undefined && {
+      ...(options?.imageFormat !== undefined && {
         imageFormat: options.imageFormat
       }),
-      ...(options.quality !== undefined && { quality: options.quality }),
-      ...(options.showCursor !== undefined && {
+      ...(options?.quality !== undefined && { quality: options.quality }),
+      ...(options?.showCursor !== undefined && {
         showCursor: options.showCursor
       })
     };
-    return this.post<ScreenshotResponse>(
+
+    const response = await this.post<ScreenshotResponse>(
       '/api/desktop/screenshot/region',
       data
     );
+
+    if (wantsBytes) {
+      return {
+        ...response,
+        data: base64ToBytes(response.data)
+      } as ScreenshotBytesResponse;
+    }
+
+    return response;
   }
 
   /**

--- a/packages/sandbox/src/clients/file-client.ts
+++ b/packages/sandbox/src/clients/file-client.ts
@@ -9,6 +9,7 @@ import type {
   ReadFileResult,
   ReadFileStreamResult,
   RenameFileResult,
+  SandboxFilesAPI,
   WriteFileResult
 } from '@repo/shared';
 import { BaseHttpClient } from './base-client';
@@ -50,7 +51,7 @@ export interface FileOperationRequest extends SessionRequest {
 /**
  * Client for file system operations
  */
-export class FileClient extends BaseHttpClient {
+export class FileClient extends BaseHttpClient implements SandboxFilesAPI {
   /**
    * Create a directory
    * @param path - Directory path to create

--- a/packages/sandbox/src/clients/git-client.ts
+++ b/packages/sandbox/src/clients/git-client.ts
@@ -1,4 +1,4 @@
-import type { GitCheckoutResult } from '@repo/shared';
+import type { GitCheckoutResult, SandboxGitAPI } from '@repo/shared';
 import {
   DEFAULT_GIT_CLONE_TIMEOUT_MS,
   extractRepoName,
@@ -26,7 +26,7 @@ export interface GitCheckoutRequest extends SessionRequest {
 /**
  * Client for Git repository operations
  */
-export class GitClient extends BaseHttpClient {
+export class GitClient extends BaseHttpClient implements SandboxGitAPI {
   private static readonly REQUEST_TIMEOUT_BUFFER_MS = 30_000;
 
   constructor(options: HttpClientOptions = {}) {

--- a/packages/sandbox/src/clients/interpreter-client.ts
+++ b/packages/sandbox/src/clients/interpreter-client.ts
@@ -6,7 +6,8 @@ import {
   type ExecutionError,
   type OutputMessage,
   type Result,
-  ResultImpl
+  ResultImpl,
+  type SandboxInterpreterAPI
 } from '@repo/shared';
 import type { ErrorResponse } from '../errors';
 import {
@@ -58,7 +59,10 @@ export interface ExecutionCallbacks {
   onError?: (error: ExecutionError) => void | Promise<void>;
 }
 
-export class InterpreterClient extends BaseHttpClient {
+export class InterpreterClient
+  extends BaseHttpClient
+  implements SandboxInterpreterAPI
+{
   private readonly maxRetries = 3;
   private readonly retryDelayMs = 1000;
 

--- a/packages/sandbox/src/clients/port-client.ts
+++ b/packages/sandbox/src/clients/port-client.ts
@@ -3,7 +3,8 @@ import type {
   PortCloseResult,
   PortExposeResult,
   PortListResult,
-  PortWatchRequest
+  PortWatchRequest,
+  SandboxPortsAPI
 } from '@repo/shared';
 import { BaseHttpClient } from './base-client';
 
@@ -25,7 +26,7 @@ export interface UnexposePortRequest {
 /**
  * Client for port management and preview URL operations
  */
-export class PortClient extends BaseHttpClient {
+export class PortClient extends BaseHttpClient implements SandboxPortsAPI {
   /**
    * Expose a port and get a preview URL
    * @param port - Port number to expose

--- a/packages/sandbox/src/clients/process-client.ts
+++ b/packages/sandbox/src/clients/process-client.ts
@@ -5,6 +5,7 @@ import type {
   ProcessListResult,
   ProcessLogsResult,
   ProcessStartResult,
+  SandboxProcessesAPI,
   StartProcessRequest
 } from '@repo/shared';
 import { BaseHttpClient } from './base-client';
@@ -24,7 +25,10 @@ export type {
 /**
  * Client for background process management
  */
-export class ProcessClient extends BaseHttpClient {
+export class ProcessClient
+  extends BaseHttpClient
+  implements SandboxProcessesAPI
+{
   /**
    * Start a background process
    * @param command - Command to execute as a background process

--- a/packages/sandbox/src/clients/utility-client.ts
+++ b/packages/sandbox/src/clients/utility-client.ts
@@ -1,3 +1,4 @@
+import type { SandboxUtilsAPI } from '@repo/shared';
 import { BaseHttpClient } from './base-client';
 import type { BaseApiResponse, HttpClientOptions } from './types';
 
@@ -64,7 +65,7 @@ export interface DeleteSessionResponse extends BaseApiResponse {
 /**
  * Client for health checks and utility operations
  */
-export class UtilityClient extends BaseHttpClient {
+export class UtilityClient extends BaseHttpClient implements SandboxUtilsAPI {
   /**
    * Ping the sandbox to check if it's responsive
    */

--- a/packages/sandbox/src/clients/utility-client.ts
+++ b/packages/sandbox/src/clients/utility-client.ts
@@ -131,4 +131,10 @@ export class UtilityClient extends BaseHttpClient implements SandboxUtilsAPI {
       return 'unknown';
     }
   }
+
+  listSessions(): Promise<{ sessions: string[] }> {
+    throw new Error(
+      'listSessions requires the RPC transport. Set SANDBOX_TRANSPORT=rpc.'
+    );
+  }
 }

--- a/packages/sandbox/src/clients/watch-client.ts
+++ b/packages/sandbox/src/clients/watch-client.ts
@@ -3,6 +3,7 @@ import {
   type CheckChangesResult,
   type FileWatchSSEEvent,
   parseSSEFrames,
+  type SandboxWatchAPI,
   type SSEPartialEvent,
   type WatchRequest
 } from '@repo/shared';
@@ -15,7 +16,7 @@ import { BaseHttpClient } from './base-client';
  * @internal This client is used internally by the SDK.
  * Users should use `sandbox.watch()` or `sandbox.checkChanges()` instead.
  */
-export class WatchClient extends BaseHttpClient {
+export class WatchClient extends BaseHttpClient implements SandboxWatchAPI {
   /**
    * Check whether a path changed since a previously returned version.
    */

--- a/packages/sandbox/src/container-control/client.ts
+++ b/packages/sandbox/src/container-control/client.ts
@@ -582,7 +582,32 @@ export class ContainerControlClient {
     return wrapStub(this.getConnection().rpc().backup, this.renewActivity);
   }
   get desktop(): SandboxDesktopAPI {
-    return wrapStub(this.getConnection().rpc().desktop, this.renewActivity);
+    const stub = wrapStub(
+      this.getConnection().rpc().desktop,
+      this.renewActivity
+    );
+    // The capnweb RPC method `type` takes `{ delay }` on the wire while
+    // the user-facing SandboxDesktopAPI exposes `{ delayMs }` (matching
+    // the HTTP DesktopTypeRequest shape). Translate here so both
+    // transports present the same `delayMs` surface to callers.
+    return new Proxy(stub, {
+      get(target, prop, receiver) {
+        if (prop === 'type') {
+          return (text: string, options?: { delayMs?: number }) => {
+            const wireOptions =
+              options?.delayMs !== undefined
+                ? { delay: options.delayMs }
+                : undefined;
+            return (
+              target as unknown as {
+                type: (t: string, o?: { delay?: number }) => Promise<void>;
+              }
+            ).type(text, wireOptions);
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      }
+    });
   }
   get watch(): SandboxWatchAPI {
     return wrapStub(this.getConnection().rpc().watch, this.renewActivity);

--- a/packages/sandbox/src/container-control/client.ts
+++ b/packages/sandbox/src/container-control/client.ts
@@ -70,6 +70,12 @@
  */
 
 import type {
+  DesktopScreenshotBytesResult,
+  DesktopScreenshotOptions,
+  DesktopScreenshotRegion,
+  DesktopScreenshotRegionRequest,
+  DesktopScreenshotRequest,
+  DesktopScreenshotResult,
   Logger,
   SandboxBackupAPI,
   SandboxCommandsAPI,
@@ -93,6 +99,7 @@ import {
   type RPCTransportContext,
   type RPCTransportErrorKind
 } from '@repo/shared/errors';
+import { base64ToBytes } from '../clients/desktop-client';
 import type { SandboxClient } from '../clients/sandbox-client';
 import { createErrorFromResponse } from '../errors/adapter';
 import {
@@ -586,10 +593,27 @@ export class ContainerControlClient {
       this.getConnection().rpc().desktop,
       this.renewActivity
     );
-    // The capnweb RPC method `type` takes `{ delay }` on the wire while
-    // the user-facing SandboxDesktopAPI exposes `{ delayMs }` (matching
-    // the HTTP DesktopTypeRequest shape). Translate here so both
-    // transports present the same `delayMs` surface to callers.
+    // The capnweb RPC stub exposes the wire shape used by the container:
+    //   - `type` takes `{ delay }` (HTTP/service use `delayMs`)
+    //   - `screenshot` / `screenshotRegion` return only base64
+    //   - `screenshotRegion` takes a single `{ region, ...options }` request
+    //
+    // SandboxDesktopAPI exposes the user-facing surface shared with the
+    // HTTP `DesktopClient` (overloaded `format: 'bytes'` returning a
+    // Uint8Array, positional `screenshotRegion(region, options?)`, and
+    // `type` options shaped as `{ delayMs }`). Translate here so both
+    // transports present the same surface to callers without changing the
+    // wire format.
+    type DesktopRpcStub = {
+      type: (t: string, o?: { delay?: number }) => Promise<void>;
+      screenshot: (
+        options?: DesktopScreenshotRequest
+      ) => Promise<DesktopScreenshotResult>;
+      screenshotRegion: (
+        request: DesktopScreenshotRegionRequest
+      ) => Promise<DesktopScreenshotResult>;
+    };
+    const wire = stub as unknown as DesktopRpcStub;
     return new Proxy(stub, {
       get(target, prop, receiver) {
         if (prop === 'type') {
@@ -598,16 +622,39 @@ export class ContainerControlClient {
               options?.delayMs !== undefined
                 ? { delay: options.delayMs }
                 : undefined;
-            return (
-              target as unknown as {
-                type: (t: string, o?: { delay?: number }) => Promise<void>;
-              }
-            ).type(text, wireOptions);
+            return wire.type(text, wireOptions);
+          };
+        }
+        if (prop === 'screenshot') {
+          return async (
+            options?: DesktopScreenshotOptions
+          ): Promise<
+            DesktopScreenshotResult | DesktopScreenshotBytesResult
+          > => {
+            const { format, ...rest } = options ?? {};
+            const result = await wire.screenshot(rest);
+            return format === 'bytes'
+              ? { ...result, data: base64ToBytes(result.data) }
+              : result;
+          };
+        }
+        if (prop === 'screenshotRegion') {
+          return async (
+            region: DesktopScreenshotRegion,
+            options?: DesktopScreenshotOptions
+          ): Promise<
+            DesktopScreenshotResult | DesktopScreenshotBytesResult
+          > => {
+            const { format, ...rest } = options ?? {};
+            const result = await wire.screenshotRegion({ region, ...rest });
+            return format === 'bytes'
+              ? { ...result, data: base64ToBytes(result.data) }
+              : result;
           };
         }
         return Reflect.get(target, prop, receiver);
       }
-    });
+    }) as unknown as SandboxDesktopAPI;
   }
   get watch(): SandboxWatchAPI {
     return wrapStub(this.getConnection().rpc().watch, this.renewActivity);

--- a/packages/sandbox/src/container-control/client.ts
+++ b/packages/sandbox/src/container-control/client.ts
@@ -594,18 +594,15 @@ export class ContainerControlClient {
       this.renewActivity
     );
     // The capnweb RPC stub exposes the wire shape used by the container:
-    //   - `type` takes `{ delay }` (HTTP/service use `delayMs`)
     //   - `screenshot` / `screenshotRegion` return only base64
     //   - `screenshotRegion` takes a single `{ region, ...options }` request
     //
     // SandboxDesktopAPI exposes the user-facing surface shared with the
     // HTTP `DesktopClient` (overloaded `format: 'bytes'` returning a
-    // Uint8Array, positional `screenshotRegion(region, options?)`, and
-    // `type` options shaped as `{ delayMs }`). Translate here so both
-    // transports present the same surface to callers without changing the
-    // wire format.
+    // Uint8Array, positional `screenshotRegion(region, options?)`).
+    // Translate here so both transports present the same surface to callers
+    // without changing the wire format.
     type DesktopRpcStub = {
-      type: (t: string, o?: { delay?: number }) => Promise<void>;
       screenshot: (
         options?: DesktopScreenshotRequest
       ) => Promise<DesktopScreenshotResult>;
@@ -616,15 +613,6 @@ export class ContainerControlClient {
     const wire = stub as unknown as DesktopRpcStub;
     return new Proxy(stub, {
       get(target, prop, receiver) {
-        if (prop === 'type') {
-          return (text: string, options?: { delayMs?: number }) => {
-            const wireOptions =
-              options?.delayMs !== undefined
-                ? { delay: options.delayMs }
-                : undefined;
-            return wire.type(text, wireOptions);
-          };
-        }
         if (prop === 'screenshot') {
           return async (
             options?: DesktopScreenshotOptions

--- a/packages/sandbox/tests/desktop-client.test.ts
+++ b/packages/sandbox/tests/desktop-client.test.ts
@@ -228,6 +228,28 @@ describe('DesktopClient', () => {
       expect(body.showCursor).toBe(true);
     });
 
+    it('should capture a screenshot as bytes', async () => {
+      // Base64 for "hello" = "aGVsbG8="
+      const mockResponse: ScreenshotResponse = {
+        success: true,
+        data: 'aGVsbG8=',
+        imageFormat: 'png',
+        width: 1024,
+        height: 768,
+        timestamp: '2023-01-01T00:00:00Z'
+      };
+
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(mockResponse), { status: 200 })
+      );
+
+      const result = await client.screenshot({ format: 'bytes' });
+
+      expect(result.data).toBeInstanceOf(Uint8Array);
+      expect(result.imageFormat).toBe('png');
+      expect(result.width).toBe(1024);
+    });
+
     it('should capture a region screenshot', async () => {
       const mockResponse: ScreenshotResponse = {
         success: true,
@@ -243,7 +265,10 @@ describe('DesktopClient', () => {
       );
 
       const result = await client.screenshotRegion({
-        region: { x: 50, y: 50, width: 200, height: 100 }
+        x: 50,
+        y: 50,
+        width: 200,
+        height: 100
       });
 
       expect(result.width).toBe(200);
@@ -256,6 +281,29 @@ describe('DesktopClient', () => {
         width: 200,
         height: 100
       });
+    });
+
+    it('should capture a region screenshot as bytes', async () => {
+      const mockResponse: ScreenshotResponse = {
+        success: true,
+        data: 'aGVsbG8=',
+        imageFormat: 'webp',
+        width: 300,
+        height: 200,
+        timestamp: '2023-01-01T00:00:00Z'
+      };
+
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(mockResponse), { status: 200 })
+      );
+
+      const result = await client.screenshotRegion(
+        { x: 0, y: 0, width: 300, height: 200 },
+        { format: 'bytes' }
+      );
+
+      expect(result.data).toBeInstanceOf(Uint8Array);
+      expect(result.imageFormat).toBe('webp');
     });
   });
 

--- a/packages/sandbox/tests/desktop-client.test.ts
+++ b/packages/sandbox/tests/desktop-client.test.ts
@@ -552,11 +552,11 @@ describe('DesktopClient', () => {
         )
       );
 
-      await client.type('slow typing', { delay: 50 });
+      await client.type('slow typing', { delayMs: 50 });
 
       const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
       expect(body.text).toBe('slow typing');
-      expect(body.delay).toBe(50);
+      expect(body.delayMs).toBe(50);
     });
 
     it('should press a key', async () => {

--- a/packages/sandbox/tests/desktop-client.test.ts
+++ b/packages/sandbox/tests/desktop-client.test.ts
@@ -552,11 +552,11 @@ describe('DesktopClient', () => {
         )
       );
 
-      await client.type('slow typing', { delayMs: 50 });
+      await client.type('slow typing', { delay: 50 });
 
       const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
       expect(body.text).toBe('slow typing');
-      expect(body.delayMs).toBe(50);
+      expect(body.delay).toBe(50);
     });
 
     it('should press a key', async () => {

--- a/packages/sandbox/tests/desktop-client.test.ts
+++ b/packages/sandbox/tests/desktop-client.test.ts
@@ -202,28 +202,6 @@ describe('DesktopClient', () => {
       expect(result.height).toBe(768);
     });
 
-    it('should capture a screenshot as bytes', async () => {
-      // Base64 for "hello" = "aGVsbG8="
-      const mockResponse: ScreenshotResponse = {
-        success: true,
-        data: 'aGVsbG8=',
-        imageFormat: 'png',
-        width: 1024,
-        height: 768,
-        timestamp: '2023-01-01T00:00:00Z'
-      };
-
-      mockFetch.mockResolvedValue(
-        new Response(JSON.stringify(mockResponse), { status: 200 })
-      );
-
-      const result = await client.screenshot({ format: 'bytes' });
-
-      expect(result.data).toBeInstanceOf(Uint8Array);
-      expect(result.imageFormat).toBe('png');
-      expect(result.width).toBe(1024);
-    });
-
     it('should pass screenshot options to the request', async () => {
       const mockResponse: ScreenshotResponse = {
         success: true,
@@ -265,10 +243,7 @@ describe('DesktopClient', () => {
       );
 
       const result = await client.screenshotRegion({
-        x: 50,
-        y: 50,
-        width: 200,
-        height: 100
+        region: { x: 50, y: 50, width: 200, height: 100 }
       });
 
       expect(result.width).toBe(200);
@@ -281,29 +256,6 @@ describe('DesktopClient', () => {
         width: 200,
         height: 100
       });
-    });
-
-    it('should capture a region screenshot as bytes', async () => {
-      const mockResponse: ScreenshotResponse = {
-        success: true,
-        data: 'aGVsbG8=',
-        imageFormat: 'webp',
-        width: 300,
-        height: 200,
-        timestamp: '2023-01-01T00:00:00Z'
-      };
-
-      mockFetch.mockResolvedValue(
-        new Response(JSON.stringify(mockResponse), { status: 200 })
-      );
-
-      const result = await client.screenshotRegion(
-        { x: 0, y: 0, width: 300, height: 200 },
-        { format: 'bytes' }
-      );
-
-      expect(result.data).toBeInstanceOf(Uint8Array);
-      expect(result.imageFormat).toBe('webp');
     });
   });
 

--- a/packages/shared/src/desktop-types.ts
+++ b/packages/shared/src/desktop-types.ts
@@ -41,6 +41,24 @@ export interface DesktopProcessHealth {
 
 export type DesktopImageFormat = 'png' | 'jpeg' | 'webp';
 
+export interface DesktopScreenshotOptions {
+  /**
+   * How the SDK returns the screenshot payload to the caller.
+   * - `'base64'` (default): `data` is a base64-encoded string (also the wire format).
+   * - `'bytes'`: client-side convenience that base64-decodes the wire payload
+   *   into a `Uint8Array` before returning. The wire/server contract is
+   *   always base64.
+   */
+  format?: 'base64' | 'bytes';
+  imageFormat?: DesktopImageFormat;
+  quality?: number;
+  showCursor?: boolean;
+}
+
+/**
+ * Wire-shape request for the HTTP `/api/desktop/screenshot` endpoint and
+ * the capnweb `desktop.screenshot` RPC method.
+ */
 export interface DesktopScreenshotRequest {
   format?: 'base64';
   imageFormat?: DesktopImageFormat;
@@ -48,6 +66,10 @@ export interface DesktopScreenshotRequest {
   showCursor?: boolean;
 }
 
+/**
+ * Wire-shape request for the HTTP `/api/desktop/screenshot/region` endpoint
+ * and the capnweb `desktop.screenshotRegion` RPC method.
+ */
 export interface DesktopScreenshotRegionRequest extends DesktopScreenshotRequest {
   region: DesktopScreenshotRegion;
 }
@@ -59,12 +81,28 @@ export interface DesktopScreenshotRegion {
   height: number;
 }
 
+/**
+ * Screenshot payload returned to the SDK caller when `format` is `'base64'`
+ * (the default). Matches the wire shape sent by the container.
+ */
 export interface DesktopScreenshotResult {
   success: boolean;
   data: string;
   imageFormat: DesktopImageFormat;
   width: number;
   height: number;
+}
+
+/**
+ * Screenshot payload returned to the SDK caller when `format: 'bytes'` is
+ * requested. The SDK client decodes the base64 wire payload into a
+ * `Uint8Array`; the server/wire contract is unchanged.
+ */
+export interface DesktopScreenshotBytesResult extends Omit<
+  DesktopScreenshotResult,
+  'data'
+> {
+  data: Uint8Array;
 }
 
 // === Mouse ===

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,6 +18,8 @@ export type {
   DesktopMouseUpRequest,
   DesktopProcessHealth,
   DesktopScreenSize,
+  DesktopScreenshotBytesResult,
+  DesktopScreenshotOptions,
   DesktopScreenshotRegion,
   DesktopScreenshotRegionRequest,
   DesktopScreenshotRequest,

--- a/packages/shared/src/rpc-types.ts
+++ b/packages/shared/src/rpc-types.ts
@@ -316,7 +316,7 @@ export interface SandboxDesktopAPI {
     amount?: number
   ): Promise<void>;
   getCursorPosition(): Promise<DesktopCursorPosition>;
-  type(text: string, options?: { delay?: number }): Promise<void>;
+  type(text: string, options?: { delayMs?: number }): Promise<void>;
   press(key: string): Promise<void>;
   keyDown(key: string): Promise<void>;
   keyUp(key: string): Promise<void>;

--- a/packages/shared/src/rpc-types.ts
+++ b/packages/shared/src/rpc-types.ts
@@ -10,8 +10,9 @@ import type {
   DesktopMouseButton,
   DesktopProcessHealth,
   DesktopScreenSize,
-  DesktopScreenshotRegionRequest,
-  DesktopScreenshotRequest,
+  DesktopScreenshotBytesResult,
+  DesktopScreenshotOptions,
+  DesktopScreenshotRegion,
   DesktopScreenshotResult,
   DesktopScrollDirection,
   DesktopStartResult,
@@ -277,11 +278,26 @@ export interface SandboxDesktopAPI {
   stop(): Promise<DesktopStopResult>;
   status(): Promise<DesktopStatusResult>;
   screenshot(
-    options?: DesktopScreenshotRequest
+    options?: DesktopScreenshotOptions & { format?: 'base64' }
+  ): Promise<DesktopScreenshotResult>;
+  screenshot(
+    options: DesktopScreenshotOptions & { format: 'bytes' }
+  ): Promise<DesktopScreenshotBytesResult>;
+  screenshot(
+    options?: DesktopScreenshotOptions
+  ): Promise<DesktopScreenshotResult | DesktopScreenshotBytesResult>;
+  screenshotRegion(
+    region: DesktopScreenshotRegion,
+    options?: DesktopScreenshotOptions & { format?: 'base64' }
   ): Promise<DesktopScreenshotResult>;
   screenshotRegion(
-    request: DesktopScreenshotRegionRequest
-  ): Promise<DesktopScreenshotResult>;
+    region: DesktopScreenshotRegion,
+    options: DesktopScreenshotOptions & { format: 'bytes' }
+  ): Promise<DesktopScreenshotBytesResult>;
+  screenshotRegion(
+    region: DesktopScreenshotRegion,
+    options?: DesktopScreenshotOptions
+  ): Promise<DesktopScreenshotResult | DesktopScreenshotBytesResult>;
   click(
     x: number,
     y: number,

--- a/packages/shared/src/rpc-types.ts
+++ b/packages/shared/src/rpc-types.ts
@@ -8,6 +8,7 @@
 import type {
   DesktopCursorPosition,
   DesktopMouseButton,
+  DesktopProcessHealth,
   DesktopScreenSize,
   DesktopScreenshotRegionRequest,
   DesktopScreenshotRequest,
@@ -320,7 +321,7 @@ export interface SandboxDesktopAPI {
   keyDown(key: string): Promise<void>;
   keyUp(key: string): Promise<void>;
   getScreenSize(): Promise<DesktopScreenSize>;
-  getProcessStatus(name: string): Promise<DesktopStatusResult>;
+  getProcessStatus(name: string): Promise<DesktopProcessHealth>;
 }
 
 export interface SandboxWatchAPI {


### PR DESCRIPTION
- **Implement SandboxAPI interfaces on HTTP sub-clients**
  Each HTTP client now declares implements on its corresponding
  SandboxAPI interface, so signature mismatches between the HTTP
  and RPC transports are caught at compile time.
  

- **Fix screenshotRegion signature to match SandboxDesktopAPI**
  The interface expects a single DesktopScreenshotRegionRequest object
  with region nested inside it. The HTTP client was taking region and
  options as separate arguments.
  
  The HTTP-only 'bytes' format overload is dropped from the public
  signature since it was never part of SandboxDesktopAPI and could
  not be used via the RPC transport.
  

- **Fix type() options to use delay instead of delayMs**
  TypeOptions had delayMs but SandboxDesktopAPI specifies
  { delay?: number }. Rename to align the two transports.
  

- **Fix getProcessStatus return type across all layers**
  The method returns per-process health (DesktopProcessHealth), not the
  full desktop status. The RPC stub was incorrectly delegating to
  status(), ignoring the name argument entirely. Fix the shared
  interface, the HTTP client, and the RPC stub to all return
  DesktopProcessHealth.
  

- **Stub listSessions on HTTP client as RPC-only**
  Satisfies SandboxUtilsAPI while making the transport
  requirement explicit at call time.
  