### PR TITLE
Allow backup bucket URL override

### DIFF
--- a/.changeset/backup-bucket-endpoint.md
+++ b/.changeset/backup-bucket-endpoint.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Allow backup and restore presigned URLs to target non-default R2 endpoints. Set `BACKUP_BUCKET_ENDPOINT`, for example `https://<account_id>.eu.r2.cloudflarestorage.com`, when your backup bucket uses an R2 jurisdiction.

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1131,7 +1131,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     // Read R2 presigned URL credentials for direct container-to-R2 backup transfers
     // R2 account id precedence: CLOUDFLARE_R2_ACCOUNT_ID > CLOUDFLARE_ACCOUNT_ID.
     // Token-derived fallback is intentionally not wired here because the
-    // backup path (requirePresignedUrlSupport) is synchronous; see
+    // backup path (requirePresignedURLSupport) is synchronous; see
     // tunnels/credentials.ts for the full chain that named tunnels use.
     this.r2AccountId =
       getEnvString(envObj, 'CLOUDFLARE_R2_ACCOUNT_ID') ??
@@ -5584,7 +5584,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    * Returns validated presigned URL configuration or throws if not configured.
    * All credential fields plus the R2 binding are required for backup to work.
    */
-  private requirePresignedUrlSupport(): {
+  private requirePresignedURLSupport(): {
     client: AwsClient;
     accountId: string;
     bucketName: string;
@@ -5643,8 +5643,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    * Generate a presigned GET URL for downloading an object from R2.
    * The container can curl this URL directly without credentials.
    */
-  private async generatePresignedGetUrl(r2Key: string): Promise<string> {
-    const { client, accountId, bucketName } = this.requirePresignedUrlSupport();
+  private async generatePresignedGetURL(r2Key: string): Promise<string> {
+    const { client, accountId, bucketName } = this.requirePresignedURLSupport();
 
     const url = this.getBackupObjectURL(accountId, bucketName, r2Key);
     url.searchParams.set(
@@ -5663,8 +5663,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    * Generate a presigned PUT URL for uploading an object to R2.
    * The container can curl PUT to this URL directly without credentials.
    */
-  private async generatePresignedPutUrl(r2Key: string): Promise<string> {
-    const { client, accountId, bucketName } = this.requirePresignedUrlSupport();
+  private async generatePresignedPutURL(r2Key: string): Promise<string> {
+    const { client, accountId, bucketName } = this.requirePresignedURLSupport();
 
     const url = this.getBackupObjectURL(accountId, bucketName, r2Key);
     url.searchParams.set(
@@ -5692,7 +5692,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     dir: string,
     backupSession: string
   ): Promise<void> {
-    const presignedUrl = await this.generatePresignedPutUrl(r2Key);
+    const presignedURL = await this.generatePresignedPutURL(r2Key);
 
     const curlCmd = [
       'curl -sSf',
@@ -5703,7 +5703,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       '--retry 2',
       '--retry-max-time 60',
       `-T ${shellEscape(archivePath)}`,
-      shellEscape(presignedUrl)
+      shellEscape(presignedURL)
     ].join(' ');
 
     const result = await this.execWithSession(curlCmd, backupSession, {
@@ -5748,12 +5748,12 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   /**
    * Generate a presigned PUT URL for a single part in a multipart upload.
    */
-  private async generatePresignedPartUrl(
+  private async generatePresignedPartURL(
     r2Key: string,
     uploadId: string,
     partNumber: number
   ): Promise<string> {
-    const { client, accountId, bucketName } = this.requirePresignedUrlSupport();
+    const { client, accountId, bucketName } = this.requirePresignedURLSupport();
 
     const url = this.getBackupObjectURL(accountId, bucketName, r2Key);
     url.searchParams.set(
@@ -5804,14 +5804,14 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       );
     }
 
-    const { client, accountId, bucketName } = this.requirePresignedUrlSupport();
-    const objectUrl = this.getBackupObjectURL(
+    const { client, accountId, bucketName } = this.requirePresignedURLSupport();
+    const objectURL = this.getBackupObjectURL(
       accountId,
       bucketName,
       r2Key
     ).toString();
 
-    const createResp = await client.fetch(`${objectUrl}?uploads`, {
+    const createResp = await client.fetch(`${objectURL}?uploads`, {
       method: 'POST'
     });
     if (!createResp.ok) {
@@ -5839,7 +5839,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
     const abortMultipart = async () => {
       await client
-        .fetch(`${objectUrl}?uploadId=${encodeURIComponent(uploadId)}`, {
+        .fetch(`${objectURL}?uploadId=${encodeURIComponent(uploadId)}`, {
           method: 'DELETE'
         })
         .catch(() => {});
@@ -5855,7 +5855,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           size: i === numParts - 1 ? sizeBytes - i * partSize : partSize
         })).map(async (part) => ({
           ...part,
-          url: await this.generatePresignedPartUrl(
+          url: await this.generatePresignedPartURL(
             r2Key,
             uploadId,
             part.partNumber
@@ -5910,7 +5910,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       ].join('');
 
       const completeResp = await client.fetch(
-        `${objectUrl}?uploadId=${encodeURIComponent(uploadId)}`,
+        `${objectURL}?uploadId=${encodeURIComponent(uploadId)}`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/xml' },
@@ -5960,7 +5960,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     dir: string,
     backupSession: string
   ): Promise<void> {
-    const presignedUrl = await this.generatePresignedGetUrl(r2Key);
+    const presignedURL = await this.generatePresignedGetURL(r2Key);
     await this.execWithSession(
       `mkdir -p ${BACKUP_CONTAINER_DIR}`,
       backupSession,
@@ -5977,7 +5977,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         '--retry 2',
         '--retry-max-time 60',
         `-o ${shellEscape(tmpPath)}`,
-        shellEscape(presignedUrl)
+        shellEscape(presignedURL)
       ].join(' ');
 
       const result = await this.execWithSession(curlCmd, backupSession, {
@@ -6018,7 +6018,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           '--connect-timeout 10',
           '--max-time 1800',
           `-H ${shellEscape(`Range: bytes=${range}`)}`,
-          shellEscape(presignedUrl),
+          shellEscape(presignedURL),
           '|',
           'dd',
           `of=${shellEscape(tmpPath)}`,
@@ -6155,7 +6155,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     options: BackupOptions
   ): Promise<DirectoryBackup> {
     const bucket = this.requireBackupBucket();
-    this.requirePresignedUrlSupport();
+    this.requirePresignedURLSupport();
     const {
       dir,
       name,
@@ -6607,7 +6607,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   ): Promise<RestoreBackupResult> {
     const restoreStartTime = Date.now();
     const bucket = this.requireBackupBucket();
-    this.requirePresignedUrlSupport();
+    this.requirePresignedURLSupport();
     const { id, dir } = backup;
 
     let outcome: 'success' | 'error' = 'error';

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -860,6 +860,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   private r2SecretAccessKey: string | null = null;
   private r2AccountId: string | null = null;
   private backupBucketName: string | null = null;
+  private backupBucketEndpoint: string | null = null;
   private r2Client: AwsClient | null = null;
 
   /**
@@ -1140,6 +1141,56 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     this.r2SecretAccessKey =
       getEnvString(envObj, 'R2_SECRET_ACCESS_KEY') ?? null;
     this.backupBucketName = getEnvString(envObj, 'BACKUP_BUCKET_NAME') ?? null;
+    const rawEndpoint = getEnvString(envObj, 'BACKUP_BUCKET_ENDPOINT') ?? null;
+    if (rawEndpoint !== null) {
+      let parsed: URL;
+      try {
+        parsed = new URL(rawEndpoint);
+      } catch {
+        const msg = `BACKUP_BUCKET_ENDPOINT is not a valid URL: "${rawEndpoint}". Expected format: https://<account_id>.eu.r2.cloudflarestorage.com`;
+        throw new InvalidBackupConfigError({
+          message: msg,
+          code: ErrorCode.INVALID_BACKUP_CONFIG,
+          httpStatus: 400,
+          context: { reason: msg },
+          timestamp: new Date().toISOString()
+        });
+      }
+      if (parsed.protocol !== 'https:') {
+        const msg = `BACKUP_BUCKET_ENDPOINT must use https://, got "${parsed.protocol.replace(':', '')}://"`;
+        throw new InvalidBackupConfigError({
+          message: msg,
+          code: ErrorCode.INVALID_BACKUP_CONFIG,
+          httpStatus: 400,
+          context: { reason: msg },
+          timestamp: new Date().toISOString()
+        });
+      }
+      if (parsed.pathname !== '/') {
+        const msg = `BACKUP_BUCKET_ENDPOINT must not include a path (got "${parsed.pathname}"). Provide only the origin, e.g. https://<account_id>.eu.r2.cloudflarestorage.com`;
+        throw new InvalidBackupConfigError({
+          message: msg,
+          code: ErrorCode.INVALID_BACKUP_CONFIG,
+          httpStatus: 400,
+          context: { reason: msg },
+          timestamp: new Date().toISOString()
+        });
+      }
+      if (parsed.search !== '' || parsed.hash !== '') {
+        const msg =
+          'BACKUP_BUCKET_ENDPOINT must not include query parameters or fragments. Provide only the origin, e.g. https://<account_id>.eu.r2.cloudflarestorage.com';
+        throw new InvalidBackupConfigError({
+          message: msg,
+          code: ErrorCode.INVALID_BACKUP_CONFIG,
+          httpStatus: 400,
+          context: { reason: msg },
+          timestamp: new Date().toISOString()
+        });
+      }
+      this.backupBucketEndpoint = rawEndpoint.replace(/\/+$/, '');
+    } else {
+      this.backupBucketEndpoint = null;
+    }
 
     if (this.r2AccessKeyId && this.r2SecretAccessKey) {
       this.r2Client = new AwsClient({
@@ -2328,7 +2379,6 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       // doesn't ghost-revive on the next sandbox under the same DO id.
       await this.ctx.storage.delete('tunnels');
       await this.ctx.storage.delete('tunnels:meta');
-
 
       // Disconnect transport after all cleanup commands have completed
       this.client.disconnect();
@@ -5566,6 +5616,29 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     };
   }
 
+  private getBackupBucketEndpoint(accountId: string): string {
+    return (
+      this.backupBucketEndpoint ??
+      `https://${accountId}.r2.cloudflarestorage.com`
+    );
+  }
+
+  private getBackupObjectURL(
+    accountId: string,
+    bucketName: string,
+    r2Key: string
+  ): URL {
+    const encodedBucket = encodeURIComponent(bucketName);
+    const encodedKey = r2Key
+      .split('/')
+      .map((seg) => encodeURIComponent(seg))
+      .join('/');
+
+    return new URL(
+      `${this.getBackupBucketEndpoint(accountId)}/${encodedBucket}/${encodedKey}`
+    );
+  }
+
   /**
    * Generate a presigned GET URL for downloading an object from R2.
    * The container can curl this URL directly without credentials.
@@ -5573,14 +5646,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   private async generatePresignedGetUrl(r2Key: string): Promise<string> {
     const { client, accountId, bucketName } = this.requirePresignedUrlSupport();
 
-    const encodedBucket = encodeURIComponent(bucketName);
-    const encodedKey = r2Key
-      .split('/')
-      .map((seg) => encodeURIComponent(seg))
-      .join('/');
-    const url = new URL(
-      `https://${accountId}.r2.cloudflarestorage.com/${encodedBucket}/${encodedKey}`
-    );
+    const url = this.getBackupObjectURL(accountId, bucketName, r2Key);
     url.searchParams.set(
       'X-Amz-Expires',
       String(Sandbox.PRESIGNED_URL_EXPIRY_SECONDS)
@@ -5600,14 +5666,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   private async generatePresignedPutUrl(r2Key: string): Promise<string> {
     const { client, accountId, bucketName } = this.requirePresignedUrlSupport();
 
-    const encodedBucket = encodeURIComponent(bucketName);
-    const encodedKey = r2Key
-      .split('/')
-      .map((seg) => encodeURIComponent(seg))
-      .join('/');
-    const url = new URL(
-      `https://${accountId}.r2.cloudflarestorage.com/${encodedBucket}/${encodedKey}`
-    );
+    const url = this.getBackupObjectURL(accountId, bucketName, r2Key);
     url.searchParams.set(
       'X-Amz-Expires',
       String(Sandbox.PRESIGNED_URL_EXPIRY_SECONDS)
@@ -5696,14 +5755,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   ): Promise<string> {
     const { client, accountId, bucketName } = this.requirePresignedUrlSupport();
 
-    const encodedBucket = encodeURIComponent(bucketName);
-    const encodedKey = r2Key
-      .split('/')
-      .map((seg) => encodeURIComponent(seg))
-      .join('/');
-    const url = new URL(
-      `https://${accountId}.r2.cloudflarestorage.com/${encodedBucket}/${encodedKey}`
-    );
+    const url = this.getBackupObjectURL(accountId, bucketName, r2Key);
     url.searchParams.set(
       'X-Amz-Expires',
       String(Sandbox.PRESIGNED_URL_EXPIRY_SECONDS)
@@ -5753,12 +5805,11 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     }
 
     const { client, accountId, bucketName } = this.requirePresignedUrlSupport();
-    const encodedBucket = encodeURIComponent(bucketName);
-    const encodedKey = r2Key
-      .split('/')
-      .map((seg) => encodeURIComponent(seg))
-      .join('/');
-    const objectUrl = `https://${accountId}.r2.cloudflarestorage.com/${encodedBucket}/${encodedKey}`;
+    const objectUrl = this.getBackupObjectURL(
+      accountId,
+      bucketName,
+      r2Key
+    ).toString();
 
     const createResp = await client.fetch(`${objectUrl}?uploads`, {
       method: 'POST'

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1157,7 +1157,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         });
       }
       if (parsed.protocol !== 'https:') {
-        const msg = `BACKUP_BUCKET_ENDPOINT must use https://, got "${parsed.protocol.replace(':', '')}://"`;
+        const msg = `BACKUP_BUCKET_ENDPOINT must use https://, got "${parsed.protocol.slice(0, -1)}://"`;
         throw new InvalidBackupConfigError({
           message: msg,
           code: ErrorCode.INVALID_BACKUP_CONFIG,
@@ -1187,7 +1187,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           timestamp: new Date().toISOString()
         });
       }
-      this.backupBucketEndpoint = rawEndpoint.replace(/\/+$/, '');
+      this.backupBucketEndpoint = parsed.origin;
     } else {
       this.backupBucketEndpoint = null;
     }

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -3088,7 +3088,7 @@ describe('Sandbox - Automatic Session Management', () => {
         .mockResolvedValueOnce({ stdout: '', stderr: '', exitCode: 0 });
       vi.spyOn(
         backupSandbox as any,
-        'generatePresignedGetUrl'
+        'generatePresignedGetURL'
       ).mockResolvedValue('https://example.com/archive');
 
       await (backupSandbox as any).downloadBackupParallel(

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -2,7 +2,11 @@ import { Container } from '@cloudflare/containers';
 import { DISABLE_SESSION_TOKEN } from '@repo/shared/internal';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { RuntimeIdentityInactiveError } from '../src/current-runtime-identity';
-import { PortNotExposedError, ProcessNotFoundError } from '../src/errors';
+import {
+  InvalidBackupConfigError,
+  PortNotExposedError,
+  ProcessNotFoundError
+} from '../src/errors';
 import { connect, Sandbox } from '../src/sandbox';
 
 // Mock dependencies before imports
@@ -2753,7 +2757,10 @@ describe('Sandbox - Automatic Session Management', () => {
       };
     }
 
-    async function createBackupSandbox(bucket = createBackupBucket()) {
+    async function createBackupSandbox(
+      bucket = createBackupBucket(),
+      env: Record<string, unknown> = {}
+    ) {
       const backupSandbox = new Sandbox(
         mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
         {
@@ -2761,7 +2768,8 @@ describe('Sandbox - Automatic Session Management', () => {
           CLOUDFLARE_ACCOUNT_ID: 'test-account',
           R2_ACCESS_KEY_ID: 'test-key',
           R2_SECRET_ACCESS_KEY: 'test-secret',
-          BACKUP_BUCKET_NAME: 'test-backups'
+          BACKUP_BUCKET_NAME: 'test-backups',
+          ...env
         }
       );
 
@@ -2771,6 +2779,100 @@ describe('Sandbox - Automatic Session Management', () => {
 
       return { backupSandbox, bucket };
     }
+
+    it('should build backup object URLs with the default R2 endpoint', async () => {
+      const { backupSandbox } = await createBackupSandbox();
+
+      const url = (
+        backupSandbox as unknown as {
+          getBackupObjectURL: (
+            accountId: string,
+            bucketName: string,
+            r2Key: string
+          ) => URL;
+        }
+      ).getBackupObjectURL(
+        'test-account',
+        'test-backups',
+        'backups/id/data.sqsh'
+      );
+
+      expect(url.toString()).toBe(
+        'https://test-account.r2.cloudflarestorage.com/test-backups/backups/id/data.sqsh'
+      );
+    });
+
+    it('should build backup object URLs with a custom R2 endpoint', async () => {
+      const { backupSandbox } = await createBackupSandbox(
+        createBackupBucket(),
+        {
+          BACKUP_BUCKET_ENDPOINT:
+            'https://test-account.eu.r2.cloudflarestorage.com/'
+        }
+      );
+
+      const url = (
+        backupSandbox as unknown as {
+          getBackupObjectURL: (
+            accountId: string,
+            bucketName: string,
+            r2Key: string
+          ) => URL;
+        }
+      ).getBackupObjectURL(
+        'test-account',
+        'test-backups',
+        'backups/id/data.sqsh'
+      );
+
+      expect(url.toString()).toBe(
+        'https://test-account.eu.r2.cloudflarestorage.com/test-backups/backups/id/data.sqsh'
+      );
+    });
+
+    it('should throw InvalidBackupConfigError for a malformed BACKUP_BUCKET_ENDPOINT', async () => {
+      await expect(
+        createBackupSandbox(createBackupBucket(), {
+          BACKUP_BUCKET_ENDPOINT: 'not-a-url'
+        })
+      ).rejects.toThrow(InvalidBackupConfigError);
+    });
+
+    it('should throw InvalidBackupConfigError for an http BACKUP_BUCKET_ENDPOINT', async () => {
+      await expect(
+        createBackupSandbox(createBackupBucket(), {
+          BACKUP_BUCKET_ENDPOINT:
+            'http://test-account.eu.r2.cloudflarestorage.com'
+        })
+      ).rejects.toThrow(InvalidBackupConfigError);
+    });
+
+    it('should throw InvalidBackupConfigError for a BACKUP_BUCKET_ENDPOINT with a path', async () => {
+      await expect(
+        createBackupSandbox(createBackupBucket(), {
+          BACKUP_BUCKET_ENDPOINT:
+            'https://test-account.eu.r2.cloudflarestorage.com/some/prefix'
+        })
+      ).rejects.toThrow(InvalidBackupConfigError);
+    });
+
+    it('should throw InvalidBackupConfigError for a BACKUP_BUCKET_ENDPOINT with a query', async () => {
+      await expect(
+        createBackupSandbox(createBackupBucket(), {
+          BACKUP_BUCKET_ENDPOINT:
+            'https://test-account.eu.r2.cloudflarestorage.com?region=eu'
+        })
+      ).rejects.toThrow(InvalidBackupConfigError);
+    });
+
+    it('should throw InvalidBackupConfigError for a BACKUP_BUCKET_ENDPOINT with a fragment', async () => {
+      await expect(
+        createBackupSandbox(createBackupBucket(), {
+          BACKUP_BUCKET_ENDPOINT:
+            'https://test-account.eu.r2.cloudflarestorage.com#bucket'
+        })
+      ).rejects.toThrow(InvalidBackupConfigError);
+    });
 
     it('should allow creating a backup from /app', async () => {
       const { backupSandbox, bucket } = await createBackupSandbox();
@@ -3618,13 +3720,11 @@ describe('Sandbox.getProcess()', () => {
       (sb as any).client = {
         getTransportMode: () => 'rpc',
         utils: {
-          createSession: vi
-            .fn()
-            .mockResolvedValue({
-              success: true,
-              id: 'default',
-              message: 'ok'
-            } as any)
+          createSession: vi.fn().mockResolvedValue({
+            success: true,
+            id: 'default',
+            message: 'ok'
+          } as any)
         },
         processes: {}
       };


### PR DESCRIPTION
# Summary

Fixes backup/restore presigned URLs for R2 buckets in jurisdictions. Previously, backup URLs were always generated against the default R2 endpoint: `https://<account_id>.r2.cloudflarestorage.com`
For jurisdiction-specific buckets, this can fail because they require endpoints like: `https://<account_id>.eu.r2.cloudflarestorage.com`

This PR adds `BACKUP_BUCKET_ENDPOINT` so users can override the R2 endpoint used for backup and restore presigned URLs. It also validates that the endpoint is HTTPS and origin-only, with tests for invalid values.

# Example

`wrangler.jsonc`
```json
	"vars": {
		"BACKUP_BUCKET_NAME": "sandbox-backup-endpoint-repro",
		"BACKUP_BUCKET_ENDPOINT": "https://<account-id>.eu.r2.cloudflarestorage.com"
	},
	"r2_buckets": [
		{
			"binding": "BACKUP_BUCKET",
			"bucket_name": "my-backup-bucket",
			"jurisdiction": "eu"
		}
	],
```