### PR TITLE
Fix bridge dropping credentialProxy property

### DIFF
--- a/bridge/worker/README.md
+++ b/bridge/worker/README.md
@@ -342,6 +342,7 @@ curl -X POST http://localhost:8787/v1/sandbox/mfrggzdfmy2tqnrz/mount \
 | `options.prefix`                      | string  | no       | Subdirectory prefix within the bucket                                           |
 | `options.credentials.accessKeyId`     | string  | no       | Explicit access key (auto-detected if omitted)                                  |
 | `options.credentials.secretAccessKey` | string  | no       | Explicit secret key (auto-detected if omitted)                                  |
+| `options.credentialProxy`             | boolean | no       | Keep credentials in the Durable Object and sign intercepted s3fs requests       |
 
 Credentials are optional — the SDK auto-detects from Worker secrets (`R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY` or `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`).
 

--- a/packages/sandbox/src/bridge/openapi.ts
+++ b/packages/sandbox/src/bridge/openapi.ts
@@ -121,6 +121,12 @@ export const OPENAPI_SCHEMA = {
             description:
               'Explicit credentials. When omitted, the SDK auto-detects from Worker secrets (R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY or AWS equivalents).'
           },
+          credentialProxy: {
+            type: 'boolean',
+            description:
+              'Keep credentials in the Durable Object and sign intercepted s3fs requests from the Worker. Credentials may be explicit or auto-detected from Worker secrets.',
+            default: false
+          },
           s3fsOptions: {
             type: 'array',
             items: { type: 'string' },

--- a/packages/sandbox/src/bridge/routes.ts
+++ b/packages/sandbox/src/bridge/routes.ts
@@ -201,6 +201,17 @@ function validateMountOptions(
     );
   }
   if (
+    'credentialProxy' in options &&
+    options.credentialProxy !== undefined &&
+    typeof options.credentialProxy !== 'boolean'
+  ) {
+    return errorJson(
+      'options.credentialProxy must be a boolean when provided',
+      'invalid_request',
+      400
+    );
+  }
+  if (
     'credentials' in options &&
     options.credentials !== undefined &&
     (typeof options.credentials !== 'object' ||
@@ -255,6 +266,12 @@ function toSDKMountOptions(
     }
     if (options.s3fsOptions !== undefined) {
       remoteOptions.s3fsOptions = options.s3fsOptions;
+    }
+    if (
+      'credentialProxy' in options &&
+      typeof options.credentialProxy === 'boolean'
+    ) {
+      remoteOptions.credentialProxy = options.credentialProxy;
     }
     return remoteOptions;
   }

--- a/packages/sandbox/src/bridge/types.ts
+++ b/packages/sandbox/src/bridge/types.ts
@@ -122,7 +122,12 @@ export interface ErrorResponse {
 export type MountBucketRequestOptions =
   | Pick<
       RemoteMountBucketOptions,
-      'endpoint' | 'readOnly' | 'prefix' | 'credentials' | 's3fsOptions'
+      | 'endpoint'
+      | 'readOnly'
+      | 'prefix'
+      | 'credentials'
+      | 's3fsOptions'
+      | 'credentialProxy'
     >
   | Pick<R2BindingMountBucketOptions, 'readOnly' | 'prefix' | 's3fsOptions'>;
 

--- a/packages/sandbox/tests/r2-egress-mount.test.ts
+++ b/packages/sandbox/tests/r2-egress-mount.test.ts
@@ -1,4 +1,6 @@
+import { getContainer } from '@cloudflare/containers';
 import { describe, expect, it, vi } from 'vitest';
+import { createBridgeApp } from '../src/bridge/routes';
 import { ContainerProxy, Sandbox } from '../src/sandbox';
 import {
   type R2EgressParams,
@@ -33,6 +35,11 @@ type TestContainerProxyOptions = {
     className: string;
     outboundByHostOverrides?: Record<string, TestOutboundHostOverride>;
   };
+};
+
+type TestDurableObjectNamespace = {
+  idFromName: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
 };
 
 const testOutboundHandlersRegistry = vi.hoisted(
@@ -358,49 +365,6 @@ describe('Sandbox credential proxy mounts', () => {
     );
   });
 
-  it('uses Worker env credentials for credential proxy mounts without explicit credentials', async () => {
-    const mockCtx = createMockCtx();
-    const sandbox = new Sandbox(
-      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
-      {
-        R2_ACCESS_KEY_ID: 'ENV_KEY',
-        R2_SECRET_ACCESS_KEY: 'ENV_SECRET'
-      }
-    );
-    const createPasswordFile = vi.fn().mockResolvedValue(undefined);
-
-    Object.assign(sandbox as object, {
-      execInternal: createCredentialProxyExecMock(),
-      createPasswordFile,
-      deletePasswordFile: vi.fn().mockResolvedValue(undefined),
-      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
-      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
-      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-env')
-    });
-
-    await sandbox.mountBucket('my-bucket', '/mnt/proxy', {
-      endpoint: 'https://abc123.r2.cloudflarestorage.com',
-      credentialProxy: true
-    });
-
-    expect(createPasswordFile).toHaveBeenCalledWith(
-      '/tmp/.s3fs-env',
-      'my-bucket',
-      { accessKeyId: 'x', secretAccessKey: 'x' }
-    );
-
-    const ContainerProxy = mockCtx.exports.ContainerProxy!;
-    const firstCall = ContainerProxy.mock.calls[0];
-    const params = firstCall[0].props.outboundByHostOverrides?.[
-      's3-credential-proxy.internal'
-    ]?.params as S3CredentialProxyParams;
-    const mount = Object.values(params.mounts)[0];
-    expect(mount.credentials).toEqual({
-      accessKeyId: 'ENV_KEY',
-      secretAccessKey: 'ENV_SECRET'
-    });
-  });
-
   it('appends required s3fs options for credential proxy mounts', async () => {
     const mockCtx = createMockCtx();
     const sandbox = new Sandbox(
@@ -553,6 +517,67 @@ describe('Sandbox credential proxy mounts', () => {
         params: { mounts: {} }
       }
     });
+  });
+
+  function createNamespace(stub: unknown): TestDurableObjectNamespace {
+    return {
+      idFromName: vi.fn((name: string) => ({ name })),
+      get: vi.fn(() => stub)
+    };
+  }
+
+  it('passes credentialProxy through bridge remote mount requests', async () => {
+    const sandboxStub = {
+      mountBucket: vi.fn().mockResolvedValue(undefined)
+    };
+    vi.mocked(getContainer).mockReturnValueOnce(
+      sandboxStub as unknown as ReturnType<typeof getContainer>
+    );
+
+    const app = createBridgeApp({
+      sandboxBinding: 'Sandbox',
+      warmPoolBinding: 'WarmPool',
+      apiPrefix: '/v1',
+      healthPath: '/health'
+    });
+    const warmPoolStub = {
+      configure: vi.fn().mockResolvedValue(undefined),
+      getContainer: vi.fn().mockResolvedValue('bridge-container-id')
+    };
+    const env = {
+      Sandbox: createNamespace(sandboxStub),
+      WarmPool: createNamespace(warmPoolStub)
+    } as unknown as Cloudflare.Env;
+    const ctx = {
+      waitUntil: vi.fn(),
+      passThroughOnException: vi.fn()
+    } as unknown as ExecutionContext;
+
+    const response = await app.fetch(
+      new Request('http://bridge.test/v1/sandbox/abc/mount', {
+        method: 'POST',
+        body: JSON.stringify({
+          bucket: 'my-bucket',
+          mountPath: '/mnt/proxy',
+          options: {
+            endpoint: 'https://abc123.r2.cloudflarestorage.com',
+            credentialProxy: true
+          }
+        })
+      }),
+      env,
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(sandboxStub.mountBucket).toHaveBeenCalledWith(
+      'my-bucket',
+      '/mnt/proxy',
+      {
+        endpoint: 'https://abc123.r2.cloudflarestorage.com',
+        credentialProxy: true
+      }
+    );
   });
 
   it('clears mount state when both mount and credential proxy cleanup reconfiguration fail', async () => {

--- a/packages/sandbox/tests/r2-egress-mount.test.ts
+++ b/packages/sandbox/tests/r2-egress-mount.test.ts
@@ -358,6 +358,49 @@ describe('Sandbox credential proxy mounts', () => {
     );
   });
 
+  it('uses Worker env credentials for credential proxy mounts without explicit credentials', async () => {
+    const mockCtx = createMockCtx();
+    const sandbox = new Sandbox(
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+      {
+        R2_ACCESS_KEY_ID: 'ENV_KEY',
+        R2_SECRET_ACCESS_KEY: 'ENV_SECRET'
+      }
+    );
+    const createPasswordFile = vi.fn().mockResolvedValue(undefined);
+
+    Object.assign(sandbox as object, {
+      execInternal: createCredentialProxyExecMock(),
+      createPasswordFile,
+      deletePasswordFile: vi.fn().mockResolvedValue(undefined),
+      createDisableExpectHeaderFile: vi.fn().mockResolvedValue(undefined),
+      deleteAdditionalHeaderFile: vi.fn().mockResolvedValue(undefined),
+      generatePasswordFilePath: vi.fn().mockReturnValue('/tmp/.s3fs-env')
+    });
+
+    await sandbox.mountBucket('my-bucket', '/mnt/proxy', {
+      endpoint: 'https://abc123.r2.cloudflarestorage.com',
+      credentialProxy: true
+    });
+
+    expect(createPasswordFile).toHaveBeenCalledWith(
+      '/tmp/.s3fs-env',
+      'my-bucket',
+      { accessKeyId: 'x', secretAccessKey: 'x' }
+    );
+
+    const ContainerProxy = mockCtx.exports.ContainerProxy!;
+    const firstCall = ContainerProxy.mock.calls[0];
+    const params = firstCall[0].props.outboundByHostOverrides?.[
+      's3-credential-proxy.internal'
+    ]?.params as S3CredentialProxyParams;
+    const mount = Object.values(params.mounts)[0];
+    expect(mount.credentials).toEqual({
+      accessKeyId: 'ENV_KEY',
+      secretAccessKey: 'ENV_SECRET'
+    });
+  });
+
   it('appends required s3fs options for credential proxy mounts', async () => {
     const mockCtx = createMockCtx();
     const sandbox = new Sandbox(


### PR DESCRIPTION
## Summary

Fixes the bridge mount API dropping the `credentialProxy` option before forwarding mount requests to the SDK.

Previously, bridge/API callers could send `credentialProxy: true`, but the bridge option conversion omitted that property. As a result, the SDK received a normal remote mount request and performed a direct s3fs mount instead of configuring the credential proxy.

For bridge-based remote mounts with credentials available, `credentialProxy: true` was silently ignored and real credentials could be written into the container-side s3fs password file. Direct SDK usage was not affected.

_Note: There is no changeset included in this PR as the S3 proxy mount behaviour is not yet part of any official release version_