### PR TITLE
Add exposed-port endpoint to Sandbox Bridge

### DIFF
--- a/.changeset/bridge-exposed-port-tunnels.md
+++ b/.changeset/bridge-exposed-port-tunnels.md
@@ -2,4 +2,4 @@
 '@cloudflare/sandbox': patch
 ---
 
-Add a bridge endpoint for resolving public URLs for sandbox services. HTTP clients can call `POST /v1/sandbox/:id/exposed-port/:port` with an optional `name` body field to request a predictable named URL instead of an ephemeral one.
+Add bridge endpoints for managing tunnels to sandbox services. HTTP clients can call `POST /v1/sandbox/:id/tunnel/:port` with an optional `name` body field for a predictable named URL, and `DELETE /v1/sandbox/:id/tunnel/:port` to remove the tunnel.

--- a/.changeset/bridge-exposed-port-tunnels.md
+++ b/.changeset/bridge-exposed-port-tunnels.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Add a bridge endpoint for resolving public URLs for sandbox services. HTTP clients can call `POST /v1/sandbox/:id/exposed-port/:port` with an optional `name` body field to request a predictable named URL instead of an ephemeral one.

--- a/bridge/worker/README.md
+++ b/bridge/worker/README.md
@@ -85,21 +85,22 @@ wrangler secret put SANDBOX_API_KEY
 
 This worker is an HTTP bridge for the `BaseSandboxSession` abstract interface. Each abstract method maps to exactly one route:
 
-| `BaseSandboxSession` method | Route                                 | Description                                      |
-| --------------------------- | ------------------------------------- | ------------------------------------------------ |
-| _(create session)_          | `POST /v1/sandbox`                    | Generate a new sandbox ID                        |
-| `_exec_internal()`          | `POST /v1/sandbox/:id/exec`           | Run a command; returns stdout/stderr/exit_code   |
-| `read()`                    | `POST /v1/sandbox/:id/read`           | Read a file from the workspace                   |
-| `write()`                   | `POST /v1/sandbox/:id/write`          | Write a file into the workspace                  |
-| `running()`                 | `GET /v1/sandbox/:id/running`         | Check sandbox liveness                           |
-| `persist_workspace()`       | `POST /v1/sandbox/:id/persist`        | Serialize workspace to a tar archive             |
-| `hydrate_workspace()`       | `POST /v1/sandbox/:id/hydrate`        | Populate workspace from a tar archive            |
-| `shutdown()`                | `DELETE /v1/sandbox/:id`              | Destroy sandbox via `destroy()` (returns 204)    |
-| _(terminal)_                | `GET /v1/sandbox/:id/pty`             | WebSocket PTY proxy (bidirectional terminal I/O) |
-| `mountBucket()`             | `POST /v1/sandbox/:id/mount`          | Mount an S3-compatible bucket                    |
-| `unmountBucket()`           | `POST /v1/sandbox/:id/unmount`        | Unmount a mounted bucket                         |
-| _(create session)_          | `POST /v1/sandbox/:id/session`        | Create an execution session                      |
-| _(delete session)_          | `DELETE /v1/sandbox/:id/session/:sid` | Delete an execution session                      |
+| `BaseSandboxSession` method | Route                                     | Description                                      |
+| --------------------------- | ----------------------------------------- | ------------------------------------------------ |
+| _(create session)_          | `POST /v1/sandbox`                        | Generate a new sandbox ID                        |
+| `_exec_internal()`          | `POST /v1/sandbox/:id/exec`               | Run a command; returns stdout/stderr/exit_code   |
+| `read()`                    | `POST /v1/sandbox/:id/read`               | Read a file from the workspace                   |
+| `write()`                   | `POST /v1/sandbox/:id/write`              | Write a file into the workspace                  |
+| `running()`                 | `GET /v1/sandbox/:id/running`             | Check sandbox liveness                           |
+| `resolve_exposed_port()`    | `POST /v1/sandbox/:id/exposed-port/:port` | Create or reuse a public endpoint for a port     |
+| `persist_workspace()`       | `POST /v1/sandbox/:id/persist`            | Serialize workspace to a tar archive             |
+| `hydrate_workspace()`       | `POST /v1/sandbox/:id/hydrate`            | Populate workspace from a tar archive            |
+| `shutdown()`                | `DELETE /v1/sandbox/:id`                  | Destroy sandbox via `destroy()` (returns 204)    |
+| _(terminal)_                | `GET /v1/sandbox/:id/pty`                 | WebSocket PTY proxy (bidirectional terminal I/O) |
+| `mountBucket()`             | `POST /v1/sandbox/:id/mount`              | Mount an S3-compatible bucket                    |
+| `unmountBucket()`           | `POST /v1/sandbox/:id/unmount`            | Unmount a mounted bucket                         |
+| _(create session)_          | `POST /v1/sandbox/:id/session`            | Create an execution session                      |
+| _(delete session)_          | `DELETE /v1/sandbox/:id/session/:sid`     | Delete an execution session                      |
 
 ## API Reference
 
