### PR TITLE
Implement egress interception for S3 mounts

### DIFF
--- a/.changeset/credential-proxy-mount.md
+++ b/.changeset/credential-proxy-mount.md
@@ -2,4 +2,4 @@
 '@cloudflare/sandbox': patch
 ---
 
-Add `credentialProxy` option to `mountBucket` to keep real S3 credentials out of the container. When enabled, the Durable Object intercepts and signs outbound S3 requests — the container only sees dummy credentials. Supports S3-compatible endpoints, R2, and GCS HMAC signing.
+Add `credentialProxy` option to `mountBucket` to keep real S3 credentials out of the container. When enabled, the Durable Object intercepts and signs outbound S3 requests — the container only sees dummy credentials. Supports S3-compatible endpoints, R2, and GCS HMAC signing, with optimized R2 mount defaults for reliable read and write performance.

--- a/.changeset/credential-proxy-mount.md
+++ b/.changeset/credential-proxy-mount.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Add `credentialProxy` option to `mountBucket` to keep real S3 credentials out of the container. When enabled, the Durable Object intercepts and signs outbound S3 requests — the container only sees dummy credentials. Supports S3-compatible endpoints, R2, and GCS HMAC signing.

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -2091,6 +2091,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
                 ? cleanupError.message
                 : String(cleanupError)
           });
+          this.activeMounts.delete(mountPath);
+          evictSigV4ClientCacheEntry(failedMount.mountId);
+          evictDirectoryMarkerCacheForMount(failedMount.mountId);
         }
       } else {
         this.activeMounts.delete(mountPath);
@@ -2142,6 +2145,32 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         await mountInfo.syncManager.stop();
         mountInfo.mounted = false;
         this.activeMounts.delete(mountPath);
+      } else if (
+        mountInfo.mountType === 'fuse' &&
+        mountInfo.credentialProxy &&
+        !mountInfo.mounted
+      ) {
+        try {
+          await this.configureS3CredentialProxyOutbound(
+            this.getS3CredentialProxyParams({
+              excludeMountId: mountInfo.mountId
+            })
+          );
+        } catch (cleanupError) {
+          this.logger.warn(
+            'credential proxy outbound reconfiguration failed on unmount',
+            {
+              mountPath,
+              error:
+                cleanupError instanceof Error
+                  ? cleanupError.message
+                  : String(cleanupError)
+            }
+          );
+        }
+        this.activeMounts.delete(mountPath);
+        evictSigV4ClientCacheEntry(mountInfo.mountId);
+        evictDirectoryMarkerCacheForMount(mountInfo.mountId);
       } else {
         // FUSE unmount
         let unmounted = false;
@@ -2171,19 +2200,45 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
                 };
               }
             }
-            await this.configureR2EgressOutbound({
-              buckets: remainingBuckets
-            });
+            try {
+              await this.configureR2EgressOutbound({
+                buckets: remainingBuckets
+              });
+            } catch (cleanupError) {
+              this.logger.warn(
+                'r2 egress outbound reconfiguration failed on unmount',
+                {
+                  mountPath,
+                  error:
+                    cleanupError instanceof Error
+                      ? cleanupError.message
+                      : String(cleanupError)
+                }
+              );
+            }
             this.activeMounts.delete(mountPath);
           } else if (
             mountInfo.mountType === 'fuse' &&
             mountInfo.credentialProxy
           ) {
-            await this.configureS3CredentialProxyOutbound(
-              this.getS3CredentialProxyParams({
-                excludeMountId: mountInfo.mountId
-              })
-            );
+            try {
+              await this.configureS3CredentialProxyOutbound(
+                this.getS3CredentialProxyParams({
+                  excludeMountId: mountInfo.mountId
+                })
+              );
+            } catch (cleanupError) {
+              this.logger.warn(
+                'credential proxy outbound reconfiguration failed on unmount',
+                {
+                  mountPath,
+                  error:
+                    cleanupError instanceof Error
+                      ? cleanupError.message
+                      : String(cleanupError)
+                }
+              );
+            }
             this.activeMounts.delete(mountPath);
             evictSigV4ClientCacheEntry(mountInfo.mountId);
             evictDirectoryMarkerCacheForMount(mountInfo.mountId);

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1714,13 +1714,21 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
   }
 
