### PR TITLE
Enforce preview URL runtime activation

### DIFF
--- a/.changeset/stale-preview-urls.md
+++ b/.changeset/stale-preview-urls.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': minor
+---
+
+Prevent stale preview URLs from waking or reaching sandbox runtimes. Invalid, revoked, or destroyed preview URLs return `404 INVALID_TOKEN`; authorized URLs that are not activated for the current runtime return `410 STALE_PREVIEW_URL` until the port is exposed again. Existing preview URLs that previously survived container restart now return `410 STALE_PREVIEW_URL` after a restart until the port is exposed again in the new runtime.

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -260,29 +260,6 @@ jobs:
           R2_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           DEPLOY_HASH: ${{ inputs.deploy_hash }}
 
-      - name: Warm container pool
-        if: ${{ steps.deploy-check.outputs.skip != 'true' }}
-        run: |
-          CONTAINERS=$(wrangler containers list --json 2>/dev/null || echo "[]")
-          WORKER="${{ inputs.worker_name_prefix }}"
-          APP_IDS=$(echo "$CONTAINERS" | jq -r --arg w "$WORKER" \
-            '[.[] | select(.name | startswith($w + "-") or . == $w)] | .[].id')
-          if [ -z "$APP_IDS" ]; then
-            echo "::warning::No container apps found for ${WORKER} — skipping warm pool"
-          else
-            for APP_ID in $APP_IDS; do
-              echo "Setting warm pool for ${WORKER} (app $APP_ID)"
-              curl -sf -X PATCH \
-                "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/containers/applications/${APP_ID}" \
-                -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-                -H "Content-Type: application/json" \
-                -d '{"configuration":{"durable_object_offset_instances": 25}}' || echo "::warning::Failed to set warm pool for app ${APP_ID}"
-            done
-          fi
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
       # Always set URL (deterministic, needed by test jobs)
       - name: Set worker URL
         id: urls

--- a/examples/codex-app-server/package.json
+++ b/examples/codex-app-server/package.json
@@ -21,6 +21,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@cloudflare/containers": "^0.3.0"
+    "@cloudflare/containers": "^0.3.5"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1752,10 +1752,10 @@
       }
     },
     "node_modules/@cloudflare/containers": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/containers/-/containers-0.3.2.tgz",
-      "integrity": "sha512-hWobJrpXCgFJ/HYii6E49eegnnlUDWGacjLd0Fb6nQwTD005+T2eHUPI6qOEq9KPJOd7xTWkhkuXEKxDFvfyqQ==",
-      "license": "ISC"
+      "version": "0.3.4",
+      "resolved": "https://pkg.pr.new/@cloudflare/containers@212",
+      "integrity": "sha512-RrF4SdOCr4xL/WEyb6BOkTVoLPgs7Zsy5tCWOTXhUsCnoUj8OoSJ12OY5af6+49xQmxDpkYuVzs4iu+QjRWeXw==",
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.4.2",
@@ -14260,7 +14260,7 @@
       "version": "0.10.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cloudflare/containers": "^0.3.0",
+        "@cloudflare/containers": "https://pkg.pr.new/@cloudflare/containers@212",
         "aws4fetch": "^1.0.20",
         "capnweb": "^0.8.0",
         "hono": "^4.12.18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,7 +137,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@cloudflare/containers": "^0.3.0"