@@ -179,6 +180,49 @@ Check whether the sandbox container is alive.
 curl http://localhost:8787/v1/sandbox/mfrggzdfmy2tqnrz/running \
   -H "Authorization: Bearer $SANDBOX_API_KEY"
 ```
+
+---
+
+#### `POST /v1/sandbox/:id/exposed-port/:port`
+
+Create or reuse a public endpoint for a service that is already running inside
+the sandbox. This may provision endpoint infrastructure, but it does not start
+the application listening on the port. Send no body for an ephemeral
+`*.trycloudflare.com` endpoint, or pass `name` to choose the subdomain prefix
+for a named endpoint, such as `"app"`. Do not pass a full hostname.
+
+Ephemeral endpoint:
+
+```sh
+curl -X POST http://localhost:8787/v1/sandbox/mfrggzdfmy2tqnrz/exposed-port/8080 \
+  -H "Authorization: Bearer $SANDBOX_API_KEY"
+```
+
+Named endpoint:
+
+```sh
+curl -X POST http://localhost:8787/v1/sandbox/mfrggzdfmy2tqnrz/exposed-port/8080 \
+  -H "Authorization: Bearer $SANDBOX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "app"}'
+```
+
+Response:
+
+```json
+{
+  "id": "11111111-2222-3333-4444-555555555555",
+  "port": 8080,
+  "url": "https://app.example.com",
+  "hostname": "app.example.com",
+  "name": "app",
+  "createdAt": "2026-05-29T00:00:00.000Z"
+}
+```
+
+Named tunnels require `CLOUDFLARE_API_TOKEN`. If the account or zone cannot be
+inferred from the token, set `CLOUDFLARE_TUNNEL_ACCOUNT_ID` or
+`CLOUDFLARE_ACCOUNT_ID`, and/or set `CLOUDFLARE_ZONE_ID`.
 
 ---
 

--- a/bridge/worker/README.md
+++ b/bridge/worker/README.md
@@ -85,22 +85,23 @@ wrangler secret put SANDBOX_API_KEY
 
 This worker is an HTTP bridge for the `BaseSandboxSession` abstract interface. Each abstract method maps to exactly one route:
 
-| `BaseSandboxSession` method | Route                                     | Description                                      |
-| --------------------------- | ----------------------------------------- | ------------------------------------------------ |
-| _(create session)_          | `POST /v1/sandbox`                        | Generate a new sandbox ID                        |
-| `_exec_internal()`          | `POST /v1/sandbox/:id/exec`               | Run a command; returns stdout/stderr/exit_code   |
-| `read()`                    | `POST /v1/sandbox/:id/read`               | Read a file from the workspace                   |
-| `write()`                   | `POST /v1/sandbox/:id/write`              | Write a file into the workspace                  |
-| `running()`                 | `GET /v1/sandbox/:id/running`             | Check sandbox liveness                           |
-| `resolve_exposed_port()`    | `POST /v1/sandbox/:id/exposed-port/:port` | Create or reuse a public endpoint for a port     |
-| `persist_workspace()`       | `POST /v1/sandbox/:id/persist`            | Serialize workspace to a tar archive             |
-| `hydrate_workspace()`       | `POST /v1/sandbox/:id/hydrate`            | Populate workspace from a tar archive            |
-| `shutdown()`                | `DELETE /v1/sandbox/:id`                  | Destroy sandbox via `destroy()` (returns 204)    |
-| _(terminal)_                | `GET /v1/sandbox/:id/pty`                 | WebSocket PTY proxy (bidirectional terminal I/O) |
-| `mountBucket()`             | `POST /v1/sandbox/:id/mount`              | Mount an S3-compatible bucket                    |
-| `unmountBucket()`           | `POST /v1/sandbox/:id/unmount`            | Unmount a mounted bucket                         |
-| _(create session)_          | `POST /v1/sandbox/:id/session`            | Create an execution session                      |
-| _(delete session)_          | `DELETE /v1/sandbox/:id/session/:sid`     | Delete an execution session                      |
+| `BaseSandboxSession` method | Route                                 | Description                                      |
+| --------------------------- | ------------------------------------- | ------------------------------------------------ |
+| _(create session)_          | `POST /v1/sandbox`                    | Generate a new sandbox ID                        |
+| `_exec_internal()`          | `POST /v1/sandbox/:id/exec`           | Run a command; returns stdout/stderr/exit_code   |
+| `read()`                    | `POST /v1/sandbox/:id/read`           | Read a file from the workspace                   |
+| `write()`                   | `POST /v1/sandbox/:id/write`          | Write a file into the workspace                  |
+| `running()`                 | `GET /v1/sandbox/:id/running`         | Check sandbox liveness                           |
+| `resolve_exposed_port()`    | `POST /v1/sandbox/:id/tunnel/:port`   | Create or reuse a tunnel for a port              |
+| _(delete tunnel)_           | `DELETE /v1/sandbox/:id/tunnel/:port` | Delete the tunnel for a port                     |
+| `persist_workspace()`       | `POST /v1/sandbox/:id/persist`        | Serialize workspace to a tar archive             |
+| `hydrate_workspace()`       | `POST /v1/sandbox/:id/hydrate`        | Populate workspace from a tar archive            |
+| `shutdown()`                | `DELETE /v1/sandbox/:id`              | Destroy sandbox via `destroy()` (returns 204)    |
+| _(terminal)_                | `GET /v1/sandbox/:id/pty`             | WebSocket PTY proxy (bidirectional terminal I/O) |
+| `mountBucket()`             | `POST /v1/sandbox/:id/mount`          | Mount an S3-compatible bucket                    |
+| `unmountBucket()`           | `POST /v1/sandbox/:id/unmount`        | Unmount a mounted bucket                         |
+| _(create session)_          | `POST /v1/sandbox/:id/session`        | Create an execution session                      |
+| _(delete session)_          | `DELETE /v1/sandbox/:id/session/:sid` | Delete an execution session                      |
 
 ## API Reference
 
@@ -183,25 +184,25 @@ curl http://localhost:8787/v1/sandbox/mfrggzdfmy2tqnrz/running \
 
 ---
 
-#### `POST /v1/sandbox/:id/exposed-port/:port`
+#### `POST /v1/sandbox/:id/tunnel/:port`
 
-Create or reuse a public endpoint for a service that is already running inside
-the sandbox. This may provision endpoint infrastructure, but it does not start
-the application listening on the port. Send no body for an ephemeral
-`*.trycloudflare.com` endpoint, or pass `name` to choose the subdomain prefix
-for a named endpoint, such as `"app"`. Do not pass a full hostname.
+Create or reuse a tunnel for a service that is already running inside the
+sandbox. This may provision tunnel infrastructure, but it does not start the
+application listening on the port. Send no body for an ephemeral
+`*.trycloudflare.com` tunnel, or pass `name` to choose the subdomain prefix for
+a named tunnel, such as `"app"`. Do not pass a full hostname.
 
-Ephemeral endpoint:
+Ephemeral tunnel:
 
 ```sh
-curl -X POST http://localhost:8787/v1/sandbox/mfrggzdfmy2tqnrz/exposed-port/8080 \
+curl -X POST http://localhost:8787/v1/sandbox/mfrggzdfmy2tqnrz/tunnel/8080 \
   -H "Authorization: Bearer $SANDBOX_API_KEY"
 ```
 
-Named endpoint:
+Named tunnel:
 
 ```sh
