### PR TITLE
Align preview port APIs with forwarding

### DIFF
--- a/.changeset/stale-preview-urls.md
+++ b/.changeset/stale-preview-urls.md
@@ -3,3 +3,5 @@
 ---
 
 Prevent stale preview URLs from waking or reaching sandbox runtimes. Invalid, revoked, or destroyed preview URLs return `404 INVALID_TOKEN`; authorized URLs that are not activated for the current runtime return `410 STALE_PREVIEW_URL` until the port is exposed again. Existing preview URLs that previously survived container restart now return `410 STALE_PREVIEW_URL` after a restart until the port is exposed again in the new runtime.
+
+`getExposedPorts()` and `isPortExposed()` now report only ports that are currently preview-forwardable in the active runtime. `unexposePort()` is now idempotent: revoking a port that is not currently exposed succeeds without contacting the container.

--- a/packages/sandbox/src/errors/classes.ts
+++ b/packages/sandbox/src/errors/classes.ts
@@ -337,7 +337,7 @@ export class SessionTerminatedError extends SandboxError<SessionTerminatedContex
 // ============================================================================
 
 /**
- * Error thrown when a port is already exposed
+ * Compatibility error for legacy port exposure registry responses.
  */
 export class PortAlreadyExposedError extends SandboxError<PortAlreadyExposedContext> {
   constructor(errorResponse: ErrorResponse<PortAlreadyExposedContext>) {
@@ -355,7 +355,7 @@ export class PortAlreadyExposedError extends SandboxError<PortAlreadyExposedCont
 }
 
 /**
- * Error thrown when a port is not exposed
+ * Compatibility error for legacy port exposure registry responses.
  */
 export class PortNotExposedError extends SandboxError<PortNotExposedContext> {
   constructor(errorResponse: ErrorResponse<PortNotExposedContext>) {

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -71,7 +71,6 @@ import {
   CustomDomainRequiredError,
   ErrorCode,
   InvalidBackupConfigError,
-  PortNotExposedError,
   ProcessExitedBeforeReadyError,
   ProcessNotFoundError,
   ProcessReadyTimeoutError,
@@ -166,6 +165,11 @@ type PreviewPortActivation = RuntimeScoped<{
 }>;
 
 type PreviewPortActivations = Record<string, PreviewPortActivation>;
+
+type CurrentPreviewPort = {
+  port: number;
+  entry: PortTokenEntry;
+};
 
 type PreviewStateStorage = Pick<
   DurableObjectStorage | DurableObjectTransaction,
@@ -2324,6 +2328,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       // doesn't ghost-revive on the next sandbox under the same DO id.
       await this.ctx.storage.delete('tunnels');
       await this.ctx.storage.delete('tunnels:meta');
+
 
       // Disconnect transport after all cleanup commands have completed
       this.client.disconnect();
@@ -4561,11 +4566,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         this.validateCustomToken(options.token);
       }
 
-      const sessionId = this.serializeExecutionContext(
-        await this.resolveExecution()
-      );
-
-      await this.client.ports.exposePort(port, sessionId, options.name);
+      await this.ensureDefaultSession();
 
       // onStart() may record runtime identity while ensureDefaultSession()
       // starts the container. Re-read before falling back to markStarted() so
@@ -4638,6 +4639,13 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
   }
 
+  /**
+   * Revoke preview URL authorization and current-runtime activation for a port.
+   *
+   * Revocation is idempotent: calling this for a port with no preview state is
+   * still successful. The operation clears Durable Object-owned preview state
+   * only and does not contact, probe, wake, or clean up the container runtime.
+   */
   async unexposePort(port: number) {
     const unexposeStartTime = Date.now();
     let outcome: 'success' | 'error' = 'error';
@@ -4649,39 +4657,22 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         );
       }
 
-      // Storage is the source of truth for preview-URL auth, so clear
-      // the token before the container RPC. A preview request that
-      // arrives during the container call sees no token, fails auth,
-      // and is rejected before containerFetch() can route it to the
-      // process running inside the sandbox. (containerFetch() does not
-      // gate on the container's exposed-port registry; it connects to
-      // the port number directly.)
-      const tokens = await this.readPortTokens();
-      if (tokens[port.toString()]) {
-        delete tokens[port.toString()];
-        await this.ctx.storage.put('portTokens', tokens);
-      }
-
-      const activations = await this.readActivePreviewPorts();
-      if (activations[port.toString()]) {
-        delete activations[port.toString()];
-        await this.writeActivePreviewPorts(activations);
-      }
-
-      const sessionId = this.serializeExecutionContext(
-        await this.resolveExecution()
-      );
-      try {
-        await this.client.ports.unexposePort(port, sessionId);
-      } catch (error) {
-        // A container that was asleep when we entered wakes with an
-        // empty exposed-port registry. We already cleared durable auth
-        // and activation state, so a "not exposed" response is the state
-        // we wanted.
-        if (!(error instanceof PortNotExposedError)) {
-          throw error;
+      // Storage is the source of truth for preview-URL auth and activation.
+      // Clearing DO-owned state is sufficient to revoke forwarding and does
+      // not need to contact the container runtime.
+      await this.ctx.storage.transaction(async (txn) => {
+        const tokens = await this.readPortTokens(txn);
+        if (tokens[port.toString()]) {
+          delete tokens[port.toString()];
+          await txn.put(PORT_TOKENS_STORAGE_KEY, tokens);
         }
-      }
+
+        const activations = await this.readActivePreviewPorts(txn);
+        if (activations[port.toString()]) {
+          delete activations[port.toString()];
+          await this.writeActivePreviewPorts(activations, txn);
+        }
+      });
 
       outcome = 'success';
     } catch (error) {
@@ -4698,12 +4689,11 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
   }
 
+  /**
+   * Returns preview URLs that are currently forwardable in the active runtime.
+   * Durable authorization without current-runtime activation is omitted.
+   */
   async getExposedPorts(hostname: string) {
-    const sessionId = this.serializeExecutionContext(
-      await this.resolveExecution()
-    );
-    const response = await this.client.ports.getExposedPorts(sessionId);
-
     // We need the sandbox name to construct preview URLs
     if (!this.sandboxName) {
       throw new Error(
@@ -4711,35 +4701,17 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       );
     }
 
-    // Read all tokens from storage (protected by input gates)
-    const tokens = await this.readPortTokens();
-
-    // A port reported by the container with no corresponding token in
-    // storage is an orphan. It cannot produce a valid preview URL (the
-    // token is what the URL binds to), so it is omitted from the result.
-    return response.ports.flatMap((port) => {
-      const entry = tokens[port.port.toString()];
-      if (!entry) {
-        this.logger.warn(
-          'Port exposed on container but no token in storage; omitting from preview URL list',
-          { port: port.port }
-        );
-        return [];
-      }
-
-      return [
-        {
-          url: this.constructPreviewUrl(
-            port.port,
-            this.sandboxName!,
-            hostname,
-            entry.token
-          ),
-          port: port.port,
-          status: port.status
-        }
-      ];
-    });
+    const activePorts = await this.getCurrentPreviewPorts();
+    return activePorts.map(({ port, entry }) => ({
+      url: this.constructPreviewUrl(
+        port,
+        this.sandboxName!,
+        hostname,
+        entry.token
+      ),
+      port,
+      status: 'active' as const
+    }));
   }
 
   /**
@@ -4855,21 +4827,18 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     return this.tunnelZoneIdPromise;
   }
 
+  /**
+   * Returns whether a port is currently preview-forwardable.
+   * This checks Durable Object-owned auth and runtime activation without
+   * contacting or waking the container.
+   */
   async isPortExposed(port: number): Promise<boolean> {
-    try {
-      const sessionId = this.serializeExecutionContext(
-        await this.resolveExecution()
-      );
-      const response = await this.client.ports.getExposedPorts(sessionId);
-      return response.ports.some((exposedPort) => exposedPort.port === port);
-    } catch (error) {
-      this.logger.error(
-        'Error checking if port is exposed',
-        error instanceof Error ? error : new Error(String(error)),
-        { port }
-      );
+    if (!validatePort(port)) {
       return false;
     }
+
+    const activePorts = await this.getCurrentPreviewPorts();
+    return activePorts.some((activePort) => activePort.port === port);
   }
 
   /**
@@ -4972,6 +4941,46 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
 
     return { status: 'active', runtime };
+  }
+
+  private async getCurrentPreviewPorts(): Promise<CurrentPreviewPort[]> {
+    const containerState = await this.getState();
+    const containerRunning = this.ctx.container?.running === true;
+    const { tokens, activations, runtime } = await this.ctx.storage.transaction(
+      async (txn) => {
+        const [previewState, runtime] = await Promise.all([
+          this.readPreviewState(txn),
+          this.currentRuntime.getStored(txn)
+        ]);
+        return { ...previewState, runtime };
+      }
+    );
+
+    if (containerState.status !== 'healthy' || !containerRunning || !runtime) {
+      return [];
+    }
+
+    const activePorts: CurrentPreviewPort[] = [];
+
+    for (const [portKey, activation] of Object.entries(activations)) {
+      const port = Number.parseInt(portKey, 10);
+      const entry = tokens[portKey];
+      if (!entry || !Number.isInteger(port) || !validatePort(port)) {
+        continue;
+      }
+
+      if (!runtime.owns(activation)) {
+        continue;
+      }
+
+      if (!this.previewTokensMatch(entry.token, activation.token)) {
+        continue;
+      }
+
+      activePorts.push({ port, entry });
+    }
+
+    return activePorts.sort((a, b) => a.port - b.port);
   }
 
   private previewTokensMatch(expected: string, actual: string): boolean {

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -1259,12 +1259,6 @@ describe('Sandbox - Automatic Session Management', () => {
   describe('port exposure - workers.dev detection', () => {
     beforeEach(async () => {
       await sandbox.setSandboxName('test-sandbox');
-      vi.spyOn(sandbox.client.ports, 'exposePort').mockResolvedValue({
-        success: true,
-        port: 8080,
-        name: 'test-service',
-        exposedAt: new Date().toISOString()
-      } as any);
     });
 
     it('should reject workers.dev domains with CustomDomainRequiredError', async () => {
@@ -1285,9 +1279,6 @@ describe('Sandbox - Automatic Session Management', () => {
           expect(error.message).toContain('custom domain');
         }
       }
-
-      // Verify client method was never called
-      expect(sandbox.client.ports.exposePort).not.toHaveBeenCalled();
     });
 
     it('should accept custom domains and subdomains', async () => {
@@ -1313,7 +1304,7 @@ describe('Sandbox - Automatic Session Management', () => {
       });
 
       expect(result.url).toContain('localhost');
-      expect(sandbox.client.ports.exposePort).toHaveBeenCalled();
+      expect(sandbox.client.utils.createSession).toHaveBeenCalled();
     });
   });
 
@@ -1726,14 +1717,6 @@ describe('Sandbox - Automatic Session Management', () => {
   describe('constructPreviewUrl validation', () => {
     it('should throw clear error for ID with uppercase letters without normalizeId', async () => {
       await sandbox.setSandboxName('MyProject-123', false);
-
-      vi.spyOn(sandbox.client.ports, 'exposePort').mockResolvedValue({
-        success: true,
-        port: 8080,
-        url: '',
-        timestamp: '2023-01-01T00:00:00Z'
-      });
-
       await expect(
         sandbox.exposePort(8080, { hostname: 'example.com' })
       ).rejects.toThrow(/Preview URLs require lowercase sandbox IDs/);
@@ -1741,14 +1724,6 @@ describe('Sandbox - Automatic Session Management', () => {
 
     it('should construct valid URL for lowercase ID', async () => {
       await sandbox.setSandboxName('my-project', false);
-
-      vi.spyOn(sandbox.client.ports, 'exposePort').mockResolvedValue({
-        success: true,
-        port: 8080,
-        url: '',
-        timestamp: '2023-01-01T00:00:00Z'
-      });
-
       const result = await sandbox.exposePort(8080, {
         hostname: 'example.com'
       });
@@ -1761,14 +1736,6 @@ describe('Sandbox - Automatic Session Management', () => {
 
     it('should construct valid URL with normalized ID', async () => {
       await sandbox.setSandboxName('myproject-123', true);
-
-      vi.spyOn(sandbox.client.ports, 'exposePort').mockResolvedValue({
-        success: true,
-        port: 4000,
-        url: '',
-        timestamp: '2023-01-01T00:00:00Z'
-      });
-
       const result = await sandbox.exposePort(4000, { hostname: 'my-app.dev' });
 
       expect(result.url).toMatch(
@@ -1779,14 +1746,6 @@ describe('Sandbox - Automatic Session Management', () => {
 
     it('should construct valid localhost URL', async () => {
       await sandbox.setSandboxName('test-sandbox', false);
-
-      vi.spyOn(sandbox.client.ports, 'exposePort').mockResolvedValue({
-        success: true,
-        port: 8080,
-        url: '',
-        timestamp: '2023-01-01T00:00:00Z'
-      });
-
       const result = await sandbox.exposePort(8080, {
         hostname: 'localhost:3000'
       });
@@ -1798,14 +1757,6 @@ describe('Sandbox - Automatic Session Management', () => {
 
     it('should include helpful guidance in error message', async () => {
       await sandbox.setSandboxName('MyProject-ABC', false);
-
-      vi.spyOn(sandbox.client.ports, 'exposePort').mockResolvedValue({
-        success: true,
-        port: 8080,
-        url: '',
-        timestamp: '2023-01-01T00:00:00Z'
-      });
-
       await expect(
         sandbox.exposePort(8080, { hostname: 'example.com' })
       ).rejects.toThrow(
@@ -1848,13 +1799,6 @@ describe('Sandbox - Automatic Session Management', () => {
   describe('custom token validation', () => {
     beforeEach(async () => {
       await sandbox.setSandboxName('test-sandbox', false);
-
-      vi.spyOn(sandbox.client.ports, 'exposePort').mockResolvedValue({
-        success: true,
-        port: 8080,
-        url: 'http://localhost:8080',
-        timestamp: new Date().toISOString()
-      });
 
       vi.mocked(mockCtx.storage!.get).mockResolvedValue({} as any);
       vi.mocked(mockCtx.storage!.put).mockResolvedValue(undefined);
@@ -1923,17 +1867,6 @@ describe('Sandbox - Automatic Session Management', () => {
   describe('preview URL runtime activation', () => {
     beforeEach(async () => {
       await sandbox.setSandboxName('test-sandbox', false);
-      vi.spyOn(sandbox.client.ports, 'exposePort').mockResolvedValue({
-        success: true,
-        port: 8080,
-        exposedAt: new Date().toISOString()
-      } as any);
-      vi.spyOn(sandbox.client.ports, 'getExposedPorts').mockResolvedValue({
-        success: true,
-        ports: [],
-        count: 0,
-        timestamp: new Date().toISOString()
-      } as any);
     });
 
     it('onStart() marks a new current runtime without restoring saved ports', async () => {
@@ -1953,8 +1886,7 @@ describe('Sandbox - Automatic Session Management', () => {
           id: expect.any(String)
         })
       );
-      expect(sandbox.client.ports.getExposedPorts).not.toHaveBeenCalled();
-      expect(sandbox.client.ports.exposePort).not.toHaveBeenCalled();
+      expect(sandbox.client.utils.createSession).not.toHaveBeenCalled();
     });
 
     it('onStop() preserves durable auth and clears runtime-scoped preview state', async () => {
@@ -2184,19 +2116,7 @@ describe('Sandbox - Automatic Session Management', () => {
         expect(ensureDefaultSessionSpy).toHaveBeenCalled()
       );
 
-      await mockCtx.storage.transaction(
-        async (txn: {
-          get: (key: string) => Promise<unknown>;
-          put: (key: string, value: unknown) => Promise<void>;
-        }) => {
-          const tokens = ((await txn.get('portTokens')) ?? {}) as Record<
-            string,
-            unknown
-          >;
-          delete tokens['8080'];
-          await txn.put('portTokens', tokens);
-        }
-      );
+      await sandbox.unexposePort(8080);
       expect(storage.get('portTokens')).toEqual({});
 
       releaseStartup();
@@ -2298,17 +2218,29 @@ describe('Sandbox - Automatic Session Management', () => {
     });
   });
 
+  describe('desktop preview URL lifecycle', () => {
+    it('does not synthesize a desktop preview URL from durable auth when exposePort fails', async () => {
+      await sandbox.setSandboxName('test-sandbox', false);
+      vi.spyOn(sandbox.client.desktop, 'status').mockResolvedValue({
+        success: true,
+        status: 'active',
+        processes: {},
+        resolution: [1024, 768],
+        dpi: 96
+      });
+      vi.mocked(mockCtx.storage.get).mockImplementation(async (key) =>
+        key === 'portTokens' ? { '6080': { token: 'oldtoken' } } : null
+      );
+      vi.spyOn(sandbox, 'exposePort').mockRejectedValue(new Error('boom'));
+
+      await expect(sandbox.getDesktopStreamUrl('example.com')).rejects.toThrow(
+        'boom'
+      );
+    });
+  });
+
   describe('validatePortToken', () => {
     beforeEach(() => {
-      // Spy on getExposedPorts so a regression that reintroduces the
-      // container round-trip is catchable via not.toHaveBeenCalled().
-      vi.spyOn(sandbox.client.ports, 'getExposedPorts').mockResolvedValue({
-        success: true,
-        ports: [],
-        count: 0,
-        timestamp: new Date().toISOString()
-      } as any);
-
       vi.mocked(mockCtx.storage.get).mockImplementation(async (key) =>
         key === 'portTokens' ? { '8080': { token: 'correcttoken' } } : null
       );
@@ -2318,7 +2250,6 @@ describe('Sandbox - Automatic Session Management', () => {
       const result = await sandbox.validatePortToken(8080, 'correcttoken');
 
       expect(result).toBe(true);
-      expect(sandbox.client.ports.getExposedPorts).not.toHaveBeenCalled();
     });
 
     it('returns false for a mismatched token', async () => {
@@ -2356,6 +2287,209 @@ describe('Sandbox - Automatic Session Management', () => {
       await sandbox.validatePortToken(8080, 'correcttoken');
 
       expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getExposedPorts Contract B', () => {
+    beforeEach(async () => {
+      await sandbox.setSandboxName('test-sandbox');
+    });
+
+    it('lists only ports activated for the current runtime without contacting the container', async () => {
+      vi.mocked(mockCtx.storage.get).mockImplementation(async (key) => {
+        if (key === 'currentRuntimeIdentity') {
+          return { id: 'runtime-1' };
+        }
+        if (key === 'portTokens') {
+          return {
+            '8080': { token: 'tok8080', name: 'api' },
+            '9090': { token: 'tok9090' }
+          };
+        }
+        if (key === 'activePreviewPorts') {
+          return {
+            '8080': {
+              runtimeIdentityID: 'runtime-1',
+              token: 'tok8080'
+            },
+            '9090': {
+              runtimeIdentityID: 'runtime-old',
+              token: 'tok9090'
+            }
+          };
+        }
+        return null;
+      });
+
+      const result = await sandbox.getExposedPorts('example.com');
+
+      expect(result).toEqual([
+        {
+          url: 'https://8080-test-sandbox-tok8080.example.com/',
+          port: 8080,
+          status: 'active'
+        }
+      ]);
+      expect(sandbox.client.utils.createSession).not.toHaveBeenCalled();
+    });
+
+    it('returns an empty list when durable auth exists without a current runtime', async () => {
+      vi.mocked(mockCtx.storage.get).mockImplementation(async (key) => {
+        if (key === 'portTokens') {
+          return { '8080': { token: 'tok8080' } };
+        }
+        if (key === 'activePreviewPorts') {
+          return {
+            '8080': {
+              runtimeIdentityID: 'runtime-1',
+              token: 'tok8080'
+            }
+          };
+        }
+        return null;
+      });
+
+      await expect(sandbox.getExposedPorts('example.com')).resolves.toEqual([]);
+      expect(sandbox.client.utils.createSession).not.toHaveBeenCalled();
+    });
+
+    it('omits durable auth without matching current-runtime activation', async () => {
+      vi.mocked(mockCtx.storage.get).mockImplementation(async (key) => {
+        if (key === 'currentRuntimeIdentity') {
+          return { id: 'runtime-1' };
+        }
+        if (key === 'portTokens') {
+          return { '8080': { token: 'tok8080' } };
+        }
+        if (key === 'activePreviewPorts') {
+          return {};
+        }
+        return null;
+      });
+
+      await expect(sandbox.getExposedPorts('example.com')).resolves.toEqual([]);
+      expect(sandbox.client.utils.createSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isPortExposed Contract B', () => {
+    beforeEach(() => {});
+
+    it('returns true only for durable auth activated in the current runtime', async () => {
+      vi.mocked(mockCtx.storage.get).mockImplementation(async (key) => {
+        if (key === 'currentRuntimeIdentity') {
+          return { id: 'runtime-1' };
+        }
+        if (key === 'portTokens') {
+          return { '8080': { token: 'tok8080' } };
+        }
+        if (key === 'activePreviewPorts') {
+          return {
+            '8080': {
+              runtimeIdentityID: 'runtime-1',
+              token: 'tok8080'
+            }
+          };
+        }
+        return null;
+      });
+
+      await expect(sandbox.isPortExposed(8080)).resolves.toBe(true);
+      expect(sandbox.client.utils.createSession).not.toHaveBeenCalled();
+    });
+
+    it('returns false for durable auth without activation', async () => {
+      vi.mocked(mockCtx.storage.get).mockImplementation(async (key) => {
+        if (key === 'currentRuntimeIdentity') {
+          return { id: 'runtime-1' };
+        }
+        if (key === 'portTokens') {
+          return { '8080': { token: 'tok8080' } };
+        }
+        if (key === 'activePreviewPorts') {
+          return {};
+        }
+        return null;
+      });
+
+      await expect(sandbox.isPortExposed(8080)).resolves.toBe(false);
+      expect(sandbox.client.utils.createSession).not.toHaveBeenCalled();
+    });
+
+    it('returns false for activation from an old runtime', async () => {
+      vi.mocked(mockCtx.storage.get).mockImplementation(async (key) => {
+        if (key === 'currentRuntimeIdentity') {
+          return { id: 'runtime-1' };
+        }
+        if (key === 'portTokens') {
+          return { '8080': { token: 'tok8080' } };
+        }
+        if (key === 'activePreviewPorts') {
+          return {
+            '8080': {
+              runtimeIdentityID: 'runtime-old',
+              token: 'tok8080'
+            }
+          };
+        }
+        return null;
+      });
+
+      await expect(sandbox.isPortExposed(8080)).resolves.toBe(false);
+      expect(sandbox.client.utils.createSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('unexposePort Contract B', () => {
+    beforeEach(() => {});
+
+    it('revokes auth and activation without waking when no current runtime is active', async () => {
+      vi.mocked(mockCtx.storage.get).mockImplementation(async (key) => {
+        if (key === 'portTokens') {
+          return { '8080': { token: 'tok8080' } };
+        }
+        if (key === 'activePreviewPorts') {
+          return {
+            '8080': {
+              runtimeIdentityID: 'runtime-1',
+              token: 'tok8080'
+            }
+          };
+        }
+        return null;
+      });
+
+      await sandbox.unexposePort(8080);
+
+      expect(mockCtx.storage.put).toHaveBeenCalledWith('portTokens', {});
+      expect(mockCtx.storage.delete).toHaveBeenCalledWith('activePreviewPorts');
+      expect(sandbox.client.utils.createSession).not.toHaveBeenCalled();
+    });
+
+    it('revokes auth and activation without touching the container registry when runtime is active', async () => {
+      vi.mocked(mockCtx.storage.get).mockImplementation(async (key) => {
+        if (key === 'currentRuntimeIdentity') {
+          return { id: 'runtime-1' };
+        }
+        if (key === 'portTokens') {
+          return { '8080': { token: 'tok8080' } };
+        }
+        if (key === 'activePreviewPorts') {
+          return {
+            '8080': {
+              runtimeIdentityID: 'runtime-1',
+              token: 'tok8080'
+            }
+          };
+        }
+        return null;
+      });
+
+      await sandbox.unexposePort(8080);
+
+      expect(mockCtx.storage.put).toHaveBeenCalledWith('portTokens', {});
+      expect(mockCtx.storage.delete).toHaveBeenCalledWith('activePreviewPorts');
+      expect(sandbox.client.utils.createSession).not.toHaveBeenCalled();
     });
   });
 
@@ -3484,11 +3618,13 @@ describe('Sandbox.getProcess()', () => {
       (sb as any).client = {
         getTransportMode: () => 'rpc',
         utils: {
-          createSession: vi.fn().mockResolvedValue({
-            success: true,
-            id: 'default',
-            message: 'ok'
-          } as any)
+          createSession: vi
+            .fn()
+            .mockResolvedValue({
+              success: true,
+              id: 'default',
+              message: 'ok'
+            } as any)
         },
         processes: {}
       };

--- a/tests/e2e/preview-url-lifecycle.test.ts
+++ b/tests/e2e/preview-url-lifecycle.test.ts
@@ -20,6 +20,7 @@ const PREVIEW_PORTS = {
   validHttp: 9852,
   webSocket: 9853,
   staleAfterStop: 9854,
+  portAPIs: 9855,
   rotatedToken: 9856,
   revoked: 9857,
   reusedURL: 9858,
@@ -30,6 +31,12 @@ const PREVIEW_PORTS = {
 const REUSED_URL_TOKEN = 'lifecycleok';
 const ROTATED_TOKEN_A = 'lifecycle_a';
 const ROTATED_TOKEN_B = 'lifecycle_b';
+
+type ExposedPortsResponse = Array<{
+  port: number;
+  url: string;
+  status: string;
+}>;
 
 async function responseText(response: Response): Promise<string> {
   return await response.text().catch(() => '<unreadable>');
@@ -151,6 +158,28 @@ async function unexposePreviewPort(
     headers
   });
   await assertOK(response, `Unexposing preview port ${port}`);
+}
+
+async function getExposedPorts(
+  workerUrl: string,
+  headers: Record<string, string>
+): Promise<ExposedPortsResponse> {
+  const response = await fetch(`${workerUrl}/api/exposed-ports`, { headers });
+  await assertOK(response, 'Reading exposed preview ports');
+  return (await response.json()) as ExposedPortsResponse;
+}
+
+async function isPortExposed(
+  workerUrl: string,
+  headers: Record<string, string>,
+  port: number
+): Promise<boolean> {
+  const response = await fetch(`${workerUrl}/api/exposed-ports/${port}`, {
+    headers
+  });
+  await assertOK(response, `Reading exposed state for preview port ${port}`);
+  const body = (await response.json()) as { exposed: boolean };
+  return body.exposed;
 }
 
 function previewURL(previewUrl: string, path: string): string {
@@ -339,6 +368,57 @@ describe('Preview URL lifecycle', () => {
         });
         expect(await getContainerStatus(workerUrl, portHeaders)).not.toBe(
           'healthy'
+        );
+      } finally {
+        await unexposePreviewPort(workerUrl, portHeaders, port).catch(
+          () => undefined
+        );
+        await stopContainer(workerUrl, portHeaders).catch(() => undefined);
+      }
+    },
+    180000
+  );
+
+  test.skipIf(skipPortExposureTests)(
+    'preview port APIs report only current-runtime activated ports without waking',
+    async () => {
+      const port = PREVIEW_PORTS.portAPIs;
+      try {
+        await startPreviewServer(workerUrl, headers, port);
+        const previewUrl = await exposePreviewPort(
+          workerUrl,
+          portHeaders,
+          port
+        );
+
+        await expect(getExposedPorts(workerUrl, portHeaders)).resolves.toEqual([
+          {
+            port,
+            url: previewUrl,
+            status: 'active'
+          }
+        ]);
+        await expect(isPortExposed(workerUrl, portHeaders, port)).resolves.toBe(
+          true
+        );
+
+        await stopContainer(workerUrl, portHeaders);
+        await expect(getExposedPorts(workerUrl, portHeaders)).resolves.toEqual(
+          []
+        );
+        await expect(isPortExposed(workerUrl, portHeaders, port)).resolves.toBe(
+          false
+        );
+        expect(await getContainerStatus(workerUrl, portHeaders)).not.toBe(
+          'healthy'
+        );
+
+        await startPreviewServer(workerUrl, headers, port);
+        await expect(getExposedPorts(workerUrl, portHeaders)).resolves.toEqual(
+          []
+        );
+        await expect(isPortExposed(workerUrl, portHeaders, port)).resolves.toBe(
+          false
         );
       } finally {
         await unexposePreviewPort(workerUrl, portHeaders, port).catch(

--- a/tests/e2e/process-lifecycle-workflow.test.ts
+++ b/tests/e2e/process-lifecycle-workflow.test.ts
@@ -359,7 +359,7 @@ console.log("Line 3");
   );
 
   test.skipIf(skipPortExposureTests)(
-    'should return error when unexposing non-exposed port',
+    'should treat unexposing a non-exposed port as idempotent revocation',
     async () => {
       const unexposeResponse = await fetch(
         `${workerUrl}/api/exposed-ports/${PORT_LIFECYCLE_TEST_PORT}`,
@@ -369,10 +369,11 @@ console.log("Line 3");
         }
       );
 
-      expect(unexposeResponse.status).toBe(404);
-      const errorData = (await unexposeResponse.json()) as { error: string };
-      expect(errorData.error).toBeTruthy();
-      expect(errorData.error).toMatch(/not found|not exposed|does not exist/i);
+      expect(unexposeResponse.status).toBe(200);
+      await expect(unexposeResponse.json()).resolves.toMatchObject({
+        success: true,
+        port: PORT_LIFECYCLE_TEST_PORT
+      });
     },
     90000
   );

--- a/tests/e2e/test-worker/index.ts
+++ b/tests/e2e/test-worker/index.ts
@@ -972,6 +972,53 @@ console.log('Terminal server on port ' + port);
         });
       }
 
+      // Port exposure status (ONLY works with sandbox - sessions don't expose ports)
+      if (url.pathname === '/api/exposed-ports' && request.method === 'GET') {
+        if (sessionId) {
+          return new Response(
+            JSON.stringify({
+              error:
+                'Port exposure not supported for explicit sessions. Use default sandbox.'
+            }),
+            {
+              status: 400,
+              headers: { 'Content-Type': 'application/json' }
+            }
+          );
+        }
+        const hostname = url.hostname + (url.port ? `:${url.port}` : '');
+        const ports = await sandbox.getExposedPorts(hostname);
+        return new Response(JSON.stringify(ports), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      if (
+        url.pathname.startsWith('/api/exposed-ports/') &&
+        request.method === 'GET'
+      ) {
+        if (sessionId) {
+          return new Response(
+            JSON.stringify({
+              error:
+                'Port exposure not supported for explicit sessions. Use default sandbox.'
+            }),
+            {
+              status: 400,
+              headers: { 'Content-Type': 'application/json' }
+            }
+          );
+        }
+        const pathParts = url.pathname.split('/');
+        const port = parseInt(pathParts[3], 10);
+        if (!Number.isNaN(port)) {
+          const exposed = await sandbox.isPortExposed(port);
+          return new Response(JSON.stringify({ exposed, port }), {
+            headers: { 'Content-Type': 'application/json' }
+          });
+        }
+      }
+
       // Port unexpose (ONLY works with sandbox - sessions don't expose ports)
       if (
         url.pathname.startsWith('/api/exposed-ports/') &&


### PR DESCRIPTION
After preview forwarding becomes current-runtime scoped, the public preview-port APIs need to report the same state that forwarding uses. Otherwise users can see a port reported as exposed even though its preview URL is stale and cannot forward without an explicit `exposePort()` call in the current runtime.

In this stack, persistent token authorization means the preview token is still valid, while current-runtime activation means `exposePort()` has been called for that port in the currently running container runtime.

This change aligns the public preview-port surface with that model.

`getExposedPorts(hostname)` now reports only ports whose preview URLs can be used without another `exposePort()` call: a valid token exists, the sandbox has a current runtime, and the port activation was created for that runtime.

`isPortExposed(port)` now answers the same question for one port. It no longer treats persistent token authorization alone as proof that the preview URL can forward.

`unexposePort(port)` is now idempotent Durable Object-owned revocation. It clears token authorization and runtime activation without waking or reaching the container.

`exposePort()` and `unexposePort()` no longer depend on the old container-local exposed-port registry RPCs. The Sandbox Durable Object’s token and activation records are now the source of truth for deciding whether preview traffic may forward.

The desktop preview integration now also obtains URLs through `exposePort()`. It can no longer synthesize a URL from a persisted token when `exposePort()` fails to create current-runtime activation.

This PR intentionally does not delete the old container-local registry. It only stops the public Sandbox preview-port surface from relying on it. The registry deletion happens in the next PR once the new source of truth is in place.

---

This is **part 2 of 3** in the preview URL lifecycle stack:

- <kbd>&nbsp;3&nbsp;</kbd> #710 — Remove container-local preview port registry
- <kbd>&nbsp;2&nbsp;</kbd> #709 — Align preview port APIs with forwarding 👈
- <kbd>&nbsp;1&nbsp;</kbd> #708 — Enforce preview URL runtime activation
- `main`