+        "@cloudflare/containers": "^0.3.5"
       },
       "devDependencies": {
         "@cloudflare/sandbox": "*",
@@ -1752,9 +1752,9 @@
       }
     },
     "node_modules/@cloudflare/containers": {
-      "version": "0.3.4",
-      "resolved": "https://pkg.pr.new/@cloudflare/containers@212",
-      "integrity": "sha512-RrF4SdOCr4xL/WEyb6BOkTVoLPgs7Zsy5tCWOTXhUsCnoUj8OoSJ12OY5af6+49xQmxDpkYuVzs4iu+QjRWeXw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@cloudflare/containers/-/containers-0.3.5.tgz",
+      "integrity": "sha512-P6jYEDkw1Q9qWRr9iFBxe1fozI5HfGMY6XrNg/jROPGZykcYrrzOluUqXv+q4N8gIoRXPCqJJ1FGALbTqnYTkg==",
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -14260,7 +14260,7 @@
       "version": "0.10.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cloudflare/containers": "https://pkg.pr.new/@cloudflare/containers@212",
+        "@cloudflare/containers": "^0.3.5",
         "aws4fetch": "^1.0.20",
         "capnweb": "^0.8.0",
         "hono": "^4.12.18"

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -8,7 +8,7 @@
   "description": "A sandboxed environment for running commands",
   "type": "module",
   "dependencies": {
-    "@cloudflare/containers": "^0.3.0",
+    "@cloudflare/containers": "https://pkg.pr.new/@cloudflare/containers@212",
     "aws4fetch": "^1.0.20",
     "capnweb": "^0.8.0",
     "hono": "^4.12.18"

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -8,7 +8,7 @@
   "description": "A sandboxed environment for running commands",
   "type": "module",
   "dependencies": {
-    "@cloudflare/containers": "https://pkg.pr.new/@cloudflare/containers@212",
+    "@cloudflare/containers": "^0.3.5",
     "aws4fetch": "^1.0.20",
     "capnweb": "^0.8.0",
     "hono": "^4.12.18"

--- a/packages/sandbox/src/current-runtime-identity.ts
+++ b/packages/sandbox/src/current-runtime-identity.ts
@@ -1,0 +1,140 @@
+export type RuntimeIdentityID = string & {
+  readonly __runtimeIdentityID: unique symbol;
+};
+
+export type RuntimeIdentityRecord = {
+  id: RuntimeIdentityID;
+};
+
+export type RuntimeScoped<T extends object> = T & {
+  readonly runtimeIdentityID: RuntimeIdentityID;
+};
+
+export type CurrentRuntimeStatus =
+  | { status: 'active'; runtime: RuntimeIdentity; containerStatus: string }
+  | {
+      status: 'inactive';
+      reason:
+        | 'runtime-not-healthy'
+        | 'runtime-not-running'
+        | 'missing-runtime-id';
+      containerStatus?: string;
+    };
+
+type RuntimeIdentityStorage = Pick<
+  DurableObjectStorage | DurableObjectTransaction,
+  'get'
+>;
+
+const CURRENT_RUNTIME_IDENTITY_STORAGE_KEY = 'currentRuntimeIdentity';
+
+export class RuntimeIdentityInactiveError extends Error {
+  constructor() {
+    super('Runtime identity is no longer active');
+    this.name = 'RuntimeIdentityInactiveError';
+  }
+}
+
+export class RuntimeIdentity {
+  readonly id: RuntimeIdentityID;
+
+  constructor(record: RuntimeIdentityRecord) {
+    this.id = record.id;
+  }
+
+  owns(record: { readonly runtimeIdentityID: RuntimeIdentityID }): boolean {
+    return record.runtimeIdentityID === this.id;
+  }
+
+  scope<T extends object>(value: T): RuntimeScoped<T> {
+    return {
+      ...value,
+      runtimeIdentityID: this.id
+    };
+  }
+}
+
+export class CurrentRuntimeIdentity {
+  /**
+   * Runtime identity is stored in Durable Object storage so a reconstructed DO
+   * can still recognize the live container runtime it owns. In-memory state is
+   * only a cache and cannot define runtime-scoped correctness.
+   */
+  constructor(
+    private readonly storage: DurableObjectState['storage'],
+    private readonly getContainerState: () => Promise<{ status: string }>,
+    private readonly isContainerRunning: () => boolean
+  ) {}
+
+  async get(): Promise<RuntimeIdentity | null> {
+    const status = await this.getStatus();
+    return status.status === 'active' ? status.runtime : null;
+  }
+
+  async getStatus(): Promise<CurrentRuntimeStatus> {
+    const state = await this.getContainerState();
+    if (state.status !== 'healthy') {
+      return {
+        status: 'inactive',
+        reason: 'runtime-not-healthy',
+        containerStatus: state.status
+      };
+    }
+
+    if (!this.isContainerRunning()) {
+      return {
+        status: 'inactive',
+        reason: 'runtime-not-running',
+        containerStatus: state.status
+      };
+    }
+
+    const runtime = await this.getStored();
+    if (!runtime) {
+      return {
+        status: 'inactive',
+        reason: 'missing-runtime-id',
+        containerStatus: state.status
+      };
+    }
+
+    return {
+      status: 'active',
+      runtime,
+      containerStatus: state.status
+    };
+  }
+
+  async getStored(
+    storage: RuntimeIdentityStorage = this.storage
+  ): Promise<RuntimeIdentity | null> {
+    const record =
+      (await storage.get<RuntimeIdentityRecord>(
+        CURRENT_RUNTIME_IDENTITY_STORAGE_KEY
+      )) ?? null;
+    return record ? new RuntimeIdentity(record) : null;
+  }
+
+  async markStarted(): Promise<RuntimeIdentity> {
+    const record: RuntimeIdentityRecord = {
+      id: crypto.randomUUID() as RuntimeIdentityID
+    };
+    await this.storage.put(CURRENT_RUNTIME_IDENTITY_STORAGE_KEY, record);
+    return new RuntimeIdentity(record);
+  }
+
+  async clear(): Promise<void> {
+    await this.storage.delete(CURRENT_RUNTIME_IDENTITY_STORAGE_KEY);
+  }
+
+  async isActive(runtime: RuntimeIdentity): Promise<boolean> {
+    const current = await this.get();
+    return current?.id === runtime.id;
+  }
+
+  async assertActive(runtime: RuntimeIdentity): Promise<void> {
+    if (!(await this.isActive(runtime))) {
+      throw new RuntimeIdentityInactiveError();
+    }
+  }
+}

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -161,11 +161,7 @@ export { collectFile, streamFile } from './file-stream';
 export { CodeInterpreter } from './interpreter.js';
 export { proxyTerminal } from './pty';
 // Re-export request handler utilities
-export {
-  proxyToSandbox,
-  type RouteInfo,
-  type SandboxEnv
-} from './request-handler';
+export { proxyToSandbox, type SandboxEnv } from './request-handler';
 // Export SSE parser for converting ReadableStream to AsyncIterable
 export {
   asyncIterableToSSEStream,

--- a/packages/sandbox/src/preview-forwarding.ts
+++ b/packages/sandbox/src/preview-forwarding.ts
@@ -1,0 +1,134 @@
+export type PreviewTCPPort = {
+  fetch(
+    input: Request | string,
+    init?: Request | RequestInit
+  ): Promise<Response>;
+};
+
+export type PreviewForwardingLifecycle = {
+  beginForward(): () => void;
+  renewActivity(): void;
+};
+
+export type PreviewForwardingResult =
+  | { status: 'response'; response: Response }
+  | { status: 'network-lost' };
+
+export async function forwardPreviewRequest(
+  tcpPort: PreviewTCPPort,
+  request: Request,
+  lifecycle: PreviewForwardingLifecycle
+): Promise<PreviewForwardingResult> {
+  const containerURL = request.url.replace('https:', 'http:');
+  const settleForward = lifecycle.beginForward();
+
+  try {
+    const response = await tcpPort.fetch(containerURL, request);
+
+    if (response.webSocket !== null) {
+      return {
+        status: 'response',
+        response: bridgePreviewWebSocket(response, lifecycle, settleForward)
+      };
+    }
+
+    if (response.body !== null) {
+      const { readable, writable } = new TransformStream();
+      response.body
+        .pipeTo(writable)
+        .finally(settleForward)
+        .catch(() => {});
+      return { status: 'response', response: new Response(readable, response) };
+    }
+
+    settleForward();
+    return { status: 'response', response };
+  } catch (error) {
+    settleForward();
+    if (
+      error instanceof Error &&
+      error.message.includes('Network connection lost.')
+    ) {
+      return { status: 'network-lost' };
+    }
+    throw error;
+  }
+}
+
+function bridgePreviewWebSocket(
+  response: Response,
+  lifecycle: PreviewForwardingLifecycle,
+  settleForward: () => void
+): Response {
+  const containerWebSocket = response.webSocket;
+  if (containerWebSocket === null) {
+    settleForward();
+    return response;
+  }
+
+  const [client, server] = Object.values(new WebSocketPair());
+  let settled = false;
+  const settle = () => {
+    if (!settled) {
+      settled = true;
+      settleForward();
+    }
+  };
+
+  containerWebSocket.accept();
+  server.accept();
+
+  server.addEventListener('message', async (event) => {
+    lifecycle.renewActivity();
+    try {
+      const data =
+        event.data instanceof Blob
+          ? await event.data.arrayBuffer()
+          : event.data;
+      containerWebSocket.send(data);
+    } catch {
+      server.close(1011, 'Failed to forward message to container');
+    }
+  });
+
+  containerWebSocket.addEventListener('message', async (event) => {
+    lifecycle.renewActivity();
+    try {
+      const data =
+        event.data instanceof Blob
+          ? await event.data.arrayBuffer()
+          : event.data;
+      server.send(data);
+    } catch {
+      containerWebSocket.close(1011, 'Failed to forward message to client');
+    }
+  });
+
+  server.addEventListener('close', (event) => {
+    settle();
+    const code = event.code === 1005 || event.code === 1006 ? 1000 : event.code;
+    containerWebSocket.close(code, event.reason);
+  });
+
+  containerWebSocket.addEventListener('close', (event) => {
+    settle();
+    const code = event.code === 1005 || event.code === 1006 ? 1000 : event.code;
+    server.close(code, event.reason);
+  });
+
+  server.addEventListener('error', () => {
+    settle();
+    containerWebSocket.close(1011, 'Client WebSocket error');
+  });
+
+  containerWebSocket.addEventListener('error', () => {
+    settle();
+    server.close(1011, 'Container WebSocket error');
+  });
+
+  return new Response(null, {
+    status: response.status,
+    webSocket: client,
+    headers: response.headers
+  });
+}

--- a/packages/sandbox/src/preview-proxy-protocol.ts
+++ b/packages/sandbox/src/preview-proxy-protocol.ts
@@ -1,0 +1,16 @@
+/** @internal */
+export const PREVIEW_PROXY_HEADER = 'x-sandbox-preview-proxy';
+/** @internal */
+export const PREVIEW_PROXY_PORT_HEADER = 'x-sandbox-preview-port';
+/** @internal */
+export const PREVIEW_PROXY_TOKEN_HEADER = 'x-sandbox-preview-token';
+/** @internal */
+export const PREVIEW_PROXY_SANDBOX_ID_HEADER = 'x-sandbox-preview-sandbox-id';
+
+/** @internal */
+export const PREVIEW_PROXY_HEADERS = [
+  PREVIEW_PROXY_HEADER,
+  PREVIEW_PROXY_PORT_HEADER,
+  PREVIEW_PROXY_TOKEN_HEADER,
+  PREVIEW_PROXY_SANDBOX_ID_HEADER
+] as const;

--- a/packages/sandbox/src/preview-url.ts
+++ b/packages/sandbox/src/preview-url.ts
@@ -1,0 +1,27 @@
+export function isLocalhostPattern(hostname: string): boolean {
+  // Handle IPv6 addresses in brackets (with or without port)
+  if (hostname.startsWith('[')) {
+    if (hostname.includes(']:')) {
+      // [::1]:port format
+      const ipv6Part = hostname.substring(0, hostname.indexOf(']:') + 1);
+      return ipv6Part === '[::1]';
+    }
+
+    // [::1] format without port
+    return hostname === '[::1]';
+  }
+
+  // Handle bare IPv6 without brackets
+  if (hostname === '::1') {
+    return true;
+  }
+
+  // For IPv4 and regular hostnames, split on colon to remove port
+  const hostPart = hostname.split(':')[0];
+
+  return (
+    hostPart === 'localhost' ||
+    hostPart === '127.0.0.1' ||
+    hostPart === '0.0.0.0'
+  );
+}

--- a/packages/sandbox/src/request-handler.ts
+++ b/packages/sandbox/src/request-handler.ts
@@ -1,5 +1,11 @@
-import { switchPort } from '@cloudflare/containers';
-import { createLogger, type LogContext, TraceContext } from '@repo/shared';
+import { createLogger, TraceContext } from '@repo/shared';
+import {
+  PREVIEW_PROXY_HEADER,
+  PREVIEW_PROXY_HEADERS,
+  PREVIEW_PROXY_PORT_HEADER,
+  PREVIEW_PROXY_SANDBOX_ID_HEADER,
+  PREVIEW_PROXY_TOKEN_HEADER
+} from './preview-proxy-protocol';
 import { getSandbox, type Sandbox } from './sandbox';
 import { sanitizeSandboxId, validatePort } from './security';
 
@@ -7,26 +13,26 @@ export interface SandboxEnv<T extends Sandbox<any> = Sandbox<any>> {
   Sandbox: DurableObjectNamespace<T>;
 }
 
-export interface RouteInfo {
+interface RouteInfo {
   port: number;
   sandboxId: string;
-  path: string;
   token: string;
+}
+
+function createProxyLogger(request: Request) {
+  const traceId =
+    TraceContext.fromHeaders(request.headers) || TraceContext.generate();
+  return createLogger({
+    component: 'sandbox-do',
+    traceId,
+    operation: 'proxy'
+  });
 }
 
 export async function proxyToSandbox<
   T extends Sandbox<any>,
   E extends SandboxEnv<T>
 >(request: Request, env: E): Promise<Response | null> {
-  // Create logger context for this request
-  const traceId =
-    TraceContext.fromHeaders(request.headers) || TraceContext.generate();
-  const logger = createLogger({
-    component: 'sandbox-do',
-    traceId,
-    operation: 'proxy'
-  });
-
   try {
     const url = new URL(request.url);
     const routeInfo = extractSandboxRoute(url);
@@ -35,82 +41,23 @@ export async function proxyToSandbox<
       return null; // Not a request to an exposed container port
     }
 
-    const { sandboxId, port, path, token } = routeInfo;
+    const { sandboxId, port, token } = routeInfo;
     // Preview URLs always use normalized (lowercase) IDs
     const sandbox = getSandbox(env.Sandbox, sandboxId, { normalizeId: true });
 
-    // Critical security check: Validate token (mandatory for all user ports)
-    // Skip check for control plane port 3000
-    if (port !== 3000) {
-      // Validate the token matches the port
-      const isValidToken = await sandbox.validatePortToken(port, token);
-      if (!isValidToken) {
-        logger.warn('Invalid token access blocked', {
-          port,
-          sandboxId,
-          path,
-          hostname: url.hostname,
-          url: request.url,
-          method: request.method,
-          userAgent: request.headers.get('User-Agent') || 'unknown'
-        });
-
-        return new Response(
-          JSON.stringify({
-            error: `Access denied: Invalid token or port not exposed`,
-            code: 'INVALID_TOKEN'
-          }),
-          {
-            status: 404,
-            headers: {
-              'Content-Type': 'application/json'
-            }
-          }
-        );
-      }
+    const headers = new Headers(request.headers);
+    for (const header of PREVIEW_PROXY_HEADERS) {
+      headers.delete(header);
     }
+    headers.set(PREVIEW_PROXY_HEADER, '1');
+    headers.set(PREVIEW_PROXY_PORT_HEADER, port.toString());
+    headers.set(PREVIEW_PROXY_TOKEN_HEADER, token);
+    headers.set(PREVIEW_PROXY_SANDBOX_ID_HEADER, sandboxId);
 
-    // Detect WebSocket upgrade request
-    const upgradeHeader = request.headers.get('Upgrade');
-    if (upgradeHeader?.toLowerCase() === 'websocket') {
-      // WebSocket path: Must use fetch() not containerFetch()
-      // This bypasses JSRPC serialization boundary which cannot handle WebSocket upgrades
-      return await sandbox.fetch(switchPort(request, port));
-    }
-
-    // Build proxy request with proper headers
-    let proxyUrl: string;
-
-    // Route based on the target port
-    if (port !== 3000) {
-      // Route directly to user's service on the specified port
-      proxyUrl = `http://localhost:${port}${path}${url.search}`;
-    } else {
-      // Port 3000 is our control plane - route normally
-      proxyUrl = `http://localhost:3000${path}${url.search}`;
-    }
-
-    const headers: Record<string, string> = {
-      'X-Original-URL': request.url,
-      'X-Forwarded-Host': url.hostname,
-      'X-Forwarded-Proto': url.protocol.replace(':', ''),
-      'X-Sandbox-Name': sandboxId
-    };
-    request.headers.forEach((value, key) => {
-      headers[key] = value;
-    });
-
-    const proxyRequest = new Request(proxyUrl, {
-      method: request.method,
-      headers,
-      body: request.body,
-      // @ts-expect-error - duplex required for body streaming in modern runtimes
-      duplex: 'half',
-      redirect: 'manual' // Do not follow redirects, return them to the client to handle
-    });
-
-    return await sandbox.containerFetch(proxyRequest, port);
+    const previewRequest = new Request(request, { headers });
+    return await sandbox.fetch(previewRequest);
   } catch (error) {
+    const logger = createProxyLogger(request);
     logger.error(
       'Proxy routing error',
       error instanceof Error ? error : new Error(String(error))
@@ -128,7 +75,6 @@ function extractSandboxRoute(url: URL): RouteInfo | null {
   }
 
   const subdomain = url.hostname.slice(0, dotIndex);
-  const domain = url.hostname.slice(dotIndex + 1);
 
   // Extract port (digits at start followed by hyphen)
   const firstHyphen = subdomain.indexOf('-');
@@ -157,7 +103,8 @@ function extractSandboxRoute(url: URL): RouteInfo | null {
   const token = rest.slice(lastHyphen + 1);
 
   // No hyphens in tokens: URL is {port}-{sandboxId}-{token}.{domain}
-  // We split at the LAST hyphen, so hyphens in tokens would be ambiguous
+  // We split at the LAST hyphen, so hyphens in tokens would be ambiguous.
+  // The SDK issues tokens up to 16 chars; 63 is the DNS label component limit.
   if (!/^[a-z0-9_]+$/.test(token) || token.length === 0 || token.length > 63) {
     return null;
   }
@@ -177,35 +124,6 @@ function extractSandboxRoute(url: URL): RouteInfo | null {
   return {
     port,
     sandboxId: sanitizedSandboxId,
-    path: url.pathname || '/',
     token
   };
-}
-
-export function isLocalhostPattern(hostname: string): boolean {
-  // Handle IPv6 addresses in brackets (with or without port)
-  if (hostname.startsWith('[')) {
-    if (hostname.includes(']:')) {
-      // [::1]:port format
-      const ipv6Part = hostname.substring(0, hostname.indexOf(']:') + 1);
-      return ipv6Part === '[::1]';
-    } else {
-      // [::1] format without port
-      return hostname === '[::1]';
-    }
-  }
-
-  // Handle bare IPv6 without brackets
-  if (hostname === '::1') {
-    return true;
-  }
-
-  // For IPv4 and regular hostnames, split on colon to remove port
-  const hostPart = hostname.split(':')[0];
-
-  return (
-    hostPart === 'localhost' ||
-    hostPart === '127.0.0.1' ||
-    hostPart === '0.0.0.0'
-  );
 }

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -57,6 +57,11 @@ import { DISABLE_SESSION_TOKEN } from '@repo/shared/internal';
 import { AwsClient } from 'aws4fetch';
 import { type Desktop, type ExecuteResponse, SandboxClient } from './clients';
 import { ContainerControlClient } from './container-control';
+import {
+  CurrentRuntimeIdentity,
+  type RuntimeIdentity,
+  type RuntimeScoped
+} from './current-runtime-identity';
 import type { ErrorResponse } from './errors';
 import {
   BackupCreateError,
@@ -76,8 +81,15 @@ import {
 import { collectFile, streamFile } from './file-stream';
 import { CodeInterpreter } from './interpreter';
 import { LocalMountSyncManager } from './local-mount-sync';
+import {
+  PREVIEW_PROXY_HEADER,
+  PREVIEW_PROXY_HEADERS,
+  PREVIEW_PROXY_PORT_HEADER,
+  PREVIEW_PROXY_SANDBOX_ID_HEADER,
+  PREVIEW_PROXY_TOKEN_HEADER
+} from './preview-proxy-protocol';
+import { isLocalhostPattern } from './preview-url';
 import { proxyTerminal } from './pty';
-import { isLocalhostPattern } from './request-handler';
 import {
   SandboxSecurityError,
   sanitizeSandboxId,
@@ -130,6 +142,35 @@ type PortTokenEntry = {
   name?: string;
 };
 
+type PreviewURLRuntimeValidation =
+  | { status: 'invalid' }
+  | {
+      status: 'stale';
+      reason:
+        | 'runtime-not-healthy'
+        | 'runtime-not-running'
+        | 'missing-runtime-id'
+        | 'missing-activation'
+        | 'runtime-mismatch'
+        | 'token-mismatch';
+      containerStatus?: string;
+    }
+  | { status: 'active'; runtime: RuntimeIdentity };
+
+type PreviewPortActivation = RuntimeScoped<{
+  token: string;
+}>;
+
+type PreviewPortActivations = Record<string, PreviewPortActivation>;
+
+type PreviewStateStorage = Pick<
+  DurableObjectStorage | DurableObjectTransaction,
+  'get' | 'put' | 'delete'
+>;
+
+const PORT_TOKENS_STORAGE_KEY = 'portTokens';
+const ACTIVE_PREVIEW_PORTS_STORAGE_KEY = 'activePreviewPorts';
+
 type SandboxConfiguration = {
   sandboxName?: {
     name: string;
@@ -181,7 +222,9 @@ Object.defineProperty(R2EgressProxyTarget, 'name', {
   value: R2_EGRESS_PROXY_TARGET_CLASS_NAME
 });
 
-R2EgressProxyTarget.outboundHandlers = { r2EgressMount: r2EgressHandler };
+Object.defineProperty(R2EgressProxyTarget, 'outboundHandlers', {
+  value: { r2EgressMount: r2EgressHandler }
+});
 
 function isFetcher(value: unknown): value is Fetcher {
   return (
@@ -770,6 +813,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   private logger: ReturnType<typeof createLogger>;
   private keepAliveEnabled: boolean = false;
   private activeMounts: Map<string, MountInfo> = new Map();
+  private currentRuntime: CurrentRuntimeIdentity;
   private transport: SandboxTransport = 'http';
 
   /**
@@ -1041,6 +1085,12 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       component: 'sandbox-do',
       sandboxId: this.ctx.id.toString()
     });
+
+    this.currentRuntime = new CurrentRuntimeIdentity(
+      this.ctx.storage,
+      () => this.getState(),
+      () => this.ctx.container?.running === true
+    );
 
     // Read transport setting from env var
     const transportEnv = envObj?.SANDBOX_TRANSPORT;
@@ -2189,6 +2239,14 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     let caughtError: Error | undefined;
 
     try {
+      // Preview URL auth and activation are cleared before await-heavy
+      // teardown work. Concurrent preview traffic should observe missing
+      // auth or runtime state and fail from DO-owned state without reaching
+      // the container.
+      await this.ctx.storage.delete(PORT_TOKENS_STORAGE_KEY);
+      await this.clearActivePreviewPorts();
+      await this.currentRuntime.clear();
+
       // Best-effort desktop stop — only when container is already running
       if (this.ctx.container?.running) {
         try {
@@ -2231,15 +2289,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         }
       }
 
-      // portTokens is cleared while still inside destroy()'s try block:
-      // super.destroy() is not serialized by blockConcurrencyWhile, so
-      // other DO RPCs run during the await. With storage already cleared,
-      // a concurrent validatePortToken() from the preview URL proxy sees
-      // no token and returns unauthorized, and a concurrent startup path
-      // finds nothing to rehydrate via restoreExposedPorts(). Teardown is
-      // still not atomic against concurrent writers, but the preview URL
-      // authorization path is race-free.
-      await this.ctx.storage.delete('portTokens');
       // Tear down every tunnel this sandbox created — stops the
       // container-side cloudflared processes and removes the Cloudflare
       // tunnel + DNS resources for named tunnels. Runs before disconnect
@@ -2286,6 +2335,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   override async onStart() {
     this.logger.debug('Sandbox started');
 
+    await this.currentRuntime.markStarted();
+
     // Fire-and-forget: version check is observability, not load-bearing.
     this.checkVersionCompatibility().catch((error) => {
       this.logger.error(
@@ -2293,23 +2344,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         error instanceof Error ? error : new Error(String(error))
       );
     });
-
-    // Re-expose ports that were exposed before the container restarted.
-    // Tokens persist in DO storage across restarts (see onStop), but the
-    // container runtime has no memory of which ports were exposed. The base
-    // @cloudflare/containers class wraps onStart in blockConcurrencyWhile,
-    // so awaiting restore here keeps the DO gate held until restore
-    // completes — requests that arrive during the startup window (including
-    // validatePortToken calls from the Worker preview-URL proxy) queue
-    // behind it.
-    try {
-      await this.restoreExposedPorts();
-    } catch (error) {
-      this.logger.error(
-        'Failed to restore exposed ports after container start',
-        error instanceof Error ? error : new Error(String(error))
-      );
-    }
 
     // Reconcile tunnel storage with the fresh container. Quick tunnels
     // are unrecoverable (their `*.trycloudflare.com` URLs died with the
@@ -2330,84 +2364,12 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
   }
 
-  /**
-   * Re-expose ports on the container runtime using tokens persisted in DO
-   * storage. Called from onStart() after a container (re)start.
-   *
-   * The DO storage holds the source of truth for which ports should be
-   * exposed, which tokens authorize them, and the friendly name (if any)
-   * that the caller set when first exposing the port. If a port is already
-   * exposed on the container this is a no-op for that port. Individual port
-   * failures are logged but do not abort the overall restore — a transient
-   * failure for one port must not prevent the others from being restored.
-   */
-  private async restoreExposedPorts(): Promise<void> {
-    const savedTokens = await this.readPortTokens();
-    const portEntries = Object.entries(savedTokens);
-    if (portEntries.length === 0) {
-      return;
-    }
-
-    const startTime = Date.now();
-    let restored = 0;
-    let skipped = 0;
-    let failed = 0;
-
-    // Fetch the container's current exposed-port list once, then check
-    // membership in the loop. On a fresh restart this is empty; on a
-    // retry path (re-entering onStart) it may already contain entries
-    // that should be skipped.
-    const exposedSet = await this.client.ports
-      .getExposedPorts(DISABLE_SESSION_TOKEN)
-      .then((response) => new Set(response.ports.map((p) => p.port)))
-      .catch((error) => {
-        this.logger.warn(
-          'Failed to fetch exposed ports for restore; assuming none exposed',
-          { error: error instanceof Error ? error.message : String(error) }
-        );
-        return new Set<number>();
-      });
-
-    for (const [portStr, entry] of portEntries) {
-      const port = Number.parseInt(portStr, 10);
-      if (!Number.isFinite(port) || !validatePort(port)) {
-        this.logger.warn('Skipping restore of invalid port in storage', {
-          port: portStr
-        });
-        failed++;
-        continue;
-      }
-
-      if (exposedSet.has(port)) {
-        skipped++;
-        continue;
-      }
-
-      try {
-        await this.client.ports.exposePort(
-          port,
-          DISABLE_SESSION_TOKEN,
-          entry.name
-        );
-        restored++;
-      } catch (error) {
-        failed++;
-        this.logger.warn('Failed to re-expose port on container restart', {
-          port,
-          error: error instanceof Error ? error.message : String(error)
-        });
-      }
-    }
-
-    logCanonicalEvent(this.logger, {
-      event: 'port.restore',
-      outcome: failed === 0 ? 'success' : 'error',
-      durationMs: Date.now() - startTime,
-      restored,
-      skipped,
-      failed,
-      total: portEntries.length
-    });
+  override async stop(
+    signal?: Parameters<Container<Env>['stop']>[0]
+  ): Promise<void> {
+    await this.currentRuntime.clear();
+    await this.clearActivePreviewPorts();
+    await super.stop(signal);
   }
 
   /**
@@ -2416,16 +2378,57 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    * ({ token, name? }). The legacy format predates port-name persistence and
    * can appear on any DO whose storage was written before that change.
    */
-  private async readPortTokens(): Promise<Record<string, PortTokenEntry>> {
+  private async readPortTokens(
+    storage: PreviewStateStorage = this.ctx.storage
+  ): Promise<Record<string, PortTokenEntry>> {
     const raw =
-      (await this.ctx.storage.get<Record<string, string | PortTokenEntry>>(
-        'portTokens'
+      (await storage.get<Record<string, string | PortTokenEntry>>(
+        PORT_TOKENS_STORAGE_KEY
       )) ?? {};
     const normalized: Record<string, PortTokenEntry> = {};
     for (const [port, value] of Object.entries(raw)) {
       normalized[port] = typeof value === 'string' ? { token: value } : value;
     }
     return normalized;
+  }
+
+  private async readActivePreviewPorts(
+    storage: PreviewStateStorage = this.ctx.storage
+  ): Promise<PreviewPortActivations> {
+    return (
+      (await storage.get<PreviewPortActivations>(
+        ACTIVE_PREVIEW_PORTS_STORAGE_KEY
+      )) ?? {}
+    );
+  }
+
+  private async writeActivePreviewPorts(
+    activations: PreviewPortActivations,
+    storage: PreviewStateStorage = this.ctx.storage
+  ): Promise<void> {
+    if (Object.keys(activations).length === 0) {
+      await storage.delete(ACTIVE_PREVIEW_PORTS_STORAGE_KEY);
+      return;
+    }
+
+    await storage.put(ACTIVE_PREVIEW_PORTS_STORAGE_KEY, activations);
+  }
+
+  private async readPreviewState(
+    storage: PreviewStateStorage = this.ctx.storage
+  ): Promise<{
+    tokens: Record<string, PortTokenEntry>;
+    activations: PreviewPortActivations;
+  }> {
+    const [tokens, activations] = await Promise.all([
+      this.readPortTokens(storage),
+      this.readActivePreviewPorts(storage)
+    ]);
+    return { tokens, activations };
+  }
+
+  private async clearActivePreviewPorts(): Promise<void> {
+    await this.ctx.storage.delete(ACTIVE_PREVIEW_PORTS_STORAGE_KEY);
   }
 
   /**
@@ -2486,6 +2489,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     this.defaultSession = null;
     this.defaultSessionInit = null;
 
+    await this.currentRuntime.clear();
+    await this.clearActivePreviewPorts();
+
     // Disconnect the active client so open sockets do not hold the DO alive.
     this.client.disconnect();
 
@@ -2505,11 +2511,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     this.activeMounts.clear();
 
     // Persist cleanup to storage so state is clean on next container start.
-    // Port tokens are preserved so preview URLs survive container restarts;
-    // they are only removed on explicit unexposePort() or full sandbox
-    // destroy(). onStart's restoreExposedPorts() replays those tokens into
-    // the container on the next start, which lets validatePortToken()
-    // answer from storage alone.
+    // Port tokens are durable authorization and survive container restarts;
+    // runtime-scoped preview activation is cleared separately above.
     await this.ctx.storage.delete('defaultSession');
   }
 
@@ -2833,6 +2836,145 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
   }
 
+  private isPreviewProxyRequest(request: Request): boolean {
+    // These headers are internal control metadata added by proxyToSandbox()
+    // before the request enters this Durable Object.
+    return request.headers.get(PREVIEW_PROXY_HEADER) === '1';
+  }
+
+  private invalidPreviewTokenResponse(): Response {
+    return new Response(
+      JSON.stringify({
+        error: 'Access denied: Invalid token or port not exposed',
+        code: 'INVALID_TOKEN'
+      }),
+      {
+        status: 404,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+  }
+
+  private stalePreviewURLResponse(): Response {
+    return new Response(
+      JSON.stringify({
+        error: 'Preview URL is stale because the sandbox runtime is not active',
+        code: 'STALE_PREVIEW_URL'
+      }),
+      {
+        status: 410,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+  }
+
+  /**
+   * Detects unavailable-container responses produced by `fetchIfRunning()` and
+   * its shared forwarding helper in `@cloudflare/containers`.
+   */
+  private async isContainerUnavailableResponse(
+    response: Response
+  ): Promise<boolean> {
+    if (response.status !== 500 && response.status !== 503) {
+      return false;
+    }
+
+    const body = await response
+      .clone()
+      .text()
+      .catch(() => null);
+    return (
+      body === 'Container is not running' ||
+      body === 'Container suddenly disconnected, try again'
+    );
+  }
+
+  private buildPreviewProxyRequest(
+    request: Request,
+    port: number,
+    sandboxId: string
+  ): Request {
+    const url = new URL(request.url);
+    const proxyUrl = `http://localhost:${port}${url.pathname}${url.search}`;
+    const headers = new Headers(request.headers);
+    for (const header of PREVIEW_PROXY_HEADERS) {
+      headers.delete(header);
+    }
+    headers.set('X-Original-URL', request.url);
+    headers.set('X-Forwarded-Host', url.hostname);
+    headers.set('X-Forwarded-Proto', url.protocol.replace(':', ''));
+    headers.set('X-Sandbox-Name', this.sandboxName ?? sandboxId);
+
+    const upgradeHeader = request.headers.get('Upgrade');
+    if (upgradeHeader?.toLowerCase() === 'websocket') {
+      // WebSocket upgrade requests keep the original Request object so the
+      // Workers runtime preserves upgrade semantics. fetchIfRunning() routes
+      // by the explicit port argument, while the request URL still provides
+      // the path and query.
+      return new Request(request, {
+        headers,
+        redirect: 'manual'
+      });
+    }
+
+    return new Request(proxyUrl, {
+      method: request.method,
+      headers,
+      body: request.body,
+      // @ts-expect-error - duplex required for body streaming in modern runtimes
+      duplex: 'half',
+      redirect: 'manual'
+    });
+  }
+
+  private async proxyPreviewRequest(request: Request): Promise<Response> {
+    const portValue = request.headers.get(PREVIEW_PROXY_PORT_HEADER);
+    const token = request.headers.get(PREVIEW_PROXY_TOKEN_HEADER);
+    const sandboxId = request.headers.get(PREVIEW_PROXY_SANDBOX_ID_HEADER);
+    const port =
+      portValue === null ? Number.NaN : Number.parseInt(portValue, 10);
+
+    if (!Number.isFinite(port) || !validatePort(port) || !token || !sandboxId) {
+      return this.invalidPreviewTokenResponse();
+    }
+
+    const proxyRequest = this.buildPreviewProxyRequest(
+      request,
+      port,
+      sandboxId
+    );
+
+    const validation = await this.validatePreviewURLForRuntime(port, token);
+    if (validation.status === 'invalid') {
+      return this.invalidPreviewTokenResponse();
+    }
+
+    if (validation.status === 'stale') {
+      this.logger.warn('Stale preview URL blocked', {
+        port,
+        sandboxId,
+        containerStatus: validation.containerStatus,
+        reason: validation.reason,
+        method: request.method
+      });
+      return this.stalePreviewURLResponse();
+    }
+
+    const response = await this.fetchIfRunning(proxyRequest, port);
+    if (
+      (await this.isContainerUnavailableResponse(response)) &&
+      !(await this.currentRuntime.isActive(validation.runtime))
+    ) {
+      return this.stalePreviewURLResponse();
+    }
+
+    return response;
+  }
+
   // Override fetch to route internal container requests to appropriate ports
   override async fetch(request: Request): Promise<Response> {
     // Extract or generate trace ID from request
@@ -2843,6 +2985,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     const requestLogger = this.logger.child({ traceId, operation: 'fetch' });
 
     const url = new URL(request.url);
+
+    if (this.isPreviewProxyRequest(request)) {
+      return await this.proxyPreviewRequest(request);
+    }
 
     // Capture and store the sandbox name from the header if present
     if (!this.sandboxName && request.headers.has('X-Sandbox-Name')) {
@@ -2892,7 +3038,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   private determinePort(url: URL): number {
-    // Extract port from proxy requests (e.g., /proxy/8080/*)
+    // Direct DO fetch compatibility path used by switchPort()/wsConnect().
+    // Public preview URL traffic enters through proxyPreviewRequest() instead.
     const proxyMatch = url.pathname.match(/^\/proxy\/(\d+)/);
     if (proxyMatch) {
       return parseInt(proxyMatch[1], 10);
@@ -4210,32 +4357,11 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       );
     }
 
-    let url: string;
-
-    // Try exposing port 6080; if already exposed, construct the URL from stored token
-    try {
-      const result = await this.exposePort(6080, {
-        hostname,
-        token: options?.token
-      });
-      url = result.url;
-    } catch {
-      // Port may already be exposed — look up the existing token from DO storage
-      const tokens = await this.readPortTokens();
-      const existingEntry = tokens['6080'];
-      if (existingEntry && this.sandboxName) {
-        url = this.constructPreviewUrl(
-          6080,
-          this.sandboxName,
-          hostname,
-          existingEntry.token
-        );
-      } else {
-        throw new Error(
-          'Failed to get desktop stream URL: port 6080 could not be exposed and no existing token found.'
-        );
-      }
-    }
+    const result = await this.exposePort(6080, {
+      hostname,
+      token: options?.token
+    });
+    const url = result.url;
 
     // Wait for the platform to detect port 6080 using the Containers runtime's
     // built-in port readiness mechanism (getTcpPort polling). This ensures the
@@ -4311,11 +4437,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   /**
    * Expose a port and get a preview URL for accessing services running in the sandbox
    *
-   * Preview URLs survive transient container restarts: the token and any
-   * friendly name are persisted in Durable Object storage, and the port is
-   * automatically re-exposed on the container when it comes back up. Tokens
-   * are cleared only on explicit `unexposePort()` or full sandbox
-   * `destroy()`.
+   * Preview URL authorization survives transient container restarts, but
+   * forwarding is active only for the runtime where `exposePort()` was last
+   * called. Call `exposePort()` again after a restart to reactivate an
+   * existing URL for the current runtime.
    *
    * @param port - Port number to expose (1024-65535)
    * @param options - Configuration options
@@ -4371,31 +4496,56 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         );
       }
 
-      let token: string;
       if (options.token !== undefined) {
         this.validateCustomToken(options.token);
-        token = options.token;
-      } else {
-        token = this.generatePortToken();
       }
 
-      // Allow re-exposing same port with same token, but reject if another port uses this token
-      const tokens = await this.readPortTokens();
-      const existingPort = Object.entries(tokens).find(
-        ([p, entry]) => entry.token === token && p !== port.toString()
-      );
-      if (existingPort) {
-        throw new SandboxSecurityError(
-          `Token '${token}' is already in use by port ${existingPort[0]}. Please use a different token.`
-        );
-      }
       const sessionId = this.serializeExecutionContext(
         await this.resolveExecution()
       );
-      await this.client.ports.exposePort(port, sessionId, options?.name);
 
-      tokens[port.toString()] = { token, name: options?.name };
-      await this.ctx.storage.put('portTokens', tokens);
+      await this.client.ports.exposePort(port, sessionId, options.name);
+
+      // onStart() may record runtime identity while ensureDefaultSession()
+      // starts the container. Re-read before falling back to markStarted() so
+      // normal start hooks remain the identity source.
+      let runtime = await this.currentRuntime.get();
+      runtime = runtime ?? (await this.currentRuntime.markStarted());
+      await this.currentRuntime.assertActive(runtime);
+
+      const token = await this.ctx.storage.transaction(async (txn) => {
+        const tokens = await this.readPortTokens(txn);
+        const existingEntry = tokens[port.toString()];
+        const nextToken =
+          options.token ?? existingEntry?.token ?? this.generatePortToken();
+
+        // Allow re-exposing same port with same token, but reject if another port uses this token
+        const existingPort = Object.entries(tokens).find(
+          ([p, entry]) => entry.token === nextToken && p !== port.toString()
+        );
+        if (existingPort) {
+          throw new SandboxSecurityError(
+            `Token '${nextToken}' is already in use by port ${existingPort[0]}. Please use a different token.`
+          );
+        }
+
+        const activations = await this.readActivePreviewPorts(txn);
+
+        tokens[port.toString()] = { token: nextToken, name: options.name };
+        activations[port.toString()] = runtime.scope({ token: nextToken });
+        await Promise.all([
+          txn.put(PORT_TOKENS_STORAGE_KEY, tokens),
+          this.writeActivePreviewPorts(activations, txn)
+        ]);
+
+        return nextToken;
+      });
+
+      // If a concurrent lifecycle hook records a newer runtime identity after
+      // the storage writes, fail instead of returning a URL that is stale on
+      // arrival. The stale activation remains harmless because preview
+      // forwarding requires ownership by the current runtime identity.
+      await this.currentRuntime.assertActive(runtime);
 
       const url = this.constructPreviewUrl(
         port,
@@ -4409,7 +4559,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       return {
         url,
         port,
-        name: options?.name
+        name: options.name
       };
     } catch (error) {
       caughtError = error instanceof Error ? error : new Error(String(error));
@@ -4420,7 +4570,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         outcome,
         port,
         durationMs: Date.now() - exposeStartTime,
-        name: options?.name,
+        name: options.name,
         hostname: options.hostname,
         error: caughtError
       });
@@ -4451,6 +4601,12 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         await this.ctx.storage.put('portTokens', tokens);
       }
 
+      const activations = await this.readActivePreviewPorts();
+      if (activations[port.toString()]) {
+        delete activations[port.toString()];
+        await this.writeActivePreviewPorts(activations);
+      }
+
       const sessionId = this.serializeExecutionContext(
         await this.resolveExecution()
       );
@@ -4458,10 +4614,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         await this.client.ports.unexposePort(port, sessionId);
       } catch (error) {
         // A container that was asleep when we entered wakes with an
-        // empty exposed-port registry; restoreExposedPorts() has
-        // nothing to replay because we just cleared the token. The
-        // container then reports the port was never exposed, which is
-        // the state we wanted.
+        // empty exposed-port registry. We already cleared durable auth
+        // and activation state, so a "not exposed" response is the state
+        // we wanted.
         if (!(error instanceof PortNotExposedError)) {
           throw error;
         }
@@ -4500,10 +4655,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
     // A port reported by the container with no corresponding token in
     // storage is an orphan. It cannot produce a valid preview URL (the
-    // token is what the URL binds to), so it is omitted from the
-    // result. The next container restart reconciles the inconsistency
-    // because restoreExposedPorts() rebuilds the container registry
-    // from storage.
+    // token is what the URL binds to), so it is omitted from the result.
     return response.ports.flatMap((port) => {
       const entry = tokens[port.port.toString()];
       if (!entry) {
@@ -4659,24 +4811,115 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
   }
 
+  /**
+   * Checks durable preview URL authorization for a port/token pair.
+   *
+   * This does not check whether the port is activated for the current runtime
+   * and is not sufficient to decide whether preview traffic may forward.
+   */
   async validatePortToken(port: number, token: string): Promise<boolean> {
-    // Preview-URL auth answers from DO storage alone. onStart's
-    // restoreExposedPorts() replays storage into the container on restart,
-    // and destroy() clears portTokens before super.destroy() runs, so a
-    // storage read gives the right answer for the interleavings this
-    // method can race.
     const tokens = await this.readPortTokens();
     const entry = tokens[port.toString()];
     if (!entry) {
       return false;
     }
 
+    return this.previewTokensMatch(entry.token, token);
+  }
+
+  private async validatePreviewURLForRuntime(
+    port: number,
+    token: string
+  ): Promise<PreviewURLRuntimeValidation> {
+    const containerState = await this.getState();
+    const containerRunning = this.ctx.container?.running === true;
+    const { tokens, activations, runtime } = await this.ctx.storage.transaction(
+      async (txn) => {
+        const [previewState, runtime] = await Promise.all([
+          this.readPreviewState(txn),
+          this.currentRuntime.getStored(txn)
+        ]);
+        return { ...previewState, runtime };
+      }
+    );
+
+    const entry = tokens[port.toString()];
+    if (!entry) {
+      return { status: 'invalid' };
+    }
+
+    const tokenMatches = this.previewTokensMatch(entry.token, token);
+    if (!tokenMatches) {
+      return { status: 'invalid' };
+    }
+
+    if (containerState.status !== 'healthy') {
+      return {
+        status: 'stale',
+        reason: 'runtime-not-healthy',
+        containerStatus: containerState.status
+      };
+    }
+
+    if (!containerRunning) {
+      return {
+        status: 'stale',
+        reason: 'runtime-not-running',
+        containerStatus: containerState.status
+      };
+    }
+
+    if (!runtime) {
+      return {
+        status: 'stale',
+        reason: 'missing-runtime-id',
+        containerStatus: containerState.status
+      };
+    }
+
+    const activation = activations[port.toString()];
+    if (!activation) {
+      return {
+        status: 'stale',
+        reason: 'missing-activation',
+        containerStatus: containerState.status
+      };
+    }
+
+    if (!runtime.owns(activation)) {
+      return {
+        status: 'stale',
+        reason: 'runtime-mismatch',
+        containerStatus: containerState.status
+      };
+    }
+
+    const activationTokenMatches = this.previewTokensMatch(
+      activation.token,
+      token
+    );
+    if (!activationTokenMatches) {
+      this.logger.warn('Preview URL activation token mismatch', {
+        port,
+        runtimeIdentityID: runtime.id
+      });
+      return {
+        status: 'stale',
+        reason: 'token-mismatch',
+        containerStatus: containerState.status
+      };
+    }
+
+    return { status: 'active', runtime };
+  }
+
+  private previewTokensMatch(expected: string, actual: string): boolean {
     const encoder = new TextEncoder();
-    const a = encoder.encode(entry.token);
-    const b = encoder.encode(token);
+    const a = encoder.encode(expected);
+    const b = encoder.encode(actual);
 
     try {
-      // Workers runtime extends SubtleCrypto with timingSafeEqual
+      // Workers runtime extends SubtleCrypto with timingSafeEqual.
       return (
         crypto.subtle as SubtleCrypto & {
           timingSafeEqual(a: ArrayBufferView, b: ArrayBufferView): boolean;

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -82,6 +82,10 @@ import { collectFile, streamFile } from './file-stream';
 import { CodeInterpreter } from './interpreter';
 import { LocalMountSyncManager } from './local-mount-sync';
 import {
+  forwardPreviewRequest,
+  type PreviewTCPPort
+} from './preview-forwarding';
+import {
   PREVIEW_PROXY_HEADER,
   PREVIEW_PROXY_HEADERS,
   PREVIEW_PROXY_PORT_HEADER,
@@ -211,6 +215,17 @@ type R2EgressContainerState = DurableObjectState<{}> & {
   container?: {
     interceptOutboundHttp(host: string, fetcher: Fetcher): Promise<void>;
   };
+};
+
+type PreviewForwardingContainerState = DurableObjectState<{}> & {
+  container?: {
+    running: boolean;
+    getTcpPort(port: number): PreviewTCPPort;
+  };
+};
+
+type PreviewForwardingLifecycleState = {
+  inflightRequests?: number;
 };
 
 const R2_EGRESS_PROXY_TARGET_CLASS_NAME =
@@ -2879,25 +2894,68 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     );
   }
 
-  /**
-   * Detects unavailable-container responses produced by `fetchIfRunning()` and
-   * its shared forwarding helper in `@cloudflare/containers`.
-   */
-  private async isContainerUnavailableResponse(
-    response: Response
-  ): Promise<boolean> {
-    if (response.status !== 500 && response.status !== 503) {
-      return false;
+  private getPreviewForwardingContainer(): PreviewForwardingContainerState['container'] {
+    return (this.ctx as PreviewForwardingContainerState).container;
+  }
+
+  private beginPreviewForward(): () => void {
+    const lifecycle = this as unknown as PreviewForwardingLifecycleState;
+    lifecycle.inflightRequests = (lifecycle.inflightRequests ?? 0) + 1;
+    this.renewActivityTimeout();
+
+    let settled = false;
+    return () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      lifecycle.inflightRequests = Math.max(
+        0,
+        (lifecycle.inflightRequests ?? 0) - 1
+      );
+      if (lifecycle.inflightRequests === 0) {
+        this.renewActivityTimeout();
+      }
+    };
+  }
+
+  private async fetchPreviewIfRunning(
+    request: Request,
+    port: number,
+    runtime: RuntimeIdentity
+  ): Promise<Response> {
+    const container = this.getPreviewForwardingContainer();
+    const state = await this.getState();
+
+    if (!container?.running || state.status !== 'healthy') {
+      return this.stalePreviewURLResponse();
     }
 
-    const body = await response
-      .clone()
-      .text()
-      .catch(() => null);
-    return (
-      body === 'Container is not running' ||
-      body === 'Container suddenly disconnected, try again'
-    );
+    if (!(await this.currentRuntime.isActive(runtime))) {
+      return this.stalePreviewURLResponse();
+    }
+
+    const tcpPort = container.getTcpPort(port);
+
+    // Keep dispatch adjacent to the final runtime check above. Stale preview
+    // traffic must not observe an active runtime and then reach a different
+    // runtime through another async interleaving.
+    const result = await forwardPreviewRequest(tcpPort, request, {
+      beginForward: () => this.beginPreviewForward(),
+      renewActivity: () => this.renewActivityTimeout()
+    });
+
+    if (result.status === 'network-lost') {
+      if (!(await this.currentRuntime.isActive(runtime))) {
+        return this.stalePreviewURLResponse();
+      }
+
+      return new Response('Container suddenly disconnected, try again', {
+        status: 500
+      });
+    }
+
+    return result.response;
   }
 
   private buildPreviewProxyRequest(
@@ -2919,7 +2977,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     const upgradeHeader = request.headers.get('Upgrade');
     if (upgradeHeader?.toLowerCase() === 'websocket') {
       // WebSocket upgrade requests keep the original Request object so the
-      // Workers runtime preserves upgrade semantics. fetchIfRunning() routes
+      // Workers runtime preserves upgrade semantics. Preview forwarding routes
       // by the explicit port argument, while the request URL still provides
       // the path and query.
       return new Request(request, {
@@ -2971,15 +3029,11 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       return this.stalePreviewURLResponse();
     }
 
-    const response = await this.fetchIfRunning(proxyRequest, port);
-    if (
-      (await this.isContainerUnavailableResponse(response)) &&
-      !(await this.currentRuntime.isActive(validation.runtime))
-    ) {
-      return this.stalePreviewURLResponse();
-    }
-
-    return response;
+    return await this.fetchPreviewIfRunning(
+      proxyRequest,
+      port,
+      validation.runtime
+    );
   }
 
   // Override fetch to route internal container requests to appropriate ports

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -222,9 +222,7 @@ Object.defineProperty(R2EgressProxyTarget, 'name', {
   value: R2_EGRESS_PROXY_TARGET_CLASS_NAME
 });
 
-Object.defineProperty(R2EgressProxyTarget, 'outboundHandlers', {
-  value: { r2EgressMount: r2EgressHandler }
-});
+R2EgressProxyTarget.outboundHandlers = { r2EgressMount: r2EgressHandler };
 
 function isFetcher(value: unknown): value is Fetcher {
   return (

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -2492,6 +2492,15 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     await this.currentRuntime.clear();
     await this.clearActivePreviewPorts();
 
+    try {
+      await pruneTunnelsForRestart(this.ctx.storage);
+    } catch (error) {
+      this.logger.error(
+        'Failed to reconcile tunnel storage after container stop',
+        error instanceof Error ? error : new Error(String(error))
+      );
+    }
+
     // Disconnect the active client so open sockets do not hold the DO alive.
     this.client.disconnect();
 

--- a/packages/sandbox/src/tunnels/tunnels-handler.ts
+++ b/packages/sandbox/src/tunnels/tunnels-handler.ts
@@ -610,13 +610,26 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
           await txn.put(META_STORAGE_KEY, currentMeta);
         });
 
-        // Stop cloudflared inside the container. TUNNEL_NOT_FOUND is
-        // swallowed so Cloudflare-side cleanup can still proceed.
+        // Stop cloudflared inside the container. This is best-effort for
+        // named tunnels: destroy() is also responsible for Cloudflare-side
+        // cleanup, which must still run if the container already stopped.
         try {
           await this.#host.client.tunnels.destroyTunnel(existing.id);
         } catch (error) {
-          if (!isTunnelNotFoundError(error)) throw error;
-          // Container already forgot — fall through to CF cleanup.
+          if (isTunnelNotFoundError(error)) {
+            // Container already forgot — fall through to CF cleanup.
+          } else if (metaBefore?.dnsRecordId) {
+            this.#host.logger.warn(
+              'tunnel.destroy: container tunnel cleanup failed',
+              {
+                port,
+                tunnelId,
+                error: error instanceof Error ? error.message : String(error)
+              }
+            );
+          } else {
+            throw error;
+          }
         }
 
         // Named-tunnel cleanup on Cloudflare. Best-effort: log failures

--- a/packages/sandbox/tests/current-runtime-identity.test.ts
+++ b/packages/sandbox/tests/current-runtime-identity.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CurrentRuntimeIdentity,
+  RuntimeIdentityInactiveError
+} from '../src/current-runtime-identity';
+
+function createStorage(initial = new Map<string, unknown>()) {
+  return {
+    get: vi.fn(async (key: string) => initial.get(key)),
+    put: vi.fn(async (key: string, value: unknown) => {
+      initial.set(key, value);
+    }),
+    delete: vi.fn(async (key: string) => {
+      initial.delete(key);
+    })
+  } as unknown as DurableObjectState['storage'];
+}
+
+describe('CurrentRuntimeIdentity', () => {
+  it('returns inactive when the container is not healthy', async () => {
+    const storage = createStorage(
+      new Map([['currentRuntimeIdentity', { id: 'runtime-1' }]])
+    );
+    const currentRuntime = new CurrentRuntimeIdentity(
+      storage,
+      async () => ({ status: 'stopped' }),
+      () => true
+    );
+
+    await expect(currentRuntime.getStatus()).resolves.toMatchObject({
+      status: 'inactive',
+      reason: 'runtime-not-healthy',
+      containerStatus: 'stopped'
+    });
+  });
+
+  it('returns inactive when the container is not running', async () => {
+    const storage = createStorage(
+      new Map([['currentRuntimeIdentity', { id: 'runtime-1' }]])
+    );
+    const currentRuntime = new CurrentRuntimeIdentity(
+      storage,
+      async () => ({ status: 'healthy' }),
+      () => false
+    );
+
+    await expect(currentRuntime.getStatus()).resolves.toMatchObject({
+      status: 'inactive',
+      reason: 'runtime-not-running',
+      containerStatus: 'healthy'
+    });
+  });
+
+  it('returns inactive when the runtime identity is missing', async () => {
+    const currentRuntime = new CurrentRuntimeIdentity(
+      createStorage(),
+      async () => ({ status: 'healthy' }),
+      () => true
+    );
+
+    await expect(currentRuntime.getStatus()).resolves.toMatchObject({
+      status: 'inactive',
+      reason: 'missing-runtime-id',
+      containerStatus: 'healthy'
+    });
+  });
+
+  it('returns active when storage, health, and running state agree', async () => {
+    const storage = createStorage(
+      new Map([['currentRuntimeIdentity', { id: 'runtime-1' }]])
+    );
+    const currentRuntime = new CurrentRuntimeIdentity(
+      storage,
+      async () => ({ status: 'healthy' }),
+      () => true
+    );
+
+    const status = await currentRuntime.getStatus();
+
+    expect(status.status).toBe('active');
+    if (status.status === 'active') {
+      expect(status.runtime.id).toBe('runtime-1');
+      expect(status.containerStatus).toBe('healthy');
+    }
+  });
+
+  it('marks and clears the current runtime identity', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentRuntime = new CurrentRuntimeIdentity(
+      storage,
+      async () => ({ status: 'healthy' }),
+      () => true
+    );
+
+    const runtime = await currentRuntime.markStarted();
+
+    expect(map.get('currentRuntimeIdentity')).toEqual({ id: runtime.id });
+
+    await currentRuntime.clear();
+
+    expect(map.has('currentRuntimeIdentity')).toBe(false);
+  });
+
+  it('throws a typed error when asserting an inactive runtime', async () => {
+    const currentRuntime = new CurrentRuntimeIdentity(
+      createStorage(),
+      async () => ({ status: 'healthy' }),
+      () => true
+    );
+    const runtime = await currentRuntime.markStarted();
+
+    await currentRuntime.clear();
+
+    await expect(currentRuntime.assertActive(runtime)).rejects.toBeInstanceOf(
+      RuntimeIdentityInactiveError
+    );
+  });
+});

--- a/packages/sandbox/tests/preview-forwarding.test.ts
+++ b/packages/sandbox/tests/preview-forwarding.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  forwardPreviewRequest,
+  type PreviewForwardingLifecycle
+} from '../src/preview-forwarding';
+
+function createLifecycle() {
+  const settle = vi.fn();
+  const lifecycle: PreviewForwardingLifecycle = {
+    beginForward: vi.fn(() => settle),
+    renewActivity: vi.fn()
+  };
+  return { lifecycle, settle };
+}
+
+describe('forwardPreviewRequest', () => {
+  it('forwards HTTP requests through the provided TCP port', async () => {
+    const { lifecycle, settle } = createLifecycle();
+    const tcpFetch = vi.fn().mockResolvedValue(new Response('ok'));
+
+    const result = await forwardPreviewRequest(
+      { fetch: tcpFetch },
+      new Request('http://localhost:8080/path?x=1'),
+      lifecycle
+    );
+
+    expect(result.status).toBe('response');
+    if (result.status === 'response') {
+      expect(await result.response.text()).toBe('ok');
+    }
+    expect(tcpFetch).toHaveBeenCalledWith(
+      'http://localhost:8080/path?x=1',
+      expect.any(Request)
+    );
+    expect(lifecycle.beginForward).toHaveBeenCalledTimes(1);
+    expect(settle).toHaveBeenCalledTimes(1);
+  });
+
+  it('settles after streamed HTTP body completion', async () => {
+    const { lifecycle, settle } = createLifecycle();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('streamed'));
+        controller.close();
+      }
+    });
+    const tcpFetch = vi.fn().mockResolvedValue(new Response(stream));
+
+    const result = await forwardPreviewRequest(
+      { fetch: tcpFetch },
+      new Request('http://localhost:8080/stream'),
+      lifecycle
+    );
+
+    expect(result.status).toBe('response');
+    expect(settle).not.toHaveBeenCalled();
+    if (result.status === 'response') {
+      expect(await result.response.text()).toBe('streamed');
+    }
+    await Promise.resolve();
+    expect(settle).toHaveBeenCalledTimes(1);
+  });
+
+  it('classifies network-loss errors', async () => {
+    const { lifecycle, settle } = createLifecycle();
+    const tcpFetch = vi
+      .fn()
+      .mockRejectedValue(new Error('Network connection lost.'));
+
+    const result = await forwardPreviewRequest(
+      { fetch: tcpFetch },
+      new Request('http://localhost:8080/'),
+      lifecycle
+    );
+
+    expect(result).toEqual({ status: 'network-lost' });
+    expect(settle).toHaveBeenCalledTimes(1);
+  });
+
+  it('settles and rethrows generic errors', async () => {
+    const { lifecycle, settle } = createLifecycle();
+    const tcpFetch = vi.fn().mockRejectedValue(new Error('boom'));
+
+    await expect(
+      forwardPreviewRequest(
+        { fetch: tcpFetch },
+        new Request('http://localhost:8080/'),
+        lifecycle
+      )
+    ).rejects.toThrow('boom');
+    expect(settle).toHaveBeenCalledTimes(1);
+  });
+
+  it('bridges WebSocket responses and settles once on close', async () => {
+    const { lifecycle, settle } = createLifecycle();
+    const pair = new WebSocketPair();
+    const [containerClient, containerServer] = Object.values(pair);
+    const tcpFetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(null, { status: 101, webSocket: containerClient })
+      );
+
+    const result = await forwardPreviewRequest(
+      { fetch: tcpFetch },
+      new Request('http://localhost:8080/ws', {
+        headers: { Upgrade: 'websocket', Connection: 'Upgrade' }
+      }),
+      lifecycle
+    );
+
+    expect(result.status).toBe('response');
+    if (result.status !== 'response') {
+      throw new Error('Expected WebSocket response');
+    }
+    expect(result.response.status).toBe(101);
+    expect(result.response.webSocket).not.toBeNull();
+
+    const clientSocket = result.response.webSocket;
+    if (!clientSocket) {
+      throw new Error('Expected client WebSocket');
+    }
+    clientSocket.accept();
+    containerServer.accept();
+    clientSocket.close(1000, 'done');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(settle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/sandbox/tests/r2-egress-mount.test.ts
+++ b/packages/sandbox/tests/r2-egress-mount.test.ts
@@ -9,38 +9,46 @@ type MockFetcher = {
   fetch: ReturnType<typeof vi.fn>;
 };
 
+type TestOutboundHandlerContext = {
+  containerId: string;
+  className: string;
+  params?: unknown;
+};
+
+type TestOutboundHandler = (
+  request: Request,
+  env: Cloudflare.Env,
+  ctx: TestOutboundHandlerContext
+) => Response | Promise<Response>;
+
+type TestOutboundHostOverride = {
+  method: string;
+  params?: unknown;
+};
+
+type TestContainerProxyOptions = {
+  props: {
+    containerId: string;
+    className: string;
+    outboundByHostOverrides?: Record<string, TestOutboundHostOverride>;
+  };
+};
+
+const testOutboundHandlersRegistry = vi.hoisted(
+  () => new Map<string, Record<string, TestOutboundHandler>>()
+);
+
 vi.mock('./interpreter', () => ({
   CodeInterpreter: vi.fn().mockImplementation(() => ({}))
 }));
 
 vi.mock('@cloudflare/containers', () => {
-  const outboundHandlersRegistry = new Map<string, Record<string, unknown>>();
   const outboundByHostRegistry = new Map<string, Record<string, unknown>>();
 
   const MockContainer = class Container {
     ctx: unknown;
     env: unknown;
     sleepAfter: string | number = '10m';
-
-    static get outboundHandlers(): Record<string, unknown> | undefined {
-      return outboundHandlersRegistry.get(Container.name);
-    }
-
-    static set outboundHandlers(handlers: Record<string, unknown>) {
-      const existing = outboundHandlersRegistry.get(Container.name) ?? {};
-      outboundHandlersRegistry.set(Container.name, {
-        ...existing,
-        ...handlers
-      });
-    }
-
-    static get outboundByHost(): Record<string, unknown> | undefined {
-      return outboundByHostRegistry.get(Container.name);
-    }
-
-    static set outboundByHost(handlers: Record<string, unknown>) {
-      outboundByHostRegistry.set(Container.name, handlers);
-    }
 
     constructor(ctx: unknown, env: unknown) {
       this.ctx = ctx;
@@ -60,7 +68,7 @@ vi.mock('@cloudflare/containers', () => {
     renewActivityTimeout() {}
 
     async setOutboundByHost(_hostname: string, _method: string): Promise<void> {
-      const handlers = outboundHandlersRegistry.get(this.constructor.name);
+      const handlers = testOutboundHandlersRegistry.get(this.constructor.name);
       if (!handlers || !(_method in handlers)) {
         throw new Error(
           `Outbound handler method '${_method}' not found in outboundHandlers for ${this.constructor.name}`
@@ -70,6 +78,31 @@ vi.mock('@cloudflare/containers', () => {
 
     async removeOutboundByHost(_hostname: string): Promise<void> {}
   };
+
+  Object.defineProperty(MockContainer, 'outboundHandlers', {
+    get: function (this: { name: string }) {
+      return testOutboundHandlersRegistry.get(this.name);
+    },
+    set: function (
+      this: { name: string },
+      handlers: Record<string, TestOutboundHandler>
+    ) {
+      const existing = testOutboundHandlersRegistry.get(this.name) ?? {};
+      testOutboundHandlersRegistry.set(this.name, {
+        ...existing,
+        ...handlers
+      });
+    }
+  });
+
+  Object.defineProperty(MockContainer, 'outboundByHost', {
+    get: function (this: { name: string }) {
+      return outboundByHostRegistry.get(this.name);
+    },
+    set: function (this: { name: string }, handlers: Record<string, unknown>) {
+      outboundByHostRegistry.set(this.name, handlers);
+    }
+  });
 
   return {
     Container: MockContainer,
@@ -82,9 +115,41 @@ function createMockCtx(options?: {
   includeContainerProxy?: boolean;
   containerProxyResult?: unknown;
 }) {
-  const containerProxyFetcher =
-    options?.containerProxyResult ?? ({ fetch: vi.fn() } satisfies MockFetcher);
-  const ContainerProxy = vi.fn().mockReturnValue(containerProxyFetcher);
+  let latestProxyOptions: TestContainerProxyOptions | undefined;
+  const containerProxyFetcher = {
+    fetch: vi.fn(async (request: Request) => {
+      const proxyOptions = latestProxyOptions;
+      if (!proxyOptions) {
+        return new Response('Origin is disallowed', { status: 530 });
+      }
+
+      const hostname = new URL(request.url).hostname;
+      const override = proxyOptions.props.outboundByHostOverrides?.[hostname];
+      const handler = override
+        ? testOutboundHandlersRegistry.get(proxyOptions.props.className)?.[
+            override.method
+          ]
+        : undefined;
+
+      if (!override || !handler) {
+        return new Response('Origin is disallowed', { status: 530 });
+      }
+
+      return handler(
+        request,
+        { MY_BUCKET: createMockR2Bucket() } as unknown as Cloudflare.Env,
+        {
+          containerId: proxyOptions.props.containerId,
+          className: proxyOptions.props.className,
+          params: override.params
+        }
+      );
+    })
+  } satisfies MockFetcher;
+  const ContainerProxy = vi.fn((proxyOptions: TestContainerProxyOptions) => {
+    latestProxyOptions = proxyOptions;
+    return options?.containerProxyResult ?? containerProxyFetcher;
+  });
   return {
     storage: {
       get: vi.fn().mockResolvedValue(null),
@@ -370,6 +435,10 @@ describe('Sandbox R2 egress mounts', () => {
       'r2.internal',
       mockCtx.containerProxyFetcher
     );
+    const proxyResponse = await mockCtx.containerProxyFetcher.fetch(
+      new Request('http://r2.internal/MY_BUCKET?location', { method: 'GET' })
+    );
+    expect(proxyResponse.status).toBe(200);
     expect(
       mockCtx.container.interceptOutboundHttp.mock.invocationCallOrder[0]
     ).toBeLessThan(execInternal.mock.invocationCallOrder[0]);

--- a/packages/sandbox/tests/request-handler.test.ts
+++ b/packages/sandbox/tests/request-handler.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { proxyToSandbox, type SandboxEnv } from '../src/request-handler';
 import type { Sandbox } from '../src/sandbox';
 
-// Mock getSandbox from sandbox.ts
 vi.mock('../src/sandbox', () => {
   const mockFn = vi.fn();
   return {
@@ -11,32 +10,35 @@ vi.mock('../src/sandbox', () => {
   };
 });
 
-// Import the mock after vi.mock is set up
 import { getSandbox } from '../src/sandbox';
 
-describe('proxyToSandbox - WebSocket Support', () => {
-  let mockSandbox: Partial<Sandbox>;
+describe('proxyToSandbox - preview URL routing', () => {
+  let mockSandbox: Pick<Sandbox, 'fetch' | 'containerFetch'>;
   let mockEnv: SandboxEnv;
 
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Mock Sandbox with necessary methods
     mockSandbox = {
-      validatePortToken: vi.fn().mockResolvedValue(true),
-      fetch: vi.fn().mockResolvedValue(new Response('WebSocket response')),
+      fetch: vi.fn().mockResolvedValue(new Response('Preview response')),
       containerFetch: vi.fn().mockResolvedValue(new Response('HTTP response'))
     };
 
     mockEnv = {
-      Sandbox: {} as any
+      Sandbox: {} as DurableObjectNamespace<Sandbox>
     };
 
     vi.mocked(getSandbox).mockReturnValue(mockSandbox as Sandbox);
   });
 
-  describe('WebSocket detection and routing', () => {
-    it('should detect WebSocket upgrade header (case-insensitive)', async () => {
+  function getForwardedRequest(): Request {
+    const request = vi.mocked(mockSandbox.fetch).mock.calls[0]?.[0];
+    expect(request).toBeInstanceOf(Request);
+    return request as Request;
+  }
+
+  describe('routing to the Sandbox Durable Object', () => {
+    it('routes WebSocket preview requests through the Sandbox fetch boundary', async () => {
       const request = new Request(
         'https://8080-sandbox-token12345678901.example.com/ws',
         {
@@ -49,30 +51,20 @@ describe('proxyToSandbox - WebSocket Support', () => {
 
       await proxyToSandbox(request, mockEnv);
 
-      // Should route through fetch() for WebSocket
       expect(mockSandbox.fetch).toHaveBeenCalledTimes(1);
       expect(mockSandbox.containerFetch).not.toHaveBeenCalled();
-    });
 
-    it('should set cf-container-target-port header for WebSocket', async () => {
-      const request = new Request(
-        'https://8080-sandbox-token12345678901.example.com/ws',
-        {
-          headers: {
-            Upgrade: 'websocket'
-          }
-        }
+      const forwarded = getForwardedRequest();
+      expect(forwarded.headers.get('Upgrade')).toBe('websocket');
+      expect(forwarded.headers.get('Connection')).toBe('Upgrade');
+      expect(forwarded.headers.get('x-sandbox-preview-proxy')).toBe('1');
+      expect(forwarded.headers.get('x-sandbox-preview-port')).toBe('8080');
+      expect(forwarded.headers.get('x-sandbox-preview-token')).toBe(
+        'token12345678901'
       );
-
-      await proxyToSandbox(request, mockEnv);
-
-      expect(mockSandbox.fetch).toHaveBeenCalledTimes(1);
-      const fetchCall = vi.mocked(mockSandbox.fetch as any).mock
-        .calls[0][0] as Request;
-      expect(fetchCall.headers.get('cf-container-target-port')).toBe('8080');
     });
 
-    it('should preserve original headers for WebSocket', async () => {
+    it('preserves original WebSocket headers', async () => {
       const request = new Request(
         'https://8080-sandbox-token12345678901.example.com/ws',
         {
@@ -87,17 +79,14 @@ describe('proxyToSandbox - WebSocket Support', () => {
 
       await proxyToSandbox(request, mockEnv);
 
-      const fetchCall = vi.mocked(mockSandbox.fetch as any).mock
-        .calls[0][0] as Request;
-      expect(fetchCall.headers.get('Upgrade')).toBe('websocket');
-      expect(fetchCall.headers.get('Sec-WebSocket-Key')).toBe('test-key-123');
-      expect(fetchCall.headers.get('Sec-WebSocket-Version')).toBe('13');
-      expect(fetchCall.headers.get('User-Agent')).toBe('test-client');
+      const forwarded = getForwardedRequest();
+      expect(forwarded.headers.get('Upgrade')).toBe('websocket');
+      expect(forwarded.headers.get('Sec-WebSocket-Key')).toBe('test-key-123');
+      expect(forwarded.headers.get('Sec-WebSocket-Version')).toBe('13');
+      expect(forwarded.headers.get('User-Agent')).toBe('test-client');
     });
-  });
 
-  describe('HTTP routing (existing behavior)', () => {
-    it('should route HTTP requests through containerFetch', async () => {
+    it('routes HTTP preview requests through the Sandbox fetch boundary', async () => {
       const request = new Request(
         'https://8080-sandbox-token12345678901.example.com/api/data',
         {
@@ -107,30 +96,43 @@ describe('proxyToSandbox - WebSocket Support', () => {
 
       await proxyToSandbox(request, mockEnv);
 
-      // Should route through containerFetch() for HTTP
-      expect(mockSandbox.containerFetch).toHaveBeenCalledTimes(1);
-      expect(mockSandbox.fetch).not.toHaveBeenCalled();
+      expect(mockSandbox.fetch).toHaveBeenCalledTimes(1);
+      expect(mockSandbox.containerFetch).not.toHaveBeenCalled();
+
+      const forwarded = getForwardedRequest();
+      expect(forwarded.headers.get('x-sandbox-preview-proxy')).toBe('1');
+      expect(forwarded.headers.get('x-sandbox-preview-port')).toBe('8080');
+      expect(forwarded.headers.get('x-sandbox-preview-token')).toBe(
+        'token12345678901'
+      );
+      expect(forwarded.headers.get('x-sandbox-preview-sandbox-id')).toBe(
+        'sandbox'
+      );
     });
 
-    it('should route POST requests through containerFetch', async () => {
+    it('preserves POST requests and request headers', async () => {
       const request = new Request(
         'https://8080-sandbox-token12345678901.example.com/api/data',
         {
           method: 'POST',
           body: JSON.stringify({ data: 'test' }),
           headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'X-Test-Header': 'test-value'
           }
         }
       );
 
       await proxyToSandbox(request, mockEnv);
 
-      expect(mockSandbox.containerFetch).toHaveBeenCalledTimes(1);
-      expect(mockSandbox.fetch).not.toHaveBeenCalled();
+      const forwarded = getForwardedRequest();
+      expect(forwarded.method).toBe('POST');
+      expect(forwarded.headers.get('Content-Type')).toBe('application/json');
+      expect(forwarded.headers.get('X-Test-Header')).toBe('test-value');
+      expect(mockSandbox.containerFetch).not.toHaveBeenCalled();
     });
 
-    it('should not detect SSE as WebSocket', async () => {
+    it('does not treat SSE requests as WebSocket requests', async () => {
       const request = new Request(
         'https://8080-sandbox-token12345678901.example.com/events',
         {
@@ -142,81 +144,14 @@ describe('proxyToSandbox - WebSocket Support', () => {
 
       await proxyToSandbox(request, mockEnv);
 
-      // SSE should use HTTP path, not WebSocket path
-      expect(mockSandbox.containerFetch).toHaveBeenCalledTimes(1);
-      expect(mockSandbox.fetch).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('Token validation', () => {
-    it('should validate token for both WebSocket and HTTP requests', async () => {
-      const wsRequest = new Request(
-        'https://8080-sandbox-token12345678901.example.com/ws',
-        {
-          headers: { Upgrade: 'websocket' }
-        }
-      );
-
-      await proxyToSandbox(wsRequest, mockEnv);
-      expect(mockSandbox.validatePortToken).toHaveBeenCalledWith(
-        8080,
-        'token12345678901'
-      );
-
-      vi.clearAllMocks();
-
-      const httpRequest = new Request(
-        'https://8080-sandbox-token12345678901.example.com/api'
-      );
-      await proxyToSandbox(httpRequest, mockEnv);
-      expect(mockSandbox.validatePortToken).toHaveBeenCalledWith(
-        8080,
-        'token12345678901'
-      );
-    });
-
-    it('should reject requests with invalid token', async () => {
-      vi.mocked(mockSandbox.validatePortToken as any).mockResolvedValue(false);
-
-      const request = new Request(
-        'https://8080-sandbox-invalidtoken1234.example.com/ws',
-        {
-          headers: { Upgrade: 'websocket' }
-        }
-      );
-
-      const response = await proxyToSandbox(request, mockEnv);
-
-      expect(response?.status).toBe(404);
-      expect(mockSandbox.fetch).not.toHaveBeenCalled();
-
-      const body = await response?.json();
-      expect(body).toMatchObject({
-        error: 'Access denied: Invalid token or port not exposed',
-        code: 'INVALID_TOKEN'
-      });
-    });
-
-    it('should reject reserved port 3000', async () => {
-      // Port 3000 is reserved as control plane port and rejected by validatePort()
-      const request = new Request(
-        'https://3000-sandbox-anytoken12345678.example.com/status',
-        {
-          method: 'GET'
-        }
-      );
-
-      const response = await proxyToSandbox(request, mockEnv);
-
-      // Port 3000 is reserved and should be rejected (extractSandboxRoute returns null)
-      expect(response).toBeNull();
-      expect(mockSandbox.validatePortToken).not.toHaveBeenCalled();
+      expect(mockSandbox.fetch).toHaveBeenCalledTimes(1);
       expect(mockSandbox.containerFetch).not.toHaveBeenCalled();
+      expect(getForwardedRequest().headers.get('Accept')).toBe(
+        'text/event-stream'
+      );
     });
-  });
 
-  describe('Port routing', () => {
-    it('should route to correct port from subdomain', async () => {
+    it('routes to the parsed preview port and sandbox ID', async () => {
       const request = new Request(
         'https://9000-sandbox-token12345678901.example.com/api',
         {
@@ -226,37 +161,158 @@ describe('proxyToSandbox - WebSocket Support', () => {
 
       await proxyToSandbox(request, mockEnv);
 
-      expect(mockSandbox.validatePortToken).toHaveBeenCalledWith(
-        9000,
+      expect(getSandbox).toHaveBeenCalledWith(mockEnv.Sandbox, 'sandbox', {
+        normalizeId: true
+      });
+
+      const forwarded = getForwardedRequest();
+      expect(forwarded.headers.get('x-sandbox-preview-port')).toBe('9000');
+      expect(forwarded.headers.get('x-sandbox-preview-token')).toBe(
         'token12345678901'
+      );
+    });
+
+    it('overwrites spoofed internal preview headers with parsed route values', async () => {
+      const request = new Request(
+        'https://8080-test-sandbox-token12345678901.example.com/hello',
+        {
+          headers: {
+            'x-sandbox-preview-proxy': '0',
+            'x-sandbox-preview-port': '9999',
+            'x-sandbox-preview-token': 'wrongtoken',
+            'x-sandbox-preview-sandbox-id': 'wrong-sandbox'
+          }
+        }
+      );
+
+      await proxyToSandbox(request, mockEnv);
+
+      const forwarded = getForwardedRequest();
+      expect(forwarded.headers.get('x-sandbox-preview-proxy')).toBe('1');
+      expect(forwarded.headers.get('x-sandbox-preview-port')).toBe('8080');
+      expect(forwarded.headers.get('x-sandbox-preview-token')).toBe(
+        'token12345678901'
+      );
+      expect(forwarded.headers.get('x-sandbox-preview-sandbox-id')).toBe(
+        'test-sandbox'
       );
     });
   });
 
+  describe('Sandbox response forwarding', () => {
+    it('returns invalid-token responses from the Sandbox Durable Object', async () => {
+      vi.mocked(mockSandbox.fetch).mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: 'Access denied: Invalid token or port not exposed',
+            code: 'INVALID_TOKEN'
+          }),
+          {
+            status: 404,
+            headers: { 'Content-Type': 'application/json' }
+          }
+        )
+      );
+
+      const request = new Request(
+        'https://8080-sandbox-invalidtoken1234.example.com/api'
+      );
+
+      const response = await proxyToSandbox(request, mockEnv);
+
+      expect(response?.status).toBe(404);
+      expect(mockSandbox.fetch).toHaveBeenCalledTimes(1);
+      expect(mockSandbox.containerFetch).not.toHaveBeenCalled();
+      expect(await response?.json()).toMatchObject({
+        code: 'INVALID_TOKEN'
+      });
+    });
+
+    it('returns stale preview URL responses from the Sandbox Durable Object', async () => {
+      vi.mocked(mockSandbox.fetch).mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error:
+              'Preview URL is stale because the sandbox runtime is not active',
+            code: 'STALE_PREVIEW_URL'
+          }),
+          {
+            status: 410,
+            headers: { 'Content-Type': 'application/json' }
+          }
+        )
+      );
+
+      const request = new Request(
+        'https://8080-sandbox-token12345678901.example.com/api'
+      );
+
+      const response = await proxyToSandbox(request, mockEnv);
+
+      expect(response?.status).toBe(410);
+      expect(mockSandbox.fetch).toHaveBeenCalledTimes(1);
+      expect(mockSandbox.containerFetch).not.toHaveBeenCalled();
+      expect(await response?.json()).toMatchObject({
+        code: 'STALE_PREVIEW_URL'
+      });
+    });
+  });
+
   describe('Non-sandbox requests', () => {
-    it('should return null for non-sandbox URLs', async () => {
+    it('returns null for non-sandbox URLs without creating a sandbox', async () => {
       const request = new Request('https://example.com/some-path');
 
       const response = await proxyToSandbox(request, mockEnv);
 
       expect(response).toBeNull();
+      expect(getSandbox).not.toHaveBeenCalled();
       expect(mockSandbox.fetch).not.toHaveBeenCalled();
       expect(mockSandbox.containerFetch).not.toHaveBeenCalled();
     });
 
-    it('should return null for invalid subdomain patterns', async () => {
+    it('returns null for invalid subdomain patterns without creating a sandbox', async () => {
       const request = new Request('https://invalid-pattern.example.com');
 
       const response = await proxyToSandbox(request, mockEnv);
 
       expect(response).toBeNull();
+      expect(getSandbox).not.toHaveBeenCalled();
+      expect(mockSandbox.fetch).not.toHaveBeenCalled();
+      expect(mockSandbox.containerFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns null for missing preview URL tokens without creating a sandbox', async () => {
+      const request = new Request('https://8080-sandbox.example.com');
+
+      const response = await proxyToSandbox(request, mockEnv);
+
+      expect(response).toBeNull();
+      expect(getSandbox).not.toHaveBeenCalled();
+      expect(mockSandbox.fetch).not.toHaveBeenCalled();
+      expect(mockSandbox.containerFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects reserved port 3000 before creating a sandbox', async () => {
+      const request = new Request(
+        'https://3000-sandbox-anytoken12345678.example.com/status',
+        {
+          method: 'GET'
+        }
+      );
+
+      const response = await proxyToSandbox(request, mockEnv);
+
+      expect(response).toBeNull();
+      expect(getSandbox).not.toHaveBeenCalled();
+      expect(mockSandbox.fetch).not.toHaveBeenCalled();
+      expect(mockSandbox.containerFetch).not.toHaveBeenCalled();
     });
   });
 
   describe('Error handling', () => {
-    it('should handle errors during WebSocket routing', async () => {
-      (mockSandbox.fetch as any).mockImplementation(() =>
-        Promise.reject(new Error('Connection failed'))
+    it('returns a proxy routing error when Sandbox fetch fails', async () => {
+      vi.mocked(mockSandbox.fetch).mockRejectedValue(
+        new Error('Connection failed')
       );
 
       const request = new Request(
@@ -271,22 +327,7 @@ describe('proxyToSandbox - WebSocket Support', () => {
       const response = await proxyToSandbox(request, mockEnv);
 
       expect(response?.status).toBe(500);
-      const text = await response?.text();
-      expect(text).toBe('Proxy routing error');
-    });
-
-    it('should handle errors during HTTP routing', async () => {
-      (mockSandbox.containerFetch as any).mockImplementation(() =>
-        Promise.reject(new Error('Service error'))
-      );
-
-      const request = new Request(
-        'https://8080-sandbox-token12345678901.example.com/api'
-      );
-
-      const response = await proxyToSandbox(request, mockEnv);
-
-      expect(response?.status).toBe(500);
+      expect(await response?.text()).toBe('Proxy routing error');
     });
   });
 });

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -2198,36 +2198,34 @@ describe('Sandbox - Automatic Session Management', () => {
   });
 
   describe('tunnels lifecycle storage', () => {
-    it('onStart() preserves named-tunnel records across restart and drops quick ones', async () => {
-      // `pruneTunnelsForRestart` walks the tunnels map: quick tunnels
-      // (no `name`) get dropped, named tunnels stay and gain
-      // `needsRespawn: true` in meta so destroy() can still clean up
-      // their Cloudflare-side resources after the restart.
-      const storedTunnels: Record<string, unknown> = {
-        '8080': {
-          id: 'quick-abc',
-          port: 8080,
-          url: 'https://x.trycloudflare.com',
-          hostname: 'x.trycloudflare.com',
-          createdAt: '2024-01-01T00:00:00.000Z'
-        },
-        '8081': {
-          id: 'uuid-1',
-          port: 8081,
-          name: 'app',
-          hostname: 'app.example.com',
-          url: 'https://app.example.com',
-          createdAt: '2024-01-01T00:00:00.000Z'
-        }
-      };
-      const storedMeta: Record<string, unknown> = {
-        '8080': { optionsHash: 'quick' },
-        '8081': { optionsHash: 'named:app', dnsRecordId: 'rec-1' }
-      };
+    function seedMixedTunnelStorage(): Array<{ key: string; value: unknown }> {
       const puts: Array<{ key: string; value: unknown }> = [];
       vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) => {
-        if (key === 'tunnels') return storedTunnels as any;
-        if (key === 'tunnels:meta') return storedMeta as any;
+        if (key === 'tunnels') {
+          return {
+            '8080': {
+              id: 'quick-abc',
+              port: 8080,
+              url: 'https://x.trycloudflare.com',
+              hostname: 'x.trycloudflare.com',
+              createdAt: '2024-01-01T00:00:00.000Z'
+            },
+            '8081': {
+              id: 'uuid-1',
+              port: 8081,
+              name: 'app',
+              hostname: 'app.example.com',
+              url: 'https://app.example.com',
+              createdAt: '2024-01-01T00:00:00.000Z'
+            }
+          };
+        }
+        if (key === 'tunnels:meta') {
+          return {
+            '8080': { optionsHash: 'quick' },
+            '8081': { optionsHash: 'named:app', dnsRecordId: 'rec-1' }
+          };
+        }
         return undefined as any;
       });
       vi.mocked(mockCtx.storage!.put).mockImplementation(
@@ -2235,25 +2233,42 @@ describe('Sandbox - Automatic Session Management', () => {
           puts.push({ key, value });
         }
       );
-      // The handler uses storage.transaction; the test mock passes the
-      // storage object itself through, which is good enough here.
       (mockCtx.storage as unknown as { transaction: unknown }).transaction = vi
         .fn()
         .mockImplementation(
           async (closure: (txn: unknown) => Promise<unknown>) =>
             closure(mockCtx.storage)
         );
+      return puts;
+    }
 
-      await (sandbox as any).onStart();
-
+    function expectOnlyNamedTunnelPreserved(
+      puts: Array<{ key: string; value: unknown }>
+    ): void {
       const nextTunnels = puts.find((p) => p.key === 'tunnels')
         ?.value as Record<string, { name?: string }>;
       const nextMeta = puts.find((p) => p.key === 'tunnels:meta')
         ?.value as Record<string, { needsRespawn?: boolean }>;
-      expect(nextTunnels).toBeDefined();
-      expect(Object.keys(nextTunnels)).toEqual(['8081']);
+
+      expect(Object.keys(nextTunnels ?? {})).toEqual(['8081']);
       expect(nextMeta?.['8081']?.needsRespawn).toBe(true);
       expect(nextMeta?.['8080']).toBeUndefined();
+    }
+
+    it('onStart() preserves named-tunnel records across restart and drops quick ones', async () => {
+      const puts = seedMixedTunnelStorage();
+
+      await (sandbox as any).onStart();
+
+      expectOnlyNamedTunnelPreserved(puts);
+    });
+
+    it('onStop() preserves named-tunnel records and drops quick ones', async () => {
+      const puts = seedMixedTunnelStorage();
+
+      await (sandbox as any).onStop();
+
+      expectOnlyNamedTunnelPreserved(puts);
     });
 
     it('destroy() deletes the tunnels storage key', async () => {

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -45,8 +45,8 @@ vi.mock('@cloudflare/containers', () => {
       // Mock implementation for HTTP path
       return new Response('Mock Container HTTP fetch');
     }
-    async fetchIfRunning(request: Request, port: number): Promise<Response> {
-      return new Response(`Mock running fetch ${port}`);
+    async startAndWaitForPorts(): Promise<void> {
+      // No-op: real container startup is not needed in tests.
     }
     async destroy(): Promise<void> {
       // No-op: real container destroy is not needed in tests; individual
@@ -83,7 +83,11 @@ interface MockCtx {
   storage: MockStorage;
   blockConcurrencyWhile: ReturnType<typeof vi.fn>;
   waitUntil: ReturnType<typeof vi.fn>;
-  container: { running: boolean };
+  container: {
+    running: boolean;
+    getTcpPort?: ReturnType<typeof vi.fn>;
+    start?: ReturnType<typeof vi.fn>;
+  };
   id: {
     toString: () => string;
     equals: ReturnType<typeof vi.fn>;
@@ -129,6 +133,38 @@ function mockPreviewStorageGet(
   );
 }
 
+function createPreviewProxyRequest(path = '/api'): Request {
+  return new Request(
+    `https://8080-test-sandbox-token12345678901.example.com${path}`,
+    {
+      headers: {
+        'x-sandbox-preview-proxy': '1',
+        'x-sandbox-preview-port': '8080',
+        'x-sandbox-preview-token': 'token12345678901',
+        'x-sandbox-preview-sandbox-id': 'test-sandbox'
+      }
+    }
+  );
+}
+
+function createPreviewWebSocketRequest(): Request {
+  return new Request(
+    'https://8080-test-sandbox-token12345678901.example.com/ws',
+    {
+      headers: {
+        Upgrade: 'websocket',
+        Connection: 'Upgrade',
+        'Sec-WebSocket-Key': 'test-key-123',
+        'Sec-WebSocket-Version': '13',
+        'x-sandbox-preview-proxy': '1',
+        'x-sandbox-preview-port': '8080',
+        'x-sandbox-preview-token': 'token12345678901',
+        'x-sandbox-preview-sandbox-id': 'test-sandbox'
+      }
+    }
+  );
+}
+
 describe('Sandbox - Automatic Session Management', () => {
   let sandbox: Sandbox;
   let mockCtx: MockCtx;
@@ -160,7 +196,7 @@ describe('Sandbox - Automatic Session Management', () => {
           <T>(callback: () => Promise<T>): Promise<T> => callback()
         ),
       waitUntil: vi.fn(),
-      container: { running: true },
+      container: { running: true, start: vi.fn() },
       id: {
         toString: () => 'test-sandbox-id',
         equals: vi.fn(),
@@ -269,7 +305,7 @@ describe('Sandbox - Automatic Session Management', () => {
             <T>(callback: () => Promise<T>): Promise<T> => callback()
           ),
         waitUntil: vi.fn(),
-        container: { running: true },
+        container: { running: true, start: vi.fn() },
         id: {
           toString: () => 'null-enable-default-session-sandbox',
           equals: vi.fn(),
@@ -1361,65 +1397,51 @@ describe('Sandbox - Automatic Session Management', () => {
       expect(passedRequest.headers.get('Sec-WebSocket-Version')).toBe('13');
     });
 
-    it('routes active preview proxy requests through fetchIfRunning', async () => {
-      (mockCtx as any).container = { running: true };
+    it('routes active preview proxy requests through the TCP port without starting', async () => {
+      const tcpFetch = vi.fn().mockResolvedValue(new Response('preview ok'));
+      mockCtx.container.running = true;
+      mockCtx.container.getTcpPort = vi
+        .fn()
+        .mockReturnValue({ fetch: tcpFetch });
       mockPreviewStorageGet(mockCtx, activePreviewStorageState());
-      const fetchIfRunningSpy = vi
-        .spyOn(sandbox, 'fetchIfRunning')
-        .mockResolvedValue(new Response('preview ok'));
       const containerFetchSpy = vi.spyOn(sandbox, 'containerFetch');
+      const startAndWaitSpy = vi.spyOn(sandbox, 'startAndWaitForPorts');
 
       const response = await sandbox.fetch(
-        new Request(
-          'https://8080-test-sandbox-token12345678901.example.com/api',
-          {
-            headers: {
-              'x-sandbox-preview-proxy': '1',
-              'x-sandbox-preview-port': '8080',
-              'x-sandbox-preview-token': 'token12345678901',
-              'x-sandbox-preview-sandbox-id': 'spoofed-sandbox'
-            }
-          }
-        )
+        createPreviewProxyRequest('/hello?x=1')
       );
 
       expect(await response.text()).toBe('preview ok');
-      expect(fetchIfRunningSpy).toHaveBeenCalledTimes(1);
-      const forwardedRequest = fetchIfRunningSpy.mock.calls[0][0] as Request;
+      expect(containerFetchSpy).not.toHaveBeenCalled();
+      expect(startAndWaitSpy).not.toHaveBeenCalled();
+      expect(mockCtx.container.start).not.toHaveBeenCalled();
+      expect(mockCtx.container.getTcpPort).toHaveBeenCalledWith(8080);
+      expect(tcpFetch).toHaveBeenCalledWith(
+        'http://localhost:8080/hello?x=1',
+        expect.any(Request)
+      );
+      const forwardedRequest = tcpFetch.mock.calls[0][1] as Request;
       expect(forwardedRequest.headers.get('X-Sandbox-Name')).toBe(
         'test-sandbox'
       );
-      expect(fetchIfRunningSpy).toHaveBeenCalledWith(expect.any(Request), 8080);
-      expect(containerFetchSpy).not.toHaveBeenCalled();
     });
 
     it('preserves WebSocket preview proxy requests when forwarding', async () => {
-      (mockCtx as any).container = { running: true };
-      mockPreviewStorageGet(mockCtx, activePreviewStorageState());
-      const fetchIfRunningSpy = vi
-        .spyOn(sandbox, 'fetchIfRunning')
+      const tcpFetch = vi
+        .fn()
         .mockResolvedValue(new Response('preview websocket ok'));
+      mockCtx.container.running = true;
+      mockCtx.container.getTcpPort = vi
+        .fn()
+        .mockReturnValue({ fetch: tcpFetch });
+      mockPreviewStorageGet(mockCtx, activePreviewStorageState());
 
-      const request = new Request(
-        'https://8080-test-sandbox-token12345678901.example.com/ws',
-        {
-          headers: {
-            Upgrade: 'websocket',
-            Connection: 'Upgrade',
-            'Sec-WebSocket-Key': 'test-key-123',
-            'Sec-WebSocket-Version': '13',
-            'x-sandbox-preview-proxy': '1',
-            'x-sandbox-preview-port': '8080',
-            'x-sandbox-preview-token': 'token12345678901',
-            'x-sandbox-preview-sandbox-id': 'test-sandbox'
-          }
-        }
-      );
+      const request = createPreviewWebSocketRequest();
 
       await sandbox.fetch(request);
 
-      expect(fetchIfRunningSpy).toHaveBeenCalledTimes(1);
-      const forwardedRequest = fetchIfRunningSpy.mock.calls[0][0] as Request;
+      expect(tcpFetch).toHaveBeenCalledTimes(1);
+      const forwardedRequest = tcpFetch.mock.calls[0][1] as Request;
       expect(forwardedRequest.url).toBe(request.url);
       expect(forwardedRequest.headers.get('Upgrade')).toBe('websocket');
       expect(forwardedRequest.headers.get('Connection')).toBe('Upgrade');
@@ -1433,32 +1455,44 @@ describe('Sandbox - Automatic Session Management', () => {
     });
 
     it('returns user 503 responses when the runtime remains active', async () => {
-      (mockCtx as any).container = { running: true };
+      const tcpFetch = vi
+        .fn()
+        .mockResolvedValue(
+          new Response('service temporarily unavailable', { status: 503 })
+        );
+      mockCtx.container.running = true;
+      mockCtx.container.getTcpPort = vi
+        .fn()
+        .mockReturnValue({ fetch: tcpFetch });
       mockPreviewStorageGet(mockCtx, activePreviewStorageState());
-      vi.spyOn(sandbox, 'fetchIfRunning').mockResolvedValue(
-        new Response('service temporarily unavailable', { status: 503 })
-      );
 
-      const response = await sandbox.fetch(
-        new Request(
-          'https://8080-test-sandbox-token12345678901.example.com/api',
-          {
-            headers: {
-              'x-sandbox-preview-proxy': '1',
-              'x-sandbox-preview-port': '8080',
-              'x-sandbox-preview-token': 'token12345678901',
-              'x-sandbox-preview-sandbox-id': 'test-sandbox'
-            }
-          }
-        )
-      );
+      const response = await sandbox.fetch(createPreviewProxyRequest());
 
       expect(response.status).toBe(503);
       expect(await response.text()).toBe('service temporarily unavailable');
     });
 
-    it('returns stale when the runtime goes inactive while forwarding', async () => {
-      (mockCtx as any).container = { running: true };
+    it('returns stale without forwarding when the container is stopped', async () => {
+      mockCtx.container.running = false;
+      mockCtx.container.getTcpPort = vi.fn();
+      mockPreviewStorageGet(mockCtx, activePreviewStorageState());
+      const containerFetchSpy = vi.spyOn(sandbox, 'containerFetch');
+      const startAndWaitSpy = vi.spyOn(sandbox, 'startAndWaitForPorts');
+
+      const response = await sandbox.fetch(createPreviewProxyRequest());
+
+      expect(response.status).toBe(410);
+      expect(await response.json()).toMatchObject({
+        code: 'STALE_PREVIEW_URL'
+      });
+      expect(mockCtx.container.getTcpPort).not.toHaveBeenCalled();
+      expect(containerFetchSpy).not.toHaveBeenCalled();
+      expect(startAndWaitSpy).not.toHaveBeenCalled();
+      expect(mockCtx.container.start).not.toHaveBeenCalled();
+    });
+
+    it('returns stale when the runtime goes inactive during network loss', async () => {
+      mockCtx.container.running = true;
       let runtimeActive = true;
       vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) => {
         const state = activePreviewStorageState();
@@ -1467,26 +1501,15 @@ describe('Sandbox - Automatic Session Management', () => {
         }
         return state[key as keyof typeof state] ?? null;
       });
-      vi.spyOn(sandbox, 'fetchIfRunning').mockImplementation(async () => {
-        // Simulate the runtime going inactive after preview validation but
-        // before the post-forward liveness check.
+      const tcpFetch = vi.fn().mockImplementation(async () => {
         runtimeActive = false;
-        return new Response('Container is not running', { status: 503 });
+        throw new Error('Network connection lost.');
       });
+      mockCtx.container.getTcpPort = vi
+        .fn()
+        .mockReturnValue({ fetch: tcpFetch });
 
-      const response = await sandbox.fetch(
-        new Request(
-          'https://8080-test-sandbox-token12345678901.example.com/api',
-          {
-            headers: {
-              'x-sandbox-preview-proxy': '1',
-              'x-sandbox-preview-port': '8080',
-              'x-sandbox-preview-token': 'token12345678901',
-              'x-sandbox-preview-sandbox-id': 'test-sandbox'
-            }
-          }
-        )
-      );
+      const response = await sandbox.fetch(createPreviewProxyRequest());
 
       expect(response.status).toBe(410);
       expect(await response.json()).toMatchObject({
@@ -1494,12 +1517,29 @@ describe('Sandbox - Automatic Session Management', () => {
       });
     });
 
+    it('returns controlled disconnect response when network loss keeps the runtime active', async () => {
+      mockCtx.container.running = true;
+      mockPreviewStorageGet(mockCtx, activePreviewStorageState());
+      const tcpFetch = vi
+        .fn()
+        .mockRejectedValue(new Error('Network connection lost.'));
+      mockCtx.container.getTcpPort = vi
+        .fn()
+        .mockReturnValue({ fetch: tcpFetch });
+
+      const response = await sandbox.fetch(createPreviewProxyRequest());
+
+      expect(response.status).toBe(500);
+      expect(await response.text()).toBe(
+        'Container suddenly disconnected, try again'
+      );
+    });
+
     it('rejects preview proxy requests without durable authorization', async () => {
-      (mockCtx as any).container = { running: true };
+      mockCtx.container.running = true;
       vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) =>
         key === 'portTokens' ? {} : null
       );
-      const fetchIfRunningSpy = vi.spyOn(sandbox, 'fetchIfRunning');
       const containerFetchSpy = vi.spyOn(sandbox, 'containerFetch');
 
       const response = await sandbox.fetch(
@@ -1517,12 +1557,11 @@ describe('Sandbox - Automatic Session Management', () => {
       expect(await response.json()).toMatchObject({
         code: 'INVALID_TOKEN'
       });
-      expect(fetchIfRunningSpy).not.toHaveBeenCalled();
       expect(containerFetchSpy).not.toHaveBeenCalled();
     });
 
     it('rejects preview proxy requests without current-runtime activation', async () => {
-      (mockCtx as any).container = { running: true };
+      mockCtx.container.running = true;
       vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) => {
         if (key === 'portTokens') {
           return { '8080': { token: 'token12345678901' } };
@@ -1535,33 +1574,19 @@ describe('Sandbox - Automatic Session Management', () => {
         }
         return null;
       });
-      const fetchIfRunningSpy = vi.spyOn(sandbox, 'fetchIfRunning');
       const containerFetchSpy = vi.spyOn(sandbox, 'containerFetch');
 
-      const response = await sandbox.fetch(
-        new Request(
-          'https://8080-test-sandbox-token12345678901.example.com/api',
-          {
-            headers: {
-              'x-sandbox-preview-proxy': '1',
-              'x-sandbox-preview-port': '8080',
-              'x-sandbox-preview-token': 'token12345678901',
-              'x-sandbox-preview-sandbox-id': 'test-sandbox'
-            }
-          }
-        )
-      );
+      const response = await sandbox.fetch(createPreviewProxyRequest());
 
       expect(response.status).toBe(410);
       expect(await response.json()).toMatchObject({
         code: 'STALE_PREVIEW_URL'
       });
-      expect(fetchIfRunningSpy).not.toHaveBeenCalled();
       expect(containerFetchSpy).not.toHaveBeenCalled();
     });
 
     it('rejects persisted preview auth without runtime identity or activation', async () => {
-      (mockCtx as any).container = { running: true };
+      mockCtx.container.running = true;
       vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) => {
         if (key === 'portTokens') {
           return { '8080': { token: 'token12345678901' } };
@@ -1574,28 +1599,14 @@ describe('Sandbox - Automatic Session Management', () => {
         }
         return null;
       });
-      const fetchIfRunningSpy = vi.spyOn(sandbox, 'fetchIfRunning');
       const containerFetchSpy = vi.spyOn(sandbox, 'containerFetch');
 
-      const response = await sandbox.fetch(
-        new Request(
-          'https://8080-test-sandbox-token12345678901.example.com/api',
-          {
-            headers: {
-              'x-sandbox-preview-proxy': '1',
-              'x-sandbox-preview-port': '8080',
-              'x-sandbox-preview-token': 'token12345678901',
-              'x-sandbox-preview-sandbox-id': 'test-sandbox'
-            }
-          }
-        )
-      );
+      const response = await sandbox.fetch(createPreviewProxyRequest());
 
       expect(response.status).toBe(410);
       expect(await response.json()).toMatchObject({
         code: 'STALE_PREVIEW_URL'
       });
-      expect(fetchIfRunningSpy).not.toHaveBeenCalled();
       expect(containerFetchSpy).not.toHaveBeenCalled();
     });
   });

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1,6 +1,7 @@
 import { Container } from '@cloudflare/containers';
 import { DISABLE_SESSION_TOKEN } from '@repo/shared/internal';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RuntimeIdentityInactiveError } from '../src/current-runtime-identity';
 import { PortNotExposedError, ProcessNotFoundError } from '../src/errors';
 import { connect, Sandbox } from '../src/sandbox';
 
@@ -44,9 +45,15 @@ vi.mock('@cloudflare/containers', () => {
       // Mock implementation for HTTP path
       return new Response('Mock Container HTTP fetch');
     }
+    async fetchIfRunning(request: Request, port: number): Promise<Response> {
+      return new Response(`Mock running fetch ${port}`);
+    }
     async destroy(): Promise<void> {
       // No-op: real container destroy is not needed in tests; individual
       // tests that want to simulate destroy behavior use vi.spyOn.
+    }
+    async stop(): Promise<void> {
+      // No-op: real container stop is not needed in tests.
     }
     async getState() {
       // Mock implementation - return healthy state
@@ -69,17 +76,57 @@ interface MockStorage {
   put: ReturnType<typeof vi.fn>;
   delete: ReturnType<typeof vi.fn>;
   list: ReturnType<typeof vi.fn>;
+  transaction: ReturnType<typeof vi.fn>;
 }
 
 interface MockCtx {
   storage: MockStorage;
   blockConcurrencyWhile: ReturnType<typeof vi.fn>;
   waitUntil: ReturnType<typeof vi.fn>;
+  container: { running: boolean };
   id: {
     toString: () => string;
     equals: ReturnType<typeof vi.fn>;
     name: string;
   };
+}
+
+const PREVIEW_TEST_PORT = 8080;
+const PREVIEW_TEST_TOKEN = 'token12345678901';
+const PREVIEW_TEST_RUNTIME_ID = 'runtime-1';
+
+function activePreviewStorageState({
+  port = PREVIEW_TEST_PORT,
+  token = PREVIEW_TEST_TOKEN,
+  runtimeIdentityID = PREVIEW_TEST_RUNTIME_ID
+}: {
+  port?: number;
+  token?: string;
+  runtimeIdentityID?: string;
+} = {}) {
+  return {
+    portTokens: {
+      [port.toString()]: { token }
+    },
+    currentRuntimeIdentity: {
+      id: runtimeIdentityID
+    },
+    activePreviewPorts: {
+      [port.toString()]: {
+        runtimeIdentityID,
+        token
+      }
+    }
+  };
+}
+
+function mockPreviewStorageGet(
+  mockCtx: MockCtx,
+  state: Partial<ReturnType<typeof activePreviewStorageState>>
+): void {
+  vi.mocked(mockCtx.storage.get).mockImplementation(
+    async (key) => state[key as keyof typeof state] ?? null
+  );
 }
 
 describe('Sandbox - Automatic Session Management', () => {
@@ -90,20 +137,30 @@ describe('Sandbox - Automatic Session Management', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
 
+    const storageState = new Map<string, unknown>();
+
+    const storage = {
+      get: vi.fn(async (key: string) => storageState.get(key) ?? null),
+      put: vi.fn(async (key: string, value: unknown) => {
+        storageState.set(key, value);
+      }),
+      delete: vi.fn(async (key: string) => {
+        storageState.delete(key);
+      }),
+      list: vi.fn().mockResolvedValue(new Map()),
+      transaction: vi.fn(async (callback) => callback(storage))
+    };
+
     // Mock DurableObjectState
     mockCtx = {
-      storage: {
-        get: vi.fn().mockResolvedValue(null),
-        put: vi.fn().mockResolvedValue(undefined),
-        delete: vi.fn().mockResolvedValue(undefined),
-        list: vi.fn().mockResolvedValue(new Map())
-      } as any,
+      storage: storage as any,
       blockConcurrencyWhile: vi
         .fn()
         .mockImplementation(
           <T>(callback: () => Promise<T>): Promise<T> => callback()
         ),
       waitUntil: vi.fn(),
+      container: { running: true },
       id: {
         toString: () => 'test-sandbox-id',
         equals: vi.fn(),
@@ -212,6 +269,7 @@ describe('Sandbox - Automatic Session Management', () => {
             <T>(callback: () => Promise<T>): Promise<T> => callback()
           ),
         waitUntil: vi.fn(),
+        container: { running: true },
         id: {
           toString: () => 'null-enable-default-session-sandbox',
           equals: vi.fn(),
@@ -1302,6 +1360,244 @@ describe('Sandbox - Automatic Session Management', () => {
       );
       expect(passedRequest.headers.get('Sec-WebSocket-Version')).toBe('13');
     });
+
+    it('routes active preview proxy requests through fetchIfRunning', async () => {
+      (mockCtx as any).container = { running: true };
+      mockPreviewStorageGet(mockCtx, activePreviewStorageState());
+      const fetchIfRunningSpy = vi
+        .spyOn(sandbox, 'fetchIfRunning')
+        .mockResolvedValue(new Response('preview ok'));
+      const containerFetchSpy = vi.spyOn(sandbox, 'containerFetch');
+
+      const response = await sandbox.fetch(
+        new Request(
+          'https://8080-test-sandbox-token12345678901.example.com/api',
+          {
+            headers: {
+              'x-sandbox-preview-proxy': '1',
+              'x-sandbox-preview-port': '8080',
+              'x-sandbox-preview-token': 'token12345678901',
+              'x-sandbox-preview-sandbox-id': 'spoofed-sandbox'
+            }
+          }
+        )
+      );
+
+      expect(await response.text()).toBe('preview ok');
+      expect(fetchIfRunningSpy).toHaveBeenCalledTimes(1);
+      const forwardedRequest = fetchIfRunningSpy.mock.calls[0][0] as Request;
+      expect(forwardedRequest.headers.get('X-Sandbox-Name')).toBe(
+        'test-sandbox'
+      );
+      expect(fetchIfRunningSpy).toHaveBeenCalledWith(expect.any(Request), 8080);
+      expect(containerFetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('preserves WebSocket preview proxy requests when forwarding', async () => {
+      (mockCtx as any).container = { running: true };
+      mockPreviewStorageGet(mockCtx, activePreviewStorageState());
+      const fetchIfRunningSpy = vi
+        .spyOn(sandbox, 'fetchIfRunning')
+        .mockResolvedValue(new Response('preview websocket ok'));
+
+      const request = new Request(
+        'https://8080-test-sandbox-token12345678901.example.com/ws',
+        {
+          headers: {
+            Upgrade: 'websocket',
+            Connection: 'Upgrade',
+            'Sec-WebSocket-Key': 'test-key-123',
+            'Sec-WebSocket-Version': '13',
+            'x-sandbox-preview-proxy': '1',
+            'x-sandbox-preview-port': '8080',
+            'x-sandbox-preview-token': 'token12345678901',
+            'x-sandbox-preview-sandbox-id': 'test-sandbox'
+          }
+        }
+      );
+
+      await sandbox.fetch(request);
+
+      expect(fetchIfRunningSpy).toHaveBeenCalledTimes(1);
+      const forwardedRequest = fetchIfRunningSpy.mock.calls[0][0] as Request;
+      expect(forwardedRequest.url).toBe(request.url);
+      expect(forwardedRequest.headers.get('Upgrade')).toBe('websocket');
+      expect(forwardedRequest.headers.get('Connection')).toBe('Upgrade');
+      expect(forwardedRequest.headers.get('Sec-WebSocket-Key')).toBe(
+        'test-key-123'
+      );
+      expect(forwardedRequest.headers.get('Sec-WebSocket-Version')).toBe('13');
+      expect(forwardedRequest.headers.has('x-sandbox-preview-proxy')).toBe(
+        false
+      );
+    });
+
+    it('returns user 503 responses when the runtime remains active', async () => {
+      (mockCtx as any).container = { running: true };
+      mockPreviewStorageGet(mockCtx, activePreviewStorageState());
+      vi.spyOn(sandbox, 'fetchIfRunning').mockResolvedValue(
+        new Response('service temporarily unavailable', { status: 503 })
+      );
+
+      const response = await sandbox.fetch(
+        new Request(
+          'https://8080-test-sandbox-token12345678901.example.com/api',
+          {
+            headers: {
+              'x-sandbox-preview-proxy': '1',
+              'x-sandbox-preview-port': '8080',
+              'x-sandbox-preview-token': 'token12345678901',
+              'x-sandbox-preview-sandbox-id': 'test-sandbox'
+            }
+          }
+        )
+      );
+
+      expect(response.status).toBe(503);
+      expect(await response.text()).toBe('service temporarily unavailable');
+    });
+
+    it('returns stale when the runtime goes inactive while forwarding', async () => {
+      (mockCtx as any).container = { running: true };
+      let runtimeActive = true;
+      vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) => {
+        const state = activePreviewStorageState();
+        if (key === 'currentRuntimeIdentity') {
+          return runtimeActive ? state.currentRuntimeIdentity : null;
+        }
+        return state[key as keyof typeof state] ?? null;
+      });
+      vi.spyOn(sandbox, 'fetchIfRunning').mockImplementation(async () => {
+        // Simulate the runtime going inactive after preview validation but
+        // before the post-forward liveness check.
+        runtimeActive = false;
+        return new Response('Container is not running', { status: 503 });
+      });
+
+      const response = await sandbox.fetch(
+        new Request(
+          'https://8080-test-sandbox-token12345678901.example.com/api',
+          {
+            headers: {
+              'x-sandbox-preview-proxy': '1',
+              'x-sandbox-preview-port': '8080',
+              'x-sandbox-preview-token': 'token12345678901',
+              'x-sandbox-preview-sandbox-id': 'test-sandbox'
+            }
+          }
+        )
+      );
+
+      expect(response.status).toBe(410);
+      expect(await response.json()).toMatchObject({
+        code: 'STALE_PREVIEW_URL'
+      });
+    });
+
+    it('rejects preview proxy requests without durable authorization', async () => {
+      (mockCtx as any).container = { running: true };
+      vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) =>
+        key === 'portTokens' ? {} : null
+      );
+      const fetchIfRunningSpy = vi.spyOn(sandbox, 'fetchIfRunning');
+      const containerFetchSpy = vi.spyOn(sandbox, 'containerFetch');
+
+      const response = await sandbox.fetch(
+        new Request('https://8080-test-sandbox-badtoken.example.com/api', {
+          headers: {
+            'x-sandbox-preview-proxy': '1',
+            'x-sandbox-preview-port': '8080',
+            'x-sandbox-preview-token': 'badtoken',
+            'x-sandbox-preview-sandbox-id': 'test-sandbox'
+          }
+        })
+      );
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toMatchObject({
+        code: 'INVALID_TOKEN'
+      });
+      expect(fetchIfRunningSpy).not.toHaveBeenCalled();
+      expect(containerFetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects preview proxy requests without current-runtime activation', async () => {
+      (mockCtx as any).container = { running: true };
+      vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) => {
+        if (key === 'portTokens') {
+          return { '8080': { token: 'token12345678901' } };
+        }
+        if (key === 'currentRuntimeIdentity') {
+          return { id: 'runtime-1' };
+        }
+        if (key === 'activePreviewPorts') {
+          return {};
+        }
+        return null;
+      });
+      const fetchIfRunningSpy = vi.spyOn(sandbox, 'fetchIfRunning');
+      const containerFetchSpy = vi.spyOn(sandbox, 'containerFetch');
+
+      const response = await sandbox.fetch(
+        new Request(
+          'https://8080-test-sandbox-token12345678901.example.com/api',
+          {
+            headers: {
+              'x-sandbox-preview-proxy': '1',
+              'x-sandbox-preview-port': '8080',
+              'x-sandbox-preview-token': 'token12345678901',
+              'x-sandbox-preview-sandbox-id': 'test-sandbox'
+            }
+          }
+        )
+      );
+
+      expect(response.status).toBe(410);
+      expect(await response.json()).toMatchObject({
+        code: 'STALE_PREVIEW_URL'
+      });
+      expect(fetchIfRunningSpy).not.toHaveBeenCalled();
+      expect(containerFetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects persisted preview auth without runtime identity or activation', async () => {
+      (mockCtx as any).container = { running: true };
+      vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) => {
+        if (key === 'portTokens') {
+          return { '8080': { token: 'token12345678901' } };
+        }
+        if (key === 'currentRuntimeIdentity') {
+          return null;
+        }
+        if (key === 'activePreviewPorts') {
+          return null;
+        }
+        return null;
+      });
+      const fetchIfRunningSpy = vi.spyOn(sandbox, 'fetchIfRunning');
+      const containerFetchSpy = vi.spyOn(sandbox, 'containerFetch');
+
+      const response = await sandbox.fetch(
+        new Request(
+          'https://8080-test-sandbox-token12345678901.example.com/api',
+          {
+            headers: {
+              'x-sandbox-preview-proxy': '1',
+              'x-sandbox-preview-port': '8080',
+              'x-sandbox-preview-token': 'token12345678901',
+              'x-sandbox-preview-sandbox-id': 'test-sandbox'
+            }
+          }
+        )
+      );
+
+      expect(response.status).toBe(410);
+      expect(await response.json()).toMatchObject({
+        code: 'STALE_PREVIEW_URL'
+      });
+      expect(fetchIfRunningSpy).not.toHaveBeenCalled();
+      expect(containerFetchSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('wsConnect() method', () => {
@@ -1613,7 +1909,7 @@ describe('Sandbox - Automatic Session Management', () => {
     });
   });
 
-  describe('port restoration on container restart', () => {
+  describe('preview URL runtime activation', () => {
     beforeEach(async () => {
       await sandbox.setSandboxName('test-sandbox', false);
       vi.spyOn(sandbox.client.ports, 'exposePort').mockResolvedValue({
@@ -1629,95 +1925,60 @@ describe('Sandbox - Automatic Session Management', () => {
       } as any);
     });
 
-    it('should re-expose saved ports with their friendly names when the container starts', async () => {
+    it('onStart() marks a new current runtime without restoring saved ports', async () => {
       vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) =>
         key === 'portTokens'
           ? {
-              '8080': { token: 'tok8080', name: 'api' },
-              '9000': { token: 'tok9000', name: 'admin' }
+              '8080': { token: 'tok8080', name: 'api' }
             }
           : null
       );
 
-      await (sandbox as any).restoreExposedPorts();
+      await (sandbox as any).onStart();
 
-      expect(sandbox.client.ports.exposePort).toHaveBeenCalledTimes(2);
-      expect(sandbox.client.ports.exposePort).toHaveBeenCalledWith(
-        8080,
-        expect.any(String),
-        'api'
+      expect(mockCtx.storage.put).toHaveBeenCalledWith(
+        'currentRuntimeIdentity',
+        expect.objectContaining({
+          id: expect.any(String)
+        })
       );
-      expect(sandbox.client.ports.exposePort).toHaveBeenCalledWith(
-        9000,
-        expect.any(String),
-        'admin'
-      );
-    });
-
-    it('should migrate legacy string-only storage entries on restore', async () => {
-      vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) =>
-        key === 'portTokens' ? { '8080': 'legacytoken1234' } : null
-      );
-
-      await (sandbox as any).restoreExposedPorts();
-
-      expect(sandbox.client.ports.exposePort).toHaveBeenCalledWith(
-        8080,
-        expect.any(String),
-        undefined
-      );
-    });
-
-    it('should skip ports the container already reports as exposed', async () => {
-      vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) =>
-        key === 'portTokens' ? { '8080': { token: 'tok8080' } } : null
-      );
-      vi.mocked(sandbox.client.ports.getExposedPorts as any).mockResolvedValue({
-        success: true,
-        ports: [{ port: 8080, status: 'active' }],
-        count: 1,
-        timestamp: new Date().toISOString()
-      } as any);
-
-      await (sandbox as any).restoreExposedPorts();
-
+      expect(sandbox.client.ports.getExposedPorts).not.toHaveBeenCalled();
       expect(sandbox.client.ports.exposePort).not.toHaveBeenCalled();
     });
 
-    it('should continue restoring other ports when one fails', async () => {
-      vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) =>
-        key === 'portTokens'
-          ? {
-              '8080': { token: 'tok8080' },
-              '9000': { token: 'tok9000' }
-            }
-          : null
-      );
-      vi.mocked(sandbox.client.ports.exposePort as any)
-        .mockRejectedValueOnce(new Error('boom'))
-        .mockResolvedValue({
-          success: true,
-          port: 9000,
-          exposedAt: new Date().toISOString()
-        } as any);
-
-      await (sandbox as any).restoreExposedPorts();
-
-      // First call failed, second succeeded — both were attempted.
-      expect(sandbox.client.ports.exposePort).toHaveBeenCalledTimes(2);
-    });
-
-    it('onStop() must preserve portTokens so restore has something to read', async () => {
+    it('onStop() preserves durable auth and clears runtime-scoped preview state', async () => {
       await (sandbox as any).onStop();
 
-      // Nothing in the onStop path should delete portTokens.
       const deletedKeys = vi
         .mocked(mockCtx.storage!.delete)
         .mock.calls.map((call) => call[0]);
       expect(deletedKeys).not.toContain('portTokens');
+      expect(deletedKeys).toContain('activePreviewPorts');
+      expect(deletedKeys).toContain('currentRuntimeIdentity');
+      expect(deletedKeys).toContain('defaultSession');
     });
 
-    it('destroy() deletes portTokens before calling super.destroy()', async () => {
+    it('stop() clears runtime-scoped preview state before signaling the container', async () => {
+      const callOrder: string[] = [];
+      vi.mocked(mockCtx.storage!.delete).mockImplementation(async (key) => {
+        callOrder.push(`delete:${String(key)}`);
+      });
+      vi.spyOn(Container.prototype, 'stop').mockImplementation(async () => {
+        callOrder.push('super.stop');
+      });
+
+      await sandbox.stop();
+
+      expect(callOrder.indexOf('delete:activePreviewPorts')).toBeLessThan(
+        callOrder.indexOf('super.stop')
+      );
+      expect(callOrder.indexOf('delete:currentRuntimeIdentity')).toBeLessThan(
+        callOrder.indexOf('super.stop')
+      );
+      expect(callOrder).not.toContain('delete:portTokens');
+    });
+
+    it('destroy() clears preview auth and runtime-scoped state before calling super.destroy()', async () => {
       const callOrder: string[] = [];
 
       vi.mocked(mockCtx.storage!.delete).mockImplementation(async (key) => {
@@ -1730,20 +1991,31 @@ describe('Sandbox - Automatic Session Management', () => {
 
       await sandbox.destroy();
 
-      // super.destroy() is not serialized by blockConcurrencyWhile, so a
-      // concurrent validatePortToken() or start path can run during the
-      // await. This test pins the ordering that keeps stale reads out of
-      // that window: portTokens deletion before super.destroy().
-      const deleteIdx = callOrder.indexOf('delete:portTokens');
       const superIdx = callOrder.indexOf('super.destroy');
-
-      expect(deleteIdx).toBeGreaterThanOrEqual(0);
-      expect(superIdx).toBeGreaterThanOrEqual(0);
-      expect(deleteIdx).toBeLessThan(superIdx);
+      for (const key of [
+        'portTokens',
+        'activePreviewPorts',
+        'currentRuntimeIdentity'
+      ]) {
+        const deleteIdx = callOrder.indexOf(`delete:${key}`);
+        expect(deleteIdx).toBeGreaterThanOrEqual(0);
+        expect(deleteIdx).toBeLessThan(superIdx);
+      }
     });
 
-    it('exposePort() persists the friendly name alongside the token', async () => {
-      vi.mocked(mockCtx.storage!.get).mockResolvedValue({} as any);
+    it('exposePort() persists durable auth and current-runtime activation', async () => {
+      vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) => {
+        if (key === 'portTokens') {
+          return {};
+        }
+        if (key === 'currentRuntimeIdentity') {
+          return { id: 'runtime-1' };
+        }
+        if (key === 'activePreviewPorts') {
+          return {};
+        }
+        return null;
+      });
       const putSpy = vi.mocked(mockCtx.storage!.put);
 
       await sandbox.exposePort(8080, {
@@ -1752,82 +2024,176 @@ describe('Sandbox - Automatic Session Management', () => {
         name: 'my-api'
       });
 
-      const portsPut = putSpy.mock.calls.find(
-        (call) => call[0] === 'portTokens'
-      );
-      expect(portsPut).toBeDefined();
-      expect(portsPut?.[1]).toEqual({
+      expect(putSpy).toHaveBeenCalledWith('portTokens', {
         '8080': { token: 'friendlytok', name: 'my-api' }
+      });
+      expect(putSpy).toHaveBeenCalledWith('activePreviewPorts', {
+        '8080': {
+          runtimeIdentityID: 'runtime-1',
+          token: 'friendlytok'
+        }
       });
     });
 
-    it('onStart() swallows restoreExposedPorts() errors so startup succeeds', async () => {
-      // Simulate a saved port whose restore will fail — getExposedPorts
-      // returning something unparseable forces the inner logic to throw.
-      vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) =>
-        key === 'portTokens' ? { '8080': { token: 'tok8080' } } : null
-      );
-      vi.spyOn(sandbox as any, 'restoreExposedPorts').mockRejectedValue(
-        new Error('restore boom')
-      );
-      const errorSpy = vi.spyOn((sandbox as any).logger, 'error');
+    it('exposePort() does not write preview state when runtime identity changes before storage writes', async () => {
+      let runtimeIdentityReads = 0;
+      vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) => {
+        if (key === 'portTokens') {
+          return {};
+        }
+        if (key === 'currentRuntimeIdentity') {
+          runtimeIdentityReads++;
+          return {
+            id: runtimeIdentityReads === 1 ? 'runtime-1' : 'runtime-2'
+          };
+        }
+        if (key === 'activePreviewPorts') {
+          return {};
+        }
+        return null;
+      });
+      vi.mocked(mockCtx.storage!.put).mockClear();
 
-      // onStart must not throw; the base class wraps this in
-      // blockConcurrencyWhile, and an unhandled rejection there would
-      // reset the DO. Instead, onStart catches, logs, and returns.
-      await expect((sandbox as any).onStart()).resolves.toBeUndefined();
+      await expect(
+        sandbox.exposePort(8080, {
+          hostname: 'example.com',
+          token: 'friendlytok'
+        })
+      ).rejects.toBeInstanceOf(RuntimeIdentityInactiveError);
 
-      expect(errorSpy).toHaveBeenCalledWith(
-        'Failed to restore exposed ports after container start',
-        expect.any(Error)
+      expect(mockCtx.storage.put).not.toHaveBeenCalledWith(
+        'portTokens',
+        expect.anything()
+      );
+      expect(mockCtx.storage.put).not.toHaveBeenCalledWith(
+        'activePreviewPorts',
+        expect.anything()
       );
     });
 
-    it('fetches the exposed-port snapshot once per restore', async () => {
-      vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) =>
-        key === 'portTokens'
-          ? {
-              '8080': { token: 'tok8080' },
-              '9000': { token: 'tok9000' },
-              '9100': { token: 'tok9100' }
-            }
-          : null
-      );
+    it('exposePort() rejects if runtime identity changes after preview state writes', async () => {
+      let runtimeIdentityReads = 0;
+      vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) => {
+        if (key === 'portTokens') {
+          return {};
+        }
+        if (key === 'currentRuntimeIdentity') {
+          runtimeIdentityReads++;
+          return {
+            id: runtimeIdentityReads <= 2 ? 'runtime-1' : 'runtime-2'
+          };
+        }
+        if (key === 'activePreviewPorts') {
+          return {};
+        }
+        return null;
+      });
+      vi.mocked(mockCtx.storage!.put).mockClear();
 
-      await (sandbox as any).restoreExposedPorts();
+      await expect(
+        sandbox.exposePort(8080, {
+          hostname: 'example.com',
+          token: 'friendlytok'
+        })
+      ).rejects.toBeInstanceOf(RuntimeIdentityInactiveError);
 
-      expect(sandbox.client.ports.getExposedPorts).toHaveBeenCalledTimes(1);
+      expect(mockCtx.storage.put).toHaveBeenCalledWith('portTokens', {
+        '8080': { token: 'friendlytok', name: undefined }
+      });
+      expect(mockCtx.storage.put).toHaveBeenCalledWith('activePreviewPorts', {
+        '8080': {
+          runtimeIdentityID: 'runtime-1',
+          token: 'friendlytok'
+        }
+      });
     });
 
-    it('falls back to attempting exposePort for all ports when getExposedPorts rejects', async () => {
-      vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) =>
-        key === 'portTokens'
-          ? {
-              '8080': { token: 'tok8080' },
-              '9000': { token: 'tok9000' }
-            }
-          : null
+    it('exposePort() reuses the existing token when re-exposing the same port without a token', async () => {
+      vi.mocked(mockCtx.storage!.get).mockImplementation(async (key) => {
+        if (key === 'portTokens') {
+          return { '8080': { token: 'stabletok' } };
+        }
+        if (key === 'currentRuntimeIdentity') {
+          return { id: 'runtime-1' };
+        }
+        if (key === 'activePreviewPorts') {
+          return {};
+        }
+        return null;
+      });
+
+      const result = await sandbox.exposePort(8080, {
+        hostname: 'example.com'
+      });
+
+      expect(result.url).toContain('stabletok');
+      expect(mockCtx.storage.put).toHaveBeenCalledWith(
+        'activePreviewPorts',
+        expect.objectContaining({
+          '8080': expect.objectContaining({ token: 'stabletok' })
+        })
       );
-      vi.mocked(sandbox.client.ports.getExposedPorts as any).mockRejectedValue(
-        new Error('snapshot unavailable')
+    });
+
+    it('exposePort() does not restore a port revoked while the runtime starts', async () => {
+      const storage = new Map<string, unknown>([
+        ['portTokens', { '8080': { token: 'oldtoken' } }],
+        ['currentRuntimeIdentity', { id: 'runtime-1' }],
+        ['activePreviewPorts', {}]
+      ]);
+      mockCtx.storage.get.mockImplementation(
+        async (key: string) => storage.get(key) ?? null
+      );
+      mockCtx.storage.put.mockImplementation(async (key: string, value) => {
+        storage.set(key, value);
+      });
+      mockCtx.storage.delete.mockImplementation(async (key: string) => {
+        storage.delete(key);
+      });
+
+      let releaseStartup!: () => void;
+      const startupGate = new Promise<void>((resolve) => {
+        releaseStartup = resolve;
+      });
+      const ensureDefaultSessionSpy = vi
+        .spyOn(
+          sandbox as unknown as { ensureDefaultSession: () => Promise<string> },
+          'ensureDefaultSession'
+        )
+        .mockImplementation(async () => {
+          await startupGate;
+          return 'sandbox-default';
+        });
+
+      const exposePromise = sandbox.exposePort(9090, {
+        hostname: 'example.com',
+        token: 'newtoken'
+      });
+      await vi.waitFor(() =>
+        expect(ensureDefaultSessionSpy).toHaveBeenCalled()
       );
 
-      await (sandbox as any).restoreExposedPorts();
+      await mockCtx.storage.transaction(
+        async (txn: {
+          get: (key: string) => Promise<unknown>;
+          put: (key: string, value: unknown) => Promise<void>;
+        }) => {
+          const tokens = ((await txn.get('portTokens')) ?? {}) as Record<
+            string,
+            unknown
+          >;
+          delete tokens['8080'];
+          await txn.put('portTokens', tokens);
+        }
+      );
+      expect(storage.get('portTokens')).toEqual({});
 
-      // With no snapshot, every saved port is attempted — the per-port
-      // failure path catches individual errors, and this preserves the
-      // prior "best-effort restore" semantics.
-      expect(sandbox.client.ports.exposePort).toHaveBeenCalledTimes(2);
-      expect(sandbox.client.ports.exposePort).toHaveBeenCalledWith(
-        8080,
-        expect.any(String),
-        undefined
-      );
-      expect(sandbox.client.ports.exposePort).toHaveBeenCalledWith(
-        9000,
-        expect.any(String),
-        undefined
-      );
+      releaseStartup();
+      await exposePromise;
+
+      expect(storage.get('portTokens')).toEqual({
+        '9090': { token: 'newtoken', name: undefined }
+      });
     });
   });
 
@@ -1964,103 +2330,6 @@ describe('Sandbox - Automatic Session Management', () => {
       await sandbox.validatePortToken(8080, 'correcttoken');
 
       expect(spy).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('unexposePort ordering', () => {
-    beforeEach(() => {
-      vi.mocked(mockCtx.storage.get).mockImplementation(async (key) =>
-        key === 'portTokens' ? { '8080': { token: 'sometoken' } } : null
-      );
-      vi.spyOn(sandbox.client.ports, 'unexposePort').mockResolvedValue(
-        undefined as any
-      );
-    });
-
-    it('revokes the token from storage before the container RPC', async () => {
-      const calls: string[] = [];
-      vi.mocked(mockCtx.storage.put).mockImplementation(async (key) => {
-        if (key === 'portTokens') {
-          calls.push('storage');
-        }
-      });
-      vi.mocked(sandbox.client.ports.unexposePort).mockImplementation(
-        async () => {
-          calls.push('container');
-          return {
-            success: true,
-            port: 8080,
-            timestamp: new Date().toISOString()
-          };
-        }
-      );
-
-      await sandbox.unexposePort(8080);
-
-      expect(calls).toEqual(['storage', 'container']);
-    });
-
-    it('treats PortNotExposedError from the container as success', async () => {
-      vi.mocked(sandbox.client.ports.unexposePort).mockRejectedValue(
-        new PortNotExposedError({
-          error: 'Port not exposed: 8080',
-          code: 'PORT_NOT_EXPOSED',
-          context: { port: 8080 }
-        } as any)
-      );
-
-      await expect(sandbox.unexposePort(8080)).resolves.toBeUndefined();
-      expect(mockCtx.storage.put).toHaveBeenCalledWith(
-        'portTokens',
-        expect.not.objectContaining({ '8080': expect.anything() })
-      );
-    });
-
-    it('rethrows non-PortNotExposedError failures from the container', async () => {
-      vi.mocked(sandbox.client.ports.unexposePort).mockRejectedValue(
-        new Error('network failure')
-      );
-
-      await expect(sandbox.unexposePort(8080)).rejects.toThrow(
-        'network failure'
-      );
-    });
-  });
-
-  describe('getExposedPorts orphan handling', () => {
-    beforeEach(async () => {
-      await sandbox.setSandboxName('test-sandbox');
-
-      vi.spyOn(sandbox.client.ports, 'getExposedPorts').mockResolvedValue({
-        success: true,
-        ports: [
-          { port: 8080, exposedAt: new Date().toISOString() },
-          { port: 9090, exposedAt: new Date().toISOString() }
-        ],
-        count: 2,
-        timestamp: new Date().toISOString()
-      } as any);
-
-      // Storage has a token for 9090 but not for 8080, so 8080 is an
-      // orphan from getExposedPorts()'s perspective.
-      vi.mocked(mockCtx.storage.get).mockImplementation(async (key) => {
-        if (key === 'portTokens') return { '9090': { token: 'token9090' } };
-        if (key === 'sandboxName') return 'test-sandbox';
-        return null;
-      });
-    });
-
-    it('omits ports with no token from the result', async () => {
-      const warnSpy = vi.spyOn((sandbox as any).logger, 'warn');
-
-      const result = await sandbox.getExposedPorts('example.com');
-
-      expect(result).toHaveLength(1);
-      expect(result[0].port).toBe(9090);
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('no token in storage'),
-        expect.objectContaining({ port: 8080 })
-      );
     });
   });
 
@@ -2319,7 +2588,8 @@ describe('Sandbox - Automatic Session Management', () => {
         put: vi.fn().mockResolvedValue(undefined),
         get: vi.fn(),
         head: vi.fn(),
-        delete: vi.fn().mockResolvedValue(undefined)
+        delete: vi.fn().mockResolvedValue(undefined),
+        list: vi.fn().mockResolvedValue({ objects: [], truncated: false })
       };
     }
 
@@ -2970,6 +3240,7 @@ describe('Sandbox - Automatic Session Management', () => {
       reject: (err: Error) => void;
       calls: () => number;
     } {
+      mockCtx.container.running = false;
       let resolve: () => void = () => {};
       let reject: (err: Error) => void = () => {};
       let calls = 0;
@@ -3000,7 +3271,7 @@ describe('Sandbox - Automatic Session Management', () => {
 
       // All three callers are awaiting the same underlying work; the parent
       // container destroy must only be invoked once.
-      expect(superDestroy.calls()).toBe(1);
+      await vi.waitFor(() => expect(superDestroy.calls()).toBe(1));
 
       superDestroy.resolve();
       await expect(Promise.all([first, second, third])).resolves.toEqual([
@@ -3015,6 +3286,7 @@ describe('Sandbox - Automatic Session Management', () => {
       const first = sandbox.destroy();
       const second = sandbox.destroy();
 
+      await vi.waitFor(() => expect(superDestroy.calls()).toBe(1));
       superDestroy.reject(new Error('container teardown failed'));
 
       await expect(first).rejects.toThrow('container teardown failed');
@@ -3024,14 +3296,14 @@ describe('Sandbox - Automatic Session Management', () => {
     it('runs a fresh teardown for a later destroy() after the previous one settles', async () => {
       const first = stubSuperDestroy();
       const firstCall = sandbox.destroy();
-      expect(first.calls()).toBe(1);
+      await vi.waitFor(() => expect(first.calls()).toBe(1));
       first.resolve();
       await firstCall;
 
       // Re-stub to track the second teardown independently.
       const second = stubSuperDestroy();
       const secondCall = sandbox.destroy();
-      expect(second.calls()).toBe(1);
+      await vi.waitFor(() => expect(second.calls()).toBe(1));
       second.resolve();
       await secondCall;
     });

--- a/packages/sandbox/tests/tunnels-handler-named.test.ts
+++ b/packages/sandbox/tests/tunnels-handler-named.test.ts
@@ -896,6 +896,56 @@ describe('tunnels handler > destroy() for named tunnels', () => {
     expect(targets.some((t) => t.includes('/accounts/acct-B/'))).toBe(false);
   });
 
+  it('continues Cloudflare cleanup when container tunnel teardown fails', async () => {
+    const cf = makeFakeCloudflare({});
+    const { client } = makeClient();
+    const storage = makeStorage();
+    await (storage.put as ReturnType<typeof vi.fn>)('tunnels', {
+      '8080': {
+        id: 'tunnel-uuid-stored',
+        port: 8080,
+        name: 'api',
+        hostname: 'api.example.com',
+        url: 'https://api.example.com',
+        createdAt: '2026-05-13T00:00:00.000Z'
+      }
+    });
+    await (storage.put as ReturnType<typeof vi.fn>)('tunnels:meta', {
+      '8080': {
+        optionsHash: 'v1:named:api',
+        dnsRecordId: 'dns-record-id',
+        accountId: 'ACCT',
+        zoneId: 'zone-id'
+      }
+    });
+    client.tunnels.destroyTunnel.mockRejectedValue(
+      new Error('container already stopped')
+    );
+    const built = createTunnelsHandler({
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage,
+      logger: makeLogger(),
+      sandboxId: 'sb1',
+      getNamedTunnelConfig: async () => ({
+        token: 'TOK',
+        accountId: 'ACCT',
+        zoneId: 'zone-id'
+      }),
+      fetcher: cf.fetcher as unknown as typeof fetch
+    });
+
+    await expect(built.tunnels.destroy(8080)).resolves.toBeUndefined();
+
+    const deletes = cf.fetcher.mock.calls.filter(
+      ([, init]) => (init as RequestInit | undefined)?.method === 'DELETE'
+    );
+    const targets = deletes.map(([url]) => String(url));
+    expect(targets.some((t) => t.includes('/dns_records/'))).toBe(true);
+    expect(targets.some((t) => t.includes('/cfd_tunnel/'))).toBe(true);
+  });
+
   it('quick-tunnel destroy() makes no Cloudflare API calls', async () => {
     const cf = makeFakeCloudflare({});
     const { tunnels, client } = makeHandler({

--- a/tests/e2e/helpers/container-lifecycle.ts
+++ b/tests/e2e/helpers/container-lifecycle.ts
@@ -1,21 +1,55 @@
 const DEFAULT_STOP_SETTLED_TIMEOUT_MS = 30_000;
 const DEFAULT_STOP_POLL_INTERVAL_MS = 250;
 const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+const DEFAULT_HEALTHY_TIMEOUT_MS = 30_000;
+const DEFAULT_HEALTHY_POLL_INTERVAL_MS = 250;
 
 type ContainerStateResponse = { status?: unknown };
 
-type StopContainerAndWaitOptions = {
+type WaitForContainerOptions = {
   timeoutMs?: number;
   pollIntervalMs?: number;
   requestTimeoutMs?: number;
 };
 
-function isActiveContainerStatus(status: string): boolean {
-  return status === 'healthy' || status === 'running';
+function isStoppedContainerStatus(status: string): boolean {
+  return status === 'stopped' || status === 'stopped_with_code';
 }
 
 async function responseText(response: Response): Promise<string> {
   return await response.text().catch(() => '<unreadable>');
+}
+
+async function waitForContainerStatus(
+  workerUrl: string,
+  headers: Record<string, string>,
+  isExpectedStatus: (status: string) => boolean,
+  timeoutMessage: (timeoutMs: number, lastStatus: string) => string,
+  options: WaitForContainerOptions
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_STOP_SETTLED_TIMEOUT_MS;
+  const pollIntervalMs =
+    options.pollIntervalMs ?? DEFAULT_STOP_POLL_INTERVAL_MS;
+  const requestTimeoutMs =
+    options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus = await getContainerStatus(
+    workerUrl,
+    headers,
+    requestTimeoutMs
+  );
+
+  while (Date.now() < deadline) {
+    if (isExpectedStatus(lastStatus)) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    lastStatus = await getContainerStatus(workerUrl, headers, requestTimeoutMs);
+  }
+
+  throw new Error(timeoutMessage(timeoutMs, lastStatus));
 }
 
 export async function getContainerStatus(
@@ -23,6 +57,8 @@ export async function getContainerStatus(
   headers: Record<string, string>,
   requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS
 ): Promise<string> {
+  // /api/state calls sandbox.getState(), which reads Durable Object-owned
+  // container state without starting, probing, or forwarding to the container.
   const response = await fetch(`${workerUrl}/api/state`, {
     headers,
     signal: AbortSignal.timeout(requestTimeoutMs)
@@ -46,15 +82,15 @@ export async function getContainerStatus(
  * `stop()` requests graceful shutdown; it is not a lifecycle barrier. Tests
  * that need a completed runtime boundary should call this helper instead of
  * assuming the stop request has fully settled before the next SDK operation.
+ *
+ * This intentionally uses the test-worker's stop endpoint to force the same
+ * stop/replacement boundary users can observe after sleep or runtime exit.
  */
 export async function stopContainerAndWait(
   workerUrl: string,
   headers: Record<string, string>,
-  options: StopContainerAndWaitOptions = {}
+  options: WaitForContainerOptions = {}
 ): Promise<void> {
-  const timeoutMs = options.timeoutMs ?? DEFAULT_STOP_SETTLED_TIMEOUT_MS;
-  const pollIntervalMs =
-    options.pollIntervalMs ?? DEFAULT_STOP_POLL_INTERVAL_MS;
   const requestTimeoutMs =
     options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
 
@@ -70,23 +106,32 @@ export async function stopContainerAndWait(
     );
   }
 
-  const deadline = Date.now() + timeoutMs;
-  let lastStatus = await getContainerStatus(
+  await waitForContainerStatus(
     workerUrl,
     headers,
-    requestTimeoutMs
+    isStoppedContainerStatus,
+    (timeoutMs, lastStatus) =>
+      `Timed out waiting ${timeoutMs}ms for container to stop; last status: ${lastStatus}`,
+    options
   );
+}
 
-  while (Date.now() < deadline) {
-    if (!isActiveContainerStatus(lastStatus)) {
-      return;
+export async function waitForContainerHealthy(
+  workerUrl: string,
+  headers: Record<string, string>,
+  options: WaitForContainerOptions = {}
+): Promise<void> {
+  await waitForContainerStatus(
+    workerUrl,
+    headers,
+    (status) => status === 'healthy',
+    (timeoutMs, lastStatus) =>
+      `Timed out waiting ${timeoutMs}ms for container to become healthy; last status: ${lastStatus}`,
+    {
+      timeoutMs: options.timeoutMs ?? DEFAULT_HEALTHY_TIMEOUT_MS,
+      pollIntervalMs:
+        options.pollIntervalMs ?? DEFAULT_HEALTHY_POLL_INTERVAL_MS,
+      requestTimeoutMs: options.requestTimeoutMs
     }
-
-    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
-    lastStatus = await getContainerStatus(workerUrl, headers, requestTimeoutMs);
-  }
-
-  throw new Error(
-    `Timed out waiting ${timeoutMs}ms for container to stop; last status: ${lastStatus}`
   );
 }

--- a/tests/e2e/helpers/container-lifecycle.ts
+++ b/tests/e2e/helpers/container-lifecycle.ts
@@ -1,0 +1,92 @@
+const DEFAULT_STOP_SETTLED_TIMEOUT_MS = 30_000;
+const DEFAULT_STOP_POLL_INTERVAL_MS = 250;
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+
+type ContainerStateResponse = { status?: unknown };
+
+type StopContainerAndWaitOptions = {
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  requestTimeoutMs?: number;
+};
+
+function isActiveContainerStatus(status: string): boolean {
+  return status === 'healthy' || status === 'running';
+}
+
+async function responseText(response: Response): Promise<string> {
+  return await response.text().catch(() => '<unreadable>');
+}
+
+export async function getContainerStatus(
+  workerUrl: string,
+  headers: Record<string, string>,
+  requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS
+): Promise<string> {
+  const response = await fetch(`${workerUrl}/api/state`, {
+    headers,
+    signal: AbortSignal.timeout(requestTimeoutMs)
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to read container state: ${response.status} ${await responseText(response)}`
+    );
+  }
+
+  const state = (await response.json()) as ContainerStateResponse;
+  if (typeof state.status !== 'string') {
+    throw new Error(`Container state response did not include a status`);
+  }
+
+  return state.status;
+}
+
+/**
+ * `stop()` requests graceful shutdown; it is not a lifecycle barrier. Tests
+ * that need a completed runtime boundary should call this helper instead of
+ * assuming the stop request has fully settled before the next SDK operation.
+ */
+export async function stopContainerAndWait(
+  workerUrl: string,
+  headers: Record<string, string>,
+  options: StopContainerAndWaitOptions = {}
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_STOP_SETTLED_TIMEOUT_MS;
+  const pollIntervalMs =
+    options.pollIntervalMs ?? DEFAULT_STOP_POLL_INTERVAL_MS;
+  const requestTimeoutMs =
+    options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+
+  const stopResponse = await fetch(`${workerUrl}/api/container/stop`, {
+    method: 'POST',
+    headers,
+    signal: AbortSignal.timeout(requestTimeoutMs)
+  });
+
+  if (!stopResponse.ok) {
+    throw new Error(
+      `Failed to stop container: ${stopResponse.status} ${await responseText(stopResponse)}`
+    );
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus = await getContainerStatus(
+    workerUrl,
+    headers,
+    requestTimeoutMs
+  );
+
+  while (Date.now() < deadline) {
+    if (!isActiveContainerStatus(lastStatus)) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    lastStatus = await getContainerStatus(workerUrl, headers, requestTimeoutMs);
+  }
+
+  throw new Error(
+    `Timed out waiting ${timeoutMs}ms for container to stop; last status: ${lastStatus}`
+  );
+}

--- a/tests/e2e/preview-url-lifecycle.test.ts
+++ b/tests/e2e/preview-url-lifecycle.test.ts
@@ -3,7 +3,8 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import WebSocket from 'ws';
 import {
   getContainerStatus,
-  stopContainerAndWait as stopContainer
+  stopContainerAndWait as stopContainer,
+  waitForContainerHealthy
 } from './helpers/container-lifecycle';
 import {
   cleanupTestSandbox,
@@ -14,17 +15,43 @@ import {
 
 const skipPortExposureTests =
   process.env.TEST_WORKER_URL?.endsWith('.workers.dev') ?? false;
-const PREVIEW_LIFECYCLE_PORT = 9852;
-const PREVIEW_TOKEN = 'lifecycleok';
+
+const PREVIEW_PORTS = {
+  validHttp: 9852,
+  webSocket: 9853,
+  staleAfterStop: 9854,
+  rotatedToken: 9856,
+  revoked: 9857,
+  reusedURL: 9858,
+  unrelatedRuntime: 9859,
+  destroy: 9860
+} as const;
+
+const REUSED_URL_TOKEN = 'lifecycleok';
+const ROTATED_TOKEN_A = 'lifecycle_a';
+const ROTATED_TOKEN_B = 'lifecycle_b';
+
+async function responseText(response: Response): Promise<string> {
+  return await response.text().catch(() => '<unreadable>');
+}
+
+async function assertOK(response: Response, action: string): Promise<void> {
+  if (!response.ok) {
+    throw new Error(
+      `${action} failed: ${response.status} ${await responseText(response)}`
+    );
+  }
+}
 
 async function writePreviewServer(
   workerUrl: string,
-  headers: Record<string, string>
+  headers: Record<string, string>,
+  port: number
 ): Promise<void> {
   const serverCode = `
 const server = Bun.serve({
   hostname: "0.0.0.0",
-  port: ${PREVIEW_LIFECYCLE_PORT},
+  port: ${port},
   fetch(req, server) {
     const url = new URL(req.url);
     if (url.pathname === "/ws") {
@@ -34,7 +61,7 @@ const server = Bun.serve({
       return new Response("Expected WebSocket", { status: 400 });
     }
     if (url.pathname === "/hello") {
-      return new Response("hello from lifecycle port", { status: 200 });
+      return new Response("hello from lifecycle port ${port}", { status: 200 });
     }
     return new Response("not found", { status: 404 });
   },
@@ -51,27 +78,28 @@ await Bun.sleep(300000);
     method: 'POST',
     headers,
     body: JSON.stringify({
-      path: '/workspace/preview-lifecycle-server.ts',
+      path: `/workspace/preview-lifecycle-server-${port}.ts`,
       content: serverCode
     })
   });
-  expect(response.status).toBe(200);
+  await assertOK(response, `Writing preview server for port ${port}`);
 }
 
 async function startPreviewServer(
   workerUrl: string,
-  headers: Record<string, string>
+  headers: Record<string, string>,
+  port: number
 ): Promise<void> {
-  await writePreviewServer(workerUrl, headers);
+  await writePreviewServer(workerUrl, headers, port);
 
   const startResponse = await fetch(`${workerUrl}/api/process/start`, {
     method: 'POST',
     headers,
     body: JSON.stringify({
-      command: 'bun run /workspace/preview-lifecycle-server.ts'
+      command: `bun run /workspace/preview-lifecycle-server-${port}.ts`
     })
   });
-  expect(startResponse.status).toBe(200);
+  await assertOK(startResponse, `Starting preview server for port ${port}`);
   const process = (await startResponse.json()) as Pick<Process, 'id'>;
 
   const waitPortResponse = await fetch(
@@ -80,38 +108,50 @@ async function startPreviewServer(
       method: 'POST',
       headers,
       body: JSON.stringify({
-        port: PREVIEW_LIFECYCLE_PORT,
+        port,
         timeout: 15000,
         mode: 'tcp'
       })
     }
   );
-  expect(waitPortResponse.status).toBe(200);
+  await assertOK(waitPortResponse, `Waiting for preview server port ${port}`);
 }
 
-async function exposeLifecyclePort(
+async function exposePreviewPort(
   workerUrl: string,
-  headers: Record<string, string>
+  headers: Record<string, string>,
+  port: number,
+  token?: string
 ): Promise<string> {
+  const body: { port: number; name: string; token?: string } = {
+    port,
+    name: `preview-lifecycle-${port}`
+  };
+  if (token !== undefined) {
+    body.token = token;
+  }
+
   const exposeResponse = await fetch(`${workerUrl}/api/port/expose`, {
     method: 'POST',
     headers,
-    body: JSON.stringify({
-      port: PREVIEW_LIFECYCLE_PORT,
-      name: 'preview-lifecycle',
-      token: PREVIEW_TOKEN
-    })
+    body: JSON.stringify(body)
   });
-  expect(exposeResponse.status).toBe(200);
+  await assertOK(exposeResponse, `Exposing preview port ${port}`);
   const preview = (await exposeResponse.json()) as PortExposeResult;
   return preview.url;
 }
 
-type ExposedPortsResponse = Array<{
-  port: number;
-  url: string;
-  status: string;
-}>;
+async function unexposePreviewPort(
+  workerUrl: string,
+  headers: Record<string, string>,
+  port: number
+): Promise<void> {
+  const response = await fetch(`${workerUrl}/api/exposed-ports/${port}`, {
+    method: 'DELETE',
+    headers
+  });
+  await assertOK(response, `Unexposing preview port ${port}`);
+}
 
 function previewURL(previewUrl: string, path: string): string {
   return new URL(path, previewUrl).toString();
@@ -159,16 +199,6 @@ async function expectWebSocketStatus(
   });
 }
 
-function replacePreviewToken(previewUrl: string, replacement: string): string {
-  const url = new URL(previewUrl);
-  const firstDot = url.hostname.indexOf('.');
-  const subdomain = url.hostname.slice(0, firstDot);
-  const domain = url.hostname.slice(firstDot + 1);
-  const lastHyphen = subdomain.lastIndexOf('-');
-  url.hostname = `${subdomain.slice(0, lastHyphen + 1)}${replacement}.${domain}`;
-  return url.toString();
-}
-
 async function writeUnrelatedRuntimeFile(
   workerUrl: string,
   headers: Record<string, string>
@@ -181,7 +211,17 @@ async function writeUnrelatedRuntimeFile(
       content: `unrelated runtime start ${Date.now()}`
     })
   });
-  expect(response.status).toBe(200);
+  await assertOK(response, 'Writing unrelated runtime file');
+}
+
+function createPortHeaders(
+  headers: Record<string, string>
+): Record<string, string> {
+  // Port APIs use the sandbox's default session, while file/process setup uses
+  // the test session headers for deterministic workspace state.
+  const portHeaders = { ...headers };
+  delete portHeaders['X-Session-Id'];
+  return portHeaders;
 }
 
 describe('Preview URL lifecycle', () => {
@@ -194,10 +234,7 @@ describe('Preview URL lifecycle', () => {
     sandbox = await createTestSandbox();
     workerUrl = sandbox.workerUrl;
     headers = sandbox.headers(createUniqueSession());
-    // Port APIs use the sandbox's default session, while file/process setup
-    // uses the test session headers for deterministic workspace state.
-    portHeaders = { ...headers };
-    delete portHeaders['X-Session-Id'];
+    portHeaders = createPortHeaders(headers);
   }, 120000);
 
   afterAll(async () => {
@@ -207,14 +244,22 @@ describe('Preview URL lifecycle', () => {
   test.skipIf(skipPortExposureTests)(
     'valid preview URL reaches a service in the current runtime',
     async () => {
+      const port = PREVIEW_PORTS.validHttp;
       try {
-        await startPreviewServer(workerUrl, headers);
-        const previewUrl = await exposeLifecyclePort(workerUrl, portHeaders);
+        await startPreviewServer(workerUrl, headers, port);
+        const previewUrl = await exposePreviewPort(
+          workerUrl,
+          portHeaders,
+          port
+        );
 
         const response = await fetch(previewURL(previewUrl, '/hello'));
         expect(response.status).toBe(200);
-        expect(await response.text()).toBe('hello from lifecycle port');
+        expect(await response.text()).toBe(`hello from lifecycle port ${port}`);
       } finally {
+        await unexposePreviewPort(workerUrl, portHeaders, port).catch(
+          () => undefined
+        );
         await stopContainer(workerUrl, portHeaders).catch(() => undefined);
       }
     },
@@ -224,10 +269,15 @@ describe('Preview URL lifecycle', () => {
   test.skipIf(skipPortExposureTests)(
     'WebSocket preview URL connects only while activated in the current runtime',
     async () => {
+      const port = PREVIEW_PORTS.webSocket;
       let ws: WebSocket | null = null;
       try {
-        await startPreviewServer(workerUrl, headers);
-        const previewUrl = await exposeLifecyclePort(workerUrl, portHeaders);
+        await startPreviewServer(workerUrl, headers, port);
+        const previewUrl = await exposePreviewPort(
+          workerUrl,
+          portHeaders,
+          port
+        );
 
         ws = await connectWebSocket(previewWebSocketURL(previewUrl, '/ws'));
         const echoPromise = new Promise<string>((resolve, reject) => {
@@ -253,6 +303,9 @@ describe('Preview URL lifecycle', () => {
         );
       } finally {
         ws?.close();
+        await unexposePreviewPort(workerUrl, portHeaders, port).catch(
+          () => undefined
+        );
         await stopContainer(workerUrl, portHeaders).catch(() => undefined);
       }
     },
@@ -262,9 +315,14 @@ describe('Preview URL lifecycle', () => {
   test.skipIf(skipPortExposureTests)(
     'authorized preview URL after container stop is stale and does not wake the container',
     async () => {
+      const port = PREVIEW_PORTS.staleAfterStop;
       try {
-        await startPreviewServer(workerUrl, headers);
-        const previewUrl = await exposeLifecyclePort(workerUrl, portHeaders);
+        await startPreviewServer(workerUrl, headers, port);
+        const previewUrl = await exposePreviewPort(
+          workerUrl,
+          portHeaders,
+          port
+        );
 
         const healthyResponse = await fetch(previewURL(previewUrl, '/hello'));
         expect(healthyResponse.status).toBe(200);
@@ -283,6 +341,9 @@ describe('Preview URL lifecycle', () => {
           'healthy'
         );
       } finally {
+        await unexposePreviewPort(workerUrl, portHeaders, port).catch(
+          () => undefined
+        );
         await stopContainer(workerUrl, portHeaders).catch(() => undefined);
       }
     },
@@ -290,16 +351,28 @@ describe('Preview URL lifecycle', () => {
   );
 
   test.skipIf(skipPortExposureTests)(
-    'bad token after container stop is rejected without waking the container',
+    'old preview URL with a rotated token is rejected without waking the container',
     async () => {
+      const port = PREVIEW_PORTS.rotatedToken;
       try {
-        await startPreviewServer(workerUrl, headers);
-        const previewUrl = await exposeLifecyclePort(workerUrl, portHeaders);
+        await startPreviewServer(workerUrl, headers, port);
+        const oldPreviewUrl = await exposePreviewPort(
+          workerUrl,
+          portHeaders,
+          port,
+          ROTATED_TOKEN_A
+        );
+        const newPreviewUrl = await exposePreviewPort(
+          workerUrl,
+          portHeaders,
+          port,
+          ROTATED_TOKEN_B
+        );
+        expect(newPreviewUrl).not.toBe(oldPreviewUrl);
 
         await stopContainer(workerUrl, portHeaders);
-        const badTokenUrl = replacePreviewToken(previewUrl, 'badtoken');
 
-        const response = await fetch(previewURL(badTokenUrl, '/hello'));
+        const response = await fetch(previewURL(oldPreviewUrl, '/hello'));
         expect(response.status).toBe(404);
         expect(await response.json()).toMatchObject({
           code: 'INVALID_TOKEN'
@@ -308,6 +381,9 @@ describe('Preview URL lifecycle', () => {
           'healthy'
         );
       } finally {
+        await unexposePreviewPort(workerUrl, portHeaders, port).catch(
+          () => undefined
+        );
         await stopContainer(workerUrl, portHeaders).catch(() => undefined);
       }
     },
@@ -317,19 +393,16 @@ describe('Preview URL lifecycle', () => {
   test.skipIf(skipPortExposureTests)(
     'revoked preview URL after container stop is rejected without waking the container',
     async () => {
+      const port = PREVIEW_PORTS.revoked;
       try {
-        await startPreviewServer(workerUrl, headers);
-        const previewUrl = await exposeLifecyclePort(workerUrl, portHeaders);
-
-        const deleteResponse = await fetch(
-          `${workerUrl}/api/exposed-ports/${PREVIEW_LIFECYCLE_PORT}`,
-          {
-            method: 'DELETE',
-            headers: portHeaders
-          }
+        await startPreviewServer(workerUrl, headers, port);
+        const previewUrl = await exposePreviewPort(
+          workerUrl,
+          portHeaders,
+          port
         );
-        expect(deleteResponse.status).toBe(200);
 
+        await unexposePreviewPort(workerUrl, portHeaders, port);
         await stopContainer(workerUrl, portHeaders);
 
         const response = await fetch(previewURL(previewUrl, '/hello'));
@@ -341,6 +414,9 @@ describe('Preview URL lifecycle', () => {
           'healthy'
         );
       } finally {
+        await unexposePreviewPort(workerUrl, portHeaders, port).catch(
+          () => undefined
+        );
         await stopContainer(workerUrl, portHeaders).catch(() => undefined);
       }
     },
@@ -350,16 +426,24 @@ describe('Preview URL lifecycle', () => {
   test.skipIf(skipPortExposureTests)(
     'same preview URL stays stale until exposePort is called in the new runtime',
     async () => {
+      const port = PREVIEW_PORTS.reusedURL;
       try {
-        await startPreviewServer(workerUrl, headers);
-        const previewUrl = await exposeLifecyclePort(workerUrl, portHeaders);
+        await startPreviewServer(workerUrl, headers, port);
+        const previewUrl = await exposePreviewPort(
+          workerUrl,
+          portHeaders,
+          port,
+          REUSED_URL_TOKEN
+        );
 
         const initialResponse = await fetch(previewURL(previewUrl, '/hello'));
         expect(initialResponse.status).toBe(200);
-        expect(await initialResponse.text()).toBe('hello from lifecycle port');
+        expect(await initialResponse.text()).toBe(
+          `hello from lifecycle port ${port}`
+        );
 
         await stopContainer(workerUrl, portHeaders);
-        await startPreviewServer(workerUrl, headers);
+        await startPreviewServer(workerUrl, headers, port);
 
         const staleResponse = await fetch(previewURL(previewUrl, '/hello'));
         expect(staleResponse.status).toBe(410);
@@ -367,9 +451,10 @@ describe('Preview URL lifecycle', () => {
           code: 'STALE_PREVIEW_URL'
         });
 
-        const reactivatedUrl = await exposeLifecyclePort(
+        const reactivatedUrl = await exposePreviewPort(
           workerUrl,
-          portHeaders
+          portHeaders,
+          port
         );
         expect(reactivatedUrl).toBe(previewUrl);
 
@@ -378,9 +463,12 @@ describe('Preview URL lifecycle', () => {
         );
         expect(reactivatedResponse.status).toBe(200);
         expect(await reactivatedResponse.text()).toBe(
-          'hello from lifecycle port'
+          `hello from lifecycle port ${port}`
         );
       } finally {
+        await unexposePreviewPort(workerUrl, portHeaders, port).catch(
+          () => undefined
+        );
         await stopContainer(workerUrl, portHeaders).catch(() => undefined);
       }
     },
@@ -390,18 +478,21 @@ describe('Preview URL lifecycle', () => {
   test.skipIf(skipPortExposureTests)(
     'old preview URL stays stale after unrelated SDK work starts a new runtime',
     async () => {
+      const port = PREVIEW_PORTS.unrelatedRuntime;
       try {
-        await startPreviewServer(workerUrl, headers);
-        const previewUrl = await exposeLifecyclePort(workerUrl, portHeaders);
+        await startPreviewServer(workerUrl, headers, port);
+        const previewUrl = await exposePreviewPort(
+          workerUrl,
+          portHeaders,
+          port
+        );
 
         const initialResponse = await fetch(previewURL(previewUrl, '/hello'));
         expect(initialResponse.status).toBe(200);
 
         await stopContainer(workerUrl, portHeaders);
         await writeUnrelatedRuntimeFile(workerUrl, headers);
-        expect(await getContainerStatus(workerUrl, portHeaders)).toBe(
-          'healthy'
-        );
+        await waitForContainerHealthy(workerUrl, portHeaders);
 
         const staleResponse = await fetch(previewURL(previewUrl, '/hello'));
         expect(staleResponse.status).toBe(410);
@@ -412,32 +503,64 @@ describe('Preview URL lifecycle', () => {
           'healthy'
         );
       } finally {
+        await unexposePreviewPort(workerUrl, portHeaders, port).catch(
+          () => undefined
+        );
         await stopContainer(workerUrl, portHeaders).catch(() => undefined);
       }
     },
     180000
   );
+});
+
+describe('Preview URL lifecycle after sandbox destroy', () => {
+  let workerUrl: string;
+  let headers: Record<string, string>;
+  let portHeaders: Record<string, string>;
+  let sandbox: TestSandbox | null = null;
+  let destroyed = false;
+
+  beforeAll(async () => {
+    sandbox = await createTestSandbox();
+    workerUrl = sandbox.workerUrl;
+    headers = sandbox.headers(createUniqueSession());
+    portHeaders = createPortHeaders(headers);
+  }, 120000);
+
+  afterAll(async () => {
+    if (!destroyed) {
+      await cleanupTestSandbox(sandbox);
+    }
+  }, 120000);
 
   test.skipIf(skipPortExposureTests)(
     'old preview URL is rejected after sandbox destroy',
     async () => {
+      const port = PREVIEW_PORTS.destroy;
       try {
-        await startPreviewServer(workerUrl, headers);
-        const previewUrl = await exposeLifecyclePort(workerUrl, portHeaders);
+        await startPreviewServer(workerUrl, headers, port);
+        const previewUrl = await exposePreviewPort(
+          workerUrl,
+          portHeaders,
+          port
+        );
 
         const cleanupResponse = await fetch(`${workerUrl}/cleanup`, {
           method: 'POST',
           headers: portHeaders
         });
-        expect(cleanupResponse.status).toBe(200);
-        sandbox = null;
+        await assertOK(cleanupResponse, 'Destroying preview lifecycle sandbox');
+        destroyed = true;
 
         const response = await fetch(previewURL(previewUrl, '/hello'));
         expect(response.status).toBe(404);
         const body = (await response.json()) as { code?: string };
         expect(body.code).toBe('INVALID_TOKEN');
       } finally {
-        if (sandbox !== null) {
+        if (!destroyed) {
+          await unexposePreviewPort(workerUrl, portHeaders, port).catch(
+            () => undefined
+          );
           await stopContainer(workerUrl, portHeaders).catch(() => undefined);
         }
       }

--- a/tests/e2e/preview-url-lifecycle.test.ts
+++ b/tests/e2e/preview-url-lifecycle.test.ts
@@ -1,0 +1,447 @@
+import type { PortExposeResult, Process } from '@repo/shared';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import WebSocket from 'ws';
+import {
+  getContainerStatus,
+  stopContainerAndWait as stopContainer
+} from './helpers/container-lifecycle';
+import {
+  cleanupTestSandbox,
+  createTestSandbox,
+  createUniqueSession,
+  type TestSandbox
+} from './helpers/global-sandbox';
+
+const skipPortExposureTests =
+  process.env.TEST_WORKER_URL?.endsWith('.workers.dev') ?? false;
+const PREVIEW_LIFECYCLE_PORT = 9852;
+const PREVIEW_TOKEN = 'lifecycleok';
+
+async function writePreviewServer(
+  workerUrl: string,
+  headers: Record<string, string>
+): Promise<void> {
+  const serverCode = `
+const server = Bun.serve({
+  hostname: "0.0.0.0",
+  port: ${PREVIEW_LIFECYCLE_PORT},
+  fetch(req, server) {
+    const url = new URL(req.url);
+    if (url.pathname === "/ws") {
+      if (server.upgrade(req)) {
+        return;
+      }
+      return new Response("Expected WebSocket", { status: 400 });
+    }
+    if (url.pathname === "/hello") {
+      return new Response("hello from lifecycle port", { status: 200 });
+    }
+    return new Response("not found", { status: 404 });
+  },
+  websocket: {
+    message(ws, message) {
+      ws.send(message);
+    }
+  }
+});
+await Bun.sleep(300000);
+  `.trim();
+
+  const response = await fetch(`${workerUrl}/api/file/write`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      path: '/workspace/preview-lifecycle-server.ts',
+      content: serverCode
+    })
+  });
+  expect(response.status).toBe(200);
+}
+
+async function startPreviewServer(
+  workerUrl: string,
+  headers: Record<string, string>
+): Promise<void> {
+  await writePreviewServer(workerUrl, headers);
+
+  const startResponse = await fetch(`${workerUrl}/api/process/start`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      command: 'bun run /workspace/preview-lifecycle-server.ts'
+    })
+  });
+  expect(startResponse.status).toBe(200);
+  const process = (await startResponse.json()) as Pick<Process, 'id'>;
+
+  const waitPortResponse = await fetch(
+    `${workerUrl}/api/process/${process.id}/waitForPort`,
+    {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        port: PREVIEW_LIFECYCLE_PORT,
+        timeout: 15000,
+        mode: 'tcp'
+      })
+    }
+  );
+  expect(waitPortResponse.status).toBe(200);
+}
+
+async function exposeLifecyclePort(
+  workerUrl: string,
+  headers: Record<string, string>
+): Promise<string> {
+  const exposeResponse = await fetch(`${workerUrl}/api/port/expose`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      port: PREVIEW_LIFECYCLE_PORT,
+      name: 'preview-lifecycle',
+      token: PREVIEW_TOKEN
+    })
+  });
+  expect(exposeResponse.status).toBe(200);
+  const preview = (await exposeResponse.json()) as PortExposeResult;
+  return preview.url;
+}
+
+type ExposedPortsResponse = Array<{
+  port: number;
+  url: string;
+  status: string;
+}>;
+
+function previewURL(previewUrl: string, path: string): string {
+  return new URL(path, previewUrl).toString();
+}
+
+function previewWebSocketURL(previewUrl: string, path: string): string {
+  return previewURL(previewUrl, path).replace(/^http/, 'ws');
+}
+
+async function connectWebSocket(url: string): Promise<WebSocket> {
+  const ws = new WebSocket(url);
+  await new Promise<void>((resolve, reject) => {
+    ws.on('open', () => resolve());
+    ws.on('error', reject);
+    setTimeout(() => reject(new Error('WebSocket open timeout')), 10_000);
+  });
+  return ws;
+}
+
+async function expectWebSocketStatus(
+  url: string,
+  expectedStatus: number
+): Promise<void> {
+  const ws = new WebSocket(url);
+  await new Promise<void>((resolve, reject) => {
+    ws.on('unexpected-response', (_request, response) => {
+      try {
+        expect(response.statusCode).toBe(expectedStatus);
+        resolve();
+      } catch (error) {
+        reject(error);
+      } finally {
+        ws.close();
+      }
+    });
+    ws.on('open', () => {
+      ws.close();
+      reject(new Error('WebSocket connected unexpectedly'));
+    });
+    ws.on('error', reject);
+    setTimeout(
+      () => reject(new Error('WebSocket status assertion timeout')),
+      10_000
+    );
+  });
+}
+
+function replacePreviewToken(previewUrl: string, replacement: string): string {
+  const url = new URL(previewUrl);
+  const firstDot = url.hostname.indexOf('.');
+  const subdomain = url.hostname.slice(0, firstDot);
+  const domain = url.hostname.slice(firstDot + 1);
+  const lastHyphen = subdomain.lastIndexOf('-');
+  url.hostname = `${subdomain.slice(0, lastHyphen + 1)}${replacement}.${domain}`;
+  return url.toString();
+}
+
+async function writeUnrelatedRuntimeFile(
+  workerUrl: string,
+  headers: Record<string, string>
+): Promise<void> {
+  const response = await fetch(`${workerUrl}/api/file/write`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      path: '/workspace/preview-lifecycle-unrelated.txt',
+      content: `unrelated runtime start ${Date.now()}`
+    })
+  });
+  expect(response.status).toBe(200);
+}
+
+describe('Preview URL lifecycle', () => {
+  let workerUrl: string;
+  let headers: Record<string, string>;
+  let portHeaders: Record<string, string>;
+  let sandbox: TestSandbox | null = null;
+
+  beforeAll(async () => {
+    sandbox = await createTestSandbox();
+    workerUrl = sandbox.workerUrl;
+    headers = sandbox.headers(createUniqueSession());
+    // Port APIs use the sandbox's default session, while file/process setup
+    // uses the test session headers for deterministic workspace state.
+    portHeaders = { ...headers };
+    delete portHeaders['X-Session-Id'];
+  }, 120000);
+
+  afterAll(async () => {
+    await cleanupTestSandbox(sandbox);
+  }, 120000);
+
+  test.skipIf(skipPortExposureTests)(
+    'valid preview URL reaches a service in the current runtime',
+    async () => {
+      try {
+        await startPreviewServer(workerUrl, headers);
+        const previewUrl = await exposeLifecyclePort(workerUrl, portHeaders);
+
+        const response = await fetch(previewURL(previewUrl, '/hello'));
+        expect(response.status).toBe(200);
+        expect(await response.text()).toBe('hello from lifecycle port');
+      } finally {
+        await stopContainer(workerUrl, portHeaders).catch(() => undefined);
+      }
+    },
+    180000
+  );
+
+  test.skipIf(skipPortExposureTests)(
+    'WebSocket preview URL connects only while activated in the current runtime',
+    async () => {
+      let ws: WebSocket | null = null;
+      try {
+        await startPreviewServer(workerUrl, headers);
+        const previewUrl = await exposeLifecyclePort(workerUrl, portHeaders);
+
+        ws = await connectWebSocket(previewWebSocketURL(previewUrl, '/ws'));
+        const echoPromise = new Promise<string>((resolve, reject) => {
+          ws?.on('message', (data) => resolve(data.toString()));
+          setTimeout(() => reject(new Error('WebSocket echo timeout')), 5_000);
+        });
+        ws.send('preview websocket lifecycle');
+        expect(await echoPromise).toBe('preview websocket lifecycle');
+        ws.close();
+        ws = null;
+
+        await stopContainer(workerUrl, portHeaders);
+        expect(await getContainerStatus(workerUrl, portHeaders)).not.toBe(
+          'healthy'
+        );
+
+        await expectWebSocketStatus(
+          previewWebSocketURL(previewUrl, '/ws'),
+          410
+        );
+        expect(await getContainerStatus(workerUrl, portHeaders)).not.toBe(
+          'healthy'
+        );
+      } finally {
+        ws?.close();
+        await stopContainer(workerUrl, portHeaders).catch(() => undefined);
+      }
+    },
+    180000
+  );
+
+  test.skipIf(skipPortExposureTests)(
+    'authorized preview URL after container stop is stale and does not wake the container',
+    async () => {
+      try {
+        await startPreviewServer(workerUrl, headers);
+        const previewUrl = await exposeLifecyclePort(workerUrl, portHeaders);
+
+        const healthyResponse = await fetch(previewURL(previewUrl, '/hello'));
+        expect(healthyResponse.status).toBe(200);
+
+        await stopContainer(workerUrl, portHeaders);
+        expect(await getContainerStatus(workerUrl, portHeaders)).not.toBe(
+          'healthy'
+        );
+
+        const staleResponse = await fetch(previewURL(previewUrl, '/hello'));
+        expect(staleResponse.status).toBe(410);
+        expect(await staleResponse.json()).toMatchObject({
+          code: 'STALE_PREVIEW_URL'
+        });
+        expect(await getContainerStatus(workerUrl, portHeaders)).not.toBe(
+          'healthy'
+        );
+      } finally {
+        await stopContainer(workerUrl, portHeaders).catch(() => undefined);
+      }
+    },
+    180000
+  );
+
+  test.skipIf(skipPortExposureTests)(
+    'bad token after container stop is rejected without waking the container',
+    async () => {
+      try {
+        await startPreviewServer(workerUrl, headers);
+        const previewUrl = await exposeLifecyclePort(workerUrl, portHeaders);
+
+        await stopContainer(workerUrl, portHeaders);
+        const badTokenUrl = replacePreviewToken(previewUrl, 'badtoken');
+
+        const response = await fetch(previewURL(badTokenUrl, '/hello'));
+        expect(response.status).toBe(404);
+        expect(await response.json()).toMatchObject({
+          code: 'INVALID_TOKEN'
+        });
+        expect(await getContainerStatus(workerUrl, portHeaders)).not.toBe(
+          'healthy'
+        );
+      } finally {
+        await stopContainer(workerUrl, portHeaders).catch(() => undefined);
+      }
+    },
+    180000
+  );
+
+  test.skipIf(skipPortExposureTests)(
+    'revoked preview URL after container stop is rejected without waking the container',
+    async () => {
+      try {
+        await startPreviewServer(workerUrl, headers);
+        const previewUrl = await exposeLifecyclePort(workerUrl, portHeaders);
+
+        const deleteResponse = await fetch(
+          `${workerUrl}/api/exposed-ports/${PREVIEW_LIFECYCLE_PORT}`,
+          {
+            method: 'DELETE',
+            headers: portHeaders
+          }
+        );
+        expect(deleteResponse.status).toBe(200);
+
+        await stopContainer(workerUrl, portHeaders);
+
+        const response = await fetch(previewURL(previewUrl, '/hello'));
+        expect(response.status).toBe(404);
+        expect(await response.json()).toMatchObject({
+          code: 'INVALID_TOKEN'
+        });
+        expect(await getContainerStatus(workerUrl, portHeaders)).not.toBe(
+          'healthy'
+        );
+      } finally {
+        await stopContainer(workerUrl, portHeaders).catch(() => undefined);
+      }
+    },
+    180000
+  );
+
+  test.skipIf(skipPortExposureTests)(
+    'same preview URL stays stale until exposePort is called in the new runtime',
+    async () => {
+      try {
+        await startPreviewServer(workerUrl, headers);
+        const previewUrl = await exposeLifecyclePort(workerUrl, portHeaders);
+
+        const initialResponse = await fetch(previewURL(previewUrl, '/hello'));
+        expect(initialResponse.status).toBe(200);
+        expect(await initialResponse.text()).toBe('hello from lifecycle port');
+
+        await stopContainer(workerUrl, portHeaders);
+        await startPreviewServer(workerUrl, headers);
+
+        const staleResponse = await fetch(previewURL(previewUrl, '/hello'));
+        expect(staleResponse.status).toBe(410);
+        expect(await staleResponse.json()).toMatchObject({
+          code: 'STALE_PREVIEW_URL'
+        });
+
+        const reactivatedUrl = await exposeLifecyclePort(
+          workerUrl,
+          portHeaders
+        );
+        expect(reactivatedUrl).toBe(previewUrl);
+
+        const reactivatedResponse = await fetch(
+          previewURL(previewUrl, '/hello')
+        );
+        expect(reactivatedResponse.status).toBe(200);
+        expect(await reactivatedResponse.text()).toBe(
+          'hello from lifecycle port'
+        );
+      } finally {
+        await stopContainer(workerUrl, portHeaders).catch(() => undefined);
+      }
+    },
+    180000
+  );
+
+  test.skipIf(skipPortExposureTests)(
+    'old preview URL stays stale after unrelated SDK work starts a new runtime',
+    async () => {
+      try {
+        await startPreviewServer(workerUrl, headers);
+        const previewUrl = await exposeLifecyclePort(workerUrl, portHeaders);
+
+        const initialResponse = await fetch(previewURL(previewUrl, '/hello'));
+        expect(initialResponse.status).toBe(200);
+
+        await stopContainer(workerUrl, portHeaders);
+        await writeUnrelatedRuntimeFile(workerUrl, headers);
+        expect(await getContainerStatus(workerUrl, portHeaders)).toBe(
+          'healthy'
+        );
+
+        const staleResponse = await fetch(previewURL(previewUrl, '/hello'));
+        expect(staleResponse.status).toBe(410);
+        expect(await staleResponse.json()).toMatchObject({
+          code: 'STALE_PREVIEW_URL'
+        });
+        expect(await getContainerStatus(workerUrl, portHeaders)).toBe(
+          'healthy'
+        );
+      } finally {
+        await stopContainer(workerUrl, portHeaders).catch(() => undefined);
+      }
+    },
+    180000
+  );
+
+  test.skipIf(skipPortExposureTests)(
+    'old preview URL is rejected after sandbox destroy',
+    async () => {
+      try {
+        await startPreviewServer(workerUrl, headers);
+        const previewUrl = await exposeLifecyclePort(workerUrl, portHeaders);
+
+        const cleanupResponse = await fetch(`${workerUrl}/cleanup`, {
+          method: 'POST',
+          headers: portHeaders
+        });
+        expect(cleanupResponse.status).toBe(200);
+        sandbox = null;
+
+        const response = await fetch(previewURL(previewUrl, '/hello'));
+        expect(response.status).toBe(404);
+        const body = (await response.json()) as { code?: string };
+        expect(body.code).toBe('INVALID_TOKEN');
+      } finally {
+        if (sandbox !== null) {
+          await stopContainer(workerUrl, portHeaders).catch(() => undefined);
+        }
+      }
+    },
+    180000
+  );
+});

--- a/tests/e2e/preview-url-restart-workflow.test.ts
+++ b/tests/e2e/preview-url-restart-workflow.test.ts
@@ -14,6 +14,18 @@ const skipPortExposureTests =
 
 const RESTART_TEST_PORT = 9851;
 
+async function responseText(response: Response): Promise<string> {
+  return await response.text().catch(() => '<unreadable>');
+}
+
+async function assertOK(response: Response, action: string): Promise<void> {
+  if (!response.ok) {
+    throw new Error(
+      `${action} failed: ${response.status} ${await responseText(response)}`
+    );
+  }
+}
+
 function previewURL(previewUrl: string, path: string): string {
   return new URL(path, previewUrl).toString();
 }
@@ -61,7 +73,7 @@ await Bun.sleep(300000);
       `.trim();
 
       const startServer = async () => {
-        await fetch(`${workerUrl}/api/file/write`, {
+        const writeResponse = await fetch(`${workerUrl}/api/file/write`, {
           method: 'POST',
           headers,
           body: JSON.stringify({
@@ -69,6 +81,8 @@ await Bun.sleep(300000);
             content: serverCode
           })
         });
+        await assertOK(writeResponse, 'Writing restart preview server');
+
         const startResponse = await fetch(`${workerUrl}/api/process/start`, {
           method: 'POST',
           headers,
@@ -76,8 +90,9 @@ await Bun.sleep(300000);
             command: `bun run /workspace/restart-server.ts`
           })
         });
-        expect(startResponse.status).toBe(200);
+        await assertOK(startResponse, 'Starting restart preview server');
         const { id: processId } = (await startResponse.json()) as Process;
+
         const waitPortResponse = await fetch(
           `${workerUrl}/api/process/${processId}/waitForPort`,
           {
@@ -90,56 +105,65 @@ await Bun.sleep(300000);
             })
           }
         );
-        expect(waitPortResponse.status).toBe(200);
+        await assertOK(waitPortResponse, 'Waiting for restart preview port');
       };
 
-      await startServer();
-      const exposeResponse = await fetch(`${workerUrl}/api/port/expose`, {
-        method: 'POST',
-        headers: portHeaders,
-        body: JSON.stringify({
-          port: RESTART_TEST_PORT,
-          name: 'restart-test',
-          token: 'stable_reboot'
-        })
-      });
-      expect(exposeResponse.status).toBe(200);
-      const { url: exposedUrl } =
-        (await exposeResponse.json()) as PortExposeResult;
+      try {
+        await startServer();
+        const exposeResponse = await fetch(`${workerUrl}/api/port/expose`, {
+          method: 'POST',
+          headers: portHeaders,
+          body: JSON.stringify({
+            port: RESTART_TEST_PORT,
+            name: 'restart-test',
+            token: 'stable_reboot'
+          })
+        });
+        await assertOK(exposeResponse, 'Exposing restart preview port');
+        const { url: exposedUrl } =
+          (await exposeResponse.json()) as PortExposeResult;
 
-      const before = await fetch(previewURL(exposedUrl, '/hello'));
-      expect(before.status).toBe(200);
-      expect(await before.text()).toBe(`hello from port ${RESTART_TEST_PORT}`);
+        const before = await fetch(previewURL(exposedUrl, '/hello'));
+        expect(before.status).toBe(200);
+        expect(await before.text()).toBe(
+          `hello from port ${RESTART_TEST_PORT}`
+        );
 
-      await stopContainerAndWait(workerUrl, portHeaders);
+        await stopContainerAndWait(workerUrl, portHeaders);
 
-      await startServer();
+        await startServer();
 
-      const stale = await fetch(previewURL(exposedUrl, '/hello'));
-      expect(stale.status).toBe(410);
-      expect(await stale.json()).toMatchObject({ code: 'STALE_PREVIEW_URL' });
+        const stale = await fetch(previewURL(exposedUrl, '/hello'));
+        expect(stale.status).toBe(410);
+        expect(await stale.json()).toMatchObject({
+          code: 'STALE_PREVIEW_URL'
+        });
 
-      const reactivateResponse = await fetch(`${workerUrl}/api/port/expose`, {
-        method: 'POST',
-        headers: portHeaders,
-        body: JSON.stringify({
-          port: RESTART_TEST_PORT,
-          name: 'restart-test'
-        })
-      });
-      expect(reactivateResponse.status).toBe(200);
-      const { url: reactivatedUrl } =
-        (await reactivateResponse.json()) as PortExposeResult;
-      expect(reactivatedUrl).toBe(exposedUrl);
+        const reactivateResponse = await fetch(`${workerUrl}/api/port/expose`, {
+          method: 'POST',
+          headers: portHeaders,
+          body: JSON.stringify({
+            port: RESTART_TEST_PORT,
+            name: 'restart-test'
+          })
+        });
+        await assertOK(reactivateResponse, 'Reactivating restart preview port');
+        const { url: reactivatedUrl } =
+          (await reactivateResponse.json()) as PortExposeResult;
+        expect(reactivatedUrl).toBe(exposedUrl);
 
-      const after = await fetch(previewURL(exposedUrl, '/hello'));
-      expect(after.status).toBe(200);
-      expect(await after.text()).toBe(`hello from port ${RESTART_TEST_PORT}`);
-
-      await fetch(`${workerUrl}/api/exposed-ports/${RESTART_TEST_PORT}`, {
-        method: 'DELETE',
-        headers: portHeaders
-      });
+        const after = await fetch(previewURL(exposedUrl, '/hello'));
+        expect(after.status).toBe(200);
+        expect(await after.text()).toBe(`hello from port ${RESTART_TEST_PORT}`);
+      } finally {
+        await fetch(`${workerUrl}/api/exposed-ports/${RESTART_TEST_PORT}`, {
+          method: 'DELETE',
+          headers: portHeaders
+        }).catch(() => undefined);
+        await stopContainerAndWait(workerUrl, portHeaders).catch(
+          () => undefined
+        );
+      }
     },
     180000
   );

--- a/tests/e2e/preview-url-restart-workflow.test.ts
+++ b/tests/e2e/preview-url-restart-workflow.test.ts
@@ -1,5 +1,6 @@
 import type { PortExposeResult, Process } from '@repo/shared';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { stopContainerAndWait } from './helpers/container-lifecycle';
 import {
   cleanupTestSandbox,
   createTestSandbox,
@@ -13,16 +14,15 @@ const skipPortExposureTests =
 
 const RESTART_TEST_PORT = 9851;
 
+function previewURL(previewUrl: string, path: string): string {
+  return new URL(path, previewUrl).toString();
+}
+
 /**
- * Preview URLs survive container restarts.
- *
- * Exposes a port with a custom token, stops the container, restarts the
- * user process inside a fresh container, and fetches the preview URL
- * again. The preview URL responds 200 without the caller re-issuing
- * exposePort() — the SDK re-registers the port with the container on
- * startup using tokens persisted in Durable Object storage.
+ * Preview URL authorization survives container restarts, but activation is
+ * scoped to the runtime where exposePort() was last called.
  */
-describe('Preview URL survives container restart', () => {
+describe('Preview URL runtime activation after container restart', () => {
   let workerUrl: string;
   let headers: Record<string, string>;
   let portHeaders: Record<string, string>;
@@ -43,9 +43,8 @@ describe('Preview URL survives container restart', () => {
   }, 120000);
 
   test.skipIf(skipPortExposureTests)(
-    'preview URL keeps working after the container is stopped and restarted',
+    'preview URL stays stale after restart until the port is exposed again',
     async () => {
-      // Bun server that responds with a stable marker on /hello.
       const serverCode = `
 const server = Bun.serve({
   hostname: "0.0.0.0",
@@ -58,7 +57,6 @@ const server = Bun.serve({
     return new Response("not found", { status: 404 });
   },
 });
-console.log("Server listening on port " + server.port);
 await Bun.sleep(300000);
       `.trim();
 
@@ -93,10 +91,8 @@ await Bun.sleep(300000);
           }
         );
         expect(waitPortResponse.status).toBe(200);
-        return processId;
       };
 
-      // Phase 1: expose the port with a stable custom token, confirm it works.
       await startServer();
       const exposeResponse = await fetch(`${workerUrl}/api/port/expose`, {
         method: 'POST',
@@ -104,35 +100,42 @@ await Bun.sleep(300000);
         body: JSON.stringify({
           port: RESTART_TEST_PORT,
           name: 'restart-test',
-          token: 'stableafterreboot'
+          token: 'stable_reboot'
         })
       });
       expect(exposeResponse.status).toBe(200);
       const { url: exposedUrl } =
         (await exposeResponse.json()) as PortExposeResult;
 
-      const before = await fetch(`${exposedUrl}/hello`);
+      const before = await fetch(previewURL(exposedUrl, '/hello'));
       expect(before.status).toBe(200);
       expect(await before.text()).toBe(`hello from port ${RESTART_TEST_PORT}`);
 
-      // Phase 2: stop the container. DO storage survives.
-      const stopResponse = await fetch(`${workerUrl}/api/container/stop`, {
-        method: 'POST',
-        headers: portHeaders
-      });
-      expect(stopResponse.status).toBe(200);
+      await stopContainerAndWait(workerUrl, portHeaders);
 
-      // Phase 3: restart the process inside a fresh container, then hit the
-      // preview URL again. The SDK should re-expose the port automatically
-      // as part of onStart() and the preview URL should respond without the
-      // caller re-issuing exposePort().
       await startServer();
 
-      const after = await fetch(`${exposedUrl}/hello`);
+      const stale = await fetch(previewURL(exposedUrl, '/hello'));
+      expect(stale.status).toBe(410);
+      expect(await stale.json()).toMatchObject({ code: 'STALE_PREVIEW_URL' });
+
+      const reactivateResponse = await fetch(`${workerUrl}/api/port/expose`, {
+        method: 'POST',
+        headers: portHeaders,
+        body: JSON.stringify({
+          port: RESTART_TEST_PORT,
+          name: 'restart-test'
+        })
+      });
+      expect(reactivateResponse.status).toBe(200);
+      const { url: reactivatedUrl } =
+        (await reactivateResponse.json()) as PortExposeResult;
+      expect(reactivatedUrl).toBe(exposedUrl);
+
+      const after = await fetch(previewURL(exposedUrl, '/hello'));
       expect(after.status).toBe(200);
       expect(await after.text()).toBe(`hello from port ${RESTART_TEST_PORT}`);
 
-      // Cleanup
       await fetch(`${workerUrl}/api/exposed-ports/${RESTART_TEST_PORT}`, {
         method: 'DELETE',
         headers: portHeaders

--- a/tests/e2e/test-worker/wrangler.template.jsonc
+++ b/tests/e2e/test-worker/wrangler.template.jsonc
@@ -38,7 +38,7 @@
       "instance_type": "standard-4",
       "unsafe": {
         "configuration": {
-          "durable_object_offset_instances": 25
+          "durable_object_offset_instances": 0
         }
       }
     },
@@ -49,7 +49,7 @@
       "instance_type": "standard-4",
       "unsafe": {
         "configuration": {
-          "durable_object_offset_instances": 25
+          "durable_object_offset_instances": 0
         }
       }
     },
@@ -60,7 +60,7 @@
       "instance_type": "standard-4",
       "unsafe": {
         "configuration": {
-          "durable_object_offset_instances": 25
+          "durable_object_offset_instances": 0
         }
       }
     },
@@ -71,7 +71,7 @@
       "instance_type": "standard-4",
       "unsafe": {
         "configuration": {
-          "durable_object_offset_instances": 25
+          "durable_object_offset_instances": 0
         }
       }
     },
@@ -82,7 +82,7 @@
       "instance_type": "standard-4",
       "unsafe": {
         "configuration": {
-          "durable_object_offset_instances": 25
+          "durable_object_offset_instances": 0
         }
       }
     }

--- a/tests/e2e/test-worker/wrangler.template.jsonc
+++ b/tests/e2e/test-worker/wrangler.template.jsonc
@@ -23,7 +23,7 @@
       "image": "{{IMAGE_SANDBOX}}",
       "name": "{{CONTAINER_NAME}}",
       "instance_type": "standard-4",
-      "max_instances": 50,
+      "max_instances": 64,
       "unsafe": {
         "configuration": {
           "durable_object_offset_instances": 25

--- a/tests/e2e/test-worker/wrangler.template.jsonc
+++ b/tests/e2e/test-worker/wrangler.template.jsonc
@@ -23,6 +23,7 @@
       "image": "{{IMAGE_SANDBOX}}",
       "name": "{{CONTAINER_NAME}}",
       "instance_type": "standard-4",
+      // CI parallelism can exceed 50 sandboxes; revisit if test sharding or parallelism changes.
       "max_instances": 64,
       "unsafe": {
         "configuration": {

--- a/turbo.json
+++ b/turbo.json
@@ -83,7 +83,8 @@
         "!tests/e2e/browser/**",
         "vitest.e2e.config.ts",
         "packages/sandbox/Dockerfile"
-      ]
+      ],
+      "passThroughEnv": ["TEST_TRANSPORT", "TEST_WORKER_URL"]
     },
     "test:perf": {
       "dependsOn": ["^build", "docker:local"],
@@ -100,7 +101,13 @@
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY"
       ],
-      "env": ["GITHUB_SHA", "GITHUB_REF_NAME", "GITHUB_EVENT_NAME", "CI", "PERF_RUN_ID"]
+      "env": [
+        "GITHUB_SHA",
+        "GITHUB_REF_NAME",
+        "GITHUB_EVENT_NAME",
+        "CI",
+        "PERF_RUN_ID"
+      ]
     },
     "test:e2e:browser": {
       "dependsOn": ["^build", "docker:local"],


### PR DESCRIPTION
Preview URLs currently mix two different concepts: persistent token authorization and live container runtime state. A preview URL token can survive container restart, but the user process serving that port does not. That means an old preview URL can start the container or reach a later container instance that never called `exposePort()` for that port.

This change separates token validity from current-runtime activation.

In this stack, “current runtime” means the currently running container instance/generation. A preview URL is active only if `exposePort()` was called for that port in that current container runtime.

`portTokens` remains persistent token authorization: it records whether a preview URL token is valid for a sandbox port across container restarts. That token staying valid does not mean a live process is currently serving the port, or that the URL may forward traffic in a later container runtime.

Preview URL traffic now enters the Sandbox Durable Object before forwarding. The Durable Object checks persistent token authorization and current-runtime activation, strips spoofed internal preview headers, then forwards only through `Container.fetchIfRunning()`, which does not start a stopped container.

Preview state updates use Durable Object storage transactions so concurrent expose/unexpose operations read and write coherent token and activation snapshots.

The response contract becomes:

- malformed or non-preview hostnames fall through without being handled as preview requests;
- invalid, revoked, or destroyed tokens return `404 INVALID_TOKEN`;
- valid tokens without current-runtime activation return `410 STALE_PREVIEW_URL`;
- valid tokens with activation also return `410 STALE_PREVIEW_URL` if the current container is no longer running and healthy;
- active preview URLs forward only when the container is already running and healthy.

`exposePort()` is now the explicit preview action that activates a port for the current runtime. Restarting a service on the same port is not enough to revive an old preview URL; callers must expose the port again.

The desktop preview integration now also goes through `exposePort()` activation. It can no longer synthesize a URL from a persisted token when current-runtime activation fails.

This PR only adds a runtime identity used to fence preview URL activation. It does not introduce a general lifecycle manager and does not change sessions, processes, interpreters, mounts, or backups.

Preview route parsing details are kept internal rather than exported as public API.

This PR depends on `@cloudflare/containers` support for `Container.fetchIfRunning()`. The dependency currently points at the preview package from cloudflare/containers#212 and must be replaced with a published version before this stack can merge.

The changeset is intentionally `minor` because preview URLs that previously auto-survived restart now return `410 STALE_PREVIEW_URL` until the port is exposed again in the new runtime.

---

This is **part 1 of 3** in the preview URL lifecycle stack:

- <kbd>&nbsp;3&nbsp;</kbd> #710 — Remove container-local preview port registry
- <kbd>&nbsp;2&nbsp;</kbd> #709 — Align preview port APIs with forwarding
- <kbd>&nbsp;1&nbsp;</kbd> #708 — Enforce preview URL runtime activation 👈
- `main`