-curl -X POST http://localhost:8787/v1/sandbox/mfrggzdfmy2tqnrz/exposed-port/8080 \
+curl -X POST http://localhost:8787/v1/sandbox/mfrggzdfmy2tqnrz/tunnel/8080 \
   -H "Authorization: Bearer $SANDBOX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"name": "app"}'
@@ -223,6 +224,20 @@ Response:
 Named tunnels require `CLOUDFLARE_API_TOKEN`. If the account or zone cannot be
 inferred from the token, set `CLOUDFLARE_TUNNEL_ACCOUNT_ID` or
 `CLOUDFLARE_ACCOUNT_ID`, and/or set `CLOUDFLARE_ZONE_ID`.
+
+---
+
+#### `DELETE /v1/sandbox/:id/tunnel/:port`
+
+Delete the tunnel for a sandbox port. This stops the tunnel process and removes
+any named-tunnel Cloudflare resources tracked by the sandbox.
+
+```sh
+curl -X DELETE http://localhost:8787/v1/sandbox/mfrggzdfmy2tqnrz/tunnel/8080 \
+  -H "Authorization: Bearer $SANDBOX_API_KEY"
+```
+
+Returns `204 No Content` when the tunnel was deleted or already absent.
 
 ---
 

--- a/bridge/worker/src/__tests__/exposed-port.test.ts
+++ b/bridge/worker/src/__tests__/exposed-port.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BASE, createMockEnv, createMockSandbox } from './helpers';
+
+const mockSandbox = createMockSandbox();
+vi.mock('../../../../packages/sandbox/src/sandbox', () => ({
+  getSandbox: vi.fn(() => mockSandbox),
+  Sandbox: class {}
+}));
+
+const { app } = await import('./bridge-app');
+
+const env = createMockEnv();
+
+function exposedPortRequest(port: string | number, body?: unknown) {
+  const init: RequestInit & { headers: Record<string, string> } = {
+    method: 'POST',
+    headers: {}
+  };
+  if (body !== undefined) {
+    init.headers['Content-Type'] = 'application/json';
+    init.body = JSON.stringify(body);
+  }
+  return app.request(`${BASE}/v1/sandbox/test/exposed-port/${port}`, init, env);
+}
+
+describe('POST /v1/sandbox/:id/exposed-port/:port', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSandbox.tunnels.get.mockResolvedValue({
+      id: 'quick-abc123',
+      port: 8080,
+      url: 'https://abc.trycloudflare.com',
+      hostname: 'abc.trycloudflare.com',
+      createdAt: '2026-05-29T00:00:00.000Z'
+    });
+  });
+
+  it('creates or reuses an ephemeral public endpoint', async () => {
+    const res = await exposedPortRequest(8080);
+
+    expect(res.status).toBe(200);
+    expect(mockSandbox.tunnels.get).toHaveBeenCalledWith(8080, undefined);
+    await expect(res.json()).resolves.toEqual({
+      id: 'quick-abc123',
+      port: 8080,
+      url: 'https://abc.trycloudflare.com',
+      hostname: 'abc.trycloudflare.com',
+      createdAt: '2026-05-29T00:00:00.000Z'
+    });
+  });
+
+  it('passes the requested name for a named public endpoint', async () => {
+    mockSandbox.tunnels.get.mockResolvedValue({
+      id: '11111111-2222-3333-4444-555555555555',
+      port: 8080,
+      url: 'https://app.example.com',
+      hostname: 'app.example.com',
+      name: 'app',
+      createdAt: '2026-05-29T00:00:00.000Z'
+    });
+
+    const res = await exposedPortRequest(8080, { name: 'app' });
+
+    expect(res.status).toBe(200);
+    expect(mockSandbox.tunnels.get).toHaveBeenCalledWith(8080, { name: 'app' });
+    await expect(res.json()).resolves.toMatchObject({
+      id: '11111111-2222-3333-4444-555555555555',
+      url: 'https://app.example.com',
+      name: 'app'
+    });
+  });
+
+  it('rejects a non-string endpoint name before calling the SDK', async () => {
+    const res = await exposedPortRequest(8080, { name: 123 });
+
+    expect(res.status).toBe(400);
+    expect(mockSandbox.tunnels.get).not.toHaveBeenCalled();
+    await expect(res.json()).resolves.toMatchObject({
+      code: 'invalid_request',
+      error: 'name must be a string when provided'
+    });
+  });
+
+  it('rejects an invalid endpoint name before calling the SDK', async () => {
+    const res = await exposedPortRequest(8080, { name: 'Bad.Name' });
+
+    expect(res.status).toBe(400);
+    expect(mockSandbox.tunnels.get).not.toHaveBeenCalled();
+    const body = (await res.json()) as { code: string; error: string };
+    expect(body.code).toBe('invalid_request');
+    expect(body.error).toContain('valid DNS label');
+  });
+
+  it('rejects an invalid exposed port before calling the SDK', async () => {
+    const res = await exposedPortRequest(3000);
+
+    expect(res.status).toBe(400);
+    expect(mockSandbox.tunnels.get).not.toHaveBeenCalled();
+    await expect(res.json()).resolves.toMatchObject({
+      code: 'invalid_request'
+    });
+  });
+
+  it('maps endpoint provisioning failures to exposed port errors', async () => {
+    mockSandbox.tunnels.get.mockRejectedValue(new Error('cloudflared failed'));
+
+    const res = await exposedPortRequest(8080, { name: 'app' });
+
+    expect(res.status).toBe(502);
+    expect(mockSandbox.tunnels.get).toHaveBeenCalledWith(8080, { name: 'app' });
+    await expect(res.json()).resolves.toMatchObject({
+      code: 'exposed_port_error',
+      error: 'exposed port failed: cloudflared failed'
+    });
+  });
+});

