### PR TITLE
Clarify wording on `prefix` field on RemoteMountBucketOptions

### DIFF
--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1262,8 +1262,8 @@ export interface RemoteMountBucketOptions {
   /**
    * Optional prefix/subdirectory within the bucket to mount.
    *
-   * When specified, only the contents under this prefix will be visible
-   * at the mount point, enabling multi-tenant isolation within a single bucket.
+   * When specified, only the contents under this prefix are visible at the
+   * mount point, scoping the mount to a subdirectory of the bucket.
    *
    * Must start with '/' (e.g., '/sessions/user123' or '/data/uploads/')
    */


### PR DESCRIPTION
The Sandbox SDK does not support multi-tenant environments. This commit
removes incorrect wording that implies that it does.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->