### PR TITLE
Fix S3/R2 mount credential proxy when catch-all handler defined

### DIFF
--- a/.changeset/fix-catch-all-mount-proxy.md
+++ b/.changeset/fix-catch-all-mount-proxy.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Fix bucket mounts when a Sandbox class defines a catch-all outbound handler by routing SDK-managed mount hosts through the SDK ContainerProxy.

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -16,8 +16,6 @@ export { getSandbox, Sandbox } from './sandbox';
 
 // Legacy types are now imported from the new client architecture
 
-// Required export for egress intercepting
-export { ContainerProxy } from '@cloudflare/containers';
 // Export core SDK types for consumers
 export type {
   BackupOptions,
@@ -155,6 +153,8 @@ export { CodeInterpreter } from './interpreter.js';
 export { proxyTerminal } from './pty';
 // Re-export request handler utilities
 export { proxyToSandbox, type SandboxEnv } from './request-handler';
+// Required export for egress intercepting
+export { ContainerProxy } from './sandbox';
 // Export SSE parser for converting ReadableStream to AsyncIterable
 export {
   asyncIterableToSSEStream,

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1,4 +1,10 @@
-import { Container, getContainer, switchPort } from '@cloudflare/containers';
+import {
+  ContainerProxy as BaseContainerProxy,
+  Container,
+  getContainer,
+  type OutboundHandlerContext,
+  switchPort
+} from '@cloudflare/containers';
 import type {
   BackupOptions,
   BucketCredentials,
@@ -260,6 +266,53 @@ Object.defineProperty(ContainerProxyOutboundTarget, 'name', {
   r2EgressMount: r2EgressHandler,
   s3CredentialProxyMount: s3CredentialProxyHandler
 };
+
+/**
+ * SDK-level ContainerProxy that directly dispatches SDK-internal mount hosts
+ * (r2.internal, s3-credential-proxy.internal) without relying on
+ * outboundHandlersRegistry lookups, which are NOT shared between the Durable
+ * Object's execution context and the ContainerProxy WorkerEntrypoint context.
+ *
+ * Users must export this class from their Worker entrypoint so the Sandbox DO
+ * can create outbound-interception fetchers that reference it.
+ */
+export class ContainerProxy extends BaseContainerProxy {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const hostname = url.hostname;
+    const props = this.ctx.props as {
+      outboundByHostOverrides?: Record<
+        string,
+        { method: string; params?: unknown }
+      >;
+      containerId?: string;
+      className?: string;
+    };
+    const override = props.outboundByHostOverrides?.[hostname];
+    if (override) {
+      const handlerCtx = {
+        containerId: props.containerId ?? '',
+        className: props.className ?? '',
+        params: override.params
+      };
+      if (override.method === 'r2EgressMount') {
+        return r2EgressHandler(
+          request,
+          this.env as Cloudflare.Env,
+          handlerCtx as OutboundHandlerContext<R2EgressParams>
+        );
+      }
+      if (override.method === 's3CredentialProxyMount') {
+        return s3CredentialProxyHandler(
+          request,
+          this.env as Cloudflare.Env,
+          handlerCtx as OutboundHandlerContext<S3CredentialProxyParams>
+        );
+      }
+    }
+    return super.fetch(request);
+  }
+}
 
 function isFetcher(value: unknown): value is Fetcher {
   return (
@@ -7396,6 +7449,23 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       );
     }
 
+    // Register r2EgressMount on the concrete subclass's local registry so
+    // setOutboundByHost's validateOutboundHandlerMethodName check passes. The
+    // actual dispatch is handled by the SDK ContainerProxy.fetch() override,
+    // which directly calls r2EgressHandler by hostname without going through
+    // the registry (which is NOT shared across execution contexts).
+    (this.constructor as unknown as OutboundHandlerRegistry).outboundHandlers =
+      { r2EgressMount: r2EgressHandler };
+    if (Object.keys(params.buckets).length > 0) {
+      await this.setOutboundByHost<R2EgressParams>(
+        'r2.internal',
+        'r2EgressMount',
+        params
+      );
+    } else {
+      await this.removeOutboundByHost('r2.internal');
+    }
+
     this.logger.debug('r2 egress: registering host interception', {
       host: 'r2.internal',
       method: 'r2EgressMount',
@@ -7443,6 +7513,26 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       S3_CREDENTIAL_PROXY_HOST,
       S3_CREDENTIAL_PROXY_DIAGNOSTIC_HOST
     ];
+
+    // Register s3CredentialProxyMount on the concrete subclass's local registry
+    // so setOutboundByHost's validateOutboundHandlerMethodName check passes.
+    // Actual dispatch is handled by the SDK ContainerProxy.fetch() override.
+    (this.constructor as unknown as OutboundHandlerRegistry).outboundHandlers =
+      { s3CredentialProxyMount: s3CredentialProxyHandler };
+    if (Object.keys(params.mounts).length > 0) {
+      for (const host of hosts) {
+        await this.setOutboundByHost<S3CredentialProxyParams>(
+          host,
+          's3CredentialProxyMount',
+          params
+        );
+      }
+    } else {
+      for (const host of hosts) {
+        await this.removeOutboundByHost(host);
+      }
+    }
+
     const hostOverrides: Record<
       string,
       { method: string; params: S3CredentialProxyParams }

--- a/packages/sandbox/tests/get-sandbox.test.ts
+++ b/packages/sandbox/tests/get-sandbox.test.ts
@@ -13,6 +13,17 @@ vi.mock('@cloudflare/containers', () => ({
       this.env = env;
     }
   },
+  ContainerProxy: class ContainerProxy {
+    ctx: any;
+    env: any;
+    constructor(ctx: any, env: any) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+    async fetch(request: Request): Promise<Response> {
+      return new Response('Mock ContainerProxy fetch');
+    }
+  },
   getContainer: vi.fn()
 }));
 

--- a/packages/sandbox/tests/local-backup.test.ts
+++ b/packages/sandbox/tests/local-backup.test.ts
@@ -34,6 +34,17 @@ vi.mock('@cloudflare/containers', () => {
 
   return {
     Container: MockContainer,
+    ContainerProxy: class ContainerProxy {
+      ctx: any;
+      env: any;
+      constructor(ctx: any, env: any) {
+        this.ctx = ctx;
+        this.env = env;
+      }
+      async fetch(request: Request): Promise<Response> {
+        return new Response('Mock ContainerProxy fetch');
+      }
+    },
     getContainer: vi.fn(),
     switchPort: mockSwitchPort
   };

--- a/packages/sandbox/tests/process-readiness.test.ts
+++ b/packages/sandbox/tests/process-readiness.test.ts
@@ -37,6 +37,17 @@ vi.mock('@cloudflare/containers', () => {
 
   return {
     Container: MockContainer,
+    ContainerProxy: class ContainerProxy {
+      ctx: any;
+      env: any;
+      constructor(ctx: any, env: any) {
+        this.ctx = ctx;
+        this.env = env;
+      }
+      async fetch(request: Request): Promise<Response> {
+        return new Response('Mock ContainerProxy fetch');
+      }
+    },
     getContainer: vi.fn(),
     switchPort: vi.fn()
   };

--- a/packages/sandbox/tests/r2-egress-mount.test.ts
+++ b/packages/sandbox/tests/r2-egress-mount.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { Sandbox } from '../src/sandbox';
+import { ContainerProxy, Sandbox } from '../src/sandbox';
 import {
   type R2EgressParams,
   r2EgressHandler
@@ -220,6 +220,16 @@ function createMockR2Bucket(): R2Bucket {
     createMultipartUpload: vi.fn(),
     resumeMultipartUpload: vi.fn()
   } as unknown as R2Bucket;
+}
+
+function createContainerProxyCtx(
+  props: TestContainerProxyOptions['props']
+): ExecutionContext<unknown> {
+  return {
+    props,
+    waitUntil: vi.fn(),
+    passThroughOnException: vi.fn()
+  } as unknown as ExecutionContext<unknown>;
 }
 
 function createExecResult(
@@ -715,6 +725,82 @@ describe('Sandbox credential proxy mounts', () => {
 });
 
 describe('Sandbox R2 egress mounts', () => {
+  describe('SDK ContainerProxy dispatch', () => {
+    it('routes r2.internal through the SDK proxy path by default', async () => {
+      const bucket = createMockR2Bucket();
+      const proxy = new ContainerProxy(
+        createContainerProxyCtx({
+          containerId: 'ctr-r2',
+          className: 'ContainerProxy',
+          outboundByHostOverrides: {
+            'r2.internal': {
+              method: 'r2EgressMount',
+              params: { buckets: { MY_BUCKET: {} } }
+            }
+          }
+        }),
+        { MY_BUCKET: bucket }
+      );
+
+      const res = await proxy.fetch(
+        new Request('http://r2.internal/MY_BUCKET/sample.txt')
+      );
+
+      expect(bucket.get).toHaveBeenCalledWith('sample.txt');
+      expect(res.status).toBe(404);
+    });
+
+    it('routes s3-credential-proxy.internal through the SDK proxy path by default', async () => {
+      const proxy = new ContainerProxy(
+        createContainerProxyCtx({
+          containerId: 'ctr-s3',
+          className: 'ContainerProxy',
+          outboundByHostOverrides: {
+            's3-credential-proxy.internal': {
+              method: 's3CredentialProxyMount',
+              params: { mounts: {} }
+            }
+          }
+        }),
+        {}
+      );
+
+      const res = await proxy.fetch(
+        new Request(
+          'http://s3-credential-proxy.internal/__sandbox_credential_proxy_self_test__'
+        )
+      );
+
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe('OK');
+    });
+
+    it('delegates unrelated outbound hosts to the base container proxy', async () => {
+      const proxy = new ContainerProxy(
+        createContainerProxyCtx({
+          containerId: 'ctr-other',
+          className: 'ContainerProxy',
+          outboundByHostOverrides: {
+            'r2.internal': {
+              method: 'r2EgressMount',
+              params: { buckets: { MY_BUCKET: {} } }
+            },
+            's3-credential-proxy.internal': {
+              method: 's3CredentialProxyMount',
+              params: { mounts: {} }
+            }
+          }
+        }),
+        { MY_BUCKET: createMockR2Bucket() }
+      );
+
+      const res = await proxy.fetch(new Request('https://example.com/'));
+
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe('Mock Container fetch');
+    });
+  });
+
   it('does not set up outbound interception at construction time for Sandbox subclasses', () => {
     class BaseSandbox extends Sandbox {}
     const mockCtx = createMockCtx();

--- a/packages/sandbox/tests/sandbox-error-handling.test.ts
+++ b/packages/sandbox/tests/sandbox-error-handling.test.ts
@@ -31,6 +31,17 @@ vi.mock('@cloudflare/containers', () => {
 
   return {
     Container: MockContainer,
+    ContainerProxy: class ContainerProxy {
+      ctx: any;
+      env: any;
+      constructor(ctx: any, env: any) {
+        this.ctx = ctx;
+        this.env = env;
+      }
+      async fetch(request: Request): Promise<Response> {
+        return new Response('Mock ContainerProxy fetch');
+      }
+    },
     getContainer: vi.fn(),
     switchPort: vi.fn()
   };

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -68,8 +68,21 @@ vi.mock('@cloudflare/containers', () => {
     }
   };
 
+  const MockContainerProxy = class ContainerProxy {
+    ctx: any;
+    env: any;
+    constructor(ctx: any, env: any) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+    async fetch(request: Request): Promise<Response> {
+      return new Response('Mock ContainerProxy fetch');
+    }
+  };
+
   return {
     Container: MockContainer,
+    ContainerProxy: MockContainerProxy,
     getContainer: vi.fn(),
     switchPort: mockSwitchPort
   };


### PR DESCRIPTION
## Summary

Fixes bucket mounts when a Sandbox class also defines a catch-all outbound handler.

Previously, `mountBucket()` configured `r2.internal` and credential-proxy hosts with `setOutboundByHost()`, but dispatch still depended on the Containers `ContainerProxy` resolving SDK-internal handler names through its outbound handler registry. In catch-all interception scenarios, mount traffic could be routed incorrectly, causing `s3fs` to exit without establishing the mount.

This PR introduces an SDK-owned `ContainerProxy` that directly dispatches SDK-reserved mount hosts to the SDK mount handlers, while preserving normal Containers behavior for all other outbound traffic.

## What changed

- **`packages/sandbox/src/sandbox.ts`**
  - Adds SDK `ContainerProxy extends BaseContainerProxy`
  - Directly handles SDK mount hosts:
    - `r2.internal` → `r2EgressHandler`
    - credential-proxy hosts → `s3CredentialProxyHandler`
  - Falls back to `super.fetch(request)` for all non-SDK outbound traffic
  - Clarifies comments around `setOutboundByHost()` validation vs actual proxy dispatch

- **`packages/sandbox/src/index.ts`**
  - Exports the SDK `ContainerProxy` instead of re-exporting it from `@cloudflare/containers`

## Stack

This PR is stacked on top of #727 and fixes both R2 & S3 handlers (implemented in that PR), but kept separate to avoid bloating #727 


Closes https://github.com/cloudflare/sandbox-sdk/issues/720