--- a/bridge/worker/src/__tests__/helpers.ts
+++ b/bridge/worker/src/__tests__/helpers.ts
@@ -73,7 +73,8 @@ export function createMockSandbox() {
     mountBucket: vi.fn(async () => {}),
     unmountBucket: vi.fn(async () => {}),
     tunnels: {
-      get: vi.fn()
+      get: vi.fn(),
+      destroy: vi.fn(async () => {})
     },
     destroy: vi.fn(async () => {})
   };

--- a/bridge/worker/src/__tests__/helpers.ts
+++ b/bridge/worker/src/__tests__/helpers.ts
@@ -34,8 +34,8 @@ export function createMockSession(id = 'mock-session') {
  * Each method is a vi.fn() so tests can inspect calls and configure returns.
  *
  * The `exec` mock supports streaming: when called with `stream: true`, it
- * invokes `onOutput` / `onComplete` / `onError` callbacks instead of just
- * returning a result.
+ * invokes `onOutput` / `onComplete` / `onError` callbacks and returns the
+ * final result.
  */
 export function createMockSandbox() {
   return {
@@ -72,6 +72,9 @@ export function createMockSandbox() {
     })),
     mountBucket: vi.fn(async () => {}),
     unmountBucket: vi.fn(async () => {}),
+    tunnels: {
+      get: vi.fn()
+    },
     destroy: vi.fn(async () => {})
   };
 }

--- a/bridge/worker/src/__tests__/tunnel.test.ts
+++ b/bridge/worker/src/__tests__/tunnel.test.ts
@@ -11,7 +11,11 @@ const { app } = await import('./bridge-app');
 
 const env = createMockEnv();
 
