### PR TITLE
Allow more time for trycloudflare DNS to propagate in E2E

### DIFF
--- a/tests/e2e/tunnel-quick-workflow.test.ts
+++ b/tests/e2e/tunnel-quick-workflow.test.ts
@@ -128,12 +128,13 @@ console.log("Server listening on port " + server.port);
         expect(listed.map((t) => t.id)).toContain(tunnel.id);
 
         // 5. Fetch the marker through the public URL. The Cloudflare edge
-        //    can take a couple of seconds to propagate even after
-        //    cloudflared reports /ready, so retry briefly.
+        //    can take 10–20 seconds to register the *.trycloudflare.com
+        //    route after cloudflared reports /ready, so allow a generous
+        //    retry budget. CI has been observed to need >10s of polling.
         const fetchedBody = await fetchWithRetry(
           `${tunnel.url}/marker`,
           marker,
-          { tries: 10, delayMs: 1000 }
+          { tries: 30, delayMs: 1000 }
         );
         expect(fetchedBody).toBe(marker);
       } finally {
@@ -324,8 +325,8 @@ Bun.serve({
 
         // Each tunnel routes to its own backing port.
         const [bodyA, bodyB] = await Promise.all([
-          fetchWithRetry(tunnelA.url, markerA, { tries: 10, delayMs: 1000 }),
-          fetchWithRetry(tunnelB.url, markerB, { tries: 10, delayMs: 1000 })
+          fetchWithRetry(tunnelA.url, markerA, { tries: 30, delayMs: 1000 }),
+          fetchWithRetry(tunnelB.url, markerB, { tries: 30, delayMs: 1000 })
         ]);
         expect(bodyA).toBe(markerA);
         expect(bodyB).toBe(markerB);
@@ -378,6 +379,11 @@ async function fetchWithRetry(
   expectedBody: string,
   opts: { tries: number; delayMs: number }
 ): Promise<string> {
+  // Sleep once before the first attempt. The cloudflared /ready signal
+  // fires before the *.trycloudflare.com DNS route has propagated through
+  // Cloudflare's edge, so the very first fetch is essentially guaranteed
+  // to fail — burning one of the retries on a race we know we'll lose.
+  await new Promise((r) => setTimeout(r, opts.delayMs));
   let lastError: unknown;
   for (let i = 0; i < opts.tries; i++) {
     try {


### PR DESCRIPTION
cloudflared signals /ready once the tunnel is registered, but the
random *.trycloudflare.com hostname does not become routable until
Cloudflare's edge picks up the new record. CI runners regularly see
that lag exceed the previous 10s retry budget, which surfaced as
"fetchWithRetry failed ... fetch failed" in the quick-tunnel test.

Triple the budget to ~30s and sleep once before the first attempt so
the inevitable cold-cache miss does not eat a retry.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->