-  private getS3CredentialProxyParams(): S3CredentialProxyParams {
+  private getS3CredentialProxyParams(options?: {
+    excludeMountId?: string;
+  }): S3CredentialProxyParams {
     const mounts: S3CredentialProxyParams['mounts'] = {};
     for (const [, m] of this.activeMounts) {
       if (m.mountType === 'fuse' && m.credentialProxy) {
+        if (m.mountId === options?.excludeMountId) {
+          continue;
+        }
         mounts[m.mountId] = {
           endpoint: m.credentialProxy.endpoint,
           bucket: m.credentialProxy.bucket,
+          ...(m.credentialProxy.prefix !== undefined
+            ? { prefix: m.credentialProxy.prefix }
+            : {}),
           credentials: m.credentialProxy.credentials,
           readOnly: m.credentialProxy.readOnly,
           provider: m.credentialProxy.provider,
@@ -1967,6 +1975,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
               credentialProxy: {
                 endpoint: options.endpoint,
                 bucket,
+                ...(prefix !== undefined ? { prefix } : {}),
                 credentials,
                 readOnly: options.readOnly ?? false,
                 provider,
@@ -2064,13 +2073,27 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
       // Clean up reservation on failure; reconfigure proxy without this mount
       const failedMount = this.activeMounts.get(mountPath);
-      this.activeMounts.delete(mountPath);
       if (failedMount?.mountType === 'fuse' && failedMount.credentialProxy) {
-        evictSigV4ClientCacheEntry(failedMount.mountId);
-        evictDirectoryMarkerCacheForMount(failedMount.mountId);
-        await this.configureS3CredentialProxyOutbound(
-          this.getS3CredentialProxyParams()
-        ).catch(() => {});
+        try {
+          await this.configureS3CredentialProxyOutbound(
+            this.getS3CredentialProxyParams({
+              excludeMountId: failedMount.mountId
+            })
+          );
+          this.activeMounts.delete(mountPath);
+          evictSigV4ClientCacheEntry(failedMount.mountId);
+          evictDirectoryMarkerCacheForMount(failedMount.mountId);
+        } catch (cleanupError) {
+          this.logger.warn('credential proxy cleanup failed', {
+            mountPath,
+            error:
+              cleanupError instanceof Error
+                ? cleanupError.message
+                : String(cleanupError)
+          });
+        }
+      } else {
+        this.activeMounts.delete(mountPath);
       }
       throw error;
     } finally {
@@ -2135,20 +2158,37 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           unmounted = true;
           mountInfo.mounted = false;
 
-          // Only remove from tracking if unmount succeeded
-          this.activeMounts.delete(mountPath);
-
           if (mountInfo.mountType === 'r2-egress') {
-            await this.configureR2EgressOutbound(this.getR2EgressParams());
+            const remainingBuckets: R2EgressParams['buckets'] = {};
+            for (const [, activeMount] of this.activeMounts) {
+              if (
+                activeMount.mountType === 'r2-egress' &&
+                activeMount.mountId !== mountInfo.mountId
+              ) {
+                remainingBuckets[activeMount.bucket] = {
+                  prefix: activeMount.prefix,
+                  readOnly: activeMount.readOnly
+                };
+              }
+            }
+            await this.configureR2EgressOutbound({
+              buckets: remainingBuckets
+            });
+            this.activeMounts.delete(mountPath);
           } else if (
             mountInfo.mountType === 'fuse' &&
             mountInfo.credentialProxy
           ) {
+            await this.configureS3CredentialProxyOutbound(
+              this.getS3CredentialProxyParams({
+                excludeMountId: mountInfo.mountId
+              })
+            );
+            this.activeMounts.delete(mountPath);
             evictSigV4ClientCacheEntry(mountInfo.mountId);
             evictDirectoryMarkerCacheForMount(mountInfo.mountId);
-            await this.configureS3CredentialProxyOutbound(
-              this.getS3CredentialProxyParams()
-            );
+          } else {
+            this.activeMounts.delete(mountPath);
           }
 
           // Remove the now-empty mount directory

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -120,6 +120,7 @@ import {
   r2EgressHandler
 } from './storage-mount/r2-egress-handler';
 import {
+  evictDirectoryMarkerCacheForMount,
   evictSigV4ClientCacheEntry,
   SELF_TEST_PATH as S3_CREDENTIAL_PROXY_SELF_TEST_PATH,
   s3CredentialProxyHandler
@@ -857,6 +858,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   private logger: ReturnType<typeof createLogger>;
   private keepAliveEnabled: boolean = false;
   private activeMounts: Map<string, MountInfo> = new Map();
+  private mountOperationQueue: Promise<void> = Promise.resolve();
   private currentRuntime: CurrentRuntimeIdentity;
   private transport: SandboxTransport = 'http';
 
@@ -1543,6 +1545,32 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     mountPath: string,
     options: MountBucketOptions
   ): Promise<void> {
+    return this.runMountOperation(async () => {
+      await this.mountBucketUnlocked(bucket, mountPath, options);
+    });
+  }
+
+  private async runMountOperation(
+    operation: () => Promise<void>
+  ): Promise<void> {
+    const previous = this.mountOperationQueue;
+    let release!: () => void;
+    this.mountOperationQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous.catch(() => {});
+    try {
+      await operation();
+    } finally {
+      release();
+    }
+  }
+
+  private async mountBucketUnlocked(
+    bucket: string,
+    mountPath: string,
+    options: MountBucketOptions
+  ): Promise<void> {
     if (options.prefix !== undefined) {
       validatePrefix(options.prefix);
     }
@@ -1671,10 +1699,11 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
   private validateProtectedS3fsOptions(
     options: string[] | undefined,
-    mountLabel: string
+    mountLabel: string,
+    extraProtected: string[] = []
   ): void {
     if (!options) return;
-    const protectedOptions = new Set(['passwd_file', 'url']);
+    const protectedOptions = new Set(['passwd_file', 'url', ...extraProtected]);
     for (const option of options) {
       const [key] = option.split('=');
       if (protectedOptions.has(key)) {
@@ -1910,7 +1939,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       if (credentialProxyEnabled) {
         this.validateProtectedS3fsOptions(
           options.s3fsOptions,
-          'credential proxy'
+          'credential proxy',
+          ['ahbe_conf', 'use_path_request_style']
         );
       }
 
@@ -1978,11 +2008,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
             endpoint: `http://${S3_CREDENTIAL_PROXY_HOST}/${mountId}`,
             s3fsOptions: [
               ...(provider === 'r2' ? R2_DEFAULT_S3FS_OPTION_ENTRIES : []),
-              ...(options.s3fsOptions ?? []).filter(
-                (o) =>
-                  !o.startsWith('use_path_request_style') &&
-                  !o.startsWith('ahbe_conf=')
-              ),
+              ...(options.s3fsOptions ?? []),
               ...(additionalHeaderFilePath
                 ? [`ahbe_conf=${additionalHeaderFilePath}`]
                 : []),
@@ -2041,6 +2067,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       this.activeMounts.delete(mountPath);
       if (failedMount?.mountType === 'fuse' && failedMount.credentialProxy) {
         evictSigV4ClientCacheEntry(failedMount.mountId);
+        evictDirectoryMarkerCacheForMount(failedMount.mountId);
         await this.configureS3CredentialProxyOutbound(
           this.getS3CredentialProxyParams()
         ).catch(() => {});
@@ -2067,6 +2094,12 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    * @throws InvalidMountConfigError if mount path doesn't exist or isn't mounted
    */
   async unmountBucket(mountPath: string): Promise<void> {
+    return this.runMountOperation(async () => {
+      await this.unmountBucketUnlocked(mountPath);
+    });
+  }
+
+  private async unmountBucketUnlocked(mountPath: string): Promise<void> {
     const unmountStartTime = Date.now();
     let unmountOutcome: 'success' | 'error' = 'error';
     let unmountError: Error | undefined;
@@ -2112,6 +2145,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
             mountInfo.credentialProxy
           ) {
             evictSigV4ClientCacheEntry(mountInfo.mountId);
+            evictDirectoryMarkerCacheForMount(mountInfo.mountId);
             await this.configureS3CredentialProxyOutbound(
               this.getS3CredentialProxyParams()
             );
@@ -2738,6 +2772,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       } else if (m.mountType === 'fuse' && m.credentialProxy) {
         hadCredentialProxyMount = true;
         evictSigV4ClientCacheEntry(m.mountId);
+        evictDirectoryMarkerCacheForMount(m.mountId);
       }
     }
     if (hadR2EgressMount) {

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1,4 +1,9 @@
-import { Container, getContainer, switchPort } from '@cloudflare/containers';
+import {
+  Container,
+  ContainerProxy,
+  getContainer,
+  switchPort
+} from '@cloudflare/containers';
 import type {
   BackupOptions,
   BucketCredentials,
@@ -119,11 +124,18 @@ import {
   type R2EgressParams,
   r2EgressHandler
 } from './storage-mount/r2-egress-handler';
+import {
+  evictSigV4ClientCacheEntry,
+  SELF_TEST_PATH as S3_CREDENTIAL_PROXY_SELF_TEST_PATH,
+  s3CredentialProxyHandler
+} from './storage-mount/s3-credential-proxy-handler';
 import type {
+  CredentialProxyAuthStrategy,
   FuseMountInfo,
   LocalSyncMountInfo,
   MountInfo,
-  R2BindingMountInfo
+  R2BindingMountInfo,
+  S3CredentialProxyParams
 } from './storage-mount/types';
 import { resolveAccountId, resolveZoneId } from './tunnels/credentials';
 import { SandboxControlCallbackImpl } from './tunnels/sandbox-control-callback';
@@ -199,7 +211,7 @@ type CachedSandboxConfiguration = {
   transport?: SandboxTransport;
 };
 
-type R2EgressContainerState = DurableObjectState<{}> & {
+type EgressContainerState = DurableObjectState<{}> & {
   exports?: {
     ContainerProxy?: (options: {
       props: {
@@ -210,7 +222,7 @@ type R2EgressContainerState = DurableObjectState<{}> & {
           string,
           {
             method: string;
-            params: R2EgressParams;
+            params: R2EgressParams | S3CredentialProxyParams;
           }
         >;
       };
@@ -232,16 +244,26 @@ type PreviewForwardingLifecycleState = {
   inflightRequests?: number;
 };
 
-const R2_EGRESS_PROXY_TARGET_CLASS_NAME =
-  'CloudflareSandboxR2EgressProxyTarget';
+type OutboundHandlerRegistry = {
+  outboundHandlers?: Record<string, unknown>;
+};
 
-class R2EgressProxyTarget extends Container {}
+const CONTAINER_PROXY_CLASS_NAME = 'ContainerProxy';
+const S3_CREDENTIAL_PROXY_HOST = 's3-credential-proxy.internal';
+const S3_CREDENTIAL_PROXY_DIAGNOSTIC_HOST = 's3-credential-proxy.sandbox.test';
 
-Object.defineProperty(R2EgressProxyTarget, 'name', {
-  value: R2_EGRESS_PROXY_TARGET_CLASS_NAME
+class ContainerProxyOutboundTarget extends Container {}
+
+Object.defineProperty(ContainerProxyOutboundTarget, 'name', {
+  value: CONTAINER_PROXY_CLASS_NAME
 });
 
-R2EgressProxyTarget.outboundHandlers = { r2EgressMount: r2EgressHandler };
+(
+  ContainerProxyOutboundTarget as unknown as OutboundHandlerRegistry
+).outboundHandlers = {
+  r2EgressMount: r2EgressHandler,
+  s3CredentialProxyMount: s3CredentialProxyHandler
+};
 
 function isFetcher(value: unknown): value is Fetcher {
   return (
@@ -1593,6 +1615,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       });
 
       const mountInfo: LocalSyncMountInfo = {
+        mountId: crypto.randomUUID(),
         mountType: 'local-sync',
         bucket,
         mountPath,
@@ -1641,18 +1664,43 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     return { buckets };
   }
 
-  private validateR2EgressS3fsOptions(options?: string[]): void {
+  private validateProtectedS3fsOptions(
+    options: string[] | undefined,
+    mountLabel: string
+  ): void {
     if (!options) return;
-
     const protectedOptions = new Set(['passwd_file', 'url']);
     for (const option of options) {
       const [key] = option.split('=');
       if (protectedOptions.has(key)) {
         throw new InvalidMountConfigError(
-          `s3fs option "${key}" cannot be overridden for R2 binding mounts`
+          `s3fs option "${key}" cannot be overridden for ${mountLabel} mounts`
         );
       }
     }
+  }
+
+  private getS3CredentialProxyParams(): S3CredentialProxyParams {
+    const mounts: S3CredentialProxyParams['mounts'] = {};
+    for (const [, m] of this.activeMounts) {
+      if (m.mountType === 'fuse' && m.credentialProxy) {
+        mounts[m.mountId] = {
+          endpoint: m.credentialProxy.endpoint,
+          bucket: m.credentialProxy.bucket,
+          credentials: m.credentialProxy.credentials,
+          readOnly: m.credentialProxy.readOnly,
+          provider: m.credentialProxy.provider,
+          authStrategy: m.credentialProxy.authStrategy
+        };
+      }
+    }
+    return { mounts };
+  }
+
+  private resolveCredentialProxyAuthStrategy(
+    provider: BucketProvider | null
+  ): CredentialProxyAuthStrategy {
+    return provider === 'gcs' ? 'gcs' : 's3-sigv4';
   }
 
   /**
@@ -1672,7 +1720,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     try {
       validateBucketBindingName(bucket, mountPath);
       this.validateMountPath(mountPath);
-      this.validateR2EgressS3fsOptions(options.s3fsOptions);
+      this.validateProtectedS3fsOptions(options.s3fsOptions, 'R2 binding');
 
       for (const [existingMountPath, mountInfo] of this.activeMounts) {
         if (
@@ -1706,6 +1754,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       });
 
       const mountInfo: R2BindingMountInfo = {
+        mountId: crypto.randomUUID(),
         mountType: 'r2-egress',
         bucket,
         mountPath,
@@ -1829,23 +1878,57 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         ...this.envVars
       });
 
+      const credentialProxyEnabled = options.credentialProxy === true;
+      if (credentialProxyEnabled) {
+        this.validateProtectedS3fsOptions(
+          options.s3fsOptions,
+          'credential proxy'
+        );
+      }
+
       // Generate unique password file path
       passwordFilePath = this.generatePasswordFilePath();
 
       // Reserve mount path before async operations so concurrent mounts see it
+      const mountId = crypto.randomUUID();
       const mountInfo: FuseMountInfo = {
+        mountId,
         mountType: 'fuse',
         bucket: s3fsSource,
         mountPath,
         endpoint: options.endpoint,
         provider,
         passwordFilePath,
-        mounted: false
+        mounted: false,
+        ...(credentialProxyEnabled
+          ? {
+              credentialProxy: {
+                endpoint: options.endpoint,
+                bucket,
+                credentials,
+                readOnly: options.readOnly ?? false,
+                provider,
+                authStrategy: this.resolveCredentialProxyAuthStrategy(provider)
+              }
+            }
+          : {})
       };
       this.activeMounts.set(mountPath, mountInfo);
 
-      // Create password file with credentials (uses bucket name only, not prefix)
-      await this.createPasswordFile(passwordFilePath, bucket, credentials);
+      // Write dummy credentials for credential proxy, real credentials otherwise
+      await this.createPasswordFile(
+        passwordFilePath,
+        bucket,
+        credentialProxyEnabled
+          ? { accessKeyId: 'x', secretAccessKey: 'x' }
+          : credentials
+      );
+
+      if (credentialProxyEnabled) {
+        await this.configureS3CredentialProxyOutbound(
+          this.getS3CredentialProxyParams()
+        );
+      }
 
       // Check if mount directory already exists before creating it, so we
       // only remove it on failure if the SDK created it
@@ -1855,10 +1938,22 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       await this.execInternal(`mkdir -p ${shellEscape(mountPath)}`);
 
       // Execute S3FS mount with password file (uses full s3fs source with prefix)
+      const effectiveOptions: RemoteMountBucketOptions = credentialProxyEnabled
+        ? {
+            ...options,
+            endpoint: `http://${S3_CREDENTIAL_PROXY_HOST}/${mountId}`,
+            s3fsOptions: [
+              ...(options.s3fsOptions ?? []).filter(
+                (o) => !o.startsWith('use_path_request_style')
+              ),
+              'use_path_request_style'
+            ]
+          }
+        : options;
       await this.executeS3FSMount(
         s3fsSource,
         mountPath,
-        options,
+        effectiveOptions,
         provider,
         passwordFilePath
       );
@@ -1896,8 +1991,14 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         }
       }
 
-      // Clean up reservation on failure
+      // Clean up reservation on failure; reconfigure proxy without this mount
+      const failedMount = this.activeMounts.get(mountPath);
       this.activeMounts.delete(mountPath);
+      if (failedMount?.mountType === 'fuse' && failedMount.credentialProxy) {
+        await this.configureS3CredentialProxyOutbound(
+          this.getS3CredentialProxyParams()
+        ).catch(() => {});
+      }
       throw error;
     } finally {
       logCanonicalEvent(this.logger, {
@@ -1958,6 +2059,14 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
           if (mountInfo.mountType === 'r2-egress') {
             await this.configureR2EgressOutbound(this.getR2EgressParams());
+          } else if (
+            mountInfo.mountType === 'fuse' &&
+            mountInfo.credentialProxy
+          ) {
+            evictSigV4ClientCacheEntry(mountInfo.mountId);
+            await this.configureS3CredentialProxyOutbound(
+              this.getS3CredentialProxyParams()
+            );
           }
 
           // Remove the now-empty mount directory
@@ -2329,7 +2438,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       await this.ctx.storage.delete('tunnels');
       await this.ctx.storage.delete('tunnels:meta');
 
-
       // Disconnect transport after all cleanup commands have completed
       this.client.disconnect();
 
@@ -2524,15 +2632,24 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
     // Stop local sync managers before clearing the map.
     let hadR2EgressMount = false;
+    let hadCredentialProxyMount = false;
     for (const [, m] of this.activeMounts) {
       if (m.mountType === 'local-sync') {
         await m.syncManager.stop().catch(() => {});
       } else if (m.mountType === 'r2-egress') {
         hadR2EgressMount = true;
+      } else if (m.mountType === 'fuse' && m.credentialProxy) {
+        hadCredentialProxyMount = true;
+        evictSigV4ClientCacheEntry(m.mountId);
       }
     }
     if (hadR2EgressMount) {
       await this.configureR2EgressOutbound({ buckets: {} }).catch(() => {});
+    }
+    if (hadCredentialProxyMount) {
+      await this.configureS3CredentialProxyOutbound({ mounts: {} }).catch(
+        () => {}
+      );
     }
 
     this.activeMounts.clear();
@@ -6984,7 +7101,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   private async configureR2EgressOutbound(
     params: R2EgressParams
   ): Promise<void> {
-    const ctx = this.ctx as R2EgressContainerState;
+    const ctx = this.ctx as EgressContainerState;
     if (!ctx.container?.interceptOutboundHttp) {
       throw new InvalidMountConfigError(
         'R2 binding mounts require container outbound interception support'
@@ -6996,11 +7113,17 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       );
     }
 
+    this.logger.debug('r2 egress: registering host interception', {
+      host: 'r2.internal',
+      method: 'r2EgressMount',
+      targetClassName: CONTAINER_PROXY_CLASS_NAME
+    });
+
     const fetcher = ctx.exports.ContainerProxy({
       props: {
         enableInternet: this.enableInternet,
         containerId: this.ctx.id.toString(),
-        className: R2_EGRESS_PROXY_TARGET_CLASS_NAME,
+        className: CONTAINER_PROXY_CLASS_NAME,
         outboundByHostOverrides: {
           'r2.internal': {
             method: 'r2EgressMount',
@@ -7016,5 +7139,73 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
 
     await ctx.container.interceptOutboundHttp('r2.internal', fetcher);
+  }
+
+  private async configureS3CredentialProxyOutbound(
+    params: S3CredentialProxyParams
+  ): Promise<void> {
+    const ctx = this.ctx as EgressContainerState;
+    if (!ctx.container?.interceptOutboundHttp) {
+      throw new InvalidMountConfigError(
+        'Credential proxy bucket mounts require container outbound interception support'
+      );
+    }
+    if (!ctx.exports?.ContainerProxy) {
+      throw new InvalidMountConfigError(
+        'Credential proxy bucket mounts require exporting ContainerProxy from the Worker entrypoint'
+      );
+    }
+
+    const hosts = [
+      S3_CREDENTIAL_PROXY_HOST,
+      S3_CREDENTIAL_PROXY_DIAGNOSTIC_HOST
+    ];
+    const hostOverrides: Record<
+      string,
+      { method: string; params: S3CredentialProxyParams }
+    > = {};
+    for (const host of hosts) {
+      hostOverrides[host] = { method: 's3CredentialProxyMount', params };
+    }
+
+    this.logger.debug('s3 credential proxy: registering host interception', {
+      hosts,
+      method: 's3CredentialProxyMount',
+      targetClassName: CONTAINER_PROXY_CLASS_NAME
+    });
+
+    const fetcher = ctx.exports.ContainerProxy({
+      props: {
+        enableInternet: this.enableInternet,
+        containerId: this.ctx.id.toString(),
+        className: CONTAINER_PROXY_CLASS_NAME,
+        outboundByHostOverrides: hostOverrides
+      }
+    });
+    if (!isFetcher(fetcher)) {
+      throw new InvalidMountConfigError(
+        'Credential proxy bucket mounts require ContainerProxy to return a valid Fetcher'
+      );
+    }
+
+    try {
+      const selfTest = await fetcher.fetch(
+        new Request(
+          `http://${S3_CREDENTIAL_PROXY_HOST}${S3_CREDENTIAL_PROXY_SELF_TEST_PATH}`
+        )
+      );
+      await selfTest.text();
+      this.logger.debug('s3 credential proxy: fetcher self-test complete', {
+        status: selfTest.status
+      });
+    } catch (error) {
+      this.logger.warn('s3 credential proxy: fetcher self-test failed', {
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+
+    for (const host of hosts) {
+      await ctx.container.interceptOutboundHttp(host, fetcher);
+    }
   }
 }

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -317,6 +317,16 @@ const R2_DEFAULT_S3FS_OPTIONS: Readonly<Record<string, string | boolean>> = {
   multipart_size: '5'
 };
 
+const R2_DEFAULT_S3FS_OPTION_ENTRIES = Object.entries(
+  R2_DEFAULT_S3FS_OPTIONS
+).map(([key, value]) => (value === true ? key : `${key}=${value}`));
+// s3fs ahbe_conf (Additional Header By Extension) format:
+// Each line is: [extension-pattern] [Header-Name]:[value]
+// A leading space as the pattern acts as a wildcard, matching all requests.
+// Setting Expect to an empty value causes s3fs to omit the Expect: 100-continue
+// header, preventing the outbound proxy from stalling waiting for a 100 response.
+const S3FS_DISABLE_EXPECT_HEADER_CONFIG = ' Expect:\n';
+
 const BACKUP_DEFAULT_TTL_SECONDS = 259200;
 const BACKUP_MAX_NAME_LENGTH = 256;
 const BACKUP_CONTAINER_DIR = '/var/backups';
@@ -1716,6 +1726,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     const prefix = options.prefix;
     let mountOutcome: 'success' | 'error' = 'error';
     let mountError: Error | undefined;
+    let passwordFilePath: string | undefined;
+    let additionalHeaderFilePath: string | undefined;
 
     try {
       validateBucketBindingName(bucket, mountPath);
@@ -1745,13 +1757,15 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         }
       }
 
-      const passwordFilePath = this.generatePasswordFilePath();
+      passwordFilePath = this.generatePasswordFilePath();
+      additionalHeaderFilePath = this.generateS3FSAdditionalHeaderFilePath();
       // s3fs requires a passwd file before it will issue requests; the R2
       // egress handler resolves the Worker binding and ignores S3 signatures.
       await this.createPasswordFile(passwordFilePath, bucket, {
         accessKeyId: 'x',
         secretAccessKey: 'x'
       });
+      await this.createDisableExpectHeaderFile(additionalHeaderFilePath);
 
       const mountInfo: R2BindingMountInfo = {
         mountId: crypto.randomUUID(),
@@ -1759,6 +1773,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         bucket,
         mountPath,
         passwordFilePath,
+        additionalHeaderFilePath,
         mounted: false,
         prefix,
         readOnly: options.readOnly ?? false
@@ -1776,6 +1791,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         ...parseS3fsOptions(resolveS3fsOptions('r2', options.s3fsOptions)),
         use_path_request_style: true,
         url: 'http://r2.internal',
+        ahbe_conf: additionalHeaderFilePath,
         ...(options.readOnly ? { ro: true } : {})
       };
 
@@ -1818,6 +1834,22 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         await this.deletePasswordFile(failedMount.passwordFilePath).catch(
           () => {}
         );
+        if (failedMount.additionalHeaderFilePath) {
+          await this.deleteAdditionalHeaderFile(
+            failedMount.additionalHeaderFilePath
+          ).catch(() => {});
+        }
+      } else {
+        // Mount was not yet registered in activeMounts (error occurred before
+        // activeMounts.set()); clean up using the local file path variables.
+        if (passwordFilePath) {
+          await this.deletePasswordFile(passwordFilePath).catch(() => {});
+        }
+        if (additionalHeaderFilePath) {
+          await this.deleteAdditionalHeaderFile(additionalHeaderFilePath).catch(
+            () => {}
+          );
+        }
       }
       const remainingParams = this.getR2EgressParams();
       await this.configureR2EgressOutbound(remainingParams).catch(() => {});
@@ -1849,6 +1881,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     let mountOutcome: 'success' | 'error' = 'error';
     let mountError: Error | undefined;
     let passwordFilePath: string | undefined;
+    let additionalHeaderFilePath: string | undefined;
     let provider: BucketProvider | null = null;
     let dirExisted = true;
     try {
@@ -1888,6 +1921,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
       // Generate unique password file path
       passwordFilePath = this.generatePasswordFilePath();
+      if (credentialProxyEnabled) {
+        additionalHeaderFilePath = this.generateS3FSAdditionalHeaderFilePath();
+      }
 
       // Reserve mount path before async operations so concurrent mounts see it
       const mountId = crypto.randomUUID();
@@ -1899,6 +1935,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         endpoint: options.endpoint,
         provider,
         passwordFilePath,
+        ...(additionalHeaderFilePath ? { additionalHeaderFilePath } : {}),
         mounted: false,
         ...(credentialProxyEnabled
           ? {
@@ -1923,8 +1960,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           ? { accessKeyId: 'x', secretAccessKey: 'x' }
           : credentials
       );
-
       if (credentialProxyEnabled) {
+        if (additionalHeaderFilePath) {
+          await this.createDisableExpectHeaderFile(additionalHeaderFilePath);
+        }
         await this.configureS3CredentialProxyOutbound(
           this.getS3CredentialProxyParams()
         );
@@ -1943,9 +1982,15 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
             ...options,
             endpoint: `http://${S3_CREDENTIAL_PROXY_HOST}/${mountId}`,
             s3fsOptions: [
+              ...(provider === 'r2' ? R2_DEFAULT_S3FS_OPTION_ENTRIES : []),
               ...(options.s3fsOptions ?? []).filter(
-                (o) => !o.startsWith('use_path_request_style')
+                (o) =>
+                  !o.startsWith('use_path_request_style') &&
+                  !o.startsWith('ahbe_conf=')
               ),
+              ...(additionalHeaderFilePath
+                ? [`ahbe_conf=${additionalHeaderFilePath}`]
+                : []),
               'use_path_request_style'
             ]
           }
@@ -1962,10 +2007,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       mountOutcome = 'success';
     } catch (error) {
       mountError = error instanceof Error ? error : new Error(String(error));
-      // Clean up password file on failure
-      if (passwordFilePath) {
-        await this.deletePasswordFile(passwordFilePath);
-      }
       // Tear down any mount that may have established between the script's
       // last `mountpoint -q` check and `executeS3FSMount()` throwing. s3fs
       // runs as a daemon, so the FUSE mount can flip live in that window;
@@ -1977,6 +2018,15 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         );
       } catch {
         // best-effort cleanup
+      }
+
+      // Clean up support files after best-effort unmount so we do not remove
+      // files while a late-established FUSE daemon may still be active.
+      if (passwordFilePath) {
+        await this.deletePasswordFile(passwordFilePath);
+      }
+      if (additionalHeaderFilePath) {
+        await this.deleteAdditionalHeaderFile(additionalHeaderFilePath);
       }
 
       // Remove the mount directory only if the SDK created it. Runs after
@@ -1995,6 +2045,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       const failedMount = this.activeMounts.get(mountPath);
       this.activeMounts.delete(mountPath);
       if (failedMount?.mountType === 'fuse' && failedMount.credentialProxy) {
+        evictSigV4ClientCacheEntry(failedMount.mountId);
         await this.configureS3CredentialProxyOutbound(
           this.getS3CredentialProxyParams()
         ).catch(() => {});
@@ -2042,6 +2093,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         this.activeMounts.delete(mountPath);
       } else {
         // FUSE unmount
+        let unmounted = false;
         try {
           const result = await this.execInternal(
             `fusermount -u ${shellEscape(mountPath)}`
@@ -2052,6 +2104,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
               `fusermount -u failed (exit ${result.exitCode}): ${stderr}`
             );
           }
+          unmounted = true;
           mountInfo.mounted = false;
 
           // Only remove from tracking if unmount succeeded
@@ -2088,8 +2141,20 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
             });
           }
         } finally {
-          // Always cleanup password file, even if unmount fails
-          await this.deletePasswordFile(mountInfo.passwordFilePath);
+          // Only delete support files after a confirmed unmount. If
+          // fusermount -u failed the s3fs daemon may still be running and
+          // actively reading both the passwd and ahbe_conf files; deleting
+          // them underneath a live daemon would cause EIO on subsequent
+          // requests. Files left in /tmp are cleaned up when the container
+          // terminates.
+          if (unmounted) {
+            await this.deletePasswordFile(mountInfo.passwordFilePath);
+            if (mountInfo.additionalHeaderFilePath) {
+              await this.deleteAdditionalHeaderFile(
+                mountInfo.additionalHeaderFilePath
+              );
+            }
+          }
         }
       }
 
@@ -2160,6 +2225,25 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   /**
+   * Generate unique ahbe_conf file path for s3fs additional header config
+   */
+  private generateS3FSAdditionalHeaderFilePath(): string {
+    const uuid = crypto.randomUUID();
+    return `/tmp/.s3fs-ahbe-${uuid}.conf`;
+  }
+
+  /**
+   * Create s3fs ahbe_conf file that suppresses the Expect: 100-continue header.
+   * Restricted to 0600 so s3fs will accept it (same requirement as passwd files).
+   */
+  private async createDisableExpectHeaderFile(
+    headerFilePath: string
+  ): Promise<void> {
+    await this.writeFile(headerFilePath, S3FS_DISABLE_EXPECT_HEADER_CONFIG);
+    await this.execInternal(`chmod 0600 ${shellEscape(headerFilePath)}`);
+  }
+
+  /**
    * Create password file with s3fs credentials
    * Format: bucket:accessKeyId:secretAccessKey
    */
@@ -2188,6 +2272,19 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     } catch (error) {
       this.logger.warn('password file cleanup failed', {
         passwordFilePath,
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  private async deleteAdditionalHeaderFile(
+    headerFilePath: string
+  ): Promise<void> {
+    try {
+      await this.execInternal(`rm -f ${shellEscape(headerFilePath)}`);
+    } catch (error) {
+      this.logger.warn('s3fs additional header file cleanup failed', {
+        headerFilePath,
         error: error instanceof Error ? error.message : String(error)
       });
     }
@@ -2410,8 +2507,13 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
             );
           }
 
-          // Always cleanup password file for FUSE mounts
+          // Always cleanup support files for FUSE mounts
           await this.deletePasswordFile(mountInfo.passwordFilePath);
+          if (mountInfo.additionalHeaderFilePath) {
+            await this.deleteAdditionalHeaderFile(
+              mountInfo.additionalHeaderFilePath
+            );
+          }
         }
       }
 

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -2308,7 +2308,11 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   private async createDisableExpectHeaderFile(
     headerFilePath: string
   ): Promise<void> {
-    await this.writeFile(headerFilePath, S3FS_DISABLE_EXPECT_HEADER_CONFIG);
+    await this.client.files.writeFile(
+      headerFilePath,
+      S3FS_DISABLE_EXPECT_HEADER_CONFIG,
+      DISABLE_SESSION_TOKEN
+    );
     await this.execInternal(`chmod 0600 ${shellEscape(headerFilePath)}`);
   }
 

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1,9 +1,4 @@
-import {
-  Container,
-  ContainerProxy,
-  getContainer,
-  switchPort
-} from '@cloudflare/containers';
+import { Container, getContainer, switchPort } from '@cloudflare/containers';
 import type {
   BackupOptions,
   BucketCredentials,

--- a/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
+++ b/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
@@ -75,29 +75,22 @@ type SigV4ClientCacheEntry = {
   region: string;
 };
 
-type ShortCircuitedZeroLengthObject = {
-  headers: [string, string][];
-};
-
 const sigV4ClientCache = new Map<string, SigV4ClientCacheEntry>();
+const directoryMarkerCache = new Map<string, [string, string][]>();
 const credentialProxyDiagnosticEvents: CredentialProxyDiagnosticEvent[] = [];
-const shortCircuitedZeroLengthObjects = new Map<
-  string,
-  ShortCircuitedZeroLengthObject
->();
 let credentialProxyDiagnosticEventCount = 0;
 
 export function evictSigV4ClientCacheEntry(mountId: string): void {
   sigV4ClientCache.delete(mountId);
-  for (const key of shortCircuitedZeroLengthObjects.keys()) {
-    if (key.startsWith(`${mountId}:`)) {
-      shortCircuitedZeroLengthObjects.delete(key);
-    }
-  }
 }
 
-function getZeroLengthObjectKey(mountId: string, path: string) {
-  return `${mountId}:${path}`;
+export function evictDirectoryMarkerCacheForMount(mountId: string): void {
+  const prefix = `${mountId}:`;
+  for (const key of directoryMarkerCache.keys()) {
+    if (key.startsWith(prefix)) {
+      directoryMarkerCache.delete(key);
+    }
+  }
 }
 
 function toHex(buffer: ArrayBuffer): string {
@@ -154,10 +147,14 @@ function buildCleanHeaders(original: Headers): Headers {
     }
   }
   const contentSHA256 = original.get('x-amz-content-sha256');
-  if (contentSHA256) {
+  if (contentSHA256 && isValidContentSHA256(contentSHA256)) {
     clean.set('x-amz-content-sha256', contentSHA256);
   }
   return clean;
+}
+
+function isValidContentSHA256(value: string): boolean {
+  return value === 'UNSIGNED-PAYLOAD' || /^[a-fA-F0-9]{64}$/.test(value);
 }
 
 function getCredentialProxyDebugConfig(
@@ -370,19 +367,27 @@ function getSigV4PayloadHash(headers: Headers): {
   return { hash: 'UNSIGNED-PAYLOAD', mode: 'unsigned' };
 }
 
-function isZeroLengthPUT(request: Request): boolean {
+function isZeroLengthDirectoryMarkerPUT(
+  request: Request,
+  realPath: string
+): boolean {
   return (
     request.method.toUpperCase() === 'PUT' &&
-    request.headers.get('content-length') === '0'
+    request.headers.get('content-length') === '0' &&
+    realPath.endsWith('/')
   );
 }
 
-function isHEAD(request: Request): boolean {
+function isDirectoryMarkerHEAD(request: Request): boolean {
   return request.method.toUpperCase() === 'HEAD';
 }
 
-function getZeroLengthObjectResponseHeaders(
-  requestHeaders: Headers
+function getDirectoryMarkerCacheKey(mountId: string, realPath: string): string {
+  return `${mountId}:${realPath.replace(/\/+$/, '')}`;
+}
+
+function getDirectoryMarkerResponseHeaders(
+  request: Request
 ): [string, string][] {
   const headers: [string, string][] = [
     ['Accept-Ranges', 'bytes'],
@@ -390,18 +395,25 @@ function getZeroLengthObjectResponseHeaders(
     ['ETag', '"d41d8cd98f00b204e9800998ecf8427e"'],
     ['Last-Modified', new Date().toUTCString()]
   ];
-  const contentType = requestHeaders.get('content-type');
+  const contentType = request.headers.get('content-type');
   if (contentType) {
     headers.push(['Content-Type', contentType]);
   }
-  for (const [key, value] of requestHeaders as unknown as Iterable<
+  for (const [name, value] of request.headers as unknown as Iterable<
     [string, string]
   >) {
-    if (key.toLowerCase().startsWith('x-amz-meta-')) {
-      headers.push([key, value]);
+    if (name.toLowerCase().startsWith('x-amz-meta-')) {
+      headers.push([name, value]);
     }
   }
   return headers;
+}
+
+function deleteDirectoryMarkerCacheEntry(
+  mountId: string,
+  realPath: string
+): void {
+  directoryMarkerCache.delete(getDirectoryMarkerCacheKey(mountId, realPath));
 }
 
 function getContentLength(request: Request): number | null {
@@ -416,19 +428,20 @@ function getContentLength(request: Request): number | null {
   return parsed;
 }
 
-function getSigV4ForwardInit(request: Request): RequestInit | undefined {
+function getSigV4ForwardInit(request: Request): RequestInit {
   const contentLength = getContentLength(request);
-  if (contentLength === null || contentLength === 0 || request.body === null) {
-    return undefined;
+  if (contentLength === 0) {
+    return { body: new Uint8Array(0) };
+  }
+  if (contentLength === null || request.body === null) {
+    return {};
   }
 
   const { readable, writable } = new FixedLengthStream(contentLength);
-  request.body.pipeTo(writable).catch(() => {});
+  request.body.pipeTo(writable).catch((error) => {
+    writable.abort(error).catch(() => {});
+  });
   return { body: readable };
-}
-
-function clearSyntheticZeroLengthObject(mountId: string, path: string): void {
-  shortCircuitedZeroLengthObjects.delete(getZeroLengthObjectKey(mountId, path));
 }
 
 async function signAndForwardSigV4(
@@ -455,15 +468,6 @@ async function signAndForwardSigV4(
   requestInfo.clientSetupMs = Date.now() - signingStarted;
 
   const upstreamStarted = Date.now();
-  const upperMethod = request.method.toUpperCase();
-  if (
-    (upperMethod === 'PUT' && getContentLength(request) !== 0) ||
-    upperMethod === 'DELETE'
-  ) {
-    // Clear any synthetic zero-length entry so a future HEAD forwards to upstream
-    // rather than returning a stale synthetic 200.
-    clearSyntheticZeroLengthObject(mountId, new URL(request.url).pathname);
-  }
   const forwardInit = getSigV4ForwardInit(request);
   requestInfo.bodyPresent =
     forwardInit?.body !== undefined || request.body !== null;
@@ -554,11 +558,13 @@ async function signAndForwardGCS(
   newHeaders.set('x-goog-content-sha256', bodyHash);
   newHeaders.set('Authorization', authorization);
 
+  const contentLength = getContentLength(request);
+  const gcsBody = contentLength === 0 ? new Uint8Array(0) : request.body;
   return fetch(
     new Request(request.url, {
       method: request.method,
       headers: newHeaders,
-      body: request.body
+      body: gcsBody
     })
   );
 }
@@ -638,13 +644,14 @@ export const s3CredentialProxyHandler: OutboundHandler<
     query: [...url.searchParams.keys()].sort()
   };
 
-  if (mount.authStrategy === 's3-sigv4' && isZeroLengthPUT(cleanRequest)) {
-    const responseHeaders = getZeroLengthObjectResponseHeaders(
-      cleanRequest.headers
-    );
-    shortCircuitedZeroLengthObjects.set(
-      getZeroLengthObjectKey(mountId, realPath),
-      { headers: responseHeaders }
+  if (
+    mount.authStrategy === 's3-sigv4' &&
+    isZeroLengthDirectoryMarkerPUT(cleanRequest, realPath)
+  ) {
+    const responseHeaders = getDirectoryMarkerResponseHeaders(cleanRequest);
+    directoryMarkerCache.set(
+      getDirectoryMarkerCacheKey(mountId, realPath),
+      responseHeaders
     );
     requestInfo.bodyPresent = request.body !== null;
     requestInfo.payloadHashMode = getSigV4PayloadHash(
@@ -665,44 +672,36 @@ export const s3CredentialProxyHandler: OutboundHandler<
     );
   }
 
-  if (mount.authStrategy === 's3-sigv4' && isHEAD(cleanRequest)) {
-    const marker = shortCircuitedZeroLengthObjects.get(
-      getZeroLengthObjectKey(mountId, realPath)
+  if (
+    mount.authStrategy === 's3-sigv4' &&
+    isDirectoryMarkerHEAD(cleanRequest)
+  ) {
+    const responseHeaders = directoryMarkerCache.get(
+      getDirectoryMarkerCacheKey(mountId, realPath)
     );
-    if (!marker) {
+    if (responseHeaders) {
+      requestInfo.bodyPresent = false;
+      requestInfo.payloadHashMode = getSigV4PayloadHash(
+        cleanRequest.headers
+      ).mode;
       return withCredentialProxyDiagnostics(
         requestInfo,
         debugConfig,
         ctx.containerId,
         realPath,
         () =>
-          signAndForwardSigV4(
-            cleanRequest,
-            mountId,
-            mount.endpoint,
-            mount.provider,
-            mount.credentials,
-            requestInfo
+          Promise.resolve(
+            new Response(null, {
+              status: 200,
+              headers: responseHeaders
+            })
           )
       );
     }
-    requestInfo.bodyPresent = request.body !== null;
-    requestInfo.payloadHashMode = getSigV4PayloadHash(
-      cleanRequest.headers
-    ).mode;
-    return withCredentialProxyDiagnostics(
-      requestInfo,
-      debugConfig,
-      ctx.containerId,
-      realPath,
-      () =>
-        Promise.resolve(
-          new Response(null, {
-            status: 200,
-            headers: marker.headers
-          })
-        )
-    );
+  }
+
+  if (cleanRequest.method.toUpperCase() !== 'HEAD') {
+    deleteDirectoryMarkerCacheEntry(mountId, realPath);
   }
 
   if (mount.authStrategy === 'gcs') {

--- a/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
+++ b/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
@@ -24,7 +24,10 @@ import type { S3CredentialProxyParams } from './types';
 
 const PER_MOUNT_SUFFIX = '.s3-credential-proxy.internal';
 export const SELF_TEST_PATH = '/__sandbox_credential_proxy_self_test__';
+export const DIAGNOSTICS_PATH = '/__sandbox_credential_proxy_diagnostics__';
 const DEFAULT_SLOW_REQUEST_MS = 1000;
+const ERROR_RESPONSE_BODY_LIMIT = 2048;
+const MAX_DIAGNOSTIC_EVENTS = 500;
 
 export const DUMMY_AUTH_HEADERS = new Set([
   'authorization',
@@ -35,6 +38,34 @@ export const DUMMY_AUTH_HEADERS = new Set([
   'x-goog-content-sha256'
 ]);
 
+type CredentialProxyDebugConfig = {
+  diagnosticsEndpointEnabled: boolean;
+  enabled: boolean;
+  slowRequestMs: number;
+};
+
+type CredentialProxyRequestInfo = {
+  authStrategy: S3CredentialProxyParams['mounts'][string]['authStrategy'];
+  bucket: string;
+  bodyPresent?: boolean;
+  contentLength: string | null;
+  method: string;
+  mountId: string;
+  payloadHashMode?: 'signed' | 'unsigned';
+  query: string[];
+  signingMs?: number;
+  upstreamMs?: number;
+};
+
+type CredentialProxyDiagnosticEvent = CredentialProxyRequestInfo & {
+  containerId: string;
+  durationMs: number;
+  ok: boolean;
+  path: string;
+  status: number;
+  timestamp: string;
+};
+
 type SigV4ClientCacheEntry = {
   client: AwsClient;
   accessKeyId: string;
@@ -44,24 +75,29 @@ type SigV4ClientCacheEntry = {
   region: string;
 };
 
-type CredentialProxyDebugConfig = {
-  enabled: boolean;
-  slowRequestMs: number;
-};
-
-type CredentialProxyRequestInfo = {
-  authStrategy: S3CredentialProxyParams['mounts'][string]['authStrategy'];
-  bucket: string;
-  contentLength: string | null;
-  method: string;
-  mountId: string;
-  query: string[];
+type ShortCircuitedZeroLengthObject = {
+  headers: [string, string][];
 };
 
 const sigV4ClientCache = new Map<string, SigV4ClientCacheEntry>();
+const credentialProxyDiagnosticEvents: CredentialProxyDiagnosticEvent[] = [];
+const shortCircuitedZeroLengthObjects = new Map<
+  string,
+  ShortCircuitedZeroLengthObject
+>();
+let credentialProxyDiagnosticEventCount = 0;
 
 export function evictSigV4ClientCacheEntry(mountId: string): void {
   sigV4ClientCache.delete(mountId);
+  for (const key of shortCircuitedZeroLengthObjects.keys()) {
+    if (key.startsWith(`${mountId}:`)) {
+      shortCircuitedZeroLengthObjects.delete(key);
+    }
+  }
+}
+
+function getZeroLengthObjectKey(mountId: string, path: string) {
+  return `${mountId}:${path}`;
 }
 
 function toHex(buffer: ArrayBuffer): string {
@@ -110,9 +146,17 @@ function buildCleanHeaders(original: Headers): Headers {
   const clean = new Headers();
   for (const [k, v] of original as unknown as Iterable<[string, string]>) {
     const lower = k.toLowerCase();
-    if (!DUMMY_AUTH_HEADERS.has(lower) && lower !== 'host') {
+    if (
+      !DUMMY_AUTH_HEADERS.has(lower) &&
+      lower !== 'host' &&
+      lower !== 'x-amz-content-sha256'
+    ) {
       clean.set(k, v);
     }
+  }
+  const contentSHA256 = original.get('x-amz-content-sha256');
+  if (contentSHA256) {
+    clean.set('x-amz-content-sha256', contentSHA256);
   }
   return clean;
 }
@@ -122,6 +166,8 @@ function getCredentialProxyDebugConfig(
 ): CredentialProxyDebugConfig {
   const envRecord = env as Record<string, unknown>;
   const enabled = envRecord.SANDBOX_CREDENTIAL_PROXY_DEBUG === 'true';
+  const diagnosticsEndpointEnabled =
+    envRecord.SANDBOX_CREDENTIAL_PROXY_DIAGNOSTICS_ENDPOINT === 'true';
   const configuredSlowRequestMs = Number(
     envRecord.SANDBOX_CREDENTIAL_PROXY_SLOW_REQUEST_MS
   );
@@ -129,18 +175,59 @@ function getCredentialProxyDebugConfig(
     Number.isFinite(configuredSlowRequestMs) && configuredSlowRequestMs >= 0
       ? configuredSlowRequestMs
       : DEFAULT_SLOW_REQUEST_MS;
-  return { enabled, slowRequestMs };
+  return { diagnosticsEndpointEnabled, enabled, slowRequestMs };
+}
+
+function recordCredentialProxyDiagnosticEvent(
+  event: CredentialProxyDiagnosticEvent
+): void {
+  credentialProxyDiagnosticEvents.push(event);
+  credentialProxyDiagnosticEventCount++;
+  while (credentialProxyDiagnosticEvents.length > MAX_DIAGNOSTIC_EVENTS) {
+    credentialProxyDiagnosticEvents.shift();
+  }
+}
+
+function getCredentialProxyDiagnosticsResponse(
+  url: URL,
+  containerId: string
+): Response {
+  const since = Number(url.searchParams.get('since') ?? '0');
+  const bufferStartCount =
+    credentialProxyDiagnosticEventCount -
+    credentialProxyDiagnosticEvents.length;
+  const events = credentialProxyDiagnosticEvents.filter((event, index) => {
+    if (event.containerId !== containerId) return false;
+    return !Number.isFinite(since) || bufferStartCount + index >= since;
+  });
+  return Response.json({
+    nextCursor: credentialProxyDiagnosticEventCount,
+    events
+  });
 }
 
 async function withCredentialProxyDiagnostics(
   requestInfo: CredentialProxyRequestInfo,
   debugConfig: CredentialProxyDebugConfig,
+  containerId: string,
+  path: string,
   operation: () => Promise<Response>
 ): Promise<Response> {
   const started = Date.now();
   try {
     const response = await operation();
     const durationMs = Date.now() - started;
+    if (debugConfig.enabled) {
+      recordCredentialProxyDiagnosticEvent({
+        ...requestInfo,
+        containerId,
+        durationMs,
+        ok: response.ok,
+        path,
+        status: response.status,
+        timestamp: new Date().toISOString()
+      });
+    }
     if (debugConfig.enabled || durationMs >= debugConfig.slowRequestMs) {
       console.info('sandbox.s3_credential_proxy.request', {
         ...requestInfo,
@@ -149,6 +236,24 @@ async function withCredentialProxyDiagnostics(
         status: response.status,
         responseContentLength: response.headers.get('content-length')
       });
+    }
+    if (!response.ok) {
+      // Read the error body asynchronously so we don't delay returning the
+      // response to s3fs (important for 4xx/throttle responses).
+      const responseForLog = response.clone();
+      const requestInfoSnapshot = { ...requestInfo };
+      responseForLog
+        .text()
+        .then((body) => {
+          console.warn('sandbox.s3_credential_proxy.upstream_error', {
+            ...requestInfoSnapshot,
+            durationMs,
+            status: response.status,
+            statusText: response.statusText,
+            errorBody: body.slice(0, ERROR_RESPONSE_BODY_LIMIT)
+          });
+        })
+        .catch(() => {});
     }
     return response;
   } catch (error) {
@@ -162,26 +267,25 @@ async function withCredentialProxyDiagnostics(
   }
 }
 
-async function signAndForwardSigV4(
-  request: Request,
+function getSigV4Client(
   mountId: string,
   endpoint: string,
   provider: BucketProvider | null,
-  credentials: { accessKeyId: string; secretAccessKey: string }
-): Promise<Response> {
-  const cacheKey = mountId;
-  const cached = sigV4ClientCache.get(cacheKey);
+  credentials: { accessKeyId: string; secretAccessKey: string },
+  region: string
+): AwsClient {
+  const cached = sigV4ClientCache.get(mountId);
   if (
     cached &&
     cached.accessKeyId === credentials.accessKeyId &&
     cached.secretAccessKey === credentials.secretAccessKey &&
     cached.endpoint === endpoint &&
-    cached.provider === provider
+    cached.provider === provider &&
+    cached.region === region
   ) {
-    return cached.client.fetch(request);
+    return cached.client;
   }
 
-  const region = detectS3Region(provider, endpoint);
   const client = new AwsClient({
     accessKeyId: credentials.accessKeyId,
     secretAccessKey: credentials.secretAccessKey,
@@ -189,7 +293,7 @@ async function signAndForwardSigV4(
     region,
     retries: 0
   });
-  sigV4ClientCache.set(cacheKey, {
+  sigV4ClientCache.set(mountId, {
     client,
     accessKeyId: credentials.accessKeyId,
     secretAccessKey: credentials.secretAccessKey,
@@ -197,7 +301,171 @@ async function signAndForwardSigV4(
     provider,
     region
   });
-  return client.fetch(request);
+  return client;
+}
+
+function encodeCanonicalQueryPart(value: string): string {
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`
+  );
+}
+
+function getCanonicalURI(url: URL): string {
+  return url.pathname
+    .split('/')
+    .map((segment) =>
+      segment
+        .split(/(%[0-9A-Fa-f]{2})/g)
+        .map((part) =>
+          /^%[0-9A-Fa-f]{2}$/.test(part)
+            ? part.toUpperCase()
+            : encodeCanonicalQueryPart(part)
+        )
+        .join('')
+    )
+    .join('/');
+}
+
+function getCanonicalQueryString(url: URL): string {
+  const query = url.search.startsWith('?') ? url.search.slice(1) : url.search;
+  if (!query) return '';
+  return query
+    .split('&')
+    .map((part): [string, string] => {
+      const separatorIndex = part.indexOf('=');
+      if (separatorIndex === -1) return [part, ''];
+      return [part.slice(0, separatorIndex), part.slice(separatorIndex + 1)];
+    })
+    .map(([key, value]): [string, string] => [
+      encodeCanonicalQueryPart(decodeURIEncodedQueryPart(key)),
+      encodeCanonicalQueryPart(decodeURIEncodedQueryPart(value))
+    ])
+    .sort(([leftKey, leftValue], [rightKey, rightValue]) => {
+      if (leftKey < rightKey) return -1;
+      if (leftKey > rightKey) return 1;
+      if (leftValue < rightValue) return -1;
+      if (leftValue > rightValue) return 1;
+      return 0;
+    })
+    .map(([key, value]) => `${key}=${value}`)
+    .join('&');
+}
+
+function decodeURIEncodedQueryPart(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function getSigV4PayloadHash(headers: Headers): {
+  hash: string;
+  mode: 'signed' | 'unsigned';
+} {
+  const existingHash = headers.get('x-amz-content-sha256');
+  if (existingHash && existingHash !== 'UNSIGNED-PAYLOAD') {
+    return { hash: existingHash, mode: 'signed' };
+  }
+  return { hash: 'UNSIGNED-PAYLOAD', mode: 'unsigned' };
+}
+
+function isZeroLengthPUT(request: Request): boolean {
+  return (
+    request.method.toUpperCase() === 'PUT' &&
+    request.headers.get('content-length') === '0'
+  );
+}
+
+function isHEAD(request: Request): boolean {
+  return request.method.toUpperCase() === 'HEAD';
+}
+
+function getZeroLengthObjectResponseHeaders(
+  requestHeaders: Headers
+): [string, string][] {
+  const headers: [string, string][] = [
+    ['Accept-Ranges', 'bytes'],
+    ['Content-Length', '0'],
+    ['ETag', '"d41d8cd98f00b204e9800998ecf8427e"'],
+    ['Last-Modified', new Date().toUTCString()]
+  ];
+  const contentType = requestHeaders.get('content-type');
+  if (contentType) {
+    headers.push(['Content-Type', contentType]);
+  }
+  for (const [key, value] of requestHeaders as unknown as Iterable<
+    [string, string]
+  >) {
+    if (key.toLowerCase().startsWith('x-amz-meta-')) {
+      headers.push([key, value]);
+    }
+  }
+  return headers;
+}
+
+function getContentLength(request: Request): number | null {
+  const contentLength = request.headers.get('content-length');
+  if (contentLength === null) {
+    return null;
+  }
+  const parsed = Number(contentLength);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    return null;
+  }
+  return parsed;
+}
+
+function getSigV4ForwardInit(request: Request): RequestInit | undefined {
+  const contentLength = getContentLength(request);
+  if (contentLength === null || contentLength === 0 || request.body === null) {
+    return undefined;
+  }
+
+  const { readable, writable } = new FixedLengthStream(contentLength);
+  request.body.pipeTo(writable).catch(() => {});
+  return { body: readable };
+}
+
+function clearSyntheticZeroLengthObject(mountId: string, path: string): void {
+  shortCircuitedZeroLengthObjects.delete(getZeroLengthObjectKey(mountId, path));
+}
+
+async function signAndForwardSigV4(
+  request: Request,
+  mountId: string,
+  endpoint: string,
+  provider: BucketProvider | null,
+  credentials: { accessKeyId: string; secretAccessKey: string },
+  requestInfo: CredentialProxyRequestInfo
+): Promise<Response> {
+  const signingStarted = Date.now();
+  const region = detectS3Region(provider, endpoint);
+  const payload = getSigV4PayloadHash(request.headers);
+  const client = getSigV4Client(
+    mountId,
+    endpoint,
+    provider,
+    credentials,
+    region
+  );
+  requestInfo.payloadHashMode = payload.mode;
+  requestInfo.signingMs = Date.now() - signingStarted;
+
+  const upstreamStarted = Date.now();
+  if (
+    request.method.toUpperCase() === 'PUT' &&
+    getContentLength(request) !== 0
+  ) {
+    clearSyntheticZeroLengthObject(mountId, new URL(request.url).pathname);
+  }
+  const forwardInit = getSigV4ForwardInit(request);
+  requestInfo.bodyPresent =
+    forwardInit?.body !== undefined || request.body !== null;
+  const response = await client.fetch(request, forwardInit);
+  requestInfo.upstreamMs = Date.now() - upstreamStarted;
+  return response;
 }
 
 async function signAndForwardGCS(
@@ -218,7 +486,7 @@ async function signAndForwardGCS(
   const bodyHash = 'UNSIGNED-PAYLOAD';
 
   const headerEntries: [string, string][] = [
-    ['host', url.hostname],
+    ['host', url.host],
     ['x-goog-content-sha256', bodyHash],
     ['x-goog-date', dateStr]
   ];
@@ -243,22 +511,10 @@ async function signAndForwardGCS(
     .map(([k, v]) => `${k}:${v}\n`)
     .join('');
 
-  const sortedParams = [...url.searchParams.entries()].sort((a, b) =>
-    a[0].localeCompare(b[0])
-  );
-  const canonicalQueryString = sortedParams
-    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
-    .join('&');
-
-  const canonicalUri = url.pathname
-    .split('/')
-    .map((s) => encodeURIComponent(decodeURIComponent(s)))
-    .join('/');
-
   const canonicalRequest = [
     request.method,
-    canonicalUri,
-    canonicalQueryString,
+    getCanonicalURI(url),
+    getCanonicalQueryString(url),
     canonicalHeaders,
     signedHeaders,
     bodyHash
@@ -317,6 +573,15 @@ export const s3CredentialProxyHandler: OutboundHandler<
     return new Response('OK', { status: 200 });
   }
 
+  const debugConfig = getCredentialProxyDebugConfig(env);
+
+  if (url.pathname === DIAGNOSTICS_PATH) {
+    if (!debugConfig.enabled || !debugConfig.diagnosticsEndpointEnabled) {
+      return new Response('Not Found', { status: 404 });
+    }
+    return getCredentialProxyDiagnosticsResponse(url, ctx.containerId);
+  }
+
   const segments = url.pathname.split('/').filter(Boolean);
   const hostname = url.hostname;
 
@@ -330,7 +595,7 @@ export const s3CredentialProxyHandler: OutboundHandler<
   } else {
     // Primary path-based shape: /${mountId}/${bucket}/${objectKey}
     mountId = segments[0] ?? null;
-    realPath = '/' + segments.slice(1).join('/');
+    realPath = mountId ? url.pathname.slice(`/${mountId}`.length) || '/' : '/';
   }
 
   if (!mountId) {
@@ -345,13 +610,8 @@ export const s3CredentialProxyHandler: OutboundHandler<
   }
 
   if (mount.readOnly) {
-    const { method } = request;
-    if (
-      method === 'PUT' ||
-      method === 'DELETE' ||
-      (method === 'POST' &&
-        (url.searchParams.has('uploads') || url.searchParams.has('uploadId')))
-    ) {
+    const method = request.method.toUpperCase();
+    if (method !== 'GET' && method !== 'HEAD' && method !== 'OPTIONS') {
       return new Response('Forbidden: bucket mount is read-only', {
         status: 403
       });
@@ -365,7 +625,6 @@ export const s3CredentialProxyHandler: OutboundHandler<
     headers: cleanHeaders,
     body: request.body
   });
-  const debugConfig = getCredentialProxyDebugConfig(env);
   const requestInfo: CredentialProxyRequestInfo = {
     authStrategy: mount.authStrategy,
     bucket: mount.bucket,
@@ -375,19 +634,96 @@ export const s3CredentialProxyHandler: OutboundHandler<
     query: [...url.searchParams.keys()].sort()
   };
 
-  if (mount.authStrategy === 'gcs') {
-    return withCredentialProxyDiagnostics(requestInfo, debugConfig, () =>
-      signAndForwardGCS(cleanRequest, mount.credentials)
+  if (mount.authStrategy === 's3-sigv4' && isZeroLengthPUT(cleanRequest)) {
+    const responseHeaders = getZeroLengthObjectResponseHeaders(
+      cleanRequest.headers
+    );
+    shortCircuitedZeroLengthObjects.set(
+      getZeroLengthObjectKey(mountId, realPath),
+      { headers: responseHeaders }
+    );
+    requestInfo.bodyPresent = request.body !== null;
+    requestInfo.payloadHashMode = getSigV4PayloadHash(
+      cleanRequest.headers
+    ).mode;
+    return withCredentialProxyDiagnostics(
+      requestInfo,
+      debugConfig,
+      ctx.containerId,
+      realPath,
+      () =>
+        Promise.resolve(
+          new Response(null, {
+            status: 200,
+            headers: responseHeaders
+          })
+        )
     );
   }
 
-  return withCredentialProxyDiagnostics(requestInfo, debugConfig, () =>
-    signAndForwardSigV4(
-      cleanRequest,
-      mountId,
-      mount.endpoint,
-      mount.provider,
-      mount.credentials
-    )
+  if (mount.authStrategy === 's3-sigv4' && isHEAD(cleanRequest)) {
+    const marker = shortCircuitedZeroLengthObjects.get(
+      getZeroLengthObjectKey(mountId, realPath)
+    );
+    if (!marker) {
+      return withCredentialProxyDiagnostics(
+        requestInfo,
+        debugConfig,
+        ctx.containerId,
+        realPath,
+        () =>
+          signAndForwardSigV4(
+            cleanRequest,
+            mountId,
+            mount.endpoint,
+            mount.provider,
+            mount.credentials,
+            requestInfo
+          )
+      );
+    }
+    requestInfo.bodyPresent = request.body !== null;
+    requestInfo.payloadHashMode = getSigV4PayloadHash(
+      cleanRequest.headers
+    ).mode;
+    return withCredentialProxyDiagnostics(
+      requestInfo,
+      debugConfig,
+      ctx.containerId,
+      realPath,
+      () =>
+        Promise.resolve(
+          new Response(null, {
+            status: 200,
+            headers: marker.headers
+          })
+        )
+    );
+  }
+
+  if (mount.authStrategy === 'gcs') {
+    return withCredentialProxyDiagnostics(
+      requestInfo,
+      debugConfig,
+      ctx.containerId,
+      realPath,
+      () => signAndForwardGCS(cleanRequest, mount.credentials)
+    );
+  }
+
+  return withCredentialProxyDiagnostics(
+    requestInfo,
+    debugConfig,
+    ctx.containerId,
+    realPath,
+    () =>
+      signAndForwardSigV4(
+        cleanRequest,
+        mountId,
+        mount.endpoint,
+        mount.provider,
+        mount.credentials,
+        requestInfo
+      )
   );
 };

--- a/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
+++ b/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
@@ -11,7 +11,7 @@
  * Real upstream URL:    ${endpoint}/${bucket}/${objectKey}
  *
  * The handler also accepts the legacy per-mount-host shape
- * (${mountId}.s3-credential-proxy.internal) for forward compatibility.
+ * (${mountId}.s3-credential-proxy.internal) for backward compatibility.
  */
 
 import type {
@@ -53,7 +53,7 @@ type CredentialProxyRequestInfo = {
   mountId: string;
   payloadHashMode?: 'signed' | 'unsigned';
   query: string[];
-  signingMs?: number;
+  clientSetupMs?: number;
   upstreamMs?: number;
 };
 
@@ -146,11 +146,10 @@ function buildCleanHeaders(original: Headers): Headers {
   const clean = new Headers();
   for (const [k, v] of original as unknown as Iterable<[string, string]>) {
     const lower = k.toLowerCase();
-    if (
-      !DUMMY_AUTH_HEADERS.has(lower) &&
-      lower !== 'host' &&
-      lower !== 'x-amz-content-sha256'
-    ) {
+    // Strip dummy signing headers and the intercepted proxy host; x-amz-content-sha256
+    // is stripped here too (it's in DUMMY_AUTH_HEADERS) so it can be re-added below
+    // only when the original value is a genuine payload hash (not a dummy signing value).
+    if (!DUMMY_AUTH_HEADERS.has(lower) && lower !== 'host') {
       clean.set(k, v);
     }
   }
@@ -451,13 +450,18 @@ async function signAndForwardSigV4(
     region
   );
   requestInfo.payloadHashMode = payload.mode;
-  requestInfo.signingMs = Date.now() - signingStarted;
+  // clientSetupMs captures region detection + client cache lookup + payload hash;
+  // the actual SigV4 signing happens inside client.fetch() and is included in upstreamMs.
+  requestInfo.clientSetupMs = Date.now() - signingStarted;
 
   const upstreamStarted = Date.now();
+  const upperMethod = request.method.toUpperCase();
   if (
-    request.method.toUpperCase() === 'PUT' &&
-    getContentLength(request) !== 0
+    (upperMethod === 'PUT' && getContentLength(request) !== 0) ||
+    upperMethod === 'DELETE'
   ) {
+    // Clear any synthetic zero-length entry so a future HEAD forwards to upstream
+    // rather than returning a stale synthetic 200.
     clearSyntheticZeroLengthObject(mountId, new URL(request.url).pathname);
   }
   const forwardInit = getSigV4ForwardInit(request);

--- a/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
+++ b/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
@@ -528,7 +528,7 @@ function getGCSHeaders(request: Request): Headers {
       DUMMY_AUTH_HEADERS.has(lower) ||
       lower === 'host' ||
       lower === 'content-length' ||
-      (lower === 'expect' && v.trim() === ':')
+      lower === 'expect'
     ) {
       continue;
     }

--- a/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
+++ b/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
@@ -444,6 +444,32 @@ function getSigV4ForwardInit(request: Request): RequestInit {
   return { body: readable };
 }
 
+function getGCSHeaders(request: Request): Headers {
+  const headers = new Headers();
+  for (const [k, v] of request.headers as unknown as Iterable<
+    [string, string]
+  >) {
+    const lower = k.toLowerCase();
+    if (
+      DUMMY_AUTH_HEADERS.has(lower) ||
+      lower === 'host' ||
+      lower === 'content-length' ||
+      (lower === 'expect' && v.trim() === ':')
+    ) {
+      continue;
+    }
+    if (lower.startsWith('x-amz-meta-')) {
+      headers.set(`x-goog-meta-${lower.slice('x-amz-meta-'.length)}`, v);
+      continue;
+    }
+    if (lower.startsWith('x-amz-')) {
+      continue;
+    }
+    headers.set(k, v);
+  }
+  return headers;
+}
+
 async function signAndForwardSigV4(
   request: Request,
   mountId: string,
@@ -478,9 +504,11 @@ async function signAndForwardSigV4(
 
 async function signAndForwardGCS(
   request: Request,
-  credentials: { accessKeyId: string; secretAccessKey: string }
+  credentials: { accessKeyId: string; secretAccessKey: string },
+  requestInfo: CredentialProxyRequestInfo
 ): Promise<Response> {
   const url = new URL(request.url);
+  const gcsHeaders = getGCSHeaders(request);
   const now = new Date();
   const dateStr = `${now
     .toISOString()
@@ -499,18 +527,8 @@ async function signAndForwardGCS(
     ['x-goog-date', dateStr]
   ];
 
-  for (const [k, v] of request.headers as unknown as Iterable<
-    [string, string]
-  >) {
-    const lower = k.toLowerCase();
-    if (
-      !DUMMY_AUTH_HEADERS.has(lower) &&
-      lower !== 'host' &&
-      lower !== 'x-goog-content-sha256' &&
-      lower !== 'x-goog-date'
-    ) {
-      headerEntries.push([lower, v.trim()]);
-    }
+  for (const [k, v] of gcsHeaders as unknown as Iterable<[string, string]>) {
+    headerEntries.push([k.toLowerCase(), v.trim()]);
   }
 
   headerEntries.sort((a, b) => a[0].localeCompare(b[0]));
@@ -550,23 +568,23 @@ async function signAndForwardGCS(
 
   const authorization = `GOOG4-HMAC-SHA256 Credential=${credentials.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
 
-  const newHeaders = new Headers(request.headers);
-  for (const h of DUMMY_AUTH_HEADERS) {
-    newHeaders.delete(h);
-  }
+  const newHeaders = new Headers(gcsHeaders);
   newHeaders.set('x-goog-date', dateStr);
   newHeaders.set('x-goog-content-sha256', bodyHash);
   newHeaders.set('Authorization', authorization);
 
   const contentLength = getContentLength(request);
   const gcsBody = contentLength === 0 ? new Uint8Array(0) : request.body;
-  return fetch(
+  const upstreamStarted = Date.now();
+  const response = await fetch(
     new Request(request.url, {
       method: request.method,
       headers: newHeaders,
       body: gcsBody
     })
   );
+  requestInfo.upstreamMs = Date.now() - upstreamStarted;
+  return response;
 }
 
 export const s3CredentialProxyHandler: OutboundHandler<
@@ -644,19 +662,18 @@ export const s3CredentialProxyHandler: OutboundHandler<
     query: [...url.searchParams.keys()].sort()
   };
 
-  if (
-    mount.authStrategy === 's3-sigv4' &&
-    isZeroLengthDirectoryMarkerPUT(cleanRequest, realPath)
-  ) {
+  if (isZeroLengthDirectoryMarkerPUT(cleanRequest, realPath)) {
     const responseHeaders = getDirectoryMarkerResponseHeaders(cleanRequest);
     directoryMarkerCache.set(
       getDirectoryMarkerCacheKey(mountId, realPath),
       responseHeaders
     );
     requestInfo.bodyPresent = request.body !== null;
-    requestInfo.payloadHashMode = getSigV4PayloadHash(
-      cleanRequest.headers
-    ).mode;
+    if (mount.authStrategy === 's3-sigv4') {
+      requestInfo.payloadHashMode = getSigV4PayloadHash(
+        cleanRequest.headers
+      ).mode;
+    }
     return withCredentialProxyDiagnostics(
       requestInfo,
       debugConfig,
@@ -672,18 +689,17 @@ export const s3CredentialProxyHandler: OutboundHandler<
     );
   }
 
-  if (
-    mount.authStrategy === 's3-sigv4' &&
-    isDirectoryMarkerHEAD(cleanRequest)
-  ) {
+  if (isDirectoryMarkerHEAD(cleanRequest)) {
     const responseHeaders = directoryMarkerCache.get(
       getDirectoryMarkerCacheKey(mountId, realPath)
     );
     if (responseHeaders) {
       requestInfo.bodyPresent = false;
-      requestInfo.payloadHashMode = getSigV4PayloadHash(
-        cleanRequest.headers
-      ).mode;
+      if (mount.authStrategy === 's3-sigv4') {
+        requestInfo.payloadHashMode = getSigV4PayloadHash(
+          cleanRequest.headers
+        ).mode;
+      }
       return withCredentialProxyDiagnostics(
         requestInfo,
         debugConfig,
@@ -710,7 +726,7 @@ export const s3CredentialProxyHandler: OutboundHandler<
       debugConfig,
       ctx.containerId,
       realPath,
-      () => signAndForwardGCS(cleanRequest, mount.credentials)
+      () => signAndForwardGCS(cleanRequest, mount.credentials, requestInfo)
     );
   }
 

--- a/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
+++ b/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
@@ -409,6 +409,80 @@ function getDirectoryMarkerResponseHeaders(
   return headers;
 }
 
+function normalizePrefix(prefix: string | undefined): string | undefined {
+  if (!prefix) return undefined;
+  return prefix.replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+function getObjectKeyForPath(realPath: string, bucket: string): string | null {
+  const pathSegments = realPath.split('/').filter(Boolean);
+  const requestBucket = pathSegments[0];
+  if (requestBucket !== bucket) {
+    return null;
+  }
+  return pathSegments.slice(1).join('/');
+}
+
+function isObjectKeyWithinPrefix(
+  objectKey: string,
+  prefix: string | undefined
+): boolean {
+  const normalizedPrefix = normalizePrefix(prefix);
+  if (!normalizedPrefix) {
+    return true;
+  }
+  return (
+    objectKey === normalizedPrefix ||
+    objectKey.startsWith(`${normalizedPrefix}/`)
+  );
+}
+
+function isRequestWithinMountScope(
+  realPath: string,
+  url: URL,
+  bucket: string,
+  prefix: string | undefined
+): boolean {
+  const objectKey = getObjectKeyForPath(realPath, bucket);
+  if (objectKey === null) {
+    return false;
+  }
+
+  const requestedPrefix = url.searchParams.get('prefix');
+  if (objectKey !== '' && !isObjectKeyWithinPrefix(objectKey, prefix)) {
+    return false;
+  }
+
+  if (
+    objectKey === '' &&
+    normalizePrefix(prefix) !== undefined &&
+    url.search !== '' &&
+    requestedPrefix === null
+  ) {
+    return false;
+  }
+
+  if (requestedPrefix !== null) {
+    return isObjectKeyWithinPrefix(requestedPrefix, prefix);
+  }
+
+  return true;
+}
+
+function isBucketRootProbe(
+  request: Request,
+  realPath: string,
+  url: URL,
+  bucket: string
+): boolean {
+  const method = request.method.toUpperCase();
+  return (
+    (method === 'GET' || method === 'HEAD') &&
+    url.search === '' &&
+    getObjectKeyForPath(realPath, bucket) === ''
+  );
+}
+
 function deleteDirectoryMarkerCacheEntry(
   mountId: string,
   realPath: string
@@ -647,6 +721,14 @@ export const s3CredentialProxyHandler: OutboundHandler<
   }
 
   const realUrl = new URL(realPath + (url.search || ''), mount.endpoint);
+  if (isBucketRootProbe(request, realPath, url, mount.bucket)) {
+    return new Response(null, { status: 200 });
+  }
+  if (!isRequestWithinMountScope(realPath, url, mount.bucket, mount.prefix)) {
+    return new Response('Forbidden: request is outside mounted bucket scope', {
+      status: 403
+    });
+  }
   const cleanHeaders = buildCleanHeaders(request.headers);
   const cleanRequest = new Request(realUrl.toString(), {
     method: request.method,
@@ -664,10 +746,6 @@ export const s3CredentialProxyHandler: OutboundHandler<
 
   if (isZeroLengthDirectoryMarkerPUT(cleanRequest, realPath)) {
     const responseHeaders = getDirectoryMarkerResponseHeaders(cleanRequest);
-    directoryMarkerCache.set(
-      getDirectoryMarkerCacheKey(mountId, realPath),
-      responseHeaders
-    );
     requestInfo.bodyPresent = request.body !== null;
     if (mount.authStrategy === 's3-sigv4') {
       requestInfo.payloadHashMode = getSigV4PayloadHash(
@@ -679,13 +757,32 @@ export const s3CredentialProxyHandler: OutboundHandler<
       debugConfig,
       ctx.containerId,
       realPath,
-      () =>
-        Promise.resolve(
-          new Response(null, {
-            status: 200,
-            headers: responseHeaders
-          })
-        )
+      async () => {
+        const response =
+          mount.authStrategy === 'gcs'
+            ? await signAndForwardGCS(
+                cleanRequest,
+                mount.credentials,
+                requestInfo
+              )
+            : await signAndForwardSigV4(
+                cleanRequest,
+                mountId,
+                mount.endpoint,
+                mount.provider,
+                mount.credentials,
+                requestInfo
+              );
+
+        if (response.ok) {
+          directoryMarkerCache.set(
+            getDirectoryMarkerCacheKey(mountId, realPath),
+            responseHeaders
+          );
+        }
+
+        return response;
+      }
     );
   }
 

--- a/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
+++ b/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
@@ -1,0 +1,393 @@
+/**
+ * Outbound handler that signs and forwards S3-compatible requests from s3fs
+ * to the configured endpoint using real credentials held in the Durable Object.
+ *
+ * s3fs inside the container sends requests to the stable internal proxy host
+ * `s3-credential-proxy.internal`. The mount ID is encoded as the first path
+ * segment so the handler can resolve the correct mount config without per-mount
+ * subdomain registration.
+ *
+ * Request path layout: /${mountId}/${bucket}/${objectKey}
+ * Real upstream URL:    ${endpoint}/${bucket}/${objectKey}
+ *
+ * The handler also accepts the legacy per-mount-host shape
+ * (${mountId}.s3-credential-proxy.internal) for forward compatibility.
+ */
+
+import type {
+  OutboundHandler,
+  OutboundHandlerContext
+} from '@cloudflare/containers';
+import type { BucketProvider } from '@repo/shared';
+import { AwsClient } from 'aws4fetch';
+import type { S3CredentialProxyParams } from './types';
+
+const PER_MOUNT_SUFFIX = '.s3-credential-proxy.internal';
+export const SELF_TEST_PATH = '/__sandbox_credential_proxy_self_test__';
+const DEFAULT_SLOW_REQUEST_MS = 1000;
+
+export const DUMMY_AUTH_HEADERS = new Set([
+  'authorization',
+  'x-amz-date',
+  'x-amz-content-sha256',
+  'x-amz-security-token',
+  'x-goog-date',
+  'x-goog-content-sha256'
+]);
+
+type SigV4ClientCacheEntry = {
+  client: AwsClient;
+  accessKeyId: string;
+  secretAccessKey: string;
+  endpoint: string;
+  provider: BucketProvider | null;
+  region: string;
+};
+
+type CredentialProxyDebugConfig = {
+  enabled: boolean;
+  slowRequestMs: number;
+};
+
+type CredentialProxyRequestInfo = {
+  authStrategy: S3CredentialProxyParams['mounts'][string]['authStrategy'];
+  bucket: string;
+  contentLength: string | null;
+  method: string;
+  mountId: string;
+  query: string[];
+};
+
+const sigV4ClientCache = new Map<string, SigV4ClientCacheEntry>();
+
+export function evictSigV4ClientCacheEntry(mountId: string): void {
+  sigV4ClientCache.delete(mountId);
+}
+
+function toHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function sha256Hex(data: string): Promise<string> {
+  return toHex(
+    await crypto.subtle.digest('SHA-256', new TextEncoder().encode(data))
+  );
+}
+
+async function hmacSHA256(
+  key: BufferSource,
+  data: string
+): Promise<ArrayBuffer> {
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    key,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  return crypto.subtle.sign('HMAC', cryptoKey, new TextEncoder().encode(data));
+}
+
+function detectS3Region(
+  provider: BucketProvider | null,
+  endpoint: string
+): string {
+  if (provider === 'r2') return 'auto';
+  try {
+    const host = new URL(endpoint).hostname;
+    const m = host.match(/s3[.-]([a-z0-9-]+)\.amazonaws\.com/);
+    if (m && m[1] !== 'amazonaws') return m[1];
+    if (host === 's3.amazonaws.com') return 'us-east-1';
+  } catch {
+    // ignore
+  }
+  return 'auto';
+}
+
+function buildCleanHeaders(original: Headers): Headers {
+  const clean = new Headers();
+  for (const [k, v] of original as unknown as Iterable<[string, string]>) {
+    const lower = k.toLowerCase();
+    if (!DUMMY_AUTH_HEADERS.has(lower) && lower !== 'host') {
+      clean.set(k, v);
+    }
+  }
+  return clean;
+}
+
+function getCredentialProxyDebugConfig(
+  env: Cloudflare.Env
+): CredentialProxyDebugConfig {
+  const envRecord = env as Record<string, unknown>;
+  const enabled = envRecord.SANDBOX_CREDENTIAL_PROXY_DEBUG === 'true';
+  const configuredSlowRequestMs = Number(
+    envRecord.SANDBOX_CREDENTIAL_PROXY_SLOW_REQUEST_MS
+  );
+  const slowRequestMs =
+    Number.isFinite(configuredSlowRequestMs) && configuredSlowRequestMs >= 0
+      ? configuredSlowRequestMs
+      : DEFAULT_SLOW_REQUEST_MS;
+  return { enabled, slowRequestMs };
+}
+
+async function withCredentialProxyDiagnostics(
+  requestInfo: CredentialProxyRequestInfo,
+  debugConfig: CredentialProxyDebugConfig,
+  operation: () => Promise<Response>
+): Promise<Response> {
+  const started = Date.now();
+  try {
+    const response = await operation();
+    const durationMs = Date.now() - started;
+    if (debugConfig.enabled || durationMs >= debugConfig.slowRequestMs) {
+      console.info('sandbox.s3_credential_proxy.request', {
+        ...requestInfo,
+        durationMs,
+        ok: response.ok,
+        status: response.status,
+        responseContentLength: response.headers.get('content-length')
+      });
+    }
+    return response;
+  } catch (error) {
+    const durationMs = Date.now() - started;
+    console.warn('sandbox.s3_credential_proxy.request_error', {
+      ...requestInfo,
+      durationMs,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    throw error;
+  }
+}
+
+async function signAndForwardSigV4(
+  request: Request,
+  mountId: string,
+  endpoint: string,
+  provider: BucketProvider | null,
+  credentials: { accessKeyId: string; secretAccessKey: string }
+): Promise<Response> {
+  const cacheKey = mountId;
+  const cached = sigV4ClientCache.get(cacheKey);
+  if (
+    cached &&
+    cached.accessKeyId === credentials.accessKeyId &&
+    cached.secretAccessKey === credentials.secretAccessKey &&
+    cached.endpoint === endpoint &&
+    cached.provider === provider
+  ) {
+    return cached.client.fetch(request);
+  }
+
+  const region = detectS3Region(provider, endpoint);
+  const client = new AwsClient({
+    accessKeyId: credentials.accessKeyId,
+    secretAccessKey: credentials.secretAccessKey,
+    service: 's3',
+    region,
+    retries: 0
+  });
+  sigV4ClientCache.set(cacheKey, {
+    client,
+    accessKeyId: credentials.accessKeyId,
+    secretAccessKey: credentials.secretAccessKey,
+    endpoint,
+    provider,
+    region
+  });
+  return client.fetch(request);
+}
+
+async function signAndForwardGCS(
+  request: Request,
+  credentials: { accessKeyId: string; secretAccessKey: string }
+): Promise<Response> {
+  const url = new URL(request.url);
+  const now = new Date();
+  const dateStr = `${now
+    .toISOString()
+    .replace(/[:-]/g, '')
+    .replace(/\.\d+Z$/, '')}Z`;
+  const dateOnly = dateStr.slice(0, 8);
+  const location = 'auto';
+  const service = 'storage';
+  const credentialScope = `${dateOnly}/${location}/${service}/goog4_request`;
+
+  const bodyHash = 'UNSIGNED-PAYLOAD';
+
+  const headerEntries: [string, string][] = [
+    ['host', url.hostname],
+    ['x-goog-content-sha256', bodyHash],
+    ['x-goog-date', dateStr]
+  ];
+
+  for (const [k, v] of request.headers as unknown as Iterable<
+    [string, string]
+  >) {
+    const lower = k.toLowerCase();
+    if (
+      !DUMMY_AUTH_HEADERS.has(lower) &&
+      lower !== 'host' &&
+      lower !== 'x-goog-content-sha256' &&
+      lower !== 'x-goog-date'
+    ) {
+      headerEntries.push([lower, v.trim()]);
+    }
+  }
+
+  headerEntries.sort((a, b) => a[0].localeCompare(b[0]));
+  const signedHeaders = headerEntries.map(([k]) => k).join(';');
+  const canonicalHeaders = headerEntries
+    .map(([k, v]) => `${k}:${v}\n`)
+    .join('');
+
+  const sortedParams = [...url.searchParams.entries()].sort((a, b) =>
+    a[0].localeCompare(b[0])
+  );
+  const canonicalQueryString = sortedParams
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&');
+
+  const canonicalUri = url.pathname
+    .split('/')
+    .map((s) => encodeURIComponent(decodeURIComponent(s)))
+    .join('/');
+
+  const canonicalRequest = [
+    request.method,
+    canonicalUri,
+    canonicalQueryString,
+    canonicalHeaders,
+    signedHeaders,
+    bodyHash
+  ].join('\n');
+
+  const canonicalRequestHash = await sha256Hex(canonicalRequest);
+
+  const stringToSign = [
+    'GOOG4-HMAC-SHA256',
+    dateStr,
+    credentialScope,
+    canonicalRequestHash
+  ].join('\n');
+
+  const enc = new TextEncoder();
+  const kDate = await hmacSHA256(
+    enc.encode(`GOOG4${credentials.secretAccessKey}`) as unknown as ArrayBuffer,
+    dateOnly
+  );
+  const kRegion = await hmacSHA256(kDate, location);
+  const kService = await hmacSHA256(kRegion, service);
+  const kSigning = await hmacSHA256(kService, 'goog4_request');
+  const sigBytes = await hmacSHA256(kSigning, stringToSign);
+  const signature = toHex(sigBytes);
+
+  const authorization = `GOOG4-HMAC-SHA256 Credential=${credentials.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+  const newHeaders = new Headers(request.headers);
+  for (const h of DUMMY_AUTH_HEADERS) {
+    newHeaders.delete(h);
+  }
+  newHeaders.set('x-goog-date', dateStr);
+  newHeaders.set('x-goog-content-sha256', bodyHash);
+  newHeaders.set('Authorization', authorization);
+
+  return fetch(
+    new Request(request.url, {
+      method: request.method,
+      headers: newHeaders,
+      body: request.body
+    })
+  );
+}
+
+export const s3CredentialProxyHandler: OutboundHandler<
+  Cloudflare.Env,
+  S3CredentialProxyParams
+> = async (
+  request: Request,
+  env: Cloudflare.Env,
+  ctx: OutboundHandlerContext<S3CredentialProxyParams>
+): Promise<Response> => {
+  const url = new URL(request.url);
+
+  if (url.pathname === SELF_TEST_PATH) {
+    return new Response('OK', { status: 200 });
+  }
+
+  const segments = url.pathname.split('/').filter(Boolean);
+  const hostname = url.hostname;
+
+  let mountId: string | null;
+  let realPath: string;
+
+  if (hostname.endsWith(PER_MOUNT_SUFFIX)) {
+    // Legacy per-mount-host shape: mountId is the subdomain
+    mountId = hostname.slice(0, -PER_MOUNT_SUFFIX.length);
+    realPath = url.pathname;
+  } else {
+    // Primary path-based shape: /${mountId}/${bucket}/${objectKey}
+    mountId = segments[0] ?? null;
+    realPath = '/' + segments.slice(1).join('/');
+  }
+
+  if (!mountId) {
+    return new Response('Bad Request: missing mount ID', { status: 400 });
+  }
+
+  const mount = ctx.params?.mounts[mountId];
+  if (!mount) {
+    return new Response(`Forbidden: unknown mount ID "${mountId}"`, {
+      status: 403
+    });
+  }
+
+  if (mount.readOnly) {
+    const { method } = request;
+    if (
+      method === 'PUT' ||
+      method === 'DELETE' ||
+      (method === 'POST' &&
+        (url.searchParams.has('uploads') || url.searchParams.has('uploadId')))
+    ) {
+      return new Response('Forbidden: bucket mount is read-only', {
+        status: 403
+      });
+    }
+  }
+
+  const realUrl = new URL(realPath + (url.search || ''), mount.endpoint);
+  const cleanHeaders = buildCleanHeaders(request.headers);
+  const cleanRequest = new Request(realUrl.toString(), {
+    method: request.method,
+    headers: cleanHeaders,
+    body: request.body
+  });
+  const debugConfig = getCredentialProxyDebugConfig(env);
+  const requestInfo: CredentialProxyRequestInfo = {
+    authStrategy: mount.authStrategy,
+    bucket: mount.bucket,
+    contentLength: request.headers.get('content-length'),
+    method: request.method,
+    mountId,
+    query: [...url.searchParams.keys()].sort()
+  };
+
+  if (mount.authStrategy === 'gcs') {
+    return withCredentialProxyDiagnostics(requestInfo, debugConfig, () =>
+      signAndForwardGCS(cleanRequest, mount.credentials)
+    );
+  }
+
+  return withCredentialProxyDiagnostics(requestInfo, debugConfig, () =>
+    signAndForwardSigV4(
+      cleanRequest,
+      mountId,
+      mount.endpoint,
+      mount.provider,
+      mount.credentials
+    )
+  );
+};

--- a/packages/sandbox/src/storage-mount/types.ts
+++ b/packages/sandbox/src/storage-mount/types.ts
@@ -15,6 +15,7 @@ export type CredentialProxyAuthStrategy = 's3-sigv4' | 'gcs';
 export interface CredentialProxyConfig {
   endpoint: string;
   bucket: string;
+  prefix?: string;
   credentials: BucketCredentials;
   readOnly: boolean;
   provider: BucketProvider | null;

--- a/packages/sandbox/src/storage-mount/types.ts
+++ b/packages/sandbox/src/storage-mount/types.ts
@@ -33,6 +33,7 @@ export interface FuseMountInfo {
   endpoint: string;
   provider: BucketProvider | null;
   passwordFilePath: string;
+  additionalHeaderFilePath?: string;
   mounted: boolean;
   credentialProxy?: CredentialProxyConfig;
 }
@@ -52,6 +53,7 @@ export interface R2BindingMountInfo {
   bucket: string;
   mountPath: string;
   passwordFilePath: string;
+  additionalHeaderFilePath?: string;
   mounted: boolean;
   prefix?: string;
   readOnly: boolean;

--- a/packages/sandbox/src/storage-mount/types.ts
+++ b/packages/sandbox/src/storage-mount/types.ts
@@ -2,7 +2,7 @@
  * Internal bucket mounting types
  */
 
-import type { BucketProvider } from '@repo/shared';
+import type { BucketCredentials, BucketProvider } from '@repo/shared';
 import type { LocalMountSyncManager } from '../local-mount-sync';
 
 /**
@@ -10,7 +10,23 @@ import type { LocalMountSyncManager } from '../local-mount-sync';
  */
 export type MountInfo = FuseMountInfo | LocalSyncMountInfo | R2BindingMountInfo;
 
+export type CredentialProxyAuthStrategy = 's3-sigv4' | 'gcs';
+
+export interface CredentialProxyConfig {
+  endpoint: string;
+  bucket: string;
+  credentials: BucketCredentials;
+  readOnly: boolean;
+  provider: BucketProvider | null;
+  authStrategy: CredentialProxyAuthStrategy;
+}
+
+export type S3CredentialProxyParams = {
+  mounts: Record<string, CredentialProxyConfig>;
+};
+
 export interface FuseMountInfo {
+  mountId: string;
   mountType: 'fuse';
   bucket: string;
   mountPath: string;
@@ -18,9 +34,11 @@ export interface FuseMountInfo {
   provider: BucketProvider | null;
   passwordFilePath: string;
   mounted: boolean;
+  credentialProxy?: CredentialProxyConfig;
 }
 
 export interface LocalSyncMountInfo {
+  mountId: string;
   mountType: 'local-sync';
   bucket: string;
   mountPath: string;
@@ -29,6 +47,7 @@ export interface LocalSyncMountInfo {
 }
 
 export interface R2BindingMountInfo {
+  mountId: string;
   mountType: 'r2-egress';
   bucket: string;
   mountPath: string;

--- a/packages/sandbox/tests/r2-egress-mount.test.ts
+++ b/packages/sandbox/tests/r2-egress-mount.test.ts
@@ -4,6 +4,7 @@ import {
   type R2EgressParams,
   r2EgressHandler
 } from '../src/storage-mount/r2-egress-handler';
+import type { S3CredentialProxyParams } from '../src/storage-mount/types';
 
 type MockFetcher = {
   fetch: ReturnType<typeof vi.fn>;
@@ -282,6 +283,41 @@ describe('Sandbox credential proxy mounts', () => {
     );
   });
 
+  it('includes prefix in credential proxy mount params', async () => {
+    const mockCtx = createMockCtx();
+    const sandbox = new Sandbox(
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+      {}
+    );
+
+    Object.assign(sandbox as object, {
+      execInternal: createCredentialProxyExecMock(),
+      createPasswordFile: vi.fn().mockResolvedValue(undefined),
+      deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-prefix')
+    });
+
+    await sandbox.mountBucket('my-bucket', '/mnt/proxy', {
+      endpoint: 'https://abc123.r2.cloudflarestorage.com',
+      credentials: { accessKeyId: 'AKID', secretAccessKey: 'SECRET' },
+      credentialProxy: true,
+      prefix: '/project-a'
+    });
+
+    const ContainerProxy = mockCtx.exports.ContainerProxy!;
+    const firstCall = ContainerProxy.mock.calls[0];
+    const params = firstCall[0].props.outboundByHostOverrides?.[
+      's3-credential-proxy.internal'
+    ]?.params as S3CredentialProxyParams;
+    const mount = Object.values(params.mounts)[0];
+    expect(mount).toMatchObject({
+      bucket: 'my-bucket',
+      prefix: '/project-a'
+    });
+  });
+
   it('writes dummy credentials into the container for credential proxy mounts', async () => {
     const mockCtx = createMockCtx();
     const sandbox = new Sandbox(
@@ -464,6 +500,57 @@ describe('Sandbox credential proxy mounts', () => {
         params: { mounts: {} }
       }
     });
+  });
+
+  it('keeps mount state when credential proxy cleanup reconfiguration fails', async () => {
+    const mockCtx = createMockCtx();
+    const sandbox = new Sandbox(
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+      {}
+    );
+
+    const execInternal = vi.fn(async (command: string) => {
+      if (command.startsWith('test -d ')) return createExecResult(command);
+      if (command.startsWith('mkdir -p ')) return createExecResult(command);
+      if (command.includes('s3fs ')) {
+        return createExecResult(command, {
+          exitCode: 1,
+          stderr: 'mount failed'
+        });
+      }
+      return createExecResult(command);
+    });
+    Object.assign(sandbox as object, {
+      execInternal,
+      createPasswordFile: vi.fn().mockResolvedValue(undefined),
+      deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi
+        .fn()
+        .mockReturnValue('/tmp/.s3fs-fail-proxy-cleanup')
+    });
+
+    mockCtx.container.interceptOutboundHttp.mockReset();
+    mockCtx.container.interceptOutboundHttp
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('intercept failed'));
+
+    await expect(
+      sandbox.mountBucket('my-bucket', '/mnt/proxy', {
+        endpoint: 'https://abc123.r2.cloudflarestorage.com',
+        credentials: { accessKeyId: 'AKID', secretAccessKey: 'SECRET' },
+        credentialProxy: true
+      })
+    ).rejects.toThrow();
+
+    const activeMounts = (
+      sandbox as unknown as {
+        activeMounts: Map<string, unknown>;
+      }
+    ).activeMounts;
+    expect(activeMounts.has('/mnt/proxy')).toBe(true);
   });
 
   it('attempts best-effort unmount before deleting credential proxy support files on mount failure', async () => {

--- a/packages/sandbox/tests/r2-egress-mount.test.ts
+++ b/packages/sandbox/tests/r2-egress-mount.test.ts
@@ -502,7 +502,7 @@ describe('Sandbox credential proxy mounts', () => {
     });
   });
 
-  it('keeps mount state when credential proxy cleanup reconfiguration fails', async () => {
+  it('clears mount state when both mount and credential proxy cleanup reconfiguration fail', async () => {
     const mockCtx = createMockCtx();
     const sandbox = new Sandbox(
       mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
@@ -550,7 +550,45 @@ describe('Sandbox credential proxy mounts', () => {
         activeMounts: Map<string, unknown>;
       }
     ).activeMounts;
-    expect(activeMounts.has('/mnt/proxy')).toBe(true);
+    expect(activeMounts.has('/mnt/proxy')).toBe(false);
+  });
+
+  it('clears mount state when credential proxy unmount reconfiguration fails', async () => {
+    const mockCtx = createMockCtx();
+    const sandbox = new Sandbox(
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+      {}
+    );
+
+    Object.assign(sandbox as object, {
+      execInternal: createCredentialProxyExecMock(),
+      createPasswordFile: vi.fn().mockResolvedValue(undefined),
+      deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi
+        .fn()
+        .mockReturnValue('/tmp/.s3fs-unmount-reconfigure-fail')
+    });
+
+    await sandbox.mountBucket('my-bucket', '/mnt/proxy', {
+      endpoint: 'https://abc123.r2.cloudflarestorage.com',
+      credentials: { accessKeyId: 'AKID', secretAccessKey: 'SECRET' },
+      credentialProxy: true
+    });
+
+    mockCtx.container.interceptOutboundHttp.mockRejectedValueOnce(
+      new Error('intercept failed on unmount')
+    );
+
+    await expect(sandbox.unmountBucket('/mnt/proxy')).resolves.toBeUndefined();
+
+    const activeMounts = (
+      sandbox as unknown as {
+        activeMounts: Map<string, unknown>;
+      }
+    ).activeMounts;
+    expect(activeMounts.has('/mnt/proxy')).toBe(false);
   });
 
   it('attempts best-effort unmount before deleting credential proxy support files on mount failure', async () => {
@@ -1128,6 +1166,56 @@ describe('Sandbox R2 egress mounts', () => {
     expect(deleteAdditionalHeaderFile).toHaveBeenCalledWith(
       '/tmp/.s3fs-ahbe-unmount.conf'
     );
+  });
+
+  it('clears mount state when R2 egress unmount reconfiguration fails', async () => {
+    const mockCtx = createMockCtx();
+    const sandbox = new Sandbox(
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+      { MY_BUCKET: createMockR2Bucket() }
+    );
+
+    Object.assign(sandbox as object, {
+      execInternal: vi.fn(async (command: string) => {
+        if (command.startsWith('mkdir -p ')) return createExecResult(command);
+        if (command.includes('s3fs ')) return createExecResult(command);
+        if (command.startsWith('mountpoint -q') && command.includes('echo')) {
+          return createExecResult(command, { stdout: 'FUSE_MOUNTED' });
+        }
+        if (command.startsWith('fusermount -u ')) {
+          return createExecResult(command);
+        }
+        if (command.startsWith('mountpoint -q') && command.includes('rmdir')) {
+          return createExecResult(command);
+        }
+        throw new Error(`Unexpected command: ${command}`);
+      }),
+      createPasswordFile: vi.fn().mockResolvedValue(undefined),
+      deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi
+        .fn()
+        .mockReturnValue('/tmp/.s3fs-r2-unmount-reconfigure-fail'),
+      generateS3FSAdditionalHeaderFilePath: vi
+        .fn()
+        .mockReturnValue('/tmp/.s3fs-r2-unmount-reconfigure-fail.conf')
+    });
+
+    await sandbox.mountBucket('MY_BUCKET', '/mnt/data', {} as any);
+
+    mockCtx.container.interceptOutboundHttp.mockRejectedValueOnce(
+      new Error('r2 configure failed on unmount')
+    );
+
+    await expect(sandbox.unmountBucket('/mnt/data')).resolves.toBeUndefined();
+
+    const activeMounts = (
+      sandbox as unknown as {
+        activeMounts: Map<string, unknown>;
+      }
+    ).activeMounts;
+    expect(activeMounts.has('/mnt/data')).toBe(false);
   });
 
   it('deletes the password file when R2 egress mount fails', async () => {

--- a/packages/sandbox/tests/r2-egress-mount.test.ts
+++ b/packages/sandbox/tests/r2-egress-mount.test.ts
@@ -104,8 +104,11 @@ vi.mock('@cloudflare/containers', () => {
     }
   });
 
+  class MockContainerProxy extends MockContainer {}
+
   return {
     Container: MockContainer,
+    ContainerProxy: MockContainerProxy,
     getContainer: vi.fn(),
     switchPort: vi.fn()
   };
@@ -228,29 +231,295 @@ function createExecResult(
   };
 }
 
+describe('Sandbox credential proxy mounts', () => {
+  function createCredentialProxyExecMock() {
+    return vi.fn(async (command: string) => {
+      if (command.startsWith('test -d ')) return createExecResult(command);
+      if (command.startsWith('mkdir -p ')) return createExecResult(command);
+      if (command.includes('s3fs ')) return createExecResult(command);
+      if (command.startsWith('mountpoint -q') && command.includes('echo')) {
+        return createExecResult(command, { stdout: 'FUSE_MOUNTED' });
+      }
+      if (command.startsWith('fusermount -u ')) {
+        return createExecResult(command);
+      }
+      if (command.startsWith('mountpoint -q') && command.includes('rmdir')) {
+        return createExecResult(command);
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+  }
+
+  it('registers the stable proxy host for interception on credential proxy mount', async () => {
+    const mockCtx = createMockCtx();
+    const sandbox = new Sandbox(
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+      {}
+    );
+
+    Object.assign(sandbox as object, {
+      execInternal: createCredentialProxyExecMock(),
+      createPasswordFile: vi.fn().mockResolvedValue(undefined),
+      deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-proxy')
+    });
+
+    await sandbox.mountBucket('my-bucket', '/mnt/proxy', {
+      endpoint: 'https://abc123.r2.cloudflarestorage.com',
+      credentials: { accessKeyId: 'AKID', secretAccessKey: 'SECRET' },
+      credentialProxy: true
+    });
+
+    expect(mockCtx.container.interceptOutboundHttp).toHaveBeenCalledWith(
+      's3-credential-proxy.internal',
+      mockCtx.containerProxyFetcher
+    );
+  });
+
+  it('writes dummy credentials into the container for credential proxy mounts', async () => {
+    const mockCtx = createMockCtx();
+    const sandbox = new Sandbox(
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+      {}
+    );
+    const createPasswordFile = vi.fn().mockResolvedValue(undefined);
+
+    Object.assign(sandbox as object, {
+      execInternal: createCredentialProxyExecMock(),
+      createPasswordFile,
+      deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-dummy')
+    });
+
+    await sandbox.mountBucket('my-bucket', '/mnt/proxy', {
+      endpoint: 'https://abc123.r2.cloudflarestorage.com',
+      credentials: { accessKeyId: 'REAL_KEY', secretAccessKey: 'REAL_SECRET' },
+      credentialProxy: true
+    });
+
+    expect(createPasswordFile).toHaveBeenCalledWith(
+      '/tmp/.s3fs-dummy',
+      'my-bucket',
+      { accessKeyId: 'x', secretAccessKey: 'x' }
+    );
+  });
+
+  it('appends use_path_request_style to s3fs options for credential proxy mounts', async () => {
+    const mockCtx = createMockCtx();
+    const sandbox = new Sandbox(
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+      {}
+    );
+    const execInternal = createCredentialProxyExecMock();
+
+    Object.assign(sandbox as object, {
+      execInternal,
+      createPasswordFile: vi.fn().mockResolvedValue(undefined),
+      deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-path-style')
+    });
+
+    await sandbox.mountBucket('my-bucket', '/mnt/proxy', {
+      endpoint: 'https://abc123.r2.cloudflarestorage.com',
+      credentials: { accessKeyId: 'AKID', secretAccessKey: 'SECRET' },
+      credentialProxy: true
+    });
+
+    const s3fsCall = execInternal.mock.calls.find((args) =>
+      String(args[0]).includes('s3fs ')
+    );
+    expect(s3fsCall).toBeDefined();
+    expect(String(s3fsCall![0])).toContain('use_path_request_style');
+    expect(String(s3fsCall![0])).toContain('s3-credential-proxy.internal');
+  });
+
+  it('passes the mount ID as the s3fs url path segment', async () => {
+    const mockCtx = createMockCtx();
+    const sandbox = new Sandbox(
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+      {}
+    );
+    const execInternal = createCredentialProxyExecMock();
+
+    Object.assign(sandbox as object, {
+      execInternal,
+      createPasswordFile: vi.fn().mockResolvedValue(undefined),
+      deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-mountid')
+    });
+
+    await sandbox.mountBucket('my-bucket', '/mnt/proxy', {
+      endpoint: 'https://abc123.r2.cloudflarestorage.com',
+      credentials: { accessKeyId: 'AKID', secretAccessKey: 'SECRET' },
+      credentialProxy: true
+    });
+
+    const s3fsCall = execInternal.mock.calls.find((args) =>
+      String(args[0]).includes('s3fs ')
+    );
+    const cmd = String(s3fsCall![0]);
+    // url should be http://s3-credential-proxy.internal/<uuid>
+    expect(cmd).toMatch(/s3-credential-proxy\.internal\/[0-9a-f-]{36}/);
+  });
+
+  it('reconfigures proxy to remove mount after unmount', async () => {
+    const mockCtx = createMockCtx();
+    const sandbox = new Sandbox(
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+      {}
+    );
+
+    Object.assign(sandbox as object, {
+      execInternal: createCredentialProxyExecMock(),
+      createPasswordFile: vi.fn().mockResolvedValue(undefined),
+      deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi
+        .fn()
+        .mockReturnValue('/tmp/.s3fs-unmount-proxy')
+    });
+
+    await sandbox.mountBucket('my-bucket', '/mnt/proxy', {
+      endpoint: 'https://abc123.r2.cloudflarestorage.com',
+      credentials: { accessKeyId: 'AKID', secretAccessKey: 'SECRET' },
+      credentialProxy: true
+    });
+
+    const ContainerProxy = mockCtx.exports.ContainerProxy!;
+    const callsBeforeUnmount = ContainerProxy.mock.calls.length;
+    await sandbox.unmountBucket('/mnt/proxy');
+
+    expect(ContainerProxy.mock.calls.length).toBeGreaterThan(
+      callsBeforeUnmount
+    );
+    const lastCall =
+      ContainerProxy.mock.calls[ContainerProxy.mock.calls.length - 1];
+    expect(lastCall[0].props.outboundByHostOverrides).toMatchObject({
+      's3-credential-proxy.internal': { method: 's3CredentialProxyMount' }
+    });
+  });
+
+  it('reconfigures proxy with empty mounts after s3fs mount failure', async () => {
+    const mockCtx = createMockCtx();
+    const sandbox = new Sandbox(
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+      {}
+    );
+
+    const execInternal = vi.fn(async (command: string) => {
+      if (command.startsWith('test -d ')) return createExecResult(command);
+      if (command.startsWith('mkdir -p ')) return createExecResult(command);
+      if (command.includes('s3fs ')) {
+        return createExecResult(command, {
+          exitCode: 1,
+          stderr: 'mount failed'
+        });
+      }
+      return createExecResult(command);
+    });
+    Object.assign(sandbox as object, {
+      execInternal,
+      createPasswordFile: vi.fn().mockResolvedValue(undefined),
+      deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-fail-proxy')
+    });
+
+    await expect(
+      sandbox.mountBucket('my-bucket', '/mnt/proxy', {
+        endpoint: 'https://abc123.r2.cloudflarestorage.com',
+        credentials: { accessKeyId: 'AKID', secretAccessKey: 'SECRET' },
+        credentialProxy: true
+      })
+    ).rejects.toThrow();
+
+    const ContainerProxy = mockCtx.exports.ContainerProxy!;
+    const lastCall =
+      ContainerProxy.mock.calls[ContainerProxy.mock.calls.length - 1];
+    expect(lastCall[0].props.outboundByHostOverrides).toMatchObject({
+      's3-credential-proxy.internal': {
+        method: 's3CredentialProxyMount',
+        params: { mounts: {} }
+      }
+    });
+  });
+
+  it('clears credential proxy interception on onStop', async () => {
+    const mockCtx = createMockCtx();
+    const sandbox = new Sandbox(
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+      {}
+    );
+
+    Object.assign(sandbox as object, {
+      execInternal: createCredentialProxyExecMock(),
+      createPasswordFile: vi.fn().mockResolvedValue(undefined),
+      deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-onstop')
+    });
+
+    await sandbox.mountBucket('my-bucket', '/mnt/proxy', {
+      endpoint: 'https://abc123.r2.cloudflarestorage.com',
+      credentials: { accessKeyId: 'AKID', secretAccessKey: 'SECRET' },
+      credentialProxy: true
+    });
+
+    const ContainerProxy = mockCtx.exports.ContainerProxy!;
+    const callsBeforeStop = ContainerProxy.mock.calls.length;
+
+    await (sandbox as unknown as { onStop(): Promise<void> }).onStop();
+
+    expect(ContainerProxy.mock.calls.length).toBeGreaterThan(callsBeforeStop);
+    const lastCall =
+      ContainerProxy.mock.calls[ContainerProxy.mock.calls.length - 1];
+    expect(lastCall[0].props.outboundByHostOverrides).toMatchObject({
+      's3-credential-proxy.internal': {
+        method: 's3CredentialProxyMount',
+        params: { mounts: {} }
+      }
+    });
+  });
+
+  it('rejects passwd_file and url overrides in s3fsOptions for credential proxy mounts', async () => {
+    for (const option of [
+      'passwd_file=/tmp/x',
+      'url=https://bad.example.com'
+    ]) {
+      const sandbox = new Sandbox(
+        createMockCtx() as unknown as ConstructorParameters<typeof Sandbox>[0],
+        {}
+      );
+      const createPasswordFile = vi.fn().mockResolvedValue(undefined);
+      Object.assign(sandbox as object, {
+        execInternal: vi.fn(),
+        createPasswordFile,
+        deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+        generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-reject')
+      });
+
+      await expect(
+        sandbox.mountBucket('my-bucket', '/mnt/proxy', {
+          endpoint: 'https://abc123.r2.cloudflarestorage.com',
+          credentials: { accessKeyId: 'AKID', secretAccessKey: 'SECRET' },
+          credentialProxy: true,
+          s3fsOptions: [option]
+        })
+      ).rejects.toThrow('cannot be overridden for credential proxy mounts');
+
+      expect(createPasswordFile).not.toHaveBeenCalled();
+    }
+  });
+});
+
 describe('Sandbox R2 egress mounts', () => {
-  it('does not register static R2 outbound interception on the base Sandbox class', () => {
+  it('does not set up outbound interception at construction time for Sandbox subclasses', () => {
     class BaseSandbox extends Sandbox {}
+    const mockCtx = createMockCtx();
     new BaseSandbox(
-      createMockCtx() as unknown as ConstructorParameters<typeof Sandbox>[0],
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
       { MY_BUCKET: createMockR2Bucket() }
     );
 
-    expect(
-      (
-        BaseSandbox as unknown as {
-          outboundByHost?: Record<string, unknown>;
-        }
-      ).outboundByHost
-    ).toBeUndefined();
-
-    expect(
-      (
-        BaseSandbox as unknown as {
-          outboundHandlers?: Record<string, unknown>;
-        }
-      ).outboundHandlers
-    ).toBeUndefined();
+    expect(mockCtx.container.interceptOutboundHttp).not.toHaveBeenCalled();
+    expect(mockCtx.exports.ContainerProxy).not.toHaveBeenCalled();
   });
 
   describe('handler prefix translation', () => {
@@ -420,7 +689,7 @@ describe('Sandbox R2 egress mounts', () => {
       props: {
         enableInternet: undefined,
         containerId: 'test-sandbox-id',
-        className: 'CloudflareSandboxR2EgressProxyTarget',
+        className: 'ContainerProxy',
         outboundByHostOverrides: {
           'r2.internal': {
             method: 'r2EgressMount',
@@ -522,7 +791,7 @@ describe('Sandbox R2 egress mounts', () => {
     expect(mockCtx.exports.ContainerProxy).toHaveBeenCalledWith(
       expect.objectContaining({
         props: expect.objectContaining({
-          className: 'CloudflareSandboxR2EgressProxyTarget',
+          className: 'ContainerProxy',
           outboundByHostOverrides: {
             'r2.internal': expect.objectContaining({
               method: 'r2EgressMount'
@@ -652,7 +921,7 @@ describe('Sandbox R2 egress mounts', () => {
       props: {
         enableInternet: undefined,
         containerId: 'test-sandbox-id',
-        className: 'CloudflareSandboxR2EgressProxyTarget',
+        className: 'ContainerProxy',
         outboundByHostOverrides: {
           'r2.internal': {
             method: 'r2EgressMount',
@@ -701,7 +970,7 @@ describe('Sandbox R2 egress mounts', () => {
       props: {
         enableInternet: undefined,
         containerId: 'test-sandbox-id',
-        className: 'CloudflareSandboxR2EgressProxyTarget',
+        className: 'ContainerProxy',
         outboundByHostOverrides: {
           'r2.internal': {
             method: 'r2EgressMount',

--- a/packages/sandbox/tests/r2-egress-mount.test.ts
+++ b/packages/sandbox/tests/r2-egress-mount.test.ts
@@ -59,6 +59,10 @@ vi.mock('@cloudflare/containers', () => {
       return new Response('Mock Container fetch');
     }
 
+    async containerFetch(): Promise<Response> {
+      return new Response('Mock Container HTTP fetch');
+    }
+
     async destroy(): Promise<void> {}
 
     async getState() {
@@ -261,6 +265,8 @@ describe('Sandbox credential proxy mounts', () => {
       execInternal: createCredentialProxyExecMock(),
       createPasswordFile: vi.fn().mockResolvedValue(undefined),
       deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
       generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-proxy')
     });
 
@@ -288,6 +294,8 @@ describe('Sandbox credential proxy mounts', () => {
       execInternal: createCredentialProxyExecMock(),
       createPasswordFile,
       deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
       generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-dummy')
     });
 
@@ -304,7 +312,7 @@ describe('Sandbox credential proxy mounts', () => {
     );
   });
 
-  it('appends use_path_request_style to s3fs options for credential proxy mounts', async () => {
+  it('appends required s3fs options for credential proxy mounts', async () => {
     const mockCtx = createMockCtx();
     const sandbox = new Sandbox(
       mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
@@ -316,7 +324,14 @@ describe('Sandbox credential proxy mounts', () => {
       execInternal,
       createPasswordFile: vi.fn().mockResolvedValue(undefined),
       deletePasswordFile: vi.fn().mockResolvedValue(undefined),
-      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-path-style')
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi
+        .fn()
+        .mockReturnValue('/tmp/.s3fs-path-style'),
+      generateS3FSAdditionalHeaderFilePath: vi
+        .fn()
+        .mockReturnValue('/tmp/.s3fs-ahbe-path-style.conf')
     });
 
     await sandbox.mountBucket('my-bucket', '/mnt/proxy', {
@@ -330,6 +345,9 @@ describe('Sandbox credential proxy mounts', () => {
     );
     expect(s3fsCall).toBeDefined();
     expect(String(s3fsCall![0])).toContain('use_path_request_style');
+    expect(String(s3fsCall![0])).toContain(
+      'ahbe_conf=/tmp/.s3fs-ahbe-path-style.conf'
+    );
     expect(String(s3fsCall![0])).toContain('s3-credential-proxy.internal');
   });
 
@@ -345,6 +363,8 @@ describe('Sandbox credential proxy mounts', () => {
       execInternal,
       createPasswordFile: vi.fn().mockResolvedValue(undefined),
       deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
       generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-mountid')
     });
 
@@ -373,6 +393,8 @@ describe('Sandbox credential proxy mounts', () => {
       execInternal: createCredentialProxyExecMock(),
       createPasswordFile: vi.fn().mockResolvedValue(undefined),
       deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
       generatePasswordFilePath: vi
         .fn()
         .mockReturnValue('/tmp/.s3fs-unmount-proxy')
@@ -420,6 +442,8 @@ describe('Sandbox credential proxy mounts', () => {
       execInternal,
       createPasswordFile: vi.fn().mockResolvedValue(undefined),
       deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
       generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-fail-proxy')
     });
 
@@ -442,6 +466,58 @@ describe('Sandbox credential proxy mounts', () => {
     });
   });
 
+  it('attempts best-effort unmount before deleting credential proxy support files on mount failure', async () => {
+    const mockCtx = createMockCtx();
+    const sandbox = new Sandbox(
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+      {}
+    );
+
+    const operationOrder: string[] = [];
+    const execInternal = vi.fn(async (command: string) => {
+      if (command.startsWith('test -d ')) return createExecResult(command);
+      if (command.startsWith('mkdir -p ')) return createExecResult(command);
+      if (command.includes('s3fs ')) {
+        return createExecResult(command, {
+          exitCode: 2,
+          stdout: 'mount failed'
+        });
+      }
+      if (
+        command.startsWith('mountpoint -q') &&
+        command.includes('fusermount')
+      ) {
+        operationOrder.push('unmount');
+        return createExecResult(command);
+      }
+      if (command.startsWith('rmdir ')) return createExecResult(command);
+      return createExecResult(command);
+    });
+    const deletePasswordFile = vi.fn().mockImplementation(async () => {
+      operationOrder.push('delete-password');
+    });
+    Object.assign(sandbox as object, {
+      execInternal,
+      createPasswordFile: vi.fn().mockResolvedValue(undefined),
+      deletePasswordFile,
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi
+        .fn()
+        .mockReturnValue('/tmp/.s3fs-fail-cleanup-order')
+    });
+
+    await expect(
+      sandbox.mountBucket('my-bucket', '/mnt/proxy', {
+        endpoint: 'https://abc123.r2.cloudflarestorage.com',
+        credentials: { accessKeyId: 'AKID', secretAccessKey: 'SECRET' },
+        credentialProxy: true
+      })
+    ).rejects.toThrow();
+
+    expect(operationOrder).toEqual(['unmount', 'delete-password']);
+  });
+
   it('clears credential proxy interception on onStop', async () => {
     const mockCtx = createMockCtx();
     const sandbox = new Sandbox(
@@ -453,6 +529,8 @@ describe('Sandbox credential proxy mounts', () => {
       execInternal: createCredentialProxyExecMock(),
       createPasswordFile: vi.fn().mockResolvedValue(undefined),
       deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
       generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-onstop')
     });
 
@@ -649,6 +727,7 @@ describe('Sandbox R2 egress mounts', () => {
         expect(command).not.toContain(':/uploads');
         expect(command).toContain('url=http://r2.internal');
         expect(command).toContain(`passwd_file=${FAKE_PASSWD}`);
+        expect(command).toContain(`ahbe_conf=${FAKE_AHBE_CONF}`);
         expect(command).toContain('use_path_request_style');
         expect(command).toContain('nomixupload');
         expect(command).toContain('stat_cache_expire=1');
@@ -671,12 +750,19 @@ describe('Sandbox R2 egress mounts', () => {
     const createPasswordFile = vi.fn().mockResolvedValue(undefined);
     const deletePasswordFile = vi.fn().mockResolvedValue(undefined);
     const generatePasswordFilePath = vi.fn().mockReturnValue(FAKE_PASSWD);
+    const FAKE_AHBE_CONF = '/tmp/.s3fs-ahbe-test.conf';
+    const generateS3FSAdditionalHeaderFilePath = vi
+      .fn()
+      .mockReturnValue(FAKE_AHBE_CONF);
 
     Object.assign(sandbox as object, {
       execInternal,
       createPasswordFile,
       deletePasswordFile,
-      generatePasswordFilePath
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath,
+      generateS3FSAdditionalHeaderFilePath
     });
 
     await sandbox.mountBucket('MY_BUCKET', '/mnt/data', {
@@ -726,6 +812,8 @@ describe('Sandbox R2 egress mounts', () => {
       execInternal: vi.fn(),
       createPasswordFile: vi.fn().mockResolvedValue(undefined),
       deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
       generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-no-proxy')
     });
 
@@ -747,6 +835,8 @@ describe('Sandbox R2 egress mounts', () => {
       execInternal: vi.fn(),
       createPasswordFile: vi.fn().mockResolvedValue(undefined),
       deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
       generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-bad-proxy')
     });
 
@@ -783,6 +873,8 @@ describe('Sandbox R2 egress mounts', () => {
       }),
       createPasswordFile: vi.fn().mockResolvedValue(undefined),
       deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
       generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-isolated')
     });
 
@@ -833,6 +925,8 @@ describe('Sandbox R2 egress mounts', () => {
       execInternal,
       createPasswordFile: vi.fn().mockResolvedValue(undefined),
       deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
       generatePasswordFilePath: vi
         .fn()
         .mockReturnValueOnce('/tmp/.s3fs-one')
@@ -868,6 +962,8 @@ describe('Sandbox R2 egress mounts', () => {
       execInternal,
       createPasswordFile: vi.fn().mockResolvedValue(undefined),
       deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
       generatePasswordFilePath: vi
         .fn()
         .mockReturnValueOnce('/tmp/.s3fs-one')
@@ -894,6 +990,7 @@ describe('Sandbox R2 egress mounts', () => {
       { MY_BUCKET: createMockR2Bucket() }
     );
 
+    const deleteAdditionalHeaderFile = vi.fn().mockResolvedValue(undefined);
     Object.assign(sandbox as object, {
       execInternal: vi.fn(async (command: string) => {
         if (command.startsWith('mkdir -p ')) return createExecResult(command);
@@ -911,7 +1008,12 @@ describe('Sandbox R2 egress mounts', () => {
       }),
       createPasswordFile: vi.fn().mockResolvedValue(undefined),
       deletePasswordFile: vi.fn().mockResolvedValue(undefined),
-      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-unmount')
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile,
+      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-unmount'),
+      generateS3FSAdditionalHeaderFilePath: vi
+        .fn()
+        .mockReturnValue('/tmp/.s3fs-ahbe-unmount.conf')
     });
 
     await sandbox.mountBucket('MY_BUCKET', '/mnt/data', {} as any);
@@ -934,6 +1036,9 @@ describe('Sandbox R2 egress mounts', () => {
       'r2.internal',
       mockCtx.containerProxyFetcher
     );
+    expect(deleteAdditionalHeaderFile).toHaveBeenCalledWith(
+      '/tmp/.s3fs-ahbe-unmount.conf'
+    );
   });
 
   it('deletes the password file when R2 egress mount fails', async () => {
@@ -954,11 +1059,17 @@ describe('Sandbox R2 egress mounts', () => {
       throw new Error(`Unexpected command: ${command}`);
     });
     const deletePasswordFile = vi.fn().mockResolvedValue(undefined);
+    const deleteAdditionalHeaderFile = vi.fn().mockResolvedValue(undefined);
     Object.assign(sandbox as object, {
       execInternal,
       createPasswordFile: vi.fn().mockResolvedValue(undefined),
       deletePasswordFile,
-      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-failed')
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile,
+      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-failed'),
+      generateS3FSAdditionalHeaderFilePath: vi
+        .fn()
+        .mockReturnValue('/tmp/.s3fs-ahbe-failed.conf')
     });
 
     await expect(
@@ -966,6 +1077,9 @@ describe('Sandbox R2 egress mounts', () => {
     ).rejects.toThrow('S3FS mount failed');
 
     expect(deletePasswordFile).toHaveBeenCalledWith('/tmp/.s3fs-failed');
+    expect(deleteAdditionalHeaderFile).toHaveBeenCalledWith(
+      '/tmp/.s3fs-ahbe-failed.conf'
+    );
     expect(mockCtx.exports.ContainerProxy).toHaveBeenLastCalledWith({
       props: {
         enableInternet: undefined,
@@ -999,6 +1113,8 @@ describe('Sandbox R2 egress mounts', () => {
       }),
       createPasswordFile: vi.fn().mockResolvedValue(undefined),
       deletePasswordFile,
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
       generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-check-fail')
     });
 

--- a/packages/sandbox/tests/r2-egress-mount.test.ts
+++ b/packages/sandbox/tests/r2-egress-mount.test.ts
@@ -559,7 +559,9 @@ describe('Sandbox credential proxy mounts', () => {
   it('rejects passwd_file and url overrides in s3fsOptions for credential proxy mounts', async () => {
     for (const option of [
       'passwd_file=/tmp/x',
-      'url=https://bad.example.com'
+      'url=https://bad.example.com',
+      'ahbe_conf=/tmp/custom-headers.conf',
+      'use_path_request_style'
     ]) {
       const sandbox = new Sandbox(
         createMockCtx() as unknown as ConstructorParameters<typeof Sandbox>[0],

--- a/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
+++ b/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
@@ -943,6 +943,33 @@ describe('s3CredentialProxyHandler GCS signing', () => {
     vi.restoreAllMocks();
   });
 
+  it('does not forward expect headers to gcs upstream requests', async () => {
+    let capturedRequest: Request | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      capturedRequest = input instanceof Request ? input : new Request(input);
+      return new Response('ok', { status: 200 });
+    });
+
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/key.txt`, 'PUT', {
+      expect: ''
+    });
+    await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(
+        makeParams({
+          provider: 'gcs',
+          authStrategy: 'gcs',
+          endpoint: 'https://storage.googleapis.com'
+        })
+      ) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(capturedRequest!.headers.has('expect')).toBe(false);
+
+    vi.restoreAllMocks();
+  });
+
   it('answers HEAD for gcs zero-length directory marker PUT requests', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response(null, { status: 200 })

--- a/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
+++ b/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
@@ -694,14 +694,105 @@ describe('s3CredentialProxyHandler GCS signing', () => {
 
     expect(capturedRequest).toBeDefined();
     expect(capturedRequest!.method).toBe('PUT');
-    expect(capturedRequest!.headers.get('content-length')).toBe('0');
+    expect(capturedRequest!.headers.get('content-length')).toBeNull();
     expect(capturedRequest!.headers.get('Authorization')).toMatch(
       /^GOOG4-HMAC-SHA256/
+    );
+    expect(capturedRequest!.headers.get('Authorization')).not.toContain(
+      'content-length'
     );
     expect(await capturedRequest!.arrayBuffer()).toHaveProperty(
       'byteLength',
       0
     );
+
+    vi.restoreAllMocks();
+  });
+
+  it('does not forward x-amz headers to gcs upstream requests', async () => {
+    let capturedRequest: Request | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      capturedRequest = input instanceof Request ? input : new Request(input);
+      return new Response('ok', { status: 200 });
+    });
+
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/small.txt`, 'PUT', {
+      'content-type': 'text/plain',
+      expect: ':',
+      'content-length': '1024',
+      'x-amz-content-sha256':
+        'a3c9b4d194aedb820ad8b22957a67476e6b737950db3777d8f25fb8d1419cf27',
+      'x-amz-meta-mode': '33188'
+    });
+    await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(
+        makeParams({
+          provider: 'gcs',
+          authStrategy: 'gcs',
+          endpoint: 'https://storage.googleapis.com'
+        })
+      ) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(capturedRequest).toBeDefined();
+    expect(capturedRequest!.headers.get('x-amz-content-sha256')).toBeNull();
+    expect(capturedRequest!.headers.get('x-amz-meta-mode')).toBeNull();
+    expect(capturedRequest!.headers.get('expect')).toBeNull();
+    expect(capturedRequest!.headers.get('content-length')).toBeNull();
+    expect(capturedRequest!.headers.get('x-goog-meta-mode')).toBe('33188');
+    expect(capturedRequest!.headers.get('x-goog-content-sha256')).toBe(
+      'UNSIGNED-PAYLOAD'
+    );
+    expect(capturedRequest!.headers.get('Authorization')).toMatch(
+      /^GOOG4-HMAC-SHA256/
+    );
+    expect(capturedRequest!.headers.get('Authorization')).not.toContain(
+      'x-amz'
+    );
+    expect(capturedRequest!.headers.get('Authorization')).not.toContain(
+      'content-length'
+    );
+
+    vi.restoreAllMocks();
+  });
+
+  it('answers HEAD for gcs zero-length directory marker PUT requests', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const ctx = makeCtx(
+      makeParams({
+        provider: 'gcs',
+        authStrategy: 'gcs',
+        endpoint: 'https://storage.googleapis.com'
+      })
+    ) as Parameters<typeof s3CredentialProxyHandler>[2];
+    const putReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/gcs-dir/`, 'PUT', {
+      'content-type': 'application/x-directory',
+      'content-length': '0',
+      'x-amz-meta-mode': '493'
+    });
+    const headReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/gcs-dir`, 'HEAD');
+
+    const putResponse = await s3CredentialProxyHandler(
+      putReq,
+      {} as Cloudflare.Env,
+      ctx
+    );
+    const headResponse = await s3CredentialProxyHandler(
+      headReq,
+      {} as Cloudflare.Env,
+      ctx
+    );
+
+    expect(putResponse.status).toBe(200);
+    expect(headResponse.status).toBe(200);
+    expect(headResponse.headers.get('Content-Length')).toBe('0');
+    expect(headResponse.headers.get('Content-Type')).toBe(
+      'application/x-directory'
+    );
+    expect(headResponse.headers.get('x-amz-meta-mode')).toBe('493');
+    expect(fetchSpy).not.toHaveBeenCalled();
 
     vi.restoreAllMocks();
   });

--- a/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
+++ b/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
@@ -389,6 +389,183 @@ describe('s3CredentialProxyHandler URL reconstruction', () => {
   });
 });
 
+describe('s3CredentialProxyHandler mount scope enforcement', () => {
+  it('rejects requests for a different bucket', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const req = makeRequest(`/${MOUNT_ID}/other-bucket/key.txt`);
+
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams()) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toContain('outside mounted bucket scope');
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('rejects object requests outside the configured prefix', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/other/file.txt`);
+
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ prefix: 'project-a' })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('allows object requests inside the configured prefix', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/project-a/file.txt`);
+
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ prefix: 'project-a' })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+
+    vi.restoreAllMocks();
+  });
+
+  it('allows bucket root probes for prefixed mounts without forwarding upstream', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/`);
+
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ prefix: 'project-a' })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+
+    expect(res.status).toBe(200);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('rejects list requests outside the configured prefix', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const req = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/project-a/?list-type=2&prefix=other%2F`
+    );
+
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ prefix: 'project-a' })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('rejects bucket root list requests without a scoped prefix query', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/?list-type=2`);
+
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ prefix: 'project-a' })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('allows bucket root list requests inside the configured prefix', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    const req = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/?delimiter=%2F&max-keys=1000&prefix=project-a%2Fvalidation%2F`
+    );
+
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ prefix: 'project-a' })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+
+    vi.restoreAllMocks();
+  });
+
+  it('rejects object requests outside the configured prefix with an allowed query prefix', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const req = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/other/file.txt?prefix=project-a%2F`
+    );
+
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ prefix: 'project-a' })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('allows list requests inside the configured prefix', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    const req = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/project-a/?list-type=2&prefix=project-a%2Fsub%2F`
+    );
+
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ prefix: 'project-a' })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+
+    vi.restoreAllMocks();
+  });
+});
+
 describe('s3CredentialProxyHandler SigV4 signing', () => {
   it('adds an AWS4-HMAC-SHA256 Authorization header for r2 provider', async () => {
     let capturedRequest: Request | undefined;
@@ -496,8 +673,14 @@ describe('s3CredentialProxyHandler SigV4 signing', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns success for zero-length directory marker PUT requests', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+  it('forwards zero-length directory marker PUT requests upstream', async () => {
+    const forwardedRequests: Request[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      forwardedRequests.push(
+        input instanceof Request ? input : new Request(input)
+      );
+      return new Response(null, { status: 200 });
+    });
     const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/dir/`, 'PUT', {
       'content-length': '0',
       'x-amz-content-sha256':
@@ -513,14 +696,17 @@ describe('s3CredentialProxyHandler SigV4 signing', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('Content-Length')).toBe('0');
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(forwardedRequests).toHaveLength(1);
+    expect(forwardedRequests[0].method).toBe('PUT');
+    expect(forwardedRequests[0].url).toContain(`${ENDPOINT}/${BUCKET}/dir/`);
 
     vi.restoreAllMocks();
   });
 
   it('answers HEAD for zero-length directory marker PUT requests', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(null, { status: 200 })
+    );
     const ctx = makeCtx(
       makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
     ) as Parameters<typeof s3CredentialProxyHandler>[2];
@@ -546,7 +732,6 @@ describe('s3CredentialProxyHandler SigV4 signing', () => {
       'application/x-directory'
     );
     expect(response.headers.get('x-amz-meta-mode')).toBe('493');
-    expect(fetchSpy).not.toHaveBeenCalled();
 
     vi.restoreAllMocks();
   });
@@ -759,7 +944,9 @@ describe('s3CredentialProxyHandler GCS signing', () => {
   });
 
   it('answers HEAD for gcs zero-length directory marker PUT requests', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(null, { status: 200 })
+    );
     const ctx = makeCtx(
       makeParams({
         provider: 'gcs',
@@ -792,7 +979,6 @@ describe('s3CredentialProxyHandler GCS signing', () => {
       'application/x-directory'
     );
     expect(headResponse.headers.get('x-amz-meta-mode')).toBe('493');
-    expect(fetchSpy).not.toHaveBeenCalled();
 
     vi.restoreAllMocks();
   });
@@ -819,9 +1005,9 @@ describe('s3CredentialProxyHandler directory marker cache eviction', () => {
     const headReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/evict-dir`, 'HEAD');
     await s3CredentialProxyHandler(headReq, {} as Cloudflare.Env, ctx);
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(fetchSpy.mock.calls[0][0]).toBeInstanceOf(Request);
-    expect((fetchSpy.mock.calls[0][0] as Request).method).toBe('HEAD');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls[1][0]).toBeInstanceOf(Request);
+    expect((fetchSpy.mock.calls[1][0] as Request).method).toBe('HEAD');
 
     vi.restoreAllMocks();
   });
@@ -873,7 +1059,7 @@ describe('s3CredentialProxyHandler directory marker cache eviction', () => {
       ctxB
     );
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
     expect(headA.status).toBe(200);
     expect(headB.status).toBe(200);
 

--- a/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
+++ b/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
@@ -720,6 +720,59 @@ describe('s3CredentialProxyHandler SigV4 signing', () => {
     vi.restoreAllMocks();
   });
 
+  it('clears short-circuited zero-length objects on DELETE', async () => {
+    const forwardedRequests: Request[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      forwardedRequests.push(
+        input instanceof Request ? input : new Request(input)
+      );
+      return new Response(null, { status: 204 });
+    });
+    const ctx = makeCtx(
+      makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+    ) as Parameters<typeof s3CredentialProxyHandler>[2];
+
+    // Short-circuit a zero-length PUT
+    const zeroPut = makeRequest(`/${MOUNT_ID}/${BUCKET}/deleted.txt`, 'PUT', {
+      'content-length': '0',
+      'x-amz-content-sha256':
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    });
+    const zeroPutResponse = await s3CredentialProxyHandler(
+      zeroPut,
+      {} as Cloudflare.Env,
+      ctx
+    );
+    expect(zeroPutResponse.status).toBe(200);
+    expect(forwardedRequests).toHaveLength(0); // short-circuited, not forwarded
+
+    // DELETE the object — should evict the synthetic cache entry
+    const deleteReq = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/deleted.txt`,
+      'DELETE'
+    );
+    await s3CredentialProxyHandler(deleteReq, {} as Cloudflare.Env, ctx);
+    expect(forwardedRequests).toHaveLength(1); // DELETE forwarded to upstream
+
+    // HEAD after DELETE must be forwarded to upstream, not served from the stale cache
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      forwardedRequests.push(
+        input instanceof Request ? input : new Request(input)
+      );
+      return new Response(null, { status: 404 });
+    });
+    const headReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/deleted.txt`, 'HEAD');
+    const headResponse = await s3CredentialProxyHandler(
+      headReq,
+      {} as Cloudflare.Env,
+      ctx
+    );
+    expect(headResponse.status).toBe(404);
+    expect(forwardedRequests).toHaveLength(2);
+
+    vi.restoreAllMocks();
+  });
+
   it('canonicalizes repeated and special query parameters for signing', async () => {
     let capturedRequest: Request | undefined;
     vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {

--- a/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
+++ b/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   DUMMY_AUTH_HEADERS,
+  evictDirectoryMarkerCacheForMount,
   s3CredentialProxyHandler
 } from '../src/storage-mount/s3-credential-proxy-handler';
 import type { S3CredentialProxyParams } from '../src/storage-mount/types';
@@ -308,16 +309,12 @@ describe('s3CredentialProxyHandler dummy header stripping', () => {
     );
 
     expect(capturedRequest).toBeDefined();
-    // SigV4 signing replaces some dummy headers with real values; verify
-    // that none of the forwarded headers carry the original dummy value.
     for (const h of DUMMY_AUTH_HEADERS) {
-      if (h === 'x-amz-content-sha256') continue;
       expect(capturedRequest!.headers.get(h)).not.toBe('dummy-value');
     }
     expect(capturedRequest!.headers.get('x-amz-content-sha256')).toBe(
-      'dummy-value'
+      'UNSIGNED-PAYLOAD'
     );
-    // GCS-specific headers must not be present on an S3/R2 signed request
     expect(capturedRequest!.headers.get('x-goog-date')).toBeNull();
     expect(capturedRequest!.headers.get('x-goog-content-sha256')).toBeNull();
 
@@ -464,81 +461,14 @@ describe('s3CredentialProxyHandler SigV4 signing', () => {
     vi.restoreAllMocks();
   });
 
-  it('short-circuits zero-length r2 object PUT requests', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch');
-
-    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/key.txt`, 'PUT', {
-      'content-type': 'text/plain',
-      'content-length': '0',
-      'x-amz-content-sha256':
-        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+  it('forwards zero-length object PUT requests upstream', async () => {
+    const forwardedRequests: Request[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      forwardedRequests.push(
+        input instanceof Request ? input : new Request(input)
+      );
+      return new Response(null, { status: 200 });
     });
-    const response = await s3CredentialProxyHandler(
-      req,
-      {} as Cloudflare.Env,
-      makeCtx(
-        makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
-      ) as Parameters<typeof s3CredentialProxyHandler>[2]
-    );
-
-    expect(response.status).toBe(200);
-    expect(fetchSpy).not.toHaveBeenCalled();
-
-    vi.restoreAllMocks();
-  });
-
-  it('short-circuits r2 directory marker PUT requests', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch');
-    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/dir/`, 'PUT', {
-      'content-length': '0',
-      'x-amz-content-sha256':
-        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
-    });
-
-    const response = await s3CredentialProxyHandler(
-      req,
-      {} as Cloudflare.Env,
-      makeCtx(
-        makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
-      ) as Parameters<typeof s3CredentialProxyHandler>[2]
-    );
-
-    expect(response.status).toBe(200);
-    expect(response.headers.get('ETag')).toBe(
-      '"d41d8cd98f00b204e9800998ecf8427e"'
-    );
-    expect(fetchSpy).not.toHaveBeenCalled();
-
-    vi.restoreAllMocks();
-  });
-
-  it('short-circuits s3 directory marker PUT requests', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch');
-    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/dir/`, 'PUT', {
-      'content-length': '0',
-      'x-amz-content-sha256':
-        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
-    });
-
-    const response = await s3CredentialProxyHandler(
-      req,
-      {} as Cloudflare.Env,
-      makeCtx(
-        makeParams({ provider: 's3', authStrategy: 's3-sigv4' })
-      ) as Parameters<typeof s3CredentialProxyHandler>[2]
-    );
-
-    expect(response.status).toBe(200);
-    expect(response.headers.get('ETag')).toBe(
-      '"d41d8cd98f00b204e9800998ecf8427e"'
-    );
-    expect(fetchSpy).not.toHaveBeenCalled();
-
-    vi.restoreAllMocks();
-  });
-
-  it('short-circuits s3 zero-length regular object PUT requests', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch');
     const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/empty.txt`, 'PUT', {
       'content-type': 'text/plain',
       'content-length': '0',
@@ -555,22 +485,53 @@ describe('s3CredentialProxyHandler SigV4 signing', () => {
     );
 
     expect(response.status).toBe(200);
+    expect(forwardedRequests).toHaveLength(1);
+    expect(forwardedRequests[0].method).toBe('PUT');
+    expect(forwardedRequests[0].headers.get('content-length')).toBe('0');
+    expect(await forwardedRequests[0].arrayBuffer()).toHaveProperty(
+      'byteLength',
+      0
+    );
+
+    vi.restoreAllMocks();
+  });
+
+  it('returns success for zero-length directory marker PUT requests', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/dir/`, 'PUT', {
+      'content-length': '0',
+      'x-amz-content-sha256':
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    });
+
+    const response = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(
+        makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+      ) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Length')).toBe('0');
     expect(fetchSpy).not.toHaveBeenCalled();
 
     vi.restoreAllMocks();
   });
 
-  it('answers HEAD for short-circuited r2 directory markers', async () => {
+  it('answers HEAD for zero-length directory marker PUT requests', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch');
     const ctx = makeCtx(
       makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
     ) as Parameters<typeof s3CredentialProxyHandler>[2];
-    const putReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/marker/`, 'PUT', {
+    const putReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/dir/`, 'PUT', {
+      'content-type': 'application/x-directory',
       'content-length': '0',
+      'x-amz-meta-mode': '493',
       'x-amz-content-sha256':
         'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
     });
-    const headReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/marker/`, 'HEAD');
+    const headReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/dir`, 'HEAD');
 
     await s3CredentialProxyHandler(putReq, {} as Cloudflare.Env, ctx);
     const response = await s3CredentialProxyHandler(
@@ -581,80 +542,34 @@ describe('s3CredentialProxyHandler SigV4 signing', () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get('Content-Length')).toBe('0');
+    expect(response.headers.get('Content-Type')).toBe(
+      'application/x-directory'
+    );
+    expect(response.headers.get('x-amz-meta-mode')).toBe('493');
     expect(fetchSpy).not.toHaveBeenCalled();
 
     vi.restoreAllMocks();
   });
 
-  it('answers HEAD for short-circuited zero-length r2 objects', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+  it('forwards HEAD requests upstream after zero-length PUT requests', async () => {
+    const forwardedRequests: Request[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      forwardedRequests.push(
+        input instanceof Request ? input : new Request(input)
+      );
+      return new Response(null, { status: 200 });
+    });
     const ctx = makeCtx(
       makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
     ) as Parameters<typeof s3CredentialProxyHandler>[2];
-    const putReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/empty.txt`, 'PUT', {
+    const zeroPut = makeRequest(`/${MOUNT_ID}/${BUCKET}/empty.txt`, 'PUT', {
       'content-length': '0',
-      'content-type': 'text/plain',
       'x-amz-content-sha256':
-        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
-      'x-amz-meta-mode': '33188'
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
     });
     const headReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/empty.txt`, 'HEAD');
 
-    await s3CredentialProxyHandler(putReq, {} as Cloudflare.Env, ctx);
-    const response = await s3CredentialProxyHandler(
-      headReq,
-      {} as Cloudflare.Env,
-      ctx
-    );
-
-    expect(response.status).toBe(200);
-    expect(response.headers.get('Content-Length')).toBe('0');
-    expect(response.headers.get('Content-Type')).toBe('text/plain');
-    expect(response.headers.get('x-amz-meta-mode')).toBe('33188');
-    expect(fetchSpy).not.toHaveBeenCalled();
-
-    vi.restoreAllMocks();
-  });
-
-  it('clears short-circuited zero-length objects on positive-length PUT', async () => {
-    const forwardedRequests: Request[] = [];
-    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
-      forwardedRequests.push(
-        input instanceof Request ? input : new Request(input)
-      );
-      return new Response('ok', {
-        status: 200,
-        headers: { 'Content-Length': '2048' }
-      });
-    });
-    const ctx = makeCtx(
-      makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
-    ) as Parameters<typeof s3CredentialProxyHandler>[2];
-    const zeroPut = makeRequest(`/${MOUNT_ID}/${BUCKET}/overwrite.txt`, 'PUT', {
-      'content-length': '0',
-      'x-amz-content-sha256':
-        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
-    });
-    const body = new ReadableStream({
-      start(controller) {
-        controller.enqueue(new TextEncoder().encode('updated'));
-        controller.close();
-      }
-    });
-    const positivePut = makeRequest(
-      `/${MOUNT_ID}/${BUCKET}/overwrite.txt`,
-      'PUT',
-      {
-        'content-length': '7',
-        'x-amz-content-sha256':
-          '27eb5e51506c911f6fc4bb345c0d9db954755119e56d03aec0a59759a03d4f1d'
-      },
-      body
-    );
-    const headReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/overwrite.txt`, 'HEAD');
-
     await s3CredentialProxyHandler(zeroPut, {} as Cloudflare.Env, ctx);
-    await s3CredentialProxyHandler(positivePut, {} as Cloudflare.Env, ctx);
     const response = await s3CredentialProxyHandler(
       headReq,
       {} as Cloudflare.Env,
@@ -662,113 +577,8 @@ describe('s3CredentialProxyHandler SigV4 signing', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('Content-Length')).toBe('2048');
     expect(forwardedRequests).toHaveLength(2);
-
-    vi.restoreAllMocks();
-  });
-
-  it('clears short-circuited s3 zero-length objects on positive-length PUT', async () => {
-    const forwardedRequests: Request[] = [];
-    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
-      forwardedRequests.push(
-        input instanceof Request ? input : new Request(input)
-      );
-      return new Response('ok', {
-        status: 200,
-        headers: { 'Content-Length': '2048' }
-      });
-    });
-    const ctx = makeCtx(
-      makeParams({ provider: 's3', authStrategy: 's3-sigv4' })
-    ) as Parameters<typeof s3CredentialProxyHandler>[2];
-    const zeroPut = makeRequest(`/${MOUNT_ID}/${BUCKET}/overwrite.txt`, 'PUT', {
-      'content-length': '0',
-      'x-amz-content-sha256':
-        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
-    });
-    const body = new ReadableStream({
-      start(controller) {
-        controller.enqueue(new TextEncoder().encode('updated'));
-        controller.close();
-      }
-    });
-    const positivePut = makeRequest(
-      `/${MOUNT_ID}/${BUCKET}/overwrite.txt`,
-      'PUT',
-      {
-        'content-length': '7',
-        'x-amz-content-sha256':
-          '27eb5e51506c911f6fc4bb345c0d9db954755119e56d03aec0a59759a03d4f1d'
-      },
-      body
-    );
-    const headReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/overwrite.txt`, 'HEAD');
-
-    await s3CredentialProxyHandler(zeroPut, {} as Cloudflare.Env, ctx);
-    await s3CredentialProxyHandler(positivePut, {} as Cloudflare.Env, ctx);
-    const response = await s3CredentialProxyHandler(
-      headReq,
-      {} as Cloudflare.Env,
-      ctx
-    );
-
-    expect(response.status).toBe(200);
-    expect(response.headers.get('Content-Length')).toBe('2048');
-    expect(forwardedRequests).toHaveLength(2);
-
-    vi.restoreAllMocks();
-  });
-
-  it('clears short-circuited zero-length objects on DELETE', async () => {
-    const forwardedRequests: Request[] = [];
-    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
-      forwardedRequests.push(
-        input instanceof Request ? input : new Request(input)
-      );
-      return new Response(null, { status: 204 });
-    });
-    const ctx = makeCtx(
-      makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
-    ) as Parameters<typeof s3CredentialProxyHandler>[2];
-
-    // Short-circuit a zero-length PUT
-    const zeroPut = makeRequest(`/${MOUNT_ID}/${BUCKET}/deleted.txt`, 'PUT', {
-      'content-length': '0',
-      'x-amz-content-sha256':
-        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
-    });
-    const zeroPutResponse = await s3CredentialProxyHandler(
-      zeroPut,
-      {} as Cloudflare.Env,
-      ctx
-    );
-    expect(zeroPutResponse.status).toBe(200);
-    expect(forwardedRequests).toHaveLength(0); // short-circuited, not forwarded
-
-    // DELETE the object — should evict the synthetic cache entry
-    const deleteReq = makeRequest(
-      `/${MOUNT_ID}/${BUCKET}/deleted.txt`,
-      'DELETE'
-    );
-    await s3CredentialProxyHandler(deleteReq, {} as Cloudflare.Env, ctx);
-    expect(forwardedRequests).toHaveLength(1); // DELETE forwarded to upstream
-
-    // HEAD after DELETE must be forwarded to upstream, not served from the stale cache
-    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
-      forwardedRequests.push(
-        input instanceof Request ? input : new Request(input)
-      );
-      return new Response(null, { status: 404 });
-    });
-    const headReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/deleted.txt`, 'HEAD');
-    const headResponse = await s3CredentialProxyHandler(
-      headReq,
-      {} as Cloudflare.Env,
-      ctx
-    );
-    expect(headResponse.status).toBe(404);
-    expect(forwardedRequests).toHaveLength(2);
+    expect(forwardedRequests[1].method).toBe('HEAD');
 
     vi.restoreAllMocks();
   });
@@ -856,6 +666,125 @@ describe('s3CredentialProxyHandler GCS signing', () => {
       /^GOOG4-HMAC-SHA256/
     );
     expect(capturedRequest!.headers.get('x-goog-date')).toBeDefined();
+
+    vi.restoreAllMocks();
+  });
+
+  it('forwards zero-length gcs PUT requests with an empty body', async () => {
+    let capturedRequest: Request | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      capturedRequest = input instanceof Request ? input : new Request(input);
+      return new Response('ok', { status: 200 });
+    });
+
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/empty.txt`, 'PUT', {
+      'content-length': '0'
+    });
+    await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(
+        makeParams({
+          provider: 'gcs',
+          authStrategy: 'gcs',
+          endpoint: 'https://storage.googleapis.com'
+        })
+      ) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(capturedRequest).toBeDefined();
+    expect(capturedRequest!.method).toBe('PUT');
+    expect(capturedRequest!.headers.get('content-length')).toBe('0');
+    expect(capturedRequest!.headers.get('Authorization')).toMatch(
+      /^GOOG4-HMAC-SHA256/
+    );
+    expect(await capturedRequest!.arrayBuffer()).toHaveProperty(
+      'byteLength',
+      0
+    );
+
+    vi.restoreAllMocks();
+  });
+});
+
+describe('s3CredentialProxyHandler directory marker cache eviction', () => {
+  it('evicts directory marker cache entries for a mount on evictDirectoryMarkerCacheForMount', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    const ctx = makeCtx(
+      makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+    ) as Parameters<typeof s3CredentialProxyHandler>[2];
+
+    const putReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/evict-dir/`, 'PUT', {
+      'content-length': '0',
+      'x-amz-content-sha256':
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    });
+    await s3CredentialProxyHandler(putReq, {} as Cloudflare.Env, ctx);
+
+    evictDirectoryMarkerCacheForMount(MOUNT_ID);
+
+    const headReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/evict-dir`, 'HEAD');
+    await s3CredentialProxyHandler(headReq, {} as Cloudflare.Env, ctx);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][0]).toBeInstanceOf(Request);
+    expect((fetchSpy.mock.calls[0][0] as Request).method).toBe('HEAD');
+
+    vi.restoreAllMocks();
+  });
+
+  it('only evicts cache entries for the given mount ID', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    const OTHER_MOUNT_ID = 'bbbbcccc-dddd-eeee-ffff-000011112222';
+    const ctxA = makeCtx(
+      makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+    ) as Parameters<typeof s3CredentialProxyHandler>[2];
+    const ctxB = makeCtx(
+      makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+    ) as Parameters<typeof s3CredentialProxyHandler>[2];
+    (ctxB as Record<string, unknown>).params = {
+      mounts: { [OTHER_MOUNT_ID]: makeParams().mounts[MOUNT_ID] }
+    };
+
+    await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/dir-a/`, 'PUT', {
+        'content-length': '0',
+        'x-amz-content-sha256':
+          'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+      }),
+      {} as Cloudflare.Env,
+      ctxA
+    );
+    await s3CredentialProxyHandler(
+      makeRequest(`/${OTHER_MOUNT_ID}/${BUCKET}/dir-b/`, 'PUT', {
+        'content-length': '0',
+        'x-amz-content-sha256':
+          'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+      }),
+      {} as Cloudflare.Env,
+      ctxB
+    );
+
+    evictDirectoryMarkerCacheForMount(MOUNT_ID);
+
+    const headA = await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/dir-a`, 'HEAD'),
+      {} as Cloudflare.Env,
+      ctxA
+    );
+    const headB = await s3CredentialProxyHandler(
+      makeRequest(`/${OTHER_MOUNT_ID}/${BUCKET}/dir-b`, 'HEAD'),
+      {} as Cloudflare.Env,
+      ctxB
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(headA.status).toBe(200);
+    expect(headB.status).toBe(200);
 
     vi.restoreAllMocks();
   });

--- a/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
+++ b/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DUMMY_AUTH_HEADERS,
+  s3CredentialProxyHandler
+} from '../src/storage-mount/s3-credential-proxy-handler';
+import type { S3CredentialProxyParams } from '../src/storage-mount/types';
+
+const MOUNT_ID = 'aaaabbbb-cccc-dddd-eeee-ffffffffffff';
+const BUCKET = 'my-bucket';
+const ENDPOINT = 'https://abc123.r2.cloudflarestorage.com';
+const CREDENTIALS = { accessKeyId: 'AKID', secretAccessKey: 'SECRET' };
+
+function makeParams(
+  overrides: Partial<S3CredentialProxyParams['mounts'][string]> = {}
+): S3CredentialProxyParams {
+  return {
+    mounts: {
+      [MOUNT_ID]: {
+        endpoint: ENDPOINT,
+        bucket: BUCKET,
+        credentials: CREDENTIALS,
+        readOnly: false,
+        provider: 'r2',
+        authStrategy: 's3-sigv4',
+        ...overrides
+      }
+    }
+  };
+}
+
+function makeCtx(params: S3CredentialProxyParams) {
+  return {
+    containerId: 'ctr-test',
+    className: 'Sandbox',
+    params
+  };
+}
+
+function makeRequest(
+  path: string,
+  method = 'GET',
+  headers: Record<string, string> = {}
+) {
+  return new Request(`http://s3-credential-proxy.internal${path}`, {
+    method,
+    headers
+  });
+}
+
+describe('s3CredentialProxyHandler self-test', () => {
+  it('returns 200 for the self-test path', async () => {
+    const req = new Request(
+      'http://s3-credential-proxy.internal/__sandbox_credential_proxy_self_test__'
+    );
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams()) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('s3CredentialProxyHandler mount resolution', () => {
+  it('returns 400 when path has no mount ID segment', async () => {
+    const req = new Request('http://s3-credential-proxy.internal/');
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams()) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 403 for an unknown mount ID', async () => {
+    const req = makeRequest('/unknown-uuid/my-bucket/key.txt');
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams()) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('resolves mount from per-mount-host shape (legacy)', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    const req = new Request(
+      `http://${MOUNT_ID}.s3-credential-proxy.internal/${BUCKET}/key.txt`
+    );
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams()) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+    expect(res.status).toBe(200);
+    fetchSpy.mockRestore();
+  });
+});
+
+describe('s3CredentialProxyHandler read-only enforcement', () => {
+  it('returns 403 for PUT on a read-only mount', async () => {
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/key.txt`, 'PUT');
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ readOnly: true })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 for DELETE on a read-only mount', async () => {
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/key.txt`, 'DELETE');
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ readOnly: true })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 for multipart POST on a read-only mount', async () => {
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/key.txt?uploads`, 'POST');
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ readOnly: true })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('allows GET on a read-only mount', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('data', { status: 200 }));
+
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/key.txt`, 'GET');
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ readOnly: true })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+    expect(res.status).toBe(200);
+    fetchSpy.mockRestore();
+  });
+});
+
+describe('s3CredentialProxyHandler dummy header stripping', () => {
+  it('strips all dummy auth headers before forwarding', async () => {
+    let capturedRequest: Request | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      capturedRequest = input instanceof Request ? input : new Request(input);
+      return new Response('ok', { status: 200 });
+    });
+
+    const dummyHeaders: Record<string, string> = {};
+    for (const h of DUMMY_AUTH_HEADERS) {
+      dummyHeaders[h] = 'dummy-value';
+    }
+    const req = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/key.txt`,
+      'GET',
+      dummyHeaders
+    );
+
+    await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams()) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(capturedRequest).toBeDefined();
+    // SigV4 signing replaces some dummy headers with real values; verify
+    // that none of the forwarded headers carry the original dummy value.
+    for (const h of DUMMY_AUTH_HEADERS) {
+      expect(capturedRequest!.headers.get(h)).not.toBe('dummy-value');
+    }
+    // GCS-specific headers must not be present on an S3/R2 signed request
+    expect(capturedRequest!.headers.get('x-goog-date')).toBeNull();
+    expect(capturedRequest!.headers.get('x-goog-content-sha256')).toBeNull();
+
+    vi.restoreAllMocks();
+  });
+});
+
+describe('s3CredentialProxyHandler URL reconstruction', () => {
+  it('strips the mount ID prefix and forwards to the real endpoint', async () => {
+    let capturedRequest: Request | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      capturedRequest = input instanceof Request ? input : new Request(input);
+      return new Response('ok', { status: 200 });
+    });
+
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/folder/file.txt`);
+    await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams()) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(capturedRequest).toBeDefined();
+    expect(capturedRequest!.url).toContain(
+      `${ENDPOINT}/${BUCKET}/folder/file.txt`
+    );
+
+    vi.restoreAllMocks();
+  });
+
+  it('preserves query parameters when forwarding', async () => {
+    let capturedRequest: Request | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      capturedRequest = input instanceof Request ? input : new Request(input);
+      return new Response('ok', { status: 200 });
+    });
+
+    const req = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/key.txt?list-type=2&prefix=foo`
+    );
+    await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams()) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(capturedRequest!.url).toContain('list-type=2');
+    expect(capturedRequest!.url).toContain('prefix=foo');
+
+    vi.restoreAllMocks();
+  });
+});
+
+describe('s3CredentialProxyHandler SigV4 signing', () => {
+  it('adds an AWS4-HMAC-SHA256 Authorization header for r2 provider', async () => {
+    let capturedRequest: Request | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      capturedRequest = input instanceof Request ? input : new Request(input);
+      return new Response('ok', { status: 200 });
+    });
+
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/key.txt`);
+    await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(
+        makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+      ) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(capturedRequest!.headers.get('Authorization')).toMatch(
+      /^AWS4-HMAC-SHA256/
+    );
+
+    vi.restoreAllMocks();
+  });
+});
+
+describe('s3CredentialProxyHandler GCS signing', () => {
+  it('adds a GOOG4-HMAC-SHA256 Authorization header for gcs provider', async () => {
+    let capturedRequest: Request | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      capturedRequest = input instanceof Request ? input : new Request(input);
+      return new Response('ok', { status: 200 });
+    });
+
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/key.txt`);
+    await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(
+        makeParams({
+          provider: 'gcs',
+          authStrategy: 'gcs',
+          endpoint: 'https://storage.googleapis.com'
+        })
+      ) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(capturedRequest!.headers.get('Authorization')).toMatch(
+      /^GOOG4-HMAC-SHA256/
+    );
+    expect(capturedRequest!.headers.get('x-goog-date')).toBeDefined();
+    expect(capturedRequest!.headers.get('x-goog-content-sha256')).toBe(
+      'UNSIGNED-PAYLOAD'
+    );
+
+    vi.restoreAllMocks();
+  });
+});
+
+describe('s3CredentialProxyHandler host header handling', () => {
+  it('strips the intercepted proxy host header before signing', async () => {
+    let capturedRequest: Request | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      capturedRequest = input instanceof Request ? input : new Request(input);
+      return new Response('ok', { status: 200 });
+    });
+
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/key.txt`, 'GET', {
+      host: 's3-credential-proxy.internal'
+    });
+
+    await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams()) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(capturedRequest).toBeDefined();
+    expect(capturedRequest!.headers.get('host')).not.toBe(
+      's3-credential-proxy.internal'
+    );
+
+    vi.restoreAllMocks();
+  });
+});

--- a/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
+++ b/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
@@ -36,14 +36,27 @@ function makeCtx(params: S3CredentialProxyParams) {
   };
 }
 
+function makeCtxWithContainerId(
+  params: S3CredentialProxyParams,
+  containerId: string
+) {
+  return {
+    containerId,
+    className: 'Sandbox',
+    params
+  };
+}
+
 function makeRequest(
   path: string,
   method = 'GET',
-  headers: Record<string, string> = {}
+  headers: Record<string, string> = {},
+  body?: BodyInit
 ) {
   return new Request(`http://s3-credential-proxy.internal${path}`, {
     method,
-    headers
+    headers,
+    body
   });
 }
 
@@ -58,6 +71,109 @@ describe('s3CredentialProxyHandler self-test', () => {
       makeCtx(makeParams()) as Parameters<typeof s3CredentialProxyHandler>[2]
     );
     expect(res.status).toBe(200);
+  });
+});
+
+describe('s3CredentialProxyHandler diagnostics', () => {
+  it('does not expose diagnostics when debug is disabled', async () => {
+    const req = new Request(
+      'http://s3-credential-proxy.internal/__sandbox_credential_proxy_diagnostics__'
+    );
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams()) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('records diagnostics when debug is enabled', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('ok', { status: 200 })
+    );
+
+    await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/key.txt`),
+      {
+        SANDBOX_CREDENTIAL_PROXY_DEBUG: 'true',
+        SANDBOX_CREDENTIAL_PROXY_DIAGNOSTICS_ENDPOINT: 'true'
+      } as unknown as Cloudflare.Env,
+      makeCtx(makeParams()) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    const res = await s3CredentialProxyHandler(
+      new Request(
+        'http://s3-credential-proxy.internal/__sandbox_credential_proxy_diagnostics__'
+      ),
+      {
+        SANDBOX_CREDENTIAL_PROXY_DEBUG: 'true',
+        SANDBOX_CREDENTIAL_PROXY_DIAGNOSTICS_ENDPOINT: 'true'
+      } as unknown as Cloudflare.Env,
+      makeCtx(makeParams()) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+    const body = (await res.json()) as {
+      events: Array<{ mountId: string; path: string }>;
+    };
+    expect(res.status).toBe(200);
+    expect(body.events).toContainEqual(
+      expect.objectContaining({
+        mountId: MOUNT_ID,
+        path: `/${BUCKET}/key.txt`
+      })
+    );
+
+    vi.restoreAllMocks();
+  });
+
+  it('only returns diagnostics for the current container', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    const env = {
+      SANDBOX_CREDENTIAL_PROXY_DEBUG: 'true',
+      SANDBOX_CREDENTIAL_PROXY_DIAGNOSTICS_ENDPOINT: 'true'
+    } as unknown as Cloudflare.Env;
+
+    await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/a.txt`),
+      env,
+      makeCtxWithContainerId(makeParams(), 'ctr-a') as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+    await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/b.txt`),
+      env,
+      makeCtxWithContainerId(makeParams(), 'ctr-b') as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+
+    const res = await s3CredentialProxyHandler(
+      new Request(
+        'http://s3-credential-proxy.internal/__sandbox_credential_proxy_diagnostics__'
+      ),
+      env,
+      makeCtxWithContainerId(makeParams(), 'ctr-a') as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+    const body = (await res.json()) as {
+      events: Array<{ containerId: string; path: string }>;
+    };
+
+    expect(body.events).toContainEqual(
+      expect.objectContaining({
+        containerId: 'ctr-a',
+        path: `/${BUCKET}/a.txt`
+      })
+    );
+    expect(body.events).not.toContainEqual(
+      expect.objectContaining({ containerId: 'ctr-b' })
+    );
+
+    vi.restoreAllMocks();
   });
 });
 
@@ -137,6 +253,18 @@ describe('s3CredentialProxyHandler read-only enforcement', () => {
     expect(res.status).toBe(403);
   });
 
+  it('returns 403 for any POST on a read-only mount', async () => {
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/key.txt?delete`, 'POST');
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ readOnly: true })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+    expect(res.status).toBe(403);
+  });
+
   it('allows GET on a read-only mount', async () => {
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
@@ -183,8 +311,12 @@ describe('s3CredentialProxyHandler dummy header stripping', () => {
     // SigV4 signing replaces some dummy headers with real values; verify
     // that none of the forwarded headers carry the original dummy value.
     for (const h of DUMMY_AUTH_HEADERS) {
+      if (h === 'x-amz-content-sha256') continue;
       expect(capturedRequest!.headers.get(h)).not.toBe('dummy-value');
     }
+    expect(capturedRequest!.headers.get('x-amz-content-sha256')).toBe(
+      'dummy-value'
+    );
     // GCS-specific headers must not be present on an S3/R2 signed request
     expect(capturedRequest!.headers.get('x-goog-date')).toBeNull();
     expect(capturedRequest!.headers.get('x-goog-content-sha256')).toBeNull();
@@ -237,6 +369,27 @@ describe('s3CredentialProxyHandler URL reconstruction', () => {
 
     vi.restoreAllMocks();
   });
+
+  it('forwards percent-containing object keys without throwing', async () => {
+    let capturedRequest: Request | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      capturedRequest = input instanceof Request ? input : new Request(input);
+      return new Response('ok', { status: 200 });
+    });
+
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/literal%key.txt`);
+    await expect(
+      s3CredentialProxyHandler(
+        req,
+        {} as Cloudflare.Env,
+        makeCtx(makeParams()) as Parameters<typeof s3CredentialProxyHandler>[2]
+      )
+    ).resolves.toBeInstanceOf(Response);
+
+    expect(capturedRequest).toBeDefined();
+
+    vi.restoreAllMocks();
+  });
 });
 
 describe('s3CredentialProxyHandler SigV4 signing', () => {
@@ -256,6 +409,336 @@ describe('s3CredentialProxyHandler SigV4 signing', () => {
       ) as Parameters<typeof s3CredentialProxyHandler>[2]
     );
 
+    expect(capturedRequest!.headers.get('Authorization')).toMatch(
+      /^AWS4-HMAC-SHA256/
+    );
+    expect(capturedRequest!.headers.get('x-amz-content-sha256')).toBe(
+      'UNSIGNED-PAYLOAD'
+    );
+    expect(capturedRequest!.headers.get('x-amz-date')).toBeDefined();
+
+    vi.restoreAllMocks();
+  });
+
+  it('forwards positive-length request bodies with a body for r2 provider', async () => {
+    let capturedRequest: Request | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      capturedRequest = input instanceof Request ? input : new Request(input);
+      return new Response('ok', { status: 200 });
+    });
+
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('streamed-body'));
+        controller.close();
+      }
+    });
+    const req = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/key.txt`,
+      'PUT',
+      {
+        'content-type': 'text/plain',
+        'content-length': '13',
+        'x-amz-content-sha256':
+          '9b2885776f8cf270a81d7a8bc7c3df429d19fb78f4a886dd0e626a83d15c8d94'
+      },
+      body
+    );
+    await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(
+        makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+      ) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(capturedRequest!.headers.get('x-amz-content-sha256')).toBe(
+      '9b2885776f8cf270a81d7a8bc7c3df429d19fb78f4a886dd0e626a83d15c8d94'
+    );
+    expect(capturedRequest!.headers.get('content-length')).toBe('13');
+    expect(capturedRequest!.headers.get('Authorization')).not.toContain(
+      'content-length'
+    );
+    expect(await capturedRequest!.text()).toBe('streamed-body');
+
+    vi.restoreAllMocks();
+  });
+
+  it('short-circuits zero-length r2 object PUT requests', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/key.txt`, 'PUT', {
+      'content-type': 'text/plain',
+      'content-length': '0',
+      'x-amz-content-sha256':
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    });
+    const response = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(
+        makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+      ) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('short-circuits r2 directory marker PUT requests', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/dir/`, 'PUT', {
+      'content-length': '0',
+      'x-amz-content-sha256':
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    });
+
+    const response = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(
+        makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+      ) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('ETag')).toBe(
+      '"d41d8cd98f00b204e9800998ecf8427e"'
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('short-circuits s3 directory marker PUT requests', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/dir/`, 'PUT', {
+      'content-length': '0',
+      'x-amz-content-sha256':
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    });
+
+    const response = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(
+        makeParams({ provider: 's3', authStrategy: 's3-sigv4' })
+      ) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('ETag')).toBe(
+      '"d41d8cd98f00b204e9800998ecf8427e"'
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('short-circuits s3 zero-length regular object PUT requests', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/empty.txt`, 'PUT', {
+      'content-type': 'text/plain',
+      'content-length': '0',
+      'x-amz-content-sha256':
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    });
+
+    const response = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(
+        makeParams({ provider: 's3', authStrategy: 's3-sigv4' })
+      ) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('answers HEAD for short-circuited r2 directory markers', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const ctx = makeCtx(
+      makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+    ) as Parameters<typeof s3CredentialProxyHandler>[2];
+    const putReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/marker/`, 'PUT', {
+      'content-length': '0',
+      'x-amz-content-sha256':
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    });
+    const headReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/marker/`, 'HEAD');
+
+    await s3CredentialProxyHandler(putReq, {} as Cloudflare.Env, ctx);
+    const response = await s3CredentialProxyHandler(
+      headReq,
+      {} as Cloudflare.Env,
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Length')).toBe('0');
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('answers HEAD for short-circuited zero-length r2 objects', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const ctx = makeCtx(
+      makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+    ) as Parameters<typeof s3CredentialProxyHandler>[2];
+    const putReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/empty.txt`, 'PUT', {
+      'content-length': '0',
+      'content-type': 'text/plain',
+      'x-amz-content-sha256':
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+      'x-amz-meta-mode': '33188'
+    });
+    const headReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/empty.txt`, 'HEAD');
+
+    await s3CredentialProxyHandler(putReq, {} as Cloudflare.Env, ctx);
+    const response = await s3CredentialProxyHandler(
+      headReq,
+      {} as Cloudflare.Env,
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Length')).toBe('0');
+    expect(response.headers.get('Content-Type')).toBe('text/plain');
+    expect(response.headers.get('x-amz-meta-mode')).toBe('33188');
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('clears short-circuited zero-length objects on positive-length PUT', async () => {
+    const forwardedRequests: Request[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      forwardedRequests.push(
+        input instanceof Request ? input : new Request(input)
+      );
+      return new Response('ok', {
+        status: 200,
+        headers: { 'Content-Length': '2048' }
+      });
+    });
+    const ctx = makeCtx(
+      makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+    ) as Parameters<typeof s3CredentialProxyHandler>[2];
+    const zeroPut = makeRequest(`/${MOUNT_ID}/${BUCKET}/overwrite.txt`, 'PUT', {
+      'content-length': '0',
+      'x-amz-content-sha256':
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    });
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('updated'));
+        controller.close();
+      }
+    });
+    const positivePut = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/overwrite.txt`,
+      'PUT',
+      {
+        'content-length': '7',
+        'x-amz-content-sha256':
+          '27eb5e51506c911f6fc4bb345c0d9db954755119e56d03aec0a59759a03d4f1d'
+      },
+      body
+    );
+    const headReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/overwrite.txt`, 'HEAD');
+
+    await s3CredentialProxyHandler(zeroPut, {} as Cloudflare.Env, ctx);
+    await s3CredentialProxyHandler(positivePut, {} as Cloudflare.Env, ctx);
+    const response = await s3CredentialProxyHandler(
+      headReq,
+      {} as Cloudflare.Env,
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Length')).toBe('2048');
+    expect(forwardedRequests).toHaveLength(2);
+
+    vi.restoreAllMocks();
+  });
+
+  it('clears short-circuited s3 zero-length objects on positive-length PUT', async () => {
+    const forwardedRequests: Request[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      forwardedRequests.push(
+        input instanceof Request ? input : new Request(input)
+      );
+      return new Response('ok', {
+        status: 200,
+        headers: { 'Content-Length': '2048' }
+      });
+    });
+    const ctx = makeCtx(
+      makeParams({ provider: 's3', authStrategy: 's3-sigv4' })
+    ) as Parameters<typeof s3CredentialProxyHandler>[2];
+    const zeroPut = makeRequest(`/${MOUNT_ID}/${BUCKET}/overwrite.txt`, 'PUT', {
+      'content-length': '0',
+      'x-amz-content-sha256':
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    });
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('updated'));
+        controller.close();
+      }
+    });
+    const positivePut = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/overwrite.txt`,
+      'PUT',
+      {
+        'content-length': '7',
+        'x-amz-content-sha256':
+          '27eb5e51506c911f6fc4bb345c0d9db954755119e56d03aec0a59759a03d4f1d'
+      },
+      body
+    );
+    const headReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/overwrite.txt`, 'HEAD');
+
+    await s3CredentialProxyHandler(zeroPut, {} as Cloudflare.Env, ctx);
+    await s3CredentialProxyHandler(positivePut, {} as Cloudflare.Env, ctx);
+    const response = await s3CredentialProxyHandler(
+      headReq,
+      {} as Cloudflare.Env,
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Length')).toBe('2048');
+    expect(forwardedRequests).toHaveLength(2);
+
+    vi.restoreAllMocks();
+  });
+
+  it('canonicalizes repeated and special query parameters for signing', async () => {
+    let capturedRequest: Request | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      capturedRequest = input instanceof Request ? input : new Request(input);
+      return new Response('ok', { status: 200 });
+    });
+
+    const req = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/key.txt?z=last&a=hello%20world&a=plus%2Bvalue`
+    );
+    await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams()) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(capturedRequest!.url).toContain('z=last');
+    expect(capturedRequest!.url).toContain('a=hello%20world');
+    expect(capturedRequest!.url).toContain('a=plus%2Bvalue');
     expect(capturedRequest!.headers.get('Authorization')).toMatch(
       /^AWS4-HMAC-SHA256/
     );
@@ -292,6 +775,34 @@ describe('s3CredentialProxyHandler GCS signing', () => {
     expect(capturedRequest!.headers.get('x-goog-content-sha256')).toBe(
       'UNSIGNED-PAYLOAD'
     );
+
+    vi.restoreAllMocks();
+  });
+
+  it('signs gcs requests when endpoint includes an explicit port', async () => {
+    let capturedRequest: Request | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      capturedRequest = input instanceof Request ? input : new Request(input);
+      return new Response('ok', { status: 200 });
+    });
+
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/key.txt`);
+    await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(
+        makeParams({
+          provider: 'gcs',
+          authStrategy: 'gcs',
+          endpoint: 'https://storage.googleapis.com:443'
+        })
+      ) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(capturedRequest!.headers.get('Authorization')).toMatch(
+      /^GOOG4-HMAC-SHA256/
+    );
+    expect(capturedRequest!.headers.get('x-goog-date')).toBeDefined();
 
     vi.restoreAllMocks();
   });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1275,6 +1275,16 @@ export interface RemoteMountBucketOptions {
    * Must start with '/' (e.g., '/workspaces/project123' or '/data/uploads/')
    */
   prefix?: string;
+
+  /**
+   * Keep real credentials in the Durable Object; write dummy credentials into
+   * the container-side s3fs password file. Outbound s3fs requests are
+   * intercepted by the DO, signed with real credentials, and forwarded to the
+   * configured endpoint.
+   *
+   * Default: false (real credentials are written into the container)
+   */
+  credentialProxy?: boolean;
 }
 
 /**


### PR DESCRIPTION
# Summary

When mounting S3-compatible storage with s3fs, the container needs direct access to real credentials, they're written to a password file on disk and used to sign every outgoing request. This means a compromised container process can read and exfiltrate the credentials, or use them to access storage outside the intended bucket scope.

This PR adds a credentialProxy option to mountBucket that removes credentials from the container entirely. Instead of giving s3fs real credentials, the Durable Object intercepts all outbound S3 requests at the network layer, re-signs them with the real credentials, and forwards them upstream. The container only ever holds dummy credentials that are useless outside the proxy.

The Durable Object supports AWS SigV4 signing (S3-compatible endpoints and R2) and GCS HMAC signing, with optimised FUSE defaults for R2 to ensure reliable read and write performance in production.

# Usage

To use the credential proxy and keep credentials out of the container the API is pretty simple, you just have to pass the `credentialProxy` parameter into the mount call (`false` by default), example:

```js
await sandbox.mountBucket('my-bucket', '/mnt/bucket', {
  endpoint: 'https://<account-id>.r2.cloudflarestorage.com',
  provider: 'r2',
  credentials: {
    accessKeyId: env.R2_ACCESS_KEY_ID,
    secretAccessKey: env.R2_SECRET_ACCESS_KEY
  },
  credentialProxy: true
});
```