-function exposedPortRequest(port: string | number, body?: unknown) {
+function tunnelRequest(port: string | number, init: RequestInit & { headers?: Record<string, string> } = {}) {
+  return app.request(`${BASE}/v1/sandbox/test/tunnel/${port}`, init, env);
+}
+
+function createTunnelRequest(port: string | number, body?: unknown) {
   const init: RequestInit & { headers: Record<string, string> } = {
     method: 'POST',
     headers: {}
@@ -20,10 +24,10 @@ function exposedPortRequest(port: string | number, body?: unknown) {
     init.headers['Content-Type'] = 'application/json';
     init.body = JSON.stringify(body);
   }
-  return app.request(`${BASE}/v1/sandbox/test/exposed-port/${port}`, init, env);
+  return tunnelRequest(port, init);
 }
 
-describe('POST /v1/sandbox/:id/exposed-port/:port', () => {
+describe('POST /v1/sandbox/:id/tunnel/:port', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSandbox.tunnels.get.mockResolvedValue({
@@ -35,8 +39,8 @@ describe('POST /v1/sandbox/:id/exposed-port/:port', () => {
     });
   });
 
-  it('creates or reuses an ephemeral public endpoint', async () => {
-    const res = await exposedPortRequest(8080);
+  it('creates or reuses an ephemeral tunnel', async () => {
+    const res = await createTunnelRequest(8080);
 
     expect(res.status).toBe(200);
     expect(mockSandbox.tunnels.get).toHaveBeenCalledWith(8080, undefined);
@@ -49,7 +53,7 @@ describe('POST /v1/sandbox/:id/exposed-port/:port', () => {
     });
   });
 
-  it('passes the requested name for a named public endpoint', async () => {
+  it('passes the requested name for a named tunnel', async () => {
     mockSandbox.tunnels.get.mockResolvedValue({
       id: '11111111-2222-3333-4444-555555555555',
       port: 8080,
@@ -59,7 +63,7 @@ describe('POST /v1/sandbox/:id/exposed-port/:port', () => {
       createdAt: '2026-05-29T00:00:00.000Z'
     });
 
-    const res = await exposedPortRequest(8080, { name: 'app' });
+    const res = await createTunnelRequest(8080, { name: 'app' });
 
     expect(res.status).toBe(200);
     expect(mockSandbox.tunnels.get).toHaveBeenCalledWith(8080, { name: 'app' });
@@ -70,8 +74,8 @@ describe('POST /v1/sandbox/:id/exposed-port/:port', () => {
     });
   });
 
-  it('rejects a non-string endpoint name before calling the SDK', async () => {
-    const res = await exposedPortRequest(8080, { name: 123 });
+  it('rejects a non-string tunnel name before calling the SDK', async () => {
+    const res = await createTunnelRequest(8080, { name: 123 });
 
     expect(res.status).toBe(400);
     expect(mockSandbox.tunnels.get).not.toHaveBeenCalled();
@@ -81,8 +85,8 @@ describe('POST /v1/sandbox/:id/exposed-port/:port', () => {
     });
   });
 
-  it('rejects an invalid endpoint name before calling the SDK', async () => {
-    const res = await exposedPortRequest(8080, { name: 'Bad.Name' });
+  it('rejects an invalid tunnel name before calling the SDK', async () => {
+    const res = await createTunnelRequest(8080, { name: 'Bad.Name' });
 
     expect(res.status).toBe(400);
     expect(mockSandbox.tunnels.get).not.toHaveBeenCalled();
@@ -91,8 +95,8 @@ describe('POST /v1/sandbox/:id/exposed-port/:port', () => {
     expect(body.error).toContain('valid DNS label');
   });
 
-  it('rejects an invalid exposed port before calling the SDK', async () => {
-    const res = await exposedPortRequest(3000);
+  it('rejects an invalid tunnel port before calling the SDK', async () => {
+    const res = await createTunnelRequest(3000);
 
     expect(res.status).toBe(400);
     expect(mockSandbox.tunnels.get).not.toHaveBeenCalled();
@@ -101,16 +105,52 @@ describe('POST /v1/sandbox/:id/exposed-port/:port', () => {
     });
   });
 
-  it('maps endpoint provisioning failures to exposed port errors', async () => {
+  it('maps tunnel provisioning failures to tunnel errors', async () => {
     mockSandbox.tunnels.get.mockRejectedValue(new Error('cloudflared failed'));
 
-    const res = await exposedPortRequest(8080, { name: 'app' });
+    const res = await createTunnelRequest(8080, { name: 'app' });
 
     expect(res.status).toBe(502);
     expect(mockSandbox.tunnels.get).toHaveBeenCalledWith(8080, { name: 'app' });
     await expect(res.json()).resolves.toMatchObject({
-      code: 'exposed_port_error',
-      error: 'exposed port failed: cloudflared failed'
+      code: 'tunnel_error',
+      error: 'tunnel failed: cloudflared failed'
+    });
+  });
+});
+
+describe('DELETE /v1/sandbox/:id/tunnel/:port', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('destroys the tunnel for a sandbox port', async () => {
+    const res = await tunnelRequest(8080, { method: 'DELETE' });
+
+    expect(res.status).toBe(204);
+    expect(mockSandbox.tunnels.destroy).toHaveBeenCalledWith(8080);
+  });
+
+  it('rejects an invalid tunnel port before calling the SDK', async () => {
+    const res = await tunnelRequest(3000, { method: 'DELETE' });
+
+    expect(res.status).toBe(400);
+    expect(mockSandbox.tunnels.destroy).not.toHaveBeenCalled();
+    await expect(res.json()).resolves.toMatchObject({
+      code: 'invalid_request'
+    });
+  });
+
+  it('maps tunnel cleanup failures to tunnel errors', async () => {
+    mockSandbox.tunnels.destroy.mockRejectedValue(new Error('cleanup failed'));
+
+    const res = await tunnelRequest(8080, { method: 'DELETE' });
+
+    expect(res.status).toBe(502);
+    expect(mockSandbox.tunnels.destroy).toHaveBeenCalledWith(8080);
+    await expect(res.json()).resolves.toEqual({
+      code: 'tunnel_error',
+      error: 'tunnel failed: cleanup failed'
     });
   });
 });

--- a/packages/sandbox/src/bridge/AGENTS.md
+++ b/packages/sandbox/src/bridge/AGENTS.md
@@ -7,7 +7,7 @@ Consumer-facing documentation (API reference, deployment, security) lives in [`b
 ## Key files
 
 - `index.ts` — `bridge()` factory: resolves DO bindings at module evaluation time, wraps `fetch` and `scheduled` handlers.
-- `routes.ts` — `createBridgeApp()`: Hono app containing all `/v1/` API routes (sandbox CRUD, exec, file I/O, tunnel-backed exposed-port resolution, persist/hydrate, mount/unmount, session CRUD, pool management, WebSocket PTY proxy). Parameterised by binding names and route prefixes.
+- `routes.ts` — `createBridgeApp()`: Hono app containing all `/v1/` API routes (sandbox CRUD, exec, file I/O, tunnel management, persist/hydrate, mount/unmount, session CRUD, pool management, WebSocket PTY proxy). Parameterised by binding names and route prefixes.
 - `warm-pool.ts` — `WarmPool` Durable Object that maintains a pool of pre-started sandbox containers (adapted from [cf-container-warm-pool](https://github.com/mikenomitch/cf-container-warm-pool)).
 - `pool.ts` — Pool management helpers used by routes.
 - `helpers.ts` — Utility functions (path validation, shell quoting, SSE formatting).

--- a/packages/sandbox/src/bridge/AGENTS.md
+++ b/packages/sandbox/src/bridge/AGENTS.md
@@ -7,7 +7,7 @@ Consumer-facing documentation (API reference, deployment, security) lives in [`b
 ## Key files
 
 - `index.ts` — `bridge()` factory: resolves DO bindings at module evaluation time, wraps `fetch` and `scheduled` handlers.
-- `routes.ts` — `createBridgeApp()`: Hono app containing all `/v1/` API routes (sandbox CRUD, exec, file I/O, persist/hydrate, mount/unmount, session CRUD, pool management, WebSocket PTY proxy). Parameterised by binding names and route prefixes.
+- `routes.ts` — `createBridgeApp()`: Hono app containing all `/v1/` API routes (sandbox CRUD, exec, file I/O, tunnel-backed exposed-port resolution, persist/hydrate, mount/unmount, session CRUD, pool management, WebSocket PTY proxy). Parameterised by binding names and route prefixes.
 - `warm-pool.ts` — `WarmPool` Durable Object that maintains a pool of pre-started sandbox containers (adapted from [cf-container-warm-pool](https://github.com/mikenomitch/cf-container-warm-pool)).
 - `pool.ts` — Pool management helpers used by routes.
 - `helpers.ts` — Utility functions (path validation, shell quoting, SSE formatting).

--- a/packages/sandbox/src/bridge/openapi.ts
+++ b/packages/sandbox/src/bridge/openapi.ts
@@ -167,25 +167,25 @@ export const OPENAPI_SCHEMA = {
           }
         }
       },
-      ExposedPortRequest: {
+      TunnelRequest: {
         type: 'object',
         properties: {
           name: {
             type: 'string',
             description:
-              'Subdomain prefix for a named endpoint, such as `app`. Do not pass a full hostname. Omit to create or reuse an ephemeral endpoint.',
+              'Subdomain prefix for a named tunnel, such as `app`. Do not pass a full hostname. Omit to create or reuse an ephemeral tunnel.',
             example: 'app'
           }
         }
       },
-      ResolvedExposedPort: {
+      Tunnel: {
         type: 'object',
         required: ['id', 'port', 'url', 'hostname', 'createdAt'],
         properties: {
           id: { type: 'string' },
           port: {
             type: 'integer',
-            description: 'Container port served by the endpoint.',
+            description: 'Container port served by the tunnel.',
             example: 8080
           },
           url: {
@@ -203,7 +203,7 @@ export const OPENAPI_SCHEMA = {
           },
           name: {
             type: 'string',
-            description: 'Present for named endpoints only.',
+            description: 'Present for named tunnels only.',
             example: 'app'
           }
         }
@@ -232,7 +232,7 @@ export const OPENAPI_SCHEMA = {
               'mount_error',
               'unmount_error',
               'session_error',
-              'exposed_port_error'
+              'tunnel_error'
             ]
           }
         }
@@ -421,27 +421,27 @@ export const OPENAPI_SCHEMA = {
         }
       }
     },
-    '/v1/sandbox/{id}/exposed-port/{port}': {
+    '/v1/sandbox/{id}/tunnel/{port}': {
       post: {
-        operationId: 'resolveExposedPort',
-        summary: 'Create or reuse a public endpoint for a sandbox port',
+        operationId: 'createTunnel',
+        summary: 'Create or reuse a tunnel for a sandbox port',
         description:
-          'Returns an existing public endpoint for the port when one is already recorded, or provisions one when needed. ' +
+          'Returns an existing tunnel for the port when one is already recorded, or provisions one when needed. ' +
           'The service must already be listening inside the sandbox. ' +
-          'Omit `name` for an ephemeral `*.trycloudflare.com` endpoint, or pass `name` to choose the subdomain prefix for a named endpoint. Use a value such as `app`, not a full hostname.',
+          'Omit `name` for an ephemeral `*.trycloudflare.com` tunnel, or pass `name` to choose the subdomain prefix for a named tunnel. Use a value such as `app`, not a full hostname.',
         'x-codeSamples': [
           {
             lang: 'curl',
-            label: 'Ephemeral endpoint',
+            label: 'Ephemeral tunnel',
             source:
-              'curl -X POST https://$HOST/v1/sandbox/my-sandbox/exposed-port/8080 \\\n' +
+              'curl -X POST https://$HOST/v1/sandbox/my-sandbox/tunnel/8080 \\\n' +
               '  -H "Authorization: Bearer $SANDBOX_API_KEY"'
           },
           {
             lang: 'curl',
-            label: 'Named endpoint',
+            label: 'Named tunnel',
             source:
-              'curl -X POST https://$HOST/v1/sandbox/my-sandbox/exposed-port/8080 \\\n' +
+              'curl -X POST https://$HOST/v1/sandbox/my-sandbox/tunnel/8080 \\\n' +
               '  -H "Authorization: Bearer $SANDBOX_API_KEY" \\\n' +
               '  -H "Content-Type: application/json" \\\n' +
               '  -d \'{"name":"app"}\''
@@ -460,36 +460,85 @@ export const OPENAPI_SCHEMA = {
             in: 'path',
             required: true,
             schema: { type: 'integer', minimum: 1024, maximum: 65535 },
-            description: 'Container port to resolve. Port 3000 is reserved.'
+            description: 'Container port to tunnel. Port 3000 is reserved.'
           }
         ],
         requestBody: {
           required: false,
           content: {
             'application/json': {
-              schema: { $ref: '#/components/schemas/ExposedPortRequest' }
+              schema: { $ref: '#/components/schemas/TunnelRequest' }
             }
           }
         },
         responses: {
           '200': {
-            description: 'Public endpoint resolved.',
+            description: 'Tunnel created or reused.',
             content: {
               'application/json': {
-                schema: { $ref: '#/components/schemas/ResolvedExposedPort' }
+                schema: { $ref: '#/components/schemas/Tunnel' }
               }
             }
           },
           '400': { $ref: '#/components/responses/InvalidRequest' },
           '401': { $ref: '#/components/responses/Unauthorized' },
           '502': {
-            description: 'Exposed port resolution failed.',
+            description: 'Tunnel creation failed.',
             content: {
               'application/json': {
                 schema: { $ref: '#/components/schemas/ErrorResponse' },
                 example: {
-                  error: 'exposed port failed: cloudflared could not be found',
-                  code: 'exposed_port_error'
+                  error: 'tunnel failed: cloudflared could not be found',
+                  code: 'tunnel_error'
+                }
+              }
+            }
+          }
+        }
+      },
+      delete: {
+        operationId: 'deleteTunnel',
+        summary: 'Delete the tunnel for a sandbox port',
+        description:
+          'Stops the tunnel process for the port and removes any named-tunnel Cloudflare resources tracked by the sandbox.',
+        'x-codeSamples': [
+          {
+            lang: 'curl',
+            label: 'Delete tunnel',
+            source:
+              'curl -X DELETE https://$HOST/v1/sandbox/my-sandbox/tunnel/8080 \\\n' +
+              '  -H "Authorization: Bearer $SANDBOX_API_KEY"'
+          }
+        ],
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+            description: 'Sandbox instance name.'
+          },
+          {
+            name: 'port',
+            in: 'path',
+            required: true,
+            schema: { type: 'integer', minimum: 1024, maximum: 65535 },
+            description:
+              'Container port whose tunnel should be deleted. Port 3000 is reserved.'
+          }
+        ],
+        responses: {
+          '204': { description: 'Tunnel deleted or already absent.' },
+          '400': { $ref: '#/components/responses/InvalidRequest' },
+          '401': { $ref: '#/components/responses/Unauthorized' },
+          '502': {
+            description: 'Tunnel deletion failed.',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                example: {
+                  error: 'tunnel failed: cleanup failed',
+                  code: 'tunnel_error'
                 }
               }
             }

--- a/packages/sandbox/src/bridge/openapi.ts
+++ b/packages/sandbox/src/bridge/openapi.ts
@@ -167,6 +167,47 @@ export const OPENAPI_SCHEMA = {
           }
         }
       },
+      ExposedPortRequest: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description:
+              'Subdomain prefix for a named endpoint, such as `app`. Do not pass a full hostname. Omit to create or reuse an ephemeral endpoint.',
+            example: 'app'
+          }
+        }
+      },
+      ResolvedExposedPort: {
+        type: 'object',
+        required: ['id', 'port', 'url', 'hostname', 'createdAt'],
+        properties: {
+          id: { type: 'string' },
+          port: {
+            type: 'integer',
+            description: 'Container port served by the endpoint.',
+            example: 8080
+          },
+          url: {
+            type: 'string',
+            format: 'uri',
+            example: 'https://app.example.com'
+          },
+          hostname: {
+            type: 'string',
+            example: 'app.example.com'
+          },
+          createdAt: {
+            type: 'string',
+            format: 'date-time'
+          },
+          name: {
+            type: 'string',
+            description: 'Present for named endpoints only.',
+            example: 'app'
+          }
+        }
+      },
       ErrorResponse: {
         type: 'object',
         required: ['error', 'code'],
@@ -190,7 +231,8 @@ export const OPENAPI_SCHEMA = {
               'pool_error',
               'mount_error',
               'unmount_error',
-              'session_error'
+              'session_error',
+              'exposed_port_error'
             ]
           }
         }
@@ -372,6 +414,82 @@ export const OPENAPI_SCHEMA = {
                 example: {
                   error: 'exec failed: connection reset',
                   code: 'exec_transport_error'
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    '/v1/sandbox/{id}/exposed-port/{port}': {
+      post: {
+        operationId: 'resolveExposedPort',
+        summary: 'Create or reuse a public endpoint for a sandbox port',
+        description:
+          'Returns an existing public endpoint for the port when one is already recorded, or provisions one when needed. ' +
+          'The service must already be listening inside the sandbox. ' +
+          'Omit `name` for an ephemeral `*.trycloudflare.com` endpoint, or pass `name` to choose the subdomain prefix for a named endpoint. Use a value such as `app`, not a full hostname.',
+        'x-codeSamples': [
+          {
+            lang: 'curl',
+            label: 'Ephemeral endpoint',
+            source:
+              'curl -X POST https://$HOST/v1/sandbox/my-sandbox/exposed-port/8080 \\\n' +
+              '  -H "Authorization: Bearer $SANDBOX_API_KEY"'
+          },
+          {
+            lang: 'curl',
+            label: 'Named endpoint',
+            source:
+              'curl -X POST https://$HOST/v1/sandbox/my-sandbox/exposed-port/8080 \\\n' +
+              '  -H "Authorization: Bearer $SANDBOX_API_KEY" \\\n' +
+              '  -H "Content-Type: application/json" \\\n' +
+              '  -d \'{"name":"app"}\''
+          }
+        ],
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+            description: 'Sandbox instance name.'
+          },
+          {
+            name: 'port',
+            in: 'path',
+            required: true,
+            schema: { type: 'integer', minimum: 1024, maximum: 65535 },
+            description: 'Container port to resolve. Port 3000 is reserved.'
+          }
+        ],
+        requestBody: {
+          required: false,
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/ExposedPortRequest' }
+            }
+          }
+        },
+        responses: {
+          '200': {
+            description: 'Public endpoint resolved.',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ResolvedExposedPort' }
+              }
+            }
+          },
+          '400': { $ref: '#/components/responses/InvalidRequest' },
+          '401': { $ref: '#/components/responses/Unauthorized' },
+          '502': {
+            description: 'Exposed port resolution failed.',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                example: {
+                  error: 'exposed port failed: cloudflared could not be found',
+                  code: 'exposed_port_error'
                 }
               }
             }

--- a/packages/sandbox/src/bridge/routes.ts
+++ b/packages/sandbox/src/bridge/routes.ts
@@ -12,11 +12,18 @@ import type {
   MountBucketOptions,
   PtyOptions,
   R2BindingMountBucketOptions,
-  RemoteMountBucketOptions
+  RemoteMountBucketOptions,
+  TunnelInfo,
+  TunnelOptions
 } from '@repo/shared';
 import { Hono, type MiddlewareHandler } from 'hono';
 import type { Sandbox } from '../sandbox';
 import { getSandbox as _getSandbox } from '../sandbox';
+import {
+  SandboxSecurityError,
+  validatePort,
+  validateTunnelName
+} from '../security';
 import {
   base32Encode,
   errorJson,
@@ -32,6 +39,7 @@ import { primePool } from './pool';
 import type {
   BridgeEnv,
   ExecRequest,
+  ExposedPortRequest,
   MountBucketRequest,
   MountBucketRequestOptions,
   RunningResponse,
@@ -57,6 +65,9 @@ type BridgeSandbox = ISandbox & {
     }
   >;
   destroy(): Promise<void>;
+  tunnels: {
+    get(port: number, options?: TunnelOptions): Promise<TunnelInfo>;
+  };
 };
 
 /** Typed wrapper around the SDK's getSandbox() that returns a BridgeSandbox. */
@@ -340,7 +351,7 @@ export function createBridgeApp(
   });
 
   // Pool resolution for bare DELETE /sandbox/:id (no trailing path).
-  // Uses lookupContainer() to avoid allocating a container just to destroy it.
+  // Destruction targets an already-assigned container when one exists.
   app.use(`${apiPrefix}/sandbox/:id`, async (c, next) => {
     // Pool resolution — only for DELETE (the only bare-path handler)
     if (c.req.method !== 'DELETE') return next();
@@ -605,6 +616,66 @@ export function createBridgeApp(
       return errorJson(
         `write failed: ${msg}`,
         'workspace_archive_write_error',
+        502
+      );
+    }
+  });
+
+  // ------------------------------------------------------------------
+  // POST /sandbox/:id/exposed-port/:port
+  // ------------------------------------------------------------------
+
+  app.post(`${apiPrefix}/sandbox/:id/exposed-port/:port`, async (c) => {
+    const port = Number(c.req.param('port'));
+    if (!validatePort(port)) {
+      return errorJson('Invalid port', 'invalid_request', 400);
+    }
+
+    let options: TunnelOptions | undefined;
+    const rawBody = await c.req.text();
+    if (rawBody.trim()) {
+      let body: ExposedPortRequest;
+      try {
+        body = JSON.parse(rawBody) as ExposedPortRequest;
+      } catch {
+        return errorJson('Invalid JSON body', 'invalid_request', 400);
+      }
+
+      if (
+        body &&
+        typeof body === 'object' &&
+        !Array.isArray(body) &&
+        body.name !== undefined
+      ) {
+        if (typeof body.name !== 'string') {
+          return errorJson(
+            'name must be a string when provided',
+            'invalid_request',
+            400
+          );
+        }
+        try {
+          validateTunnelName(body.name);
+        } catch (err) {
+          if (err instanceof SandboxSecurityError) {
+            return errorJson(err.message, 'invalid_request', 400);
+          }
+          throw err;
+        }
+        options = { name: body.name };
+      }
+    }
+
+    const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
+
+    try {
+      const tunnel = await sandbox.tunnels.get(port, options);
+      return c.json(tunnel);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return errorJson(
+        `exposed port failed: ${msg}`,
+        'exposed_port_error',
         502
       );
     }

--- a/packages/sandbox/src/bridge/routes.ts
+++ b/packages/sandbox/src/bridge/routes.ts
@@ -39,10 +39,10 @@ import { primePool } from './pool';
 import type {
   BridgeEnv,
   ExecRequest,
-  ExposedPortRequest,
   MountBucketRequest,
   MountBucketRequestOptions,
   RunningResponse,
+  TunnelRequest,
   UnmountBucketRequest,
   WriteResponse
 } from './types';
@@ -67,6 +67,7 @@ type BridgeSandbox = ISandbox & {
   destroy(): Promise<void>;
   tunnels: {
     get(port: number, options?: TunnelOptions): Promise<TunnelInfo>;
+    destroy(port: number): Promise<void>;
   };
 };
 
@@ -100,6 +101,47 @@ function isStringArray(value: unknown): value is string[] {
   return (
     Array.isArray(value) && value.every((item) => typeof item === 'string')
   );
+}
+
+function parseTunnelOptions(
+  rawBody: string
+): TunnelOptions | Response | undefined {
+  if (!rawBody.trim()) return undefined;
+
+  let body: TunnelRequest;
+  try {
+    body = JSON.parse(rawBody) as TunnelRequest;
+  } catch {
+    return errorJson('Invalid JSON body', 'invalid_request', 400);
+  }
+
+  if (
+    !body ||
+    typeof body !== 'object' ||
+    Array.isArray(body) ||
+    body.name === undefined
+  ) {
+    return undefined;
+  }
+
+  if (typeof body.name !== 'string') {
+    return errorJson(
+      'name must be a string when provided',
+      'invalid_request',
+      400
+    );
+  }
+
+  try {
+    validateTunnelName(body.name);
+  } catch (err) {
+    if (err instanceof SandboxSecurityError) {
+      return errorJson(err.message, 'invalid_request', 400);
+    }
+    throw err;
+  }
+
+  return { name: body.name };
 }
 
 function validateMountOptions(
@@ -622,49 +664,18 @@ export function createBridgeApp(
   });
 
   // ------------------------------------------------------------------
-  // POST /sandbox/:id/exposed-port/:port
+  // POST /sandbox/:id/tunnel/:port
+  // DELETE /sandbox/:id/tunnel/:port
   // ------------------------------------------------------------------
 
-  app.post(`${apiPrefix}/sandbox/:id/exposed-port/:port`, async (c) => {
+  app.post(`${apiPrefix}/sandbox/:id/tunnel/:port`, async (c) => {
     const port = Number(c.req.param('port'));
     if (!validatePort(port)) {
       return errorJson('Invalid port', 'invalid_request', 400);
     }
 
-    let options: TunnelOptions | undefined;
-    const rawBody = await c.req.text();
-    if (rawBody.trim()) {
-      let body: ExposedPortRequest;
-      try {
-        body = JSON.parse(rawBody) as ExposedPortRequest;
-      } catch {
-        return errorJson('Invalid JSON body', 'invalid_request', 400);
-      }
-
-      if (
-        body &&
-        typeof body === 'object' &&
-        !Array.isArray(body) &&
-        body.name !== undefined
-      ) {
-        if (typeof body.name !== 'string') {
-          return errorJson(
-            'name must be a string when provided',
-            'invalid_request',
-            400
-          );
-        }
-        try {
-          validateTunnelName(body.name);
-        } catch (err) {
-          if (err instanceof SandboxSecurityError) {
-            return errorJson(err.message, 'invalid_request', 400);
-          }
-          throw err;
-        }
-        options = { name: body.name };
-      }
-    }
+    const options = parseTunnelOptions(await c.req.text());
+    if (options instanceof Response) return options;
 
     const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
 
@@ -673,11 +684,24 @@ export function createBridgeApp(
       return c.json(tunnel);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(
-        `exposed port failed: ${msg}`,
-        'exposed_port_error',
-        502
-      );
+      return errorJson(`tunnel failed: ${msg}`, 'tunnel_error', 502);
+    }
+  });
+
+  app.delete(`${apiPrefix}/sandbox/:id/tunnel/:port`, async (c) => {
+    const port = Number(c.req.param('port'));
+    if (!validatePort(port)) {
+      return errorJson('Invalid port', 'invalid_request', 400);
+    }
+
+    const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
+
+    try {
+      await sandbox.tunnels.destroy(port);
+      return c.body(null, 204);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return errorJson(`tunnel failed: ${msg}`, 'tunnel_error', 502);
     }
   });
 

--- a/packages/sandbox/src/bridge/types.ts
+++ b/packages/sandbox/src/bridge/types.ts
@@ -105,9 +105,9 @@ export interface RunningResponse {
   running: boolean;
 }
 
-/** Sent by the client for /exposed-port requests. */
-export interface ExposedPortRequest {
-  /** Subdomain prefix for a named endpoint, such as "app". */
+/** Sent by the client for tunnel creation requests. */
+export interface TunnelRequest {
+  /** Subdomain prefix for a named tunnel, such as "app". */
   name?: string;
 }
 

--- a/packages/sandbox/src/bridge/types.ts
+++ b/packages/sandbox/src/bridge/types.ts
@@ -105,6 +105,12 @@ export interface RunningResponse {
   running: boolean;
 }
 
+/** Sent by the client for /exposed-port requests. */
+export interface ExposedPortRequest {
+  /** Subdomain prefix for a named endpoint, such as "app". */
+  name?: string;
+}
+
 /** Returned by all error paths. */
 export interface ErrorResponse {
   error: string;


### PR DESCRIPTION
Add `POST /v1/sandbox/:id/exposed-port/:port` to the Sandbox Bridge to provide public HTTP access to services running inside a sandbox.

Consumers using the Bridge API need a REST interface for routing external traffic to internal container services such as web servers, API backends, or language servers. This endpoint creates or reuses a public endpoint for a service that is already listening inside the sandbox.

Empty requests return an ephemeral `*.trycloudflare.com` endpoint. Requests with a `name` field create or reuse a named endpoint under the configured Cloudflare zone. The endpoint is backed by Sandbox tunnels.

Tests Run:

- `npm run check`
- `npm test -w @cloudflare/sandbox-bridge`
