### PR TITLE
Consolidate SDK streaming APIs

### DIFF
--- a/.changeset/exec-process-api.md
+++ b/.changeset/exec-process-api.md
@@ -1,0 +1,27 @@
+---
+'@cloudflare/sandbox': minor
+---
+
+Return `ExecProcess` from `exec()` for streaming and buffered access
+
+`sandbox.exec()` and `session.exec()` now return `ExecProcess` instead of `Promise<ExecResult>`. The `ExecProcess` handle provides both streaming and buffered access to command output, aligned with the Containers SDK `ExecProcess` pattern.
+
+Because `ExecProcess` implements `PromiseLike<ExecResult>`, existing code that awaits the result continues to work unchanged:
+
+```ts
+// Existing code — still works, no migration needed
+const result = await sandbox.exec('ls -la');
+console.log(result.stdout);
+
+// Streaming — don't await, use the streams
+const proc = sandbox.exec('tail -f /var/log/app.log');
+for await (const chunk of proc.stdout) { ... }
+
+// Explicit buffered
+const result = await sandbox.exec('ls').output();
+
+// Exit code only
+const exitCode = await sandbox.exec('test -f /config').exitCode;
+```
+
+`execStream()` is now deprecated in favor of `exec().stdout`.

--- a/packages/sandbox/src/bridge/routes.ts
+++ b/packages/sandbox/src/bridge/routes.ts
@@ -533,7 +533,7 @@ export function createBridgeApp(
           closeStream();
         }
       })
-      .catch((err: unknown) => {
+      .then(null, (err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
         writeSSE(
           'error',
@@ -837,7 +837,10 @@ export function createBridgeApp(
       const stream = await sandbox.readFileStream(tmpPath);
 
       // Best-effort cleanup; don't await so we don't delay the response.
-      sandbox.exec(`rm -f ${shellQuote(tmpPath)}`).catch(() => {});
+      sandbox.exec(`rm -f ${shellQuote(tmpPath)}`).then(
+        () => {},
+        () => {}
+      );
 
       return new Response(sseToByteStream(stream), {
         status: 200,

--- a/packages/sandbox/src/exec-process.ts
+++ b/packages/sandbox/src/exec-process.ts
@@ -3,196 +3,56 @@ import type { ExecEvent, ExecProcess, ExecResult } from '@repo/shared';
 import { parseSSEStream } from './sse-parser';
 
 /**
- * Read a ReadableStream<Uint8Array> to completion, returning the decoded text.
+ * Options for creating an {@link ExecProcess}.
+ * @internal
  */
-async function readStreamAsText(
-  stream: ReadableStream<Uint8Array>
-): Promise<string> {
-  const reader = stream.getReader();
-  const decoder = new TextDecoder();
-  let result = '';
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      result += decoder.decode(value, { stream: true });
-    }
-    result += decoder.decode();
-  } finally {
-    reader.releaseLock();
-  }
-  return result;
+export interface ExecProcessOptions {
+  /** Factory that returns the buffered ExecResult (used by output()/then()) */
+  buffered: () => Promise<ExecResult>;
+  /** Factory that returns the SSE stream (used by .stdout/.stderr, started lazily on first read) */
+  stream: () => Promise<ReadableStream<Uint8Array>>;
+  signal?: AbortSignal;
 }
 
 /**
- * Create an {@link ExecProcess} from an SSE event stream (or a promise of one).
- *
- * Accepts either a resolved `ReadableStream` or a `Promise<ReadableStream>`
- * so callers can kick off async setup (session resolution, RPC) and still
- * return `ExecProcess` synchronously. The stdout/stderr TransformStreams are
- * created immediately; the SSE demux starts once the promise resolves.
+ * Create an {@link ExecProcess} that uses the **buffered** exec path for
+ * `output()` / `then()` and the **streaming** SSE path for `.stdout` /
+ * `.stderr`. Each path is started lazily — only when the caller actually
+ * accesses it — so no extra container round-trips happen for the common
+ * `await sandbox.exec(cmd)` case.
  *
  * @internal
  */
-export function createExecProcess(
-  command: string,
-  sseStreamOrPromise:
-    | ReadableStream<Uint8Array>
-    | Promise<ReadableStream<Uint8Array>>,
-  signal?: AbortSignal
-): ExecProcess {
-  const encoder = new TextEncoder();
-  const startTime = Date.now();
-
-  const controllers: {
-    stdout: ReadableStreamDefaultController<Uint8Array> | null;
-    stderr: ReadableStreamDefaultController<Uint8Array> | null;
-  } = { stdout: null, stderr: null };
-
-  let exitCodeResolve!: (code: number) => void;
-  let exitCodeReject!: (err: Error) => void;
-  const exitCodePromise = new Promise<number>((resolve, reject) => {
-    exitCodeResolve = resolve;
-    exitCodeReject = reject;
-  });
-  // Prevent unhandled rejection when exec() is fire-and-forget
-  exitCodePromise.catch(() => {});
-
-  let sessionId: string | undefined;
-  let startTimestamp: string | undefined;
-
-  const stdout = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controllers.stdout = controller;
-    }
-  });
-
-  const stderr = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controllers.stderr = controller;
-    }
-  });
-
-  function closeStreams() {
-    try {
-      controllers.stdout?.close();
-    } catch {
-      // Already closed
-    }
-    try {
-      controllers.stderr?.close();
-    } catch {
-      // Already closed
-    }
-  }
-
-  async function consumeSSE(
-    sseStream: ReadableStream<Uint8Array>
-  ): Promise<void> {
-    for await (const event of parseSSEStream<ExecEvent>(sseStream, signal)) {
-      switch (event.type) {
-        case 'start':
-          sessionId = event.sessionId;
-          startTimestamp = event.timestamp;
-          break;
-
-        case 'stdout':
-          if (event.data && controllers.stdout) {
-            controllers.stdout.enqueue(encoder.encode(event.data));
-          }
-          break;
-
-        case 'stderr':
-          if (event.data && controllers.stderr) {
-            controllers.stderr.enqueue(encoder.encode(event.data));
-          }
-          break;
-
-        case 'complete':
-          closeStreams();
-          exitCodeResolve(event.exitCode ?? 0);
-          return;
-
-        case 'error': {
-          const err = new Error(event.data || 'Command execution failed');
-          closeStreams();
-          exitCodeReject(err);
-          return;
-        }
-      }
-    }
-
-    closeStreams();
-    exitCodeReject(new Error('Stream ended without completion event'));
-  }
-
-  // Kick off the SSE demux in the background. If the input is a promise
-  // (lazy session resolution / RPC), we wait for it first.
-  void Promise.resolve(sseStreamOrPromise)
-    .then((stream) => consumeSSE(stream))
-    .catch((err) => {
-      closeStreams();
-      exitCodeReject(err instanceof Error ? err : new Error(String(err)));
-    });
-
-  return new SandboxExecProcess(
-    stdout,
-    stderr,
-    exitCodePromise,
-    command,
-    startTime,
-    () => startTimestamp,
-    () => sessionId
-  );
+export function createExecProcess(opts: ExecProcessOptions): ExecProcess {
+  return new SandboxExecProcess(opts);
 }
 
 class SandboxExecProcess implements ExecProcess {
-  readonly stdout: ReadableStream<Uint8Array>;
-  readonly stderr: ReadableStream<Uint8Array>;
-  readonly exitCode: Promise<number>;
+  private readonly _opts: ExecProcessOptions;
+  private _streamState: StreamState | null = null;
+  private _bufferedPromise: Promise<ExecResult> | null = null;
 
-  private readonly _command: string;
-  private readonly _startTime: number;
-  private readonly _getStartTimestamp: () => string | undefined;
-  private readonly _getSessionId: () => string | undefined;
+  constructor(opts: ExecProcessOptions) {
+    this._opts = opts;
+  }
 
-  constructor(
-    stdout: ReadableStream<Uint8Array>,
-    stderr: ReadableStream<Uint8Array>,
-    exitCode: Promise<number>,
-    command: string,
-    startTime: number,
-    getStartTimestamp: () => string | undefined,
-    getSessionId: () => string | undefined
-  ) {
-    this.stdout = stdout;
-    this.stderr = stderr;
-    this.exitCode = exitCode;
-    this._command = command;
-    this._startTime = startTime;
-    this._getStartTimestamp = getStartTimestamp;
-    this._getSessionId = getSessionId;
+  get stdout(): ReadableStream<Uint8Array> {
+    return this._ensureStreams().stdout;
+  }
+
+  get stderr(): ReadableStream<Uint8Array> {
+    return this._ensureStreams().stderr;
+  }
+
+  get exitCode(): Promise<number> {
+    return this._ensureStreams().exitCode;
   }
 
   output(): Promise<ExecResult> {
-    return Promise.all([
-      readStreamAsText(this.stdout),
-      readStreamAsText(this.stderr),
-      this.exitCode
-    ]).then(([stdoutText, stderrText, code]) => ({
-      success: code === 0,
-      exitCode: code,
-      // The SSE streaming path appends '\n' per line, while the legacy
-      // buffered path used lines.join('\n') which omits the trailing
-      // newline. Strip it here so output() matches the old ExecResult shape.
-      stdout: stdoutText.replace(/\n$/, ''),
-      stderr: stderrText.replace(/\n$/, ''),
-      command: this._command,
-      duration: Date.now() - this._startTime,
-      timestamp:
-        this._getStartTimestamp() ?? new Date(this._startTime).toISOString(),
-      sessionId: this._getSessionId()
-    }));
+    if (!this._bufferedPromise) {
+      this._bufferedPromise = this._opts.buffered();
+    }
+    return this._bufferedPromise;
   }
 
   // biome-ignore lint/suspicious/noThenProperty: intentional PromiseLike implementation
@@ -204,4 +64,96 @@ class SandboxExecProcess implements ExecProcess {
   ): Promise<TResult1 | TResult2> {
     return this.output().then(onfulfilled, onrejected);
   }
+
+  private _ensureStreams(): StreamState {
+    if (this._streamState) return this._streamState;
+
+    const encoder = new TextEncoder();
+    const controllers: {
+      stdout: ReadableStreamDefaultController<Uint8Array> | null;
+      stderr: ReadableStreamDefaultController<Uint8Array> | null;
+    } = { stdout: null, stderr: null };
+
+    let exitCodeResolve!: (code: number) => void;
+    let exitCodeReject!: (err: Error) => void;
+    const exitCodePromise = new Promise<number>((resolve, reject) => {
+      exitCodeResolve = resolve;
+      exitCodeReject = reject;
+    });
+    exitCodePromise.catch(() => {});
+
+    const stdout = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controllers.stdout = controller;
+      }
+    });
+
+    const stderr = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controllers.stderr = controller;
+      }
+    });
+
+    function closeStreams() {
+      try {
+        controllers.stdout?.close();
+      } catch {
+        // Already closed
+      }
+      try {
+        controllers.stderr?.close();
+      } catch {
+        // Already closed
+      }
+    }
+
+    const signal = this._opts.signal;
+
+    void this._opts
+      .stream()
+      .then(async (sseStream) => {
+        for await (const event of parseSSEStream<ExecEvent>(
+          sseStream,
+          signal
+        )) {
+          switch (event.type) {
+            case 'stdout':
+              if (event.data && controllers.stdout) {
+                controllers.stdout.enqueue(encoder.encode(event.data));
+              }
+              break;
+            case 'stderr':
+              if (event.data && controllers.stderr) {
+                controllers.stderr.enqueue(encoder.encode(event.data));
+              }
+              break;
+            case 'complete':
+              closeStreams();
+              exitCodeResolve(event.exitCode ?? 0);
+              return;
+            case 'error': {
+              const err = new Error(event.data || 'Command execution failed');
+              closeStreams();
+              exitCodeReject(err);
+              return;
+            }
+          }
+        }
+        closeStreams();
+        exitCodeReject(new Error('Stream ended without completion event'));
+      })
+      .catch((err) => {
+        closeStreams();
+        exitCodeReject(err instanceof Error ? err : new Error(String(err)));
+      });
+
+    this._streamState = { stdout, stderr, exitCode: exitCodePromise };
+    return this._streamState;
+  }
+}
+
+interface StreamState {
+  stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+  exitCode: Promise<number>;
 }

