### PR TITLE
Fix Office file binary detection

### DIFF
--- a/.changeset/fix-office-file-binary-detection.md
+++ b/.changeset/fix-office-file-binary-detection.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Classify Office Open XML files such as `.xlsx` and `.docx` as binary when reading files so they are returned with base64 encoding instead of text decoding.

--- a/packages/sandbox-container/src/services/file-service.ts
+++ b/packages/sandbox-container/src/services/file-service.ts
@@ -24,8 +24,31 @@ export interface SecurityService {
   validatePath(path: string): { isValid: boolean; errors: string[] };
 }
 
-// Maximum file size for RPC transfers is 32 MiB to prevent performance issues. For larger files, clients should use streaming APIs.
+// Maximum file size for RPC transfers is 32 MiB. Larger files should use streaming APIs.
 const MAX_RPC_FILE_SIZE = 32 * 1_048_576; // 32 MiB
+
+const TEXT_MIME_TYPES = new Set([
+  'application/ecmascript',
+  'application/javascript',
+  'application/json',
+  'application/json-seq',
+  'application/rtf',
+  'application/sql',
+  'application/toml',
+  'application/typescript',
+  'application/x-empty',
+  'application/x-httpd-php',
+  'application/x-javascript',
+  'application/x-sh',
+  'application/x-shellscript',
+  'application/x-typescript',
+  'application/x-yaml',
+  'application/xml',
+  'application/xml-dtd',
+  'application/xml-external-parsed-entity',
+  'application/yaml',
+  'inode/x-empty'
+]);
 
 // File system operations interface with session support
 export interface FileSystemOperations {
@@ -1533,15 +1556,18 @@ export class FileService implements FileSystemOperations {
 
   /**
    * Determine if a MIME type represents binary content.
-   * Text MIME types: text/*, application/json, application/xml, application/javascript, etc.
+   * Text MIME types include text/*, exact textual application types, and
+   * structured syntax suffixes such as +json and +xml.
    */
   private isBinaryMimeType(mimeType: string): boolean {
-    return (
-      !mimeType.startsWith('text/') &&
-      !mimeType.includes('json') &&
-      !mimeType.includes('xml') &&
-      !mimeType.includes('javascript') &&
-      !mimeType.includes('x-empty')
+    const normalizedMimeType = mimeType.split(';')[0].trim().toLowerCase();
+    const subtype = normalizedMimeType.split('/')[1] ?? '';
+
+    return !(
+      normalizedMimeType.startsWith('text/') ||
+      TEXT_MIME_TYPES.has(normalizedMimeType) ||
+      subtype.endsWith('+json') ||
+      subtype.endsWith('+xml')
     );
   }
 

--- a/packages/sandbox-container/src/services/file-service.ts
+++ b/packages/sandbox-container/src/services/file-service.ts
@@ -24,8 +24,8 @@ export interface SecurityService {
   validatePath(path: string): { isValid: boolean; errors: string[] };
 }
 
-// Maximum file size for RPC transfers is 32 MiB. Larger files should use streaming APIs.
-const MAX_RPC_FILE_SIZE = 32 * 1_048_576; // 32 MiB
+// Maximum size for encoded readFile responses is 32 MiB. Larger files should use readFile() with { encoding: 'none' } and the RPC transport.
+const MAX_ENCODED_FILE_SIZE = 32 * 1_048_576; // 32 MiB
 
 const TEXT_MIME_TYPES = new Set([
   'application/ecmascript',
@@ -153,16 +153,16 @@ export class FileService implements FileSystemOperations {
 
           // Size and MIME type come directly from the BunFile object.
           const fileSize = bunFile.size;
-          // RPC transfers have a hard limit of 32 MiB to prevent issues for large files, enforce this limit upfront before reading content.
-          if (fileSize > MAX_RPC_FILE_SIZE) {
+          // Encoded responses have a hard limit of 32 MiB. Larger files should use readFile() with { encoding: 'none' } and the RPC transport.
+          if (fileSize > MAX_ENCODED_FILE_SIZE) {
             throw {
-              message: `File too large. Size ${fileSize} bytes exceeds the 32 MiB limit. Consider using streaming APIs for large files.`,
+              message: `File too large. Size ${fileSize} bytes exceeds the 32 MiB limit. Use readFile() with { encoding: 'none' } and the RPC transport for large files.`,
               code: ErrorCode.FILE_TOO_LARGE,
               details: {
                 path,
                 operation: Operation.FILE_READ,
                 actualSize: fileSize,
-                maxSize: MAX_RPC_FILE_SIZE
+                maxSize: MAX_ENCODED_FILE_SIZE
               } satisfies FileTooLargeContext
             };
           }

--- a/packages/sandbox-container/tests/services/file-service.test.ts
+++ b/packages/sandbox-container/tests/services/file-service.test.ts
@@ -273,6 +273,61 @@ describe('FileService', () => {
       }
     });
 
+    it('should detect Office Open XML files as binary', async () => {
+      const testPath = '/tmp/workbook.xlsx';
+      const binaryData = new Uint8Array([0x50, 0x4b, 0x03, 0x04]);
+      const binaryBuffer = binaryData.buffer as ArrayBuffer;
+
+      mockBunFile({
+        exists: true,
+        size: 1024,
+        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        arrayBuffer: binaryBuffer
+      });
+
+      const result = await fileService.read(testPath, {}, 'session-123');
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.metadata?.encoding).toBe('base64');
+        expect(result.metadata?.isBinary).toBe(true);
+        expect(result.metadata?.mimeType).toBe(
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        );
+      }
+    });
+
+    it('should detect representative textual MIME types as text', async () => {
+      const cases = [
+        { mimeType: 'application/atom+xml', content: '<feed />' },
+        { mimeType: 'application/vnd.api+json', content: '{"data": []}' },
+        { mimeType: 'inode/x-empty', content: '' }
+      ];
+
+      for (const { mimeType, content } of cases) {
+        mockBunFile({
+          exists: true,
+          size: content.length,
+          type: mimeType,
+          text: content
+        });
+
+        const result = await fileService.read(
+          '/tmp/test-file',
+          {},
+          'session-123'
+        );
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data).toBe(content);
+          expect(result.metadata?.encoding).toBe('utf-8');
+          expect(result.metadata?.isBinary).toBe(false);
+          expect(result.metadata?.mimeType).toBe(mimeType);
+        }
+      }
+    });
+
     it('should detect JavaScript files as text', async () => {
       const testPath = '/tmp/script.js';
       const testContent = 'console.log("test");';
@@ -1142,6 +1197,32 @@ describe('FileService', () => {
         expect(result.data.mimeType).toBe('application/json');
         expect(result.data.isBinary).toBe(false);
         expect(result.data.encoding).toBe('utf-8');
+      }
+
+      expect(mockExec).not.toHaveBeenCalled();
+    });
+
+    it('should classify Office Open XML metadata as binary', async () => {
+      const testPath = '/tmp/document.docx';
+
+      mockBunFile({
+        exists: true,
+        size: 2048,
+        type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+      });
+
+      const mockExec = vi.fn();
+
+      const result = await fileService.getFileMetadata(testPath, mockExec);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.size).toBe(2048);
+        expect(result.data.mimeType).toBe(
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        );
+        expect(result.data.isBinary).toBe(true);
+        expect(result.data.encoding).toBe('base64');
       }
 
       expect(mockExec).not.toHaveBeenCalled();


### PR DESCRIPTION
Office Open XML MIME types contain \`xml\` in their vendor subtype, but the files
are ZIP-based binary documents. The existing MIME classifier treated them as
text, so reading \`.xlsx\` and \`.docx\` files returned UTF-8 content instead of
base64.

Classify textual MIME types by exact known types and structured \`+json\`/\`+xml\`
suffixes so JSON/XML-like files stay readable while Office documents are
returned as binary content.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->