### PR TITLE
Add Codex app-server WebSocket auth

### DIFF
--- a/examples/codex-app-server/README.md
+++ b/examples/codex-app-server/README.md
@@ -71,8 +71,10 @@ export class Sandbox extends BaseSandbox<Env> {
 Each WebSocket connection targets `/ws/<session-name>`. The session name maps to a Sandbox Durable Object instance. On connect, the Worker:
 
 1. Destroys any existing sandbox for that session (clean slate)
-2. Starts the Codex app-server process inside the container
-3. Bridges WebSocket frames between the browser and container through the handler pipeline
+2. Generates a high-entropy Codex WebSocket capability token
+3. Writes the token to `/tmp/codex-ws-token` inside the sandbox
+4. Starts the Codex app-server process inside the container with `--ws-auth capability-token --ws-token-file /tmp/codex-ws-token`
+5. Bridges WebSocket frames between the browser and container through the handler pipeline, using `Authorization: Bearer <token>` only for the private Worker-to-container connection
 
 The client then runs the connection flow:
 
@@ -82,6 +84,12 @@ The client then runs the connection flow:
 4. `turn/start` — send prompts, receive streamed responses
 
 Each session operates a single thread. On disconnect, the sandbox sleeps after `SANDBOX_SLEEP_AFTER`. Reconnecting with the same session name destroys and recreates it.
+
+### Codex WebSocket authentication
+
+Codex app-server's WebSocket transport supports bearer-token authentication for non-loopback listeners. This example uses the documented `capability-token` mode with `--ws-token-file`, so the raw token never appears in the process command line.
+
+The token is internal to the Worker-to-container connection. Browser clients authenticate to the Worker with `AUTH_TOKEN` when configured, but they never receive the Codex app-server capability token.
 
 ### Handler pipeline
 

--- a/examples/codex-app-server/src/index.ts
+++ b/examples/codex-app-server/src/index.ts
@@ -34,6 +34,7 @@ declare global {
 }
 
 const CODEX_WS_PORT = 4500;
+const CODEX_WS_TOKEN_FILE = '/tmp/codex-ws-token';
 
 // --- Egress control ---
 // The container uses OPENAI_BASE_URL=http://api.openai.com/v1 so requests
@@ -150,27 +151,39 @@ function sandboxExec(sandbox: ReturnType<typeof getSandbox>): MessageHandler {
 
 // --- Sandbox lifecycle ---
 
+function generateCapabilityToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join(
+    ''
+  );
+}
+
 async function ensureCodexRunning(
   sandbox: ReturnType<typeof getSandbox>
-): Promise<void> {
+): Promise<string> {
   const procs = await sandbox.listProcesses();
   const existing = procs.find((p) => p.id === 'codex-app-server');
   if (
     existing &&
     (existing.status === 'running' || existing.status === 'starting')
   )
-    return;
+    return (await sandbox.readFile(CODEX_WS_TOKEN_FILE)).content;
+
+  const codexWsToken = generateCapabilityToken();
 
   await sandbox.setEnvVars({
     OPENAI_BASE_URL: 'http://api.openai.com/v1',
     OPENAI_API_KEY: 'proxy-injected'
   });
+  await sandbox.writeFile(CODEX_WS_TOKEN_FILE, codexWsToken);
 
   const proc = await sandbox.startProcess(
-    'bash -lc "codex app-server --listen ws://0.0.0.0:4500"',
+    `bash -lc "codex app-server --listen ws://0.0.0.0:${CODEX_WS_PORT} --ws-auth capability-token --ws-token-file ${CODEX_WS_TOKEN_FILE}"`,
     { processId: 'codex-app-server' }
   );
   await proc.waitForPort(CODEX_WS_PORT, { mode: 'tcp' });
+  return codexWsToken;
 }
 
 // --- Auth ---
@@ -216,11 +229,16 @@ export default {
 // --- WebSocket bridge ---
 
 async function connectToContainer(
-  sandbox: ReturnType<typeof getSandbox>
+  sandbox: ReturnType<typeof getSandbox>,
+  codexWsToken: string
 ): Promise<WebSocket> {
   const wsRequest = switchPort(
     new Request('http://container/ws', {
-      headers: { Upgrade: 'websocket', Connection: 'Upgrade' }
+      headers: {
+        Upgrade: 'websocket',
+        Connection: 'Upgrade',
+        Authorization: `Bearer ${codexWsToken}`
+      }
     }),
     CODEX_WS_PORT
   );
@@ -245,9 +263,9 @@ async function handleWebSocket(
   const sleepAfter = env.SANDBOX_SLEEP_AFTER || '1m';
   const sandbox = getSandbox(env.Sandbox, `codex-${sandboxId}`, { sleepAfter });
   await sandbox.destroy();
-  await ensureCodexRunning(sandbox);
+  const codexWsToken = await ensureCodexRunning(sandbox);
 
-  const containerWs = await connectToContainer(sandbox);
+  const containerWs = await connectToContainer(sandbox, codexWsToken);
 
   const [clientWs, serverWs] = Object.values(new WebSocketPair());
   const sendJson = (ws: WebSocket) => (msg: JsonRpcMessage) =>


### PR DESCRIPTION
## Summary

Updates the Codex app-server example to use Codex documented WebSocket authentication for the private Worker-to-container connection.

## Reviewer notes

Codex app-server now documents auth configuration for non-loopback WebSocket listeners. This example listens on 0.0.0.0:4500 inside the sandbox, so the Worker now generates a per-start capability token, writes it to /tmp/codex-ws-token, and starts Codex with --ws-auth capability-token --ws-token-file /tmp/codex-ws-token.

The bearer token is only used when the Worker connects to the container through switchPort. Browser clients still connect to the Worker WebSocket as before, and they never receive the internal Codex app-server token. The existing optional AUTH_TOKEN behavior remains the browser-facing auth layer.

## Docs

The example README now describes the internal capability-token flow so readers can distinguish it from the public Worker WebSocket authentication.

Fixes #745

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->