--- a/packages/sandbox/src/exec-process.ts
+++ b/packages/sandbox/src/exec-process.ts
@@ -182,8 +182,11 @@ class SandboxExecProcess implements ExecProcess {
     ]).then(([stdoutText, stderrText, code]) => ({
       success: code === 0,
       exitCode: code,
-      stdout: stdoutText,
-      stderr: stderrText,
+      // The SSE streaming path appends '\n' per line, while the legacy
+      // buffered path used lines.join('\n') which omits the trailing
+      // newline. Strip it here so output() matches the old ExecResult shape.
+      stdout: stdoutText.replace(/\n$/, ''),
+      stderr: stderrText.replace(/\n$/, ''),
       command: this._command,
       duration: Date.now() - this._startTime,
       timestamp:

--- a/packages/sandbox/src/exec-process.ts
+++ b/packages/sandbox/src/exec-process.ts
@@ -1,0 +1,204 @@
+import type { ExecEvent, ExecProcess, ExecResult } from '@repo/shared';
+
+import { parseSSEStream } from './sse-parser';
+
+/**
+ * Read a ReadableStream<Uint8Array> to completion, returning the decoded text.
+ */
+async function readStreamAsText(
+  stream: ReadableStream<Uint8Array>
+): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let result = '';
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      result += decoder.decode(value, { stream: true });
+    }
+    result += decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+  return result;
+}
+
+/**
+ * Create an {@link ExecProcess} from an SSE event stream (or a promise of one).
+ *
+ * Accepts either a resolved `ReadableStream` or a `Promise<ReadableStream>`
+ * so callers can kick off async setup (session resolution, RPC) and still
+ * return `ExecProcess` synchronously. The stdout/stderr TransformStreams are
+ * created immediately; the SSE demux starts once the promise resolves.
+ *
+ * @internal
+ */
+export function createExecProcess(
+  command: string,
+  sseStreamOrPromise:
+    | ReadableStream<Uint8Array>
+    | Promise<ReadableStream<Uint8Array>>,
+  signal?: AbortSignal
+): ExecProcess {
+  const encoder = new TextEncoder();
+  const startTime = Date.now();
+
+  const controllers: {
+    stdout: ReadableStreamDefaultController<Uint8Array> | null;
+    stderr: ReadableStreamDefaultController<Uint8Array> | null;
+  } = { stdout: null, stderr: null };
+
+  let exitCodeResolve!: (code: number) => void;
+  let exitCodeReject!: (err: Error) => void;
+  const exitCodePromise = new Promise<number>((resolve, reject) => {
+    exitCodeResolve = resolve;
+    exitCodeReject = reject;
+  });
+  // Prevent unhandled rejection when exec() is fire-and-forget
+  exitCodePromise.catch(() => {});
+
+  let sessionId: string | undefined;
+  let startTimestamp: string | undefined;
+
+  const stdout = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controllers.stdout = controller;
+    }
+  });
+
+  const stderr = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controllers.stderr = controller;
+    }
+  });
+
+  function closeStreams() {
+    try {
+      controllers.stdout?.close();
+    } catch {
+      // Already closed
+    }
+    try {
+      controllers.stderr?.close();
+    } catch {
+      // Already closed
+    }
+  }
+
+  async function consumeSSE(
+    sseStream: ReadableStream<Uint8Array>
+  ): Promise<void> {
+    for await (const event of parseSSEStream<ExecEvent>(sseStream, signal)) {
+      switch (event.type) {
+        case 'start':
+          sessionId = event.sessionId;
+          startTimestamp = event.timestamp;
+          break;
+
+        case 'stdout':
+          if (event.data && controllers.stdout) {
+            controllers.stdout.enqueue(encoder.encode(event.data));
+          }
+          break;
+
+        case 'stderr':
+          if (event.data && controllers.stderr) {
+            controllers.stderr.enqueue(encoder.encode(event.data));
+          }
+          break;
+
+        case 'complete':
+          closeStreams();
+          exitCodeResolve(event.exitCode ?? 0);
+          return;
+
+        case 'error': {
+          const err = new Error(event.data || 'Command execution failed');
+          closeStreams();
+          exitCodeReject(err);
+          return;
+        }
+      }
+    }
+
+    closeStreams();
+    exitCodeReject(new Error('Stream ended without completion event'));
+  }
+
+  // Kick off the SSE demux in the background. If the input is a promise
+  // (lazy session resolution / RPC), we wait for it first.
+  void Promise.resolve(sseStreamOrPromise)
+    .then((stream) => consumeSSE(stream))
+    .catch((err) => {
+      closeStreams();
+      exitCodeReject(err instanceof Error ? err : new Error(String(err)));
+    });
+
+  return new SandboxExecProcess(
+    stdout,
+    stderr,
+    exitCodePromise,
+    command,
+    startTime,
+    () => startTimestamp,
+    () => sessionId
+  );
+}
+
+class SandboxExecProcess implements ExecProcess {
+  readonly stdout: ReadableStream<Uint8Array>;
+  readonly stderr: ReadableStream<Uint8Array>;
+  readonly exitCode: Promise<number>;
+
+  private readonly _command: string;
+  private readonly _startTime: number;
+  private readonly _getStartTimestamp: () => string | undefined;
+  private readonly _getSessionId: () => string | undefined;
+
+  constructor(
+    stdout: ReadableStream<Uint8Array>,
+    stderr: ReadableStream<Uint8Array>,
+    exitCode: Promise<number>,
+    command: string,
+    startTime: number,
+    getStartTimestamp: () => string | undefined,
+    getSessionId: () => string | undefined
+  ) {
+    this.stdout = stdout;
+    this.stderr = stderr;
+    this.exitCode = exitCode;
+    this._command = command;
+    this._startTime = startTime;
+    this._getStartTimestamp = getStartTimestamp;
+    this._getSessionId = getSessionId;
+  }
+
+  output(): Promise<ExecResult> {
+    return Promise.all([
+      readStreamAsText(this.stdout),
+      readStreamAsText(this.stderr),
+      this.exitCode
+    ]).then(([stdoutText, stderrText, code]) => ({
+      success: code === 0,
+      exitCode: code,
+      stdout: stdoutText,
+      stderr: stderrText,
+      command: this._command,
+      duration: Date.now() - this._startTime,
+      timestamp:
+        this._getStartTimestamp() ?? new Date(this._startTime).toISOString(),
+      sessionId: this._getSessionId()
+    }));
+  }
+
+  // biome-ignore lint/suspicious/noThenProperty: intentional PromiseLike implementation
+  then<TResult1 = ExecResult, TResult2 = never>(
+    onfulfilled?:
+      | ((value: ExecResult) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): Promise<TResult1 | TResult2> {
+    return this.output().then(onfulfilled, onrejected);
+  }
+}

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -11,6 +11,7 @@ export {
   SandboxClient,
   UtilityClient
 } from './clients';
+export { createExecProcess } from './exec-process';
 export { getSandbox, Sandbox } from './sandbox';
 
 // Legacy types are now imported from the new client architecture
@@ -28,6 +29,7 @@ export type {
   DirectoryBackup,
   ExecEvent,
   ExecOptions,
+  ExecProcess,
   ExecResult,
   ExecutionResult,
   ExecutionSession,

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -678,16 +678,26 @@ export function getSandbox<T extends Sandbox<any>>(
   // to ensure the returned session uses proxyTerminal instead of RPC's terminal.
   const enhancedMethods = {
     fetch: (request: Request) => stub.fetch(request),
-    exec: (command: string, execOptions?: ExecOptions) => {
-      const streamPromise = useDefaultSession
-        ? stub.execStream(command, execOptions)
-        : stub.execStreamWithSessionToken(
-            command,
-            DISABLE_SESSION_TOKEN,
-            execOptions
-          );
-      return createExecProcess(command, streamPromise, execOptions?.signal);
-    },
+    exec: (command: string, execOptions?: ExecOptions) =>
+      createExecProcess({
+        buffered: () =>
+          useDefaultSession
+            ? stub.exec(command, execOptions).then((r) => r)
+            : stub.execWithSessionToken(
+                command,
+                DISABLE_SESSION_TOKEN,
+                execOptions
+              ),
+        stream: () =>
+          useDefaultSession
+            ? stub.execStream(command, execOptions)
+            : stub.execStreamWithSessionToken(
+                command,
+                DISABLE_SESSION_TOKEN,
+                execOptions
+              ),
+        signal: execOptions?.signal
+      }),
     startProcess: (command: string, processOptions?: ProcessOptions) =>
       useDefaultSession || processOptions?.sessionId !== undefined
         ? stub.startProcess(command, processOptions)
@@ -3711,11 +3721,20 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   }
 
   exec(command: string, options?: ExecOptions): ExecProcess {
-    const streamPromise = this.resolveExecution().then((context) => {
-      const session = this.serializeExecutionContext(context);
-      return this.execStreamWithSession(command, session, options);
+    const sessionPromise = this.resolveExecution().then((context) =>
+      this.serializeExecutionContext(context)
+    );
+    return createExecProcess({
+      buffered: () =>
+        sessionPromise.then((session) =>
+          this.execWithSession(command, session, options)
+        ),
+      stream: () =>
+        sessionPromise.then((session) =>
+          this.execStreamWithSession(command, session, options)
+        ),
+      signal: options?.signal
     });
-    return createExecProcess(command, streamPromise, options?.signal);
   }
 
   async execWithSessionToken(
@@ -5540,14 +5559,12 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       id: sessionId,
       terminal: null as unknown as ExecutionSession['terminal'],
 
-      exec: (command, options) => {
-        const streamPromise = this.execStreamWithSession(
-          command,
-          sessionId,
-          options
-        );
-        return createExecProcess(command, streamPromise, options?.signal);
-      },
+      exec: (command, options) =>
+        createExecProcess({
+          buffered: () => this.execWithSession(command, sessionId, options),
+          stream: () => this.execStreamWithSession(command, sessionId, options),
+          signal: options?.signal
+        }),
       execStream: (command, options) =>
         this.execStreamWithSession(command, sessionId, options),
 

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -16,6 +16,7 @@ import type {
   DirectoryBackup,
   ExecEvent,
   ExecOptions,
+  ExecProcess,
   ExecResult,
   ExecutionResult,
   ExecutionSession,
@@ -83,6 +84,7 @@ import {
   SandboxError,
   SessionAlreadyExistsError
 } from './errors';
+import { createExecProcess } from './exec-process';
 import { collectFile, streamFile } from './file-stream';
 import { CodeInterpreter } from './interpreter';
 import { LocalMountSyncManager } from './local-mount-sync';
@@ -676,14 +678,16 @@ export function getSandbox<T extends Sandbox<any>>(
   // to ensure the returned session uses proxyTerminal instead of RPC's terminal.
   const enhancedMethods = {
     fetch: (request: Request) => stub.fetch(request),
-    exec: (command: string, execOptions?: ExecOptions) =>
-      useDefaultSession
-        ? stub.exec(command, execOptions)
-        : stub.execWithSessionToken(
+    exec: (command: string, execOptions?: ExecOptions) => {
+      const streamPromise = useDefaultSession
+        ? stub.execStream(command, execOptions)
+        : stub.execStreamWithSessionToken(
             command,
             DISABLE_SESSION_TOKEN,
             execOptions
-          ),
+          );
+      return createExecProcess(command, streamPromise, execOptions?.signal);
+    },
     startProcess: (command: string, processOptions?: ProcessOptions) =>
       useDefaultSession || processOptions?.sessionId !== undefined
         ? stub.startProcess(command, processOptions)
@@ -3706,10 +3710,12 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     };
   }
 
-  async exec(command: string, options?: ExecOptions): Promise<ExecResult> {
-    const context = await this.resolveExecution();
-    const session = this.serializeExecutionContext(context);
-    return this.execWithSession(command, session, options);
+  exec(command: string, options?: ExecOptions): ExecProcess {
+    const streamPromise = this.resolveExecution().then((context) => {
+      const session = this.serializeExecutionContext(context);
+      return this.execStreamWithSession(command, session, options);
+    });
+    return createExecProcess(command, streamPromise, options?.signal);
   }
 
   async execWithSessionToken(
@@ -5534,8 +5540,14 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       id: sessionId,
       terminal: null as unknown as ExecutionSession['terminal'],
 
-      exec: (command, options) =>
-        this.execWithSession(command, sessionId, options),
+      exec: (command, options) => {
+        const streamPromise = this.execStreamWithSession(
+          command,
+          sessionId,
+          options
+        );
+        return createExecProcess(command, streamPromise, options?.signal);
+      },
       execStream: (command, options) =>
         this.execStreamWithSession(command, sessionId, options),
 

--- a/packages/sandbox/tests/exec-process.test.ts
+++ b/packages/sandbox/tests/exec-process.test.ts
@@ -1,0 +1,215 @@
+import type { ExecEvent, ExecResult } from '@repo/shared';
+import { describe, expect, it } from 'vitest';
+import { createExecProcess } from '../src/exec-process';
+
+function createSSEStream(events: ExecEvent[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify(event)}\n\n`)
+        );
+      }
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+      controller.close();
+    }
+  });
+}
+
+function stdEvents(opts: {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+}): ExecEvent[] {
+  const ts = new Date().toISOString();
+  const events: ExecEvent[] = [
+    { type: 'start', timestamp: ts, pid: 42, sessionId: 'sess-1' }
+  ];
+  if (opts.stdout != null) {
+    events.push({ type: 'stdout', data: opts.stdout, timestamp: ts });
+  }
+  if (opts.stderr != null) {
+    events.push({ type: 'stderr', data: opts.stderr, timestamp: ts });
+  }
+  events.push({
+    type: 'complete',
+    exitCode: opts.exitCode ?? 0,
+    timestamp: ts
+  });
+  return events;
+}
+
+describe('createExecProcess', () => {
+  describe('output()', () => {
+    it('buffers stdout and stderr into ExecResult', async () => {
+      const proc = createExecProcess(
+        'echo hello',
+        createSSEStream(stdEvents({ stdout: 'hello\n', stderr: 'warn\n' }))
+      );
+      const result = await proc.output();
+
+      expect(result.stdout).toBe('hello\n');
+      expect(result.stderr).toBe('warn\n');
+      expect(result.exitCode).toBe(0);
+      expect(result.success).toBe(true);
+      expect(result.command).toBe('echo hello');
+      expect(result.sessionId).toBe('sess-1');
+      expect(result.duration).toBeGreaterThanOrEqual(0);
+      expect(result.timestamp).toBeTruthy();
+    });
+
+    it('reports failure for non-zero exit code', async () => {
+      const proc = createExecProcess(
+        'false',
+        createSSEStream(stdEvents({ exitCode: 1 }))
+      );
+      const result = await proc.output();
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('handles empty stdout and stderr', async () => {
+      const proc = createExecProcess('true', createSSEStream(stdEvents({})));
+      const result = await proc.output();
+
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toBe('');
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe('PromiseLike (then)', () => {
+    it('resolves to ExecResult when awaited', async () => {
+      const proc = createExecProcess(
+        'echo hi',
+        createSSEStream(stdEvents({ stdout: 'hi\n' }))
+      );
+      const result: ExecResult = await proc;
+
+      expect(result.stdout).toBe('hi\n');
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('supports .then() chaining', async () => {
+      const proc = createExecProcess(
+        'echo chain',
+        createSSEStream(stdEvents({ stdout: 'chain\n' }))
+      );
+      const stdout = await proc.then((r) => r.stdout);
+
+      expect(stdout).toBe('chain\n');
+    });
+
+    it('supports .then(null, onRejected) for errors', async () => {
+      const ts = new Date().toISOString();
+      const proc = createExecProcess(
+        'bad',
+        createSSEStream([
+          { type: 'start', timestamp: ts },
+          { type: 'error', data: 'kaboom', timestamp: ts }
+        ])
+      );
+      const err = await proc.then(
+        () => null,
+        (e) => e
+      );
+
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toBe('kaboom');
+    });
+  });
+
+  describe('exitCode', () => {
+    it('resolves with exit code from complete event', async () => {
+      const proc = createExecProcess(
+        'exit 42',
+        createSSEStream(stdEvents({ exitCode: 42 }))
+      );
+      await expect(proc.exitCode).resolves.toBe(42);
+    });
+
+    it('rejects on error event', async () => {
+      const ts = new Date().toISOString();
+      const proc = createExecProcess(
+        'fail',
+        createSSEStream([
+          { type: 'start', timestamp: ts },
+          { type: 'error', data: 'oops', timestamp: ts }
+        ])
+      );
+      await expect(proc.exitCode).rejects.toThrow('oops');
+    });
+
+    it('rejects when stream ends without completion', async () => {
+      const proc = createExecProcess(
+        'hang',
+        createSSEStream([
+          { type: 'start', timestamp: new Date().toISOString() }
+        ])
+      );
+      await expect(proc.exitCode).rejects.toThrow(
+        'Stream ended without completion event'
+      );
+    });
+  });
+
+  describe('stdout / stderr streams', () => {
+    it('demuxes stdout and stderr into separate streams', async () => {
+      const proc = createExecProcess(
+        'mixed',
+        createSSEStream(stdEvents({ stdout: 'out-data', stderr: 'err-data' }))
+      );
+
+      const decoder = new TextDecoder();
+      const stdoutChunks: string[] = [];
+      const stderrChunks: string[] = [];
+
+      const [stdoutReader, stderrReader] = [
+        proc.stdout.getReader(),
+        proc.stderr.getReader()
+      ];
+
+      for (;;) {
+        const { done, value } = await stdoutReader.read();
+        if (done) break;
+        stdoutChunks.push(decoder.decode(value));
+      }
+      for (;;) {
+        const { done, value } = await stderrReader.read();
+        if (done) break;
+        stderrChunks.push(decoder.decode(value));
+      }
+
+      expect(stdoutChunks.join('')).toBe('out-data');
+      expect(stderrChunks.join('')).toBe('err-data');
+    });
+  });
+
+  describe('lazy promise input', () => {
+    it('accepts a Promise<ReadableStream> for deferred setup', async () => {
+      const streamPromise = Promise.resolve(
+        createSSEStream(stdEvents({ stdout: 'lazy\n' }))
+      );
+      const proc = createExecProcess('echo lazy', streamPromise);
+      const result = await proc;
+
+      expect(result.stdout).toBe('lazy\n');
+    });
+
+    it('propagates setup rejection through exitCode', async () => {
+      const streamPromise = Promise.reject(new Error('setup failed'));
+      const proc = createExecProcess('fail', streamPromise);
+
+      await expect(proc.exitCode).rejects.toThrow('setup failed');
+    });
+
+    it('propagates setup rejection through then()', async () => {
+      const streamPromise = Promise.reject(new Error('rpc down'));
+      const proc = createExecProcess('fail', streamPromise);
+
+      await expect(proc.then((r) => r)).rejects.toThrow('rpc down');
+    });
+  });
+});

--- a/packages/sandbox/tests/exec-process.test.ts
+++ b/packages/sandbox/tests/exec-process.test.ts
@@ -49,8 +49,8 @@ describe('createExecProcess', () => {
       );
       const result = await proc.output();
 
-      expect(result.stdout).toBe('hello\n');
-      expect(result.stderr).toBe('warn\n');
+      expect(result.stdout).toBe('hello');
+      expect(result.stderr).toBe('warn');
       expect(result.exitCode).toBe(0);
       expect(result.success).toBe(true);
       expect(result.command).toBe('echo hello');
@@ -88,7 +88,7 @@ describe('createExecProcess', () => {
       );
       const result: ExecResult = await proc;
 
-      expect(result.stdout).toBe('hi\n');
+      expect(result.stdout).toBe('hi');
       expect(result.exitCode).toBe(0);
     });
 
@@ -99,7 +99,7 @@ describe('createExecProcess', () => {
       );
       const stdout = await proc.then((r) => r.stdout);
 
-      expect(stdout).toBe('chain\n');
+      expect(stdout).toBe('chain');
     });
 
     it('supports .then(null, onRejected) for errors', async () => {
@@ -195,7 +195,7 @@ describe('createExecProcess', () => {
       const proc = createExecProcess('echo lazy', streamPromise);
       const result = await proc;
 
-      expect(result.stdout).toBe('lazy\n');
+      expect(result.stdout).toBe('lazy');
     });
 
     it('propagates setup rejection through exitCode', async () => {

--- a/packages/sandbox/tests/exec-process.test.ts
+++ b/packages/sandbox/tests/exec-process.test.ts
@@ -1,6 +1,33 @@
-import type { ExecEvent, ExecResult } from '@repo/shared';
+import type { ExecEvent, ExecProcess, ExecResult } from '@repo/shared';
 import { describe, expect, it } from 'vitest';
 import { createExecProcess } from '../src/exec-process';
+
+function mockProcess(events: ExecEvent[]): ExecProcess {
+  return createExecProcess({
+    buffered: async () => {
+      let stdout = '';
+      let stderr = '';
+      let exitCode = 0;
+      for (const e of events) {
+        if (e.type === 'stdout' && e.data) stdout += e.data;
+        if (e.type === 'stderr' && e.data) stderr += e.data;
+        if (e.type === 'complete') exitCode = e.exitCode ?? 0;
+        if (e.type === 'error')
+          throw new Error(e.data || 'Command execution failed');
+      }
+      return {
+        success: exitCode === 0,
+        exitCode,
+        stdout,
+        stderr,
+        command: '',
+        duration: 0,
+        timestamp: ''
+      };
+    },
+    stream: () => Promise.resolve(createSSEStream(events))
+  });
+}
 
 function createSSEStream(events: ExecEvent[]): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
@@ -41,29 +68,21 @@ function stdEvents(opts: {
 }
 
 describe('createExecProcess', () => {
-  describe('output()', () => {
-    it('buffers stdout and stderr into ExecResult', async () => {
-      const proc = createExecProcess(
-        'echo hello',
-        createSSEStream(stdEvents({ stdout: 'hello\n', stderr: 'warn\n' }))
+  describe('output() — buffered path', () => {
+    it('returns the buffered ExecResult', async () => {
+      const proc = mockProcess(
+        stdEvents({ stdout: 'hello\n', stderr: 'warn\n' })
       );
       const result = await proc.output();
 
-      expect(result.stdout).toBe('hello');
-      expect(result.stderr).toBe('warn');
+      expect(result.stdout).toBe('hello\n');
+      expect(result.stderr).toBe('warn\n');
       expect(result.exitCode).toBe(0);
       expect(result.success).toBe(true);
-      expect(result.command).toBe('echo hello');
-      expect(result.sessionId).toBe('sess-1');
-      expect(result.duration).toBeGreaterThanOrEqual(0);
-      expect(result.timestamp).toBeTruthy();
     });
 
     it('reports failure for non-zero exit code', async () => {
-      const proc = createExecProcess(
-        'false',
-        createSSEStream(stdEvents({ exitCode: 1 }))
-      );
+      const proc = mockProcess(stdEvents({ exitCode: 1 }));
       const result = await proc.output();
 
       expect(result.success).toBe(false);
@@ -71,7 +90,7 @@ describe('createExecProcess', () => {
     });
 
     it('handles empty stdout and stderr', async () => {
-      const proc = createExecProcess('true', createSSEStream(stdEvents({})));
+      const proc = mockProcess(stdEvents({}));
       const result = await proc.output();
 
       expect(result.stdout).toBe('');
@@ -80,37 +99,28 @@ describe('createExecProcess', () => {
     });
   });
 
-  describe('PromiseLike (then)', () => {
+  describe('PromiseLike (then) — uses buffered path', () => {
     it('resolves to ExecResult when awaited', async () => {
-      const proc = createExecProcess(
-        'echo hi',
-        createSSEStream(stdEvents({ stdout: 'hi\n' }))
-      );
+      const proc = mockProcess(stdEvents({ stdout: 'hi\n' }));
       const result: ExecResult = await proc;
 
-      expect(result.stdout).toBe('hi');
+      expect(result.stdout).toBe('hi\n');
       expect(result.exitCode).toBe(0);
     });
 
     it('supports .then() chaining', async () => {
-      const proc = createExecProcess(
-        'echo chain',
-        createSSEStream(stdEvents({ stdout: 'chain\n' }))
-      );
+      const proc = mockProcess(stdEvents({ stdout: 'chain\n' }));
       const stdout = await proc.then((r) => r.stdout);
 
-      expect(stdout).toBe('chain');
+      expect(stdout).toBe('chain\n');
     });
 
     it('supports .then(null, onRejected) for errors', async () => {
       const ts = new Date().toISOString();
-      const proc = createExecProcess(
-        'bad',
-        createSSEStream([
-          { type: 'start', timestamp: ts },
-          { type: 'error', data: 'kaboom', timestamp: ts }
-        ])
-      );
+      const proc = mockProcess([
+        { type: 'start', timestamp: ts },
+        { type: 'error', data: 'kaboom', timestamp: ts }
+      ]);
       const err = await proc.then(
         () => null,
         (e) => e
@@ -121,45 +131,35 @@ describe('createExecProcess', () => {
     });
   });
 
-  describe('exitCode', () => {
+  describe('exitCode — streaming path', () => {
     it('resolves with exit code from complete event', async () => {
-      const proc = createExecProcess(
-        'exit 42',
-        createSSEStream(stdEvents({ exitCode: 42 }))
-      );
+      const proc = mockProcess(stdEvents({ exitCode: 42 }));
       await expect(proc.exitCode).resolves.toBe(42);
     });
 
     it('rejects on error event', async () => {
       const ts = new Date().toISOString();
-      const proc = createExecProcess(
-        'fail',
-        createSSEStream([
-          { type: 'start', timestamp: ts },
-          { type: 'error', data: 'oops', timestamp: ts }
-        ])
-      );
+      const proc = mockProcess([
+        { type: 'start', timestamp: ts },
+        { type: 'error', data: 'oops', timestamp: ts }
+      ]);
       await expect(proc.exitCode).rejects.toThrow('oops');
     });
 
     it('rejects when stream ends without completion', async () => {
-      const proc = createExecProcess(
-        'hang',
-        createSSEStream([
-          { type: 'start', timestamp: new Date().toISOString() }
-        ])
-      );
+      const proc = mockProcess([
+        { type: 'start', timestamp: new Date().toISOString() }
+      ]);
       await expect(proc.exitCode).rejects.toThrow(
         'Stream ended without completion event'
       );
     });
   });
 
-  describe('stdout / stderr streams', () => {
+  describe('stdout / stderr — streaming path', () => {
     it('demuxes stdout and stderr into separate streams', async () => {
-      const proc = createExecProcess(
-        'mixed',
-        createSSEStream(stdEvents({ stdout: 'out-data', stderr: 'err-data' }))
+      const proc = mockProcess(
+        stdEvents({ stdout: 'out-data', stderr: 'err-data' })
       );
 
       const decoder = new TextDecoder();
@@ -187,29 +187,21 @@ describe('createExecProcess', () => {
     });
   });
 
-  describe('lazy promise input', () => {
-    it('accepts a Promise<ReadableStream> for deferred setup', async () => {
-      const streamPromise = Promise.resolve(
-        createSSEStream(stdEvents({ stdout: 'lazy\n' }))
-      );
-      const proc = createExecProcess('echo lazy', streamPromise);
-      const result = await proc;
-
-      expect(result.stdout).toBe('lazy');
-    });
-
-    it('propagates setup rejection through exitCode', async () => {
-      const streamPromise = Promise.reject(new Error('setup failed'));
-      const proc = createExecProcess('fail', streamPromise);
-
-      await expect(proc.exitCode).rejects.toThrow('setup failed');
-    });
-
-    it('propagates setup rejection through then()', async () => {
-      const streamPromise = Promise.reject(new Error('rpc down'));
-      const proc = createExecProcess('fail', streamPromise);
-
+  describe('error propagation', () => {
+    it('propagates buffered rejection through then()', async () => {
+      const proc = createExecProcess({
+        buffered: () => Promise.reject(new Error('rpc down')),
+        stream: () => Promise.resolve(createSSEStream([]))
+      });
       await expect(proc.then((r) => r)).rejects.toThrow('rpc down');
+    });
+
+    it('propagates stream rejection through exitCode', async () => {
+      const proc = createExecProcess({
+        buffered: () => Promise.resolve({} as ExecResult),
+        stream: () => Promise.reject(new Error('stream failed'))
+      });
+      await expect(proc.exitCode).rejects.toThrow('stream failed');
     });
   });
 });

--- a/packages/sandbox/tests/openai-shell-editor.test.ts
+++ b/packages/sandbox/tests/openai-shell-editor.test.ts
@@ -1,7 +1,20 @@
 import type { ApplyPatchOperation } from '@openai/agents';
+import type { ExecProcess, ExecResult } from '@repo/shared';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Editor, Shell } from '../src/openai/index';
 import type { Sandbox } from '../src/sandbox';
+
+function mockExecProcess(result: ExecResult): ExecProcess {
+  return {
+    stdout: new ReadableStream(),
+    stderr: new ReadableStream(),
+    exitCode: Promise.resolve(result.exitCode),
+    output: () => Promise.resolve(result),
+    // biome-ignore lint/suspicious/noThenProperty: intentional PromiseLike mock
+    then: (onFulfilled, onRejected) =>
+      Promise.resolve(result).then(onFulfilled, onRejected)
+  };
+}
 
 interface MockSandbox {
   exec?: ReturnType<typeof vi.fn>;
@@ -41,11 +54,17 @@ describe('Shell', () => {
   });
 
   it('runs commands and collects results', async () => {
-    const execMock = vi.fn().mockResolvedValue({
-      stdout: 'hello\n',
-      stderr: '',
-      exitCode: 0
-    });
+    const execMock = vi.fn().mockImplementation(() =>
+      mockExecProcess({
+        stdout: 'hello\n',
+        stderr: '',
+        exitCode: 0,
+        success: true,
+        command: 'echo hello',
+        duration: 0,
+        timestamp: new Date().toISOString()
+      })
+    );
 
     const mockSandbox: MockSandbox = { exec: execMock };
     const shell = new Shell(mockSandbox as unknown as Sandbox);

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -112,6 +112,49 @@ interface MockCtx {
   };
 }
 
+/**
+ * Create a mock SSE ReadableStream that emits ExecEvent-shaped data.
+ * Used to mock `client.commands.executeStream` for tests that exercise
+ * the new ExecProcess-based `exec()`.
+ */
+function createMockSSEStream(
+  opts: {
+    stdout?: string;
+    stderr?: string;
+    exitCode?: number;
+    command?: string;
+  } = {}
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  const events: string[] = [];
+  events.push(
+    `data: ${JSON.stringify({ type: 'start', timestamp: new Date().toISOString(), pid: 1 })}\n\n`
+  );
+  if (opts.stdout) {
+    events.push(
+      `data: ${JSON.stringify({ type: 'stdout', data: opts.stdout, timestamp: new Date().toISOString() })}\n\n`
+    );
+  }
+  if (opts.stderr) {
+    events.push(
+      `data: ${JSON.stringify({ type: 'stderr', data: opts.stderr, timestamp: new Date().toISOString() })}\n\n`
+    );
+  }
+  events.push(
+    `data: ${JSON.stringify({ type: 'complete', exitCode: opts.exitCode ?? 0, timestamp: new Date().toISOString() })}\n\n`
+  );
+  events.push('data: [DONE]\n\n');
+
+  return new ReadableStream({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(encoder.encode(event));
+      }
+      controller.close();
+    }
+  });
+}
+
 const PREVIEW_TEST_PORT = 8080;
 const PREVIEW_TEST_TOKEN = 'token12345678901';
 const PREVIEW_TEST_RUNTIME_ID = 'runtime-1';
@@ -260,6 +303,10 @@ describe('Sandbox - Automatic Session Management', () => {
       timestamp: new Date().toISOString()
     } as any);
 
+    vi.spyOn(sandbox.client.commands, 'executeStream').mockImplementation(() =>
+      Promise.resolve(createMockSSEStream())
+    );
+
     vi.spyOn(sandbox.client.files, 'writeFile').mockResolvedValue({
       success: true,
       path: '/test.txt',
@@ -280,15 +327,6 @@ describe('Sandbox - Automatic Session Management', () => {
 
   describe('default session management', () => {
     it('should create default session on first operation', async () => {
-      vi.mocked(sandbox.client.commands.execute).mockResolvedValueOnce({
-        success: true,
-        stdout: 'test output',
-        stderr: '',
-        exitCode: 0,
-        command: 'echo test',
-        timestamp: new Date().toISOString()
-      } as any);
-
       await sandbox.exec('echo test');
 
       expect(sandbox.client.utils.createSession).toHaveBeenCalledTimes(1);
@@ -299,7 +337,7 @@ describe('Sandbox - Automatic Session Management', () => {
         })
       );
 
-      expect(sandbox.client.commands.execute).toHaveBeenCalledWith(
+      expect(sandbox.client.commands.executeStream).toHaveBeenCalledWith(
         'echo test',
         expect.stringMatching(/^sandbox-/),
         undefined
@@ -354,14 +392,10 @@ describe('Sandbox - Automatic Session Management', () => {
         message: 'Created'
       } as any);
 
-      vi.spyOn(freshSandbox.client.commands, 'execute').mockResolvedValue({
-        success: true,
-        stdout: 'test output',
-        stderr: '',
-        exitCode: 0,
-        command: 'echo test',
-        timestamp: new Date().toISOString()
-      } as any);
+      vi.spyOn(
+        freshSandbox.client.commands,
+        'executeStream'
+      ).mockImplementation(() => Promise.resolve(createMockSSEStream()));
 
       await freshSandbox.exec('echo test');
 
@@ -369,7 +403,7 @@ describe('Sandbox - Automatic Session Management', () => {
         'enableDefaultSession'
       );
       expect(freshSandbox.client.utils.createSession).toHaveBeenCalledTimes(1);
-      expect(freshSandbox.client.commands.execute).toHaveBeenCalledWith(
+      expect(freshSandbox.client.commands.executeStream).toHaveBeenCalledWith(
         'echo test',
         expect.stringMatching(/^sandbox-/),
         undefined
@@ -383,7 +417,7 @@ describe('Sandbox - Automatic Session Management', () => {
         timeout: 5000
       });
 
-      expect(sandbox.client.commands.execute).toHaveBeenCalledWith(
+      expect(sandbox.client.commands.executeStream).toHaveBeenCalledWith(
         'echo $OPTION',
         expect.stringMatching(/^sandbox-/),
         {
@@ -572,12 +606,12 @@ describe('Sandbox - Automatic Session Management', () => {
 
       expect(sandbox.client.utils.createSession).toHaveBeenCalledTimes(1);
 
-      const firstSessionId = vi.mocked(sandbox.client.commands.execute).mock
-        .calls[0][1];
+      const firstSessionId = vi.mocked(sandbox.client.commands.executeStream)
+        .mock.calls[0][1];
       const fileSessionId = vi.mocked(sandbox.client.files.writeFile).mock
         .calls[0][2];
-      const secondSessionId = vi.mocked(sandbox.client.commands.execute).mock
-        .calls[1][1];
+      const secondSessionId = vi.mocked(sandbox.client.commands.executeStream)
+        .mock.calls[1][1];
 
       expect(firstSessionId).toBe(fileSessionId);
       expect(firstSessionId).toBe(secondSessionId);
@@ -851,7 +885,7 @@ describe('Sandbox - Automatic Session Management', () => {
       await Promise.all([first, second, third]);
 
       expect(sandbox.client.utils.createSession).toHaveBeenCalledTimes(2);
-      const calls = vi.mocked(sandbox.client.commands.execute).mock.calls;
+      const calls = vi.mocked(sandbox.client.commands.executeStream).mock.calls;
       expect(calls[0][1]).toBe('sandbox-default');
       expect(calls[1][1]).toBe('sandbox-renamed');
       expect(calls[2][1]).toBe('sandbox-renamed');
@@ -912,14 +946,12 @@ describe('Sandbox - Automatic Session Management', () => {
       (sandbox as unknown as { defaultSession: string }).defaultSession =
         'sandbox-default';
 
-      vi.mocked(sandbox.client.commands.execute).mockResolvedValueOnce({
-        success: true,
-        stdout: 'sessionless',
-        stderr: '',
-        exitCode: 0,
-        command: 'printf sessionless',
-        timestamp: new Date().toISOString()
-      } as never);
+      vi.mocked(sandbox.client.commands.executeStream).mockResolvedValueOnce(
+        createMockSSEStream({
+          stdout: 'sessionless',
+          command: 'printf sessionless'
+        })
+      );
 
       const result = await sandbox.exec('printf sessionless');
 
@@ -995,7 +1027,7 @@ describe('Sandbox - Automatic Session Management', () => {
 
       await session.exec('echo test');
 
-      expect(sandbox.client.commands.execute).toHaveBeenCalledWith(
+      expect(sandbox.client.commands.executeStream).toHaveBeenCalledWith(
         'echo test',
         'isolated-session',
         undefined
@@ -1021,9 +1053,9 @@ describe('Sandbox - Automatic Session Management', () => {
       await session1.exec('echo build');
       await session2.exec('echo test');
 
-      const session1Id = vi.mocked(sandbox.client.commands.execute).mock
+      const session1Id = vi.mocked(sandbox.client.commands.executeStream).mock
         .calls[0][1];
-      const session2Id = vi.mocked(sandbox.client.commands.execute).mock
+      const session2Id = vi.mocked(sandbox.client.commands.executeStream).mock
         .calls[1][1];
 
       expect(session1Id).toBe('session-1');
@@ -1053,12 +1085,12 @@ describe('Sandbox - Automatic Session Management', () => {
 
       await sandbox.exec('echo default-again');
 
-      const defaultSessionId1 = vi.mocked(sandbox.client.commands.execute).mock
-        .calls[0][1];
-      const explicitSessionId = vi.mocked(sandbox.client.commands.execute).mock
-        .calls[1][1];
-      const defaultSessionId2 = vi.mocked(sandbox.client.commands.execute).mock
-        .calls[2][1];
+      const defaultSessionId1 = vi.mocked(sandbox.client.commands.executeStream)
+        .mock.calls[0][1];
+      const explicitSessionId = vi.mocked(sandbox.client.commands.executeStream)
+        .mock.calls[1][1];
+      const defaultSessionId2 = vi.mocked(sandbox.client.commands.executeStream)
+        .mock.calls[2][1];
 
       expect(defaultSessionId1).toBe('sandbox-default');
       expect(explicitSessionId).toBe('explicit-session');
@@ -1165,7 +1197,7 @@ describe('Sandbox - Automatic Session Management', () => {
 
     it('should execute command with session context', async () => {
       await session.exec('pwd');
-      expect(sandbox.client.commands.execute).toHaveBeenCalledWith(
+      expect(sandbox.client.commands.executeStream).toHaveBeenCalledWith(
         'pwd',
         'test-session',
         undefined

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -337,7 +337,7 @@ describe('Sandbox - Automatic Session Management', () => {
         })
       );
 
-      expect(sandbox.client.commands.executeStream).toHaveBeenCalledWith(
+      expect(sandbox.client.commands.execute).toHaveBeenCalledWith(
         'echo test',
         expect.stringMatching(/^sandbox-/),
         undefined
@@ -392,10 +392,14 @@ describe('Sandbox - Automatic Session Management', () => {
         message: 'Created'
       } as any);
 
-      vi.spyOn(
-        freshSandbox.client.commands,
-        'executeStream'
-      ).mockImplementation(() => Promise.resolve(createMockSSEStream()));
+      vi.spyOn(freshSandbox.client.commands, 'execute').mockResolvedValue({
+        success: true,
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        command: 'echo test',
+        timestamp: new Date().toISOString()
+      } as any);
 
       await freshSandbox.exec('echo test');
 
@@ -403,7 +407,7 @@ describe('Sandbox - Automatic Session Management', () => {
         'enableDefaultSession'
       );
       expect(freshSandbox.client.utils.createSession).toHaveBeenCalledTimes(1);
-      expect(freshSandbox.client.commands.executeStream).toHaveBeenCalledWith(
+      expect(freshSandbox.client.commands.execute).toHaveBeenCalledWith(
         'echo test',
         expect.stringMatching(/^sandbox-/),
         undefined
@@ -417,7 +421,7 @@ describe('Sandbox - Automatic Session Management', () => {
         timeout: 5000
       });
 
-      expect(sandbox.client.commands.executeStream).toHaveBeenCalledWith(
+      expect(sandbox.client.commands.execute).toHaveBeenCalledWith(
         'echo $OPTION',
         expect.stringMatching(/^sandbox-/),
         {
@@ -606,12 +610,12 @@ describe('Sandbox - Automatic Session Management', () => {
 
       expect(sandbox.client.utils.createSession).toHaveBeenCalledTimes(1);
 
-      const firstSessionId = vi.mocked(sandbox.client.commands.executeStream)
-        .mock.calls[0][1];
+      const firstSessionId = vi.mocked(sandbox.client.commands.execute).mock
+        .calls[0][1];
       const fileSessionId = vi.mocked(sandbox.client.files.writeFile).mock
         .calls[0][2];
-      const secondSessionId = vi.mocked(sandbox.client.commands.executeStream)
-        .mock.calls[1][1];
+      const secondSessionId = vi.mocked(sandbox.client.commands.execute).mock
+        .calls[1][1];
 
       expect(firstSessionId).toBe(fileSessionId);
       expect(firstSessionId).toBe(secondSessionId);
@@ -885,7 +889,7 @@ describe('Sandbox - Automatic Session Management', () => {
       await Promise.all([first, second, third]);
 
       expect(sandbox.client.utils.createSession).toHaveBeenCalledTimes(2);
-      const calls = vi.mocked(sandbox.client.commands.executeStream).mock.calls;
+      const calls = vi.mocked(sandbox.client.commands.execute).mock.calls;
       expect(calls[0][1]).toBe('sandbox-default');
       expect(calls[1][1]).toBe('sandbox-renamed');
       expect(calls[2][1]).toBe('sandbox-renamed');
@@ -946,12 +950,14 @@ describe('Sandbox - Automatic Session Management', () => {
       (sandbox as unknown as { defaultSession: string }).defaultSession =
         'sandbox-default';
 
-      vi.mocked(sandbox.client.commands.executeStream).mockResolvedValueOnce(
-        createMockSSEStream({
-          stdout: 'sessionless',
-          command: 'printf sessionless'
-        })
-      );
+      vi.mocked(sandbox.client.commands.execute).mockResolvedValueOnce({
+        success: true,
+        stdout: 'sessionless',
+        stderr: '',
+        exitCode: 0,
+        command: 'printf sessionless',
+        timestamp: new Date().toISOString()
+      } as any);
 
       const result = await sandbox.exec('printf sessionless');
 
@@ -1027,7 +1033,7 @@ describe('Sandbox - Automatic Session Management', () => {
 
       await session.exec('echo test');
 
-      expect(sandbox.client.commands.executeStream).toHaveBeenCalledWith(
+      expect(sandbox.client.commands.execute).toHaveBeenCalledWith(
         'echo test',
         'isolated-session',
         undefined
@@ -1053,9 +1059,9 @@ describe('Sandbox - Automatic Session Management', () => {
       await session1.exec('echo build');
       await session2.exec('echo test');
 
-      const session1Id = vi.mocked(sandbox.client.commands.executeStream).mock
+      const session1Id = vi.mocked(sandbox.client.commands.execute).mock
         .calls[0][1];
-      const session2Id = vi.mocked(sandbox.client.commands.executeStream).mock
+      const session2Id = vi.mocked(sandbox.client.commands.execute).mock
         .calls[1][1];
 
       expect(session1Id).toBe('session-1');
@@ -1085,12 +1091,12 @@ describe('Sandbox - Automatic Session Management', () => {
 
       await sandbox.exec('echo default-again');
 
-      const defaultSessionId1 = vi.mocked(sandbox.client.commands.executeStream)
-        .mock.calls[0][1];
-      const explicitSessionId = vi.mocked(sandbox.client.commands.executeStream)
-        .mock.calls[1][1];
-      const defaultSessionId2 = vi.mocked(sandbox.client.commands.executeStream)
-        .mock.calls[2][1];
+      const defaultSessionId1 = vi.mocked(sandbox.client.commands.execute).mock
+        .calls[0][1];
+      const explicitSessionId = vi.mocked(sandbox.client.commands.execute).mock
+        .calls[1][1];
+      const defaultSessionId2 = vi.mocked(sandbox.client.commands.execute).mock
+        .calls[2][1];
 
       expect(defaultSessionId1).toBe('sandbox-default');
       expect(explicitSessionId).toBe('explicit-session');
@@ -1197,7 +1203,7 @@ describe('Sandbox - Automatic Session Management', () => {
 
     it('should execute command with session context', async () => {
       await session.exec('pwd');
-      expect(sandbox.client.commands.executeStream).toHaveBeenCalledWith(
+      expect(sandbox.client.commands.execute).toHaveBeenCalledWith(
         'pwd',
         'test-session',
         undefined

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -123,6 +123,7 @@ export type {
   EnvSetResult,
   ExecEvent,
   ExecOptions,
+  ExecProcess,
   ExecResult,
   ExecutionSession,
   // File streaming types

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -118,6 +118,51 @@ export interface ExecResult {
 }
 
 /**
+ * Handle for a running command, providing both streaming and buffered access.
+ *
+ * Modeled after the Containers SDK `ExecProcess` pattern. `exec()` returns
+ * this object **synchronously** — async setup happens lazily inside.
+ *
+ * Because `ExecProcess` implements `PromiseLike<ExecResult>`, you can
+ * `await` it directly for backward-compatible buffered output, or access
+ * the streams for real-time data.
+ *
+ * @example
+ * ```ts
+ * // Buffered — backward compatible, just await it
+ * const result = await sandbox.exec('ls -la');
+ * console.log(result.stdout);
+ *
+ * // Explicit buffered
+ * const result = await sandbox.exec('ls -la').output();
+ *
+ * // Streaming — don't await, use the streams
+ * const proc = sandbox.exec('tail -f /var/log/app.log');
+ * for await (const chunk of proc.stdout) { ... }
+ *
+ * // Exit code only
+ * const exitCode = await sandbox.exec('test -f /etc/config').exitCode;
+ * ```
+ */
+export interface ExecProcess extends PromiseLike<ExecResult> {
+  /** Readable stream of stdout bytes */
+  readonly stdout: ReadableStream<Uint8Array>;
+  /** Readable stream of stderr bytes */
+  readonly stderr: ReadableStream<Uint8Array>;
+  /** Resolves with the exit code when the process completes */
+  readonly exitCode: Promise<number>;
+  /** Collect all output and return a buffered {@link ExecResult} */
+  output(): Promise<ExecResult>;
+  /** Override to return a full Promise so .then().catch() chains work */
+  then<TResult1 = ExecResult, TResult2 = never>(
+    onfulfilled?:
+      | ((value: ExecResult) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): Promise<TResult1 | TResult2>;
+}
+
+/**
  * Result from waiting for a log pattern
  */
 export interface WaitForLogResult {
@@ -1031,7 +1076,10 @@ export interface ExecutionSession {
   readonly id: string;
 
   // Command execution
-  exec(command: string, options?: ExecOptions): Promise<ExecResult>;
+  exec(command: string, options?: ExecOptions): ExecProcess;
+  /**
+   * @deprecated Use `exec(command).stdout` for streaming output.
+   */
   execStream(
     command: string,
     options?: StreamOptions
@@ -1357,7 +1405,7 @@ export type MountBucketOptions =
 // Main Sandbox interface
 export interface ISandbox {
   // Command execution
-  exec(command: string, options?: ExecOptions): Promise<ExecResult>;
+  exec(command: string, options?: ExecOptions): ExecProcess;
 
   // Background process management
   startProcess(command: string, options?: ProcessOptions): Promise<Process>;
@@ -1367,6 +1415,9 @@ export interface ISandbox {
   killAllProcesses(): Promise<number>;
 
   // Streaming operations
+  /**
+   * @deprecated Use `exec(command).stdout` for streaming output.
+   */
   execStream(
     command: string,
     options?: StreamOptions


### PR DESCRIPTION
# Summary

Replaces the `exec()` return type with `ExecProcess` — a process handle that provides both streaming and buffered access to command output, aligned with the Containers SDK `ExecProcess` pattern.

`exec()` now returns synchronously. Because `ExecProcess` implements `PromiseLike<ExecResult>`, existing code that awaits the result continues to work with **zero migration**:

```ts
// Before AND after — identical, no changes needed
const result = await sandbox.exec("ls -la");
console.log(result.stdout);
```

New streaming and exit-code-only patterns are now available without a separate method:

```ts
// Stream stdout in real time
const proc = sandbox.exec("tail -f /var/log/app.log");
for await (const chunk of proc.stdout) {
  // process chunk
}

// Explicit buffered output
const result = await sandbox.exec("npm test").output();

// Just the exit code
const exitCode = await sandbox.exec("test -f /config").exitCode;
```

`execStream()` is now deprecated in favor of `exec().stdout`.

# Architecture

`ExecProcess` uses a **dual-path** design to preserve exact behavioral parity:

- **`output()` / `then()` (await)** — uses the existing buffered HTTP exec endpoint (`/api/execute`). This is the same code path as the old `exec()`, so timeout errors, exit codes, and stdout/stderr formatting are identical.
- **`.stdout` / `.stderr` / `.exitCode`** — lazily starts the SSE streaming endpoint (`/api/execute/stream`) only when first accessed. No extra container round-trip happens for the common `await sandbox.exec(cmd)` case.