### PR TITLE
Retry transient WebSocket upgrade failures

### DIFF
--- a/.changeset/retry-websocket-upgrades.md
+++ b/.changeset/retry-websocket-upgrades.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Recover automatically from transient infrastructure failures when the SDK opens its WebSocket control connection to a sandbox. Previously, any 5xx response other than 503 on the upgrade would fail the SDK call even when the container was healthy.

--- a/packages/sandbox-container/src/server.ts
+++ b/packages/sandbox-container/src/server.ts
@@ -29,6 +29,10 @@ export type WSData =
 const logger = createLogger({ component: 'container' });
 const SERVER_PORT = 3000;
 
+export function webSocketUpgradeFailedResponse(): Response {
+  return new Response('WebSocket upgrade failed', { status: 503 });
+}
+
 // Global error handlers to prevent fragmented stack traces in logs
 // Bun's default handler writes stack traces line-by-line to stderr,
 // which Cloudflare captures as separate log entries
@@ -122,7 +126,7 @@ async function createApplication(): Promise<{
             // cast through `unknown`. See: https://bun.sh/docs/api/websockets#upgrade
             return undefined as unknown as Response;
           }
-          return new Response('WebSocket upgrade failed', { status: 500 });
+          return webSocketUpgradeFailedResponse();
         }
 
         if (url.pathname === '/ws' || url.pathname === '/api/ws') {
@@ -135,7 +139,7 @@ async function createApplication(): Promise<{
           if (upgraded) {
             return undefined as unknown as Response;
           }
-          return new Response('WebSocket upgrade failed', { status: 500 });
+          return webSocketUpgradeFailedResponse();
         }
 
         if (url.pathname === '/rpc') {
@@ -149,7 +153,7 @@ async function createApplication(): Promise<{
           if (upgraded) {
             return undefined as unknown as Response;
           }
-          return new Response('WebSocket upgrade failed', { status: 500 });
+          return webSocketUpgradeFailedResponse();
         }
       }
 

--- a/packages/sandbox-container/tests/server.test.ts
+++ b/packages/sandbox-container/tests/server.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'bun:test';
+import { webSocketUpgradeFailedResponse } from '../src/server';
+
+describe('server WebSocket upgrade failures', () => {
+  it('returns 503 so SDK upgrade transports can retry', async () => {
+    const response = webSocketUpgradeFailedResponse();
+
+    expect(response.status).toBe(503);
+    await expect(response.text()).resolves.toBe('WebSocket upgrade failed');
+  });
+});

--- a/packages/sandbox/src/clients/sandbox-client.ts
+++ b/packages/sandbox/src/clients/sandbox-client.ts
@@ -83,7 +83,7 @@ export class SandboxClient {
   }
 
   /**
-   * Update the 503 retry budget on all transports without recreating the client.
+   * Update the transport retry budget without recreating the client.
    *
    * In WebSocket mode a single shared transport is used, so one update covers
    * every sub-client. In HTTP mode each sub-client owns its own transport, so

--- a/packages/sandbox/src/clients/transport/base-transport.ts
+++ b/packages/sandbox/src/clients/transport/base-transport.ts
@@ -1,5 +1,6 @@
 import type { Logger } from '@repo/shared';
 import { createNoOpLogger } from '@repo/shared';
+import { fetchWithResponseRetry } from '../../response-retry';
 import type {
   ITransport,
   RouteTransportMode,
@@ -50,43 +51,22 @@ export abstract class BaseTransport implements ITransport {
    * transport-specific doFetch() with retry logic for container startup.
    */
   async fetch(path: string, options?: TransportRequestInit): Promise<Response> {
-    const startTime = Date.now();
-    let attempt = 0;
-
-    while (true) {
-      const response = await this.doFetch(path, options);
-
-      // Check for retryable 503 (container starting)
-      if (response.status === 503) {
-        const elapsed = Date.now() - startTime;
-        const remaining = this.retryTimeoutMs - elapsed;
-
-        if (remaining > MIN_TIME_FOR_RETRY_MS) {
-          const delay = Math.min(3000 * 2 ** attempt, 30000);
-
-          this.logger.info('Container not ready, retrying', {
-            status: response.status,
-            attempt: attempt + 1,
-            delayMs: delay,
-            remainingSec: Math.floor(remaining / 1000),
-            mode: this.getMode()
-          });
-
-          await this.sleep(delay);
-          attempt++;
-          continue;
-        }
-
+    return fetchWithResponseRetry(() => this.doFetch(path, options), {
+      retryTimeoutMs: this.retryTimeoutMs,
+      minTimeForRetryMs: MIN_TIME_FOR_RETRY_MS,
+      logger: this.logger,
+      retryLogMessage: 'Container not ready, retrying',
+      shouldRetry: (response) => response.status === 503,
+      getRetryLogContext: () => ({ mode: this.getMode() }),
+      onRetryExhausted: ({ attempts, elapsedMs }) => {
         this.logger.error(
           'Container failed to become ready',
           new Error(
-            `Failed after ${attempt + 1} attempts over ${Math.floor(elapsed / 1000)}s`
+            `Failed after ${attempts} attempts over ${Math.floor(elapsedMs / 1000)}s`
           )
         );
       }
-
-      return response;
-    }
+    });
   }
 
   /**
@@ -179,12 +159,5 @@ export abstract class BaseTransport implements ITransport {
       throw new Error('No response body for streaming');
     }
     return response.body;
-  }
-
-  /**
-   * Sleep utility for retry delays
-   */
-  protected sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 }

--- a/packages/sandbox/src/clients/transport/types.ts
+++ b/packages/sandbox/src/clients/transport/types.ts
@@ -42,10 +42,11 @@ export interface TransportConfig {
   /** Connection timeout in milliseconds (WebSocket only) */
   connectTimeoutMs?: number;
 
-  /** Total retry budget in milliseconds for 503 retries during container startup.
-   *  Defaults to 120_000 (2 minutes). Should be at least as large as the sum of
-   *  instanceGetTimeoutMS + portReadyTimeoutMS to avoid the client giving up
-   *  before the container has finished starting. */
+  /** Total retry budget in milliseconds for retryable transport responses.
+   *  Used for WebSocket upgrade retries and HTTP 503 startup retries. Defaults
+   *  to 120_000 (2 minutes). Set this at least as large as
+   *  instanceGetTimeoutMS + portReadyTimeoutMS so the client waits through the
+   *  expected container startup window. */
   retryTimeoutMs?: number;
 }
 
@@ -100,7 +101,7 @@ export interface ITransport {
   isConnected(): boolean;
 
   /**
-   * Update the 503 retry budget without recreating the transport
+   * Update the upgrade retry budget without recreating the transport
    */
   setRetryTimeoutMs(ms: number): void;
 }

--- a/packages/sandbox/src/clients/transport/ws-transport.ts
+++ b/packages/sandbox/src/clients/transport/ws-transport.ts
@@ -9,6 +9,10 @@ import {
   type WSServerMessage,
   type WSStreamChunk
 } from '@repo/shared';
+import {
+  fetchWithResponseRetry,
+  isRetryableWebSocketUpgradeResponse
+} from '../../response-retry';
 import { BaseTransport } from './base-transport';
 import type {
   RouteTransportMode,
@@ -246,36 +250,13 @@ export class WebSocketTransport extends BaseTransport {
   private async fetchUpgradeWithRetry(
     attemptUpgrade: () => Promise<Response>
   ): Promise<Response> {
-    const retryTimeoutMs = this.getRetryTimeoutMs();
-    const startTime = Date.now();
-    let attempt = 0;
-
-    while (true) {
-      const response = await attemptUpgrade();
-
-      if (response.status !== 503) {
-        return response;
-      }
-
-      const elapsed = Date.now() - startTime;
-      const remaining = retryTimeoutMs - elapsed;
-
-      if (remaining <= MIN_TIME_FOR_CONNECT_RETRY_MS) {
-        return response;
-      }
-
-      const delay = Math.min(3000 * 2 ** attempt, 30000);
-
-      this.logger.info('WebSocket container not ready, retrying', {
-        status: response.status,
-        attempt: attempt + 1,
-        delayMs: delay,
-        remainingSec: Math.floor(remaining / 1000)
-      });
-
-      await this.sleep(delay);
-      attempt++;
-    }
+    return fetchWithResponseRetry(attemptUpgrade, {
+      retryTimeoutMs: this.getRetryTimeoutMs(),
+      minTimeForRetryMs: MIN_TIME_FOR_CONNECT_RETRY_MS,
+      logger: this.logger,
+      retryLogMessage: 'WebSocket upgrade returned retryable status, retrying',
+      shouldRetry: isRetryableWebSocketUpgradeResponse
+    });
   }
 
   /**

--- a/packages/sandbox/src/clients/types.ts
+++ b/packages/sandbox/src/clients/types.ts
@@ -54,7 +54,8 @@ export interface HttpClientOptions {
   transport?: ITransport;
 
   /**
-   * Total retry budget in milliseconds for 503 retries during container startup.
+   * Total retry budget in milliseconds for retryable transport responses.
+   * Used for WebSocket upgrade retries and HTTP 503 startup retries.
    * Passed through to the transport layer. Defaults to 120_000 (2 minutes).
    */
   retryTimeoutMs?: number;

--- a/packages/sandbox/src/container-control/client.ts
+++ b/packages/sandbox/src/container-control/client.ts
@@ -691,7 +691,7 @@ export class ContainerControlClient {
   }
 
   /**
-   * Update the 503 upgrade-retry budget. Applies to the current connection
+   * Update the upgrade retry budget. Applies to the current connection
    * (if any) and is remembered for any future connections created after the
    * client is torn down and reconnected.
    */

--- a/packages/sandbox/src/container-control/connection.ts
+++ b/packages/sandbox/src/container-control/connection.ts
@@ -22,15 +22,18 @@ import type {
 } from '@repo/shared';
 import { createNoOpLogger } from '@repo/shared';
 import { RpcSession, type RpcStub, type RpcTransport } from 'capnweb';
+import {
+  fetchWithResponseRetry,
+  isRetryableWebSocketUpgradeResponse
+} from '../response-retry';
 
 // ---------------------------------------------------------------------------
 // Connection manager
 // ---------------------------------------------------------------------------
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
-const DEFAULT_RETRY_TIMEOUT_MS = 120_000; // 2 minute total budget for 503 retries
+const DEFAULT_RETRY_TIMEOUT_MS = 120_000; // 2 minute total budget for upgrade retries
 const MIN_TIME_FOR_RETRY_MS = 15_000; // Need at least 15s remaining to attempt a retry
-const MAX_RETRY_BACKOFF_MS = 30_000; // Cap exponential backoff at 30s
 
 /** Stub that can issue a WebSocket-upgrade fetch through the DO's Container base class. */
 export interface ContainerFetchStub {
@@ -42,9 +45,9 @@ export interface ContainerControlConnectionOptions {
   port?: number;
   logger?: Logger;
   /**
-   * Total retry budget (ms) for 503 upgrade responses while the container
-   * is starting. Defaults to 120 000 (2 minutes), matching the route-based
-   * `WebSocketTransport`. Set to 0 to disable retries.
+   * Total retry budget (ms) for retryable upgrade responses while the
+   * container is unavailable. Defaults to 120 000 (2 minutes), matching the
+   * route-based `WebSocketTransport`. Set to 0 to disable retries.
    */
   retryTimeoutMs?: number;
   /**
@@ -171,7 +174,7 @@ export class ContainerControlConnection {
   }
 
   /**
-   * Update the 503 retry budget without recreating the connection. Takes
+   * Update the upgrade retry budget without recreating the connection. Takes
    * effect on the next `connect()`; an in-flight connect uses the value
    * captured at start. Mirrors `WebSocketTransport.setRetryTimeoutMs`.
    */
@@ -266,45 +269,19 @@ export class ContainerControlConnection {
   }
 
   /**
-   * Issue WebSocket upgrade fetches, retrying transient 503 responses with
-   * exponential backoff (3s → 6s → 12s → … capped at 30s) until either
-   * the upgrade succeeds, a non-503 status is returned, or the retry budget
-   * runs out. Mirrors `WebSocketTransport.fetchUpgradeWithRetry` so both
-   * transports behave the same way during container startup.
+   * Issue WebSocket upgrade fetches, retrying transient control-plane
+   * unavailability responses until either the upgrade succeeds, a
+   * non-retryable status is returned, or the retry budget runs out.
    */
   private async fetchUpgradeWithRetry(): Promise<Response> {
-    const retryTimeoutMs = this.retryTimeoutMs;
-    const startTime = Date.now();
-    let attempt = 0;
-
-    while (true) {
-      const response = await this.fetchUpgradeAttempt();
-
-      if (response.status !== 503) {
-        return response;
-      }
-
-      const elapsed = Date.now() - startTime;
-      const remaining = retryTimeoutMs - elapsed;
-
-      if (remaining <= MIN_TIME_FOR_RETRY_MS) {
-        return response;
-      }
-
-      const delay = Math.min(3000 * 2 ** attempt, MAX_RETRY_BACKOFF_MS);
-
-      this.logger.info(
-        'ContainerControlConnection upgrade returned 503, retrying',
-        {
-          attempt: attempt + 1,
-          delayMs: delay,
-          remainingSec: Math.floor(remaining / 1000)
-        }
-      );
-
-      await this.sleep(delay);
-      attempt++;
-    }
+    return fetchWithResponseRetry(() => this.fetchUpgradeAttempt(), {
+      retryTimeoutMs: this.retryTimeoutMs,
+      minTimeForRetryMs: MIN_TIME_FOR_RETRY_MS,
+      logger: this.logger,
+      retryLogMessage:
+        'ContainerControlConnection upgrade returned retryable status, retrying',
+      shouldRetry: isRetryableWebSocketUpgradeResponse
+    });
   }
 
   /**
@@ -332,10 +309,6 @@ export class ContainerControlConnection {
     } finally {
       clearTimeout(timeout);
     }
-  }
-
-  private sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 }
 

--- a/packages/sandbox/src/response-retry.ts
+++ b/packages/sandbox/src/response-retry.ts
@@ -1,0 +1,74 @@
+import type { LogContext, Logger } from '@repo/shared';
+
+const DEFAULT_INITIAL_RETRY_DELAY_MS = 3_000;
+const DEFAULT_MAX_RETRY_DELAY_MS = 30_000;
+const RETRYABLE_WEBSOCKET_UPGRADE_STATUSES = new Set([500, 502, 503, 504]);
+
+export function isRetryableWebSocketUpgradeResponse(
+  response: Response
+): boolean {
+  return RETRYABLE_WEBSOCKET_UPGRADE_STATUSES.has(response.status);
+}
+
+export interface ResponseRetryOptions {
+  retryTimeoutMs: number;
+  minTimeForRetryMs: number;
+  logger: Logger;
+  retryLogMessage: string;
+  shouldRetry(response: Response): boolean;
+  getRetryLogContext?: (response: Response) => Partial<LogContext>;
+  onRetryExhausted?: (params: {
+    attempts: number;
+    elapsedMs: number;
+    response: Response;
+  }) => void;
+}
+
+/**
+ * Retry Response-returning operations while their response remains retryable.
+ * The retry budget covers the whole operation; each attempt owns any
+ * per-request timeout inside the caller-provided `fetchResponse` function.
+ */
+export async function fetchWithResponseRetry(
+  fetchResponse: () => Promise<Response>,
+  options: ResponseRetryOptions
+): Promise<Response> {
+  const startTime = Date.now();
+  let attempt = 0;
+
+  while (true) {
+    const response = await fetchResponse();
+
+    if (!options.shouldRetry(response)) {
+      return response;
+    }
+
+    const elapsed = Date.now() - startTime;
+    const remaining = options.retryTimeoutMs - elapsed;
+
+    if (remaining <= options.minTimeForRetryMs) {
+      options.onRetryExhausted?.({
+        attempts: attempt + 1,
+        elapsedMs: elapsed,
+        response
+      });
+      return response;
+    }
+
+    const delay = Math.min(
+      DEFAULT_INITIAL_RETRY_DELAY_MS * 2 ** attempt,
+      DEFAULT_MAX_RETRY_DELAY_MS
+    );
+
+    options.logger.info(options.retryLogMessage, {
+      status: response.status,
+      attempt: attempt + 1,
+      delayMs: delay,
+      remainingSec: Math.floor(remaining / 1000),
+      ...options.getRetryLogContext?.(response)
+    });
+
+    await new Promise<void>((resolve) => setTimeout(resolve, delay));
+    attempt++;
+  }
+}

--- a/packages/sandbox/tests/container-connection.test.ts
+++ b/packages/sandbox/tests/container-connection.test.ts
@@ -286,7 +286,7 @@ describe('ContainerControlConnection', () => {
     });
   });
 
-  describe('503 upgrade retry', () => {
+  describe('WebSocket upgrade retry', () => {
     /**
      * Build a fake successful upgrade Response. Mirrors what
      * Cloudflare's Container base class returns from `stub.fetch()`:
@@ -311,20 +311,20 @@ describe('ContainerControlConnection', () => {
       } as unknown as Response;
     }
 
-    function make503(): Response {
-      return new Response('Container is starting.', {
-        status: 503,
+    function makeUpgradeFailure(status: number): Response {
+      return new Response('Container upgrade unavailable.', {
+        status,
         statusText: 'Service Unavailable'
       });
     }
 
-    it('retries 503 upgrade responses until success', async () => {
+    it('retries retryable upgrade responses until success', async () => {
       vi.useFakeTimers();
       try {
         const fetchMock = vi
           .fn<(req: Request) => Promise<Response>>()
-          .mockResolvedValueOnce(make503())
-          .mockResolvedValueOnce(make503())
+          .mockResolvedValueOnce(makeUpgradeFailure(500))
+          .mockResolvedValueOnce(makeUpgradeFailure(500))
           .mockResolvedValueOnce(makeUpgradeResponse());
 
         const conn = new ContainerControlConnection({
@@ -351,12 +351,12 @@ describe('ContainerControlConnection', () => {
       }
     });
 
-    it('gives up on 503 once the retry budget is exhausted', async () => {
+    it('gives up on a retryable upgrade response once the retry budget is exhausted', async () => {
       vi.useFakeTimers();
       try {
         const fetchMock = vi
           .fn<(req: Request) => Promise<Response>>()
-          .mockResolvedValue(make503());
+          .mockResolvedValue(makeUpgradeFailure(500));
 
         const conn = new ContainerControlConnection({
           stub: { fetch: fetchMock },
@@ -370,7 +370,7 @@ describe('ContainerControlConnection', () => {
 
         const connectPromise = conn.connect();
         const assertion = expect(connectPromise).rejects.toThrow(
-          'WebSocket upgrade failed: 503'
+          'WebSocket upgrade failed: 500'
         );
 
         // Run all timers — connect() must settle even with fake timers.
@@ -385,10 +385,10 @@ describe('ContainerControlConnection', () => {
       }
     });
 
-    it('does not retry non-503 upgrade failures', async () => {
+    it('does not retry terminal upgrade failures', async () => {
       const fetchMock = vi
         .fn<(req: Request) => Promise<Response>>()
-        .mockResolvedValue(new Response('Not Found', { status: 404 }));
+        .mockResolvedValue(new Response('Not retryable', { status: 404 }));
 
       const conn = new ContainerControlConnection({
         stub: { fetch: fetchMock },
@@ -404,12 +404,7 @@ describe('ContainerControlConnection', () => {
     it('disables retries when retryTimeoutMs is set to 0', async () => {
       const fetchMock = vi
         .fn<(req: Request) => Promise<Response>>()
-        .mockResolvedValue(
-          new Response('Container is starting.', {
-            status: 503,
-            statusText: 'Service Unavailable'
-          })
-        );
+        .mockResolvedValue(makeUpgradeFailure(500));
 
       const conn = new ContainerControlConnection({
         stub: { fetch: fetchMock },
@@ -417,7 +412,7 @@ describe('ContainerControlConnection', () => {
       });
 
       await expect(conn.connect()).rejects.toThrow(
-        'WebSocket upgrade failed: 503'
+        'WebSocket upgrade failed: 500'
       );
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
@@ -427,7 +422,7 @@ describe('ContainerControlConnection', () => {
       try {
         const fetchMock = vi
           .fn<(req: Request) => Promise<Response>>()
-          .mockResolvedValueOnce(make503())
+          .mockResolvedValueOnce(makeUpgradeFailure(503))
           .mockResolvedValueOnce(makeUpgradeResponse());
 
         const conn = new ContainerControlConnection({
@@ -451,7 +446,7 @@ describe('ContainerControlConnection', () => {
       try {
         const fetchMock = vi
           .fn<(req: Request) => Promise<Response>>()
-          .mockResolvedValue(make503());
+          .mockResolvedValue(makeUpgradeFailure(503));
 
         const conn = new ContainerControlConnection({
           stub: { fetch: fetchMock },
@@ -485,7 +480,7 @@ describe('ContainerControlConnection', () => {
           .fn<(req: Request) => Promise<Response>>()
           .mockImplementationOnce(async (req) => {
             seenRequests.push(req);
-            return make503();
+            return makeUpgradeFailure(503);
           })
           .mockImplementationOnce(async (req) => {
             seenRequests.push(req);

--- a/packages/sandbox/tests/response-retry.test.ts
+++ b/packages/sandbox/tests/response-retry.test.ts
@@ -1,0 +1,106 @@
+import { createNoOpLogger } from '@repo/shared';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  fetchWithResponseRetry,
+  isRetryableWebSocketUpgradeResponse
+} from '../src/response-retry';
+
+function responseWithStatus(status: number): Response {
+  return new Response(null, { status });
+}
+
+describe('response retry helpers', () => {
+  describe('isRetryableWebSocketUpgradeResponse', () => {
+    it.each([500, 502, 503, 504])(
+      'treats %i as a retryable upgrade response',
+      (status) => {
+        expect(
+          isRetryableWebSocketUpgradeResponse(responseWithStatus(status))
+        ).toBe(true);
+      }
+    );
+
+    it.each([400, 401, 403, 404])(
+      'treats %i as a terminal upgrade response',
+      (status) => {
+        expect(
+          isRetryableWebSocketUpgradeResponse(responseWithStatus(status))
+        ).toBe(false);
+      }
+    );
+  });
+
+  describe('fetchWithResponseRetry', () => {
+    it('retries matching responses until success', async () => {
+      vi.useFakeTimers();
+
+      try {
+        const fetchResponse = vi
+          .fn<() => Promise<Response>>()
+          .mockResolvedValueOnce(responseWithStatus(503))
+          .mockResolvedValueOnce(responseWithStatus(200));
+
+        const retrying = fetchWithResponseRetry(fetchResponse, {
+          retryTimeoutMs: 20_000,
+          minTimeForRetryMs: 15_000,
+          logger: createNoOpLogger(),
+          retryLogMessage: 'retrying test response',
+          shouldRetry: (response) => response.status === 503
+        });
+
+        await vi.advanceTimersByTimeAsync(0);
+        expect(fetchResponse).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(3_000);
+        const response = await retrying;
+
+        expect(fetchResponse).toHaveBeenCalledTimes(2);
+        expect(response.status).toBe(200);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('returns terminal responses without retrying', async () => {
+      const fetchResponse = vi
+        .fn<() => Promise<Response>>()
+        .mockResolvedValue(responseWithStatus(404));
+
+      const response = await fetchWithResponseRetry(fetchResponse, {
+        retryTimeoutMs: 20_000,
+        minTimeForRetryMs: 15_000,
+        logger: createNoOpLogger(),
+        retryLogMessage: 'retrying test response',
+        shouldRetry: (candidate) => candidate.status === 503
+      });
+
+      expect(response.status).toBe(404);
+      expect(fetchResponse).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns retryable responses when the retry budget is exhausted', async () => {
+      const response503 = responseWithStatus(503);
+      const fetchResponse = vi
+        .fn<() => Promise<Response>>()
+        .mockResolvedValue(response503);
+      const onRetryExhausted = vi.fn();
+
+      const response = await fetchWithResponseRetry(fetchResponse, {
+        retryTimeoutMs: 0,
+        minTimeForRetryMs: 15_000,
+        logger: createNoOpLogger(),
+        retryLogMessage: 'retrying test response',
+        shouldRetry: (candidate) => candidate.status === 503,
+        onRetryExhausted
+      });
+
+      expect(response).toBe(response503);
+      expect(fetchResponse).toHaveBeenCalledTimes(1);
+      expect(onRetryExhausted).toHaveBeenCalledWith({
+        attempts: 1,
+        elapsedMs: expect.any(Number),
+        response: response503
+      });
+    });
+  });
+});

--- a/packages/sandbox/tests/ws-transport.test.ts
+++ b/packages/sandbox/tests/ws-transport.test.ts
@@ -729,51 +729,12 @@ describe('WebSocketTransport', () => {
   });
 
   describe('fetch without connection', () => {
-    it('retries 503 upgrade responses with updated retry budget', async () => {
-      vi.useFakeTimers();
-
-      try {
-        const transport = new WebSocketTransport({
-          wsUrl: 'ws://localhost:8671/ws',
-          retryTimeoutMs: 1_000
-        });
-        transport.setRetryTimeoutMs(20_000);
-
-        const attemptUpgrade = vi
-          .fn<() => Promise<Response>>()
-          .mockResolvedValueOnce(
-            new Response('Container is starting.', {
-              status: 503,
-              statusText: 'Service Unavailable'
-            })
-          )
-          .mockResolvedValueOnce(
-            new Response(null, {
-              status: 200,
-              statusText: 'OK'
-            })
-          );
-
-        const connectPromise = (
-          transport as unknown as {
-            fetchUpgradeWithRetry: (
-              attemptUpgrade: () => Promise<Response>
-            ) => Promise<Response>;
-          }
-        ).fetchUpgradeWithRetry(attemptUpgrade);
-        await vi.advanceTimersByTimeAsync(0);
-
-        expect(attemptUpgrade).toHaveBeenCalledTimes(1);
-
-        await vi.advanceTimersByTimeAsync(3_000);
-        const response = await connectPromise;
-
-        expect(attemptUpgrade).toHaveBeenCalledTimes(2);
-        expect(response.status).toBe(200);
-      } finally {
-        vi.useRealTimers();
-      }
-    });
+    function makeUpgradeFailure(status: number): Response {
+      return new Response('Container upgrade unavailable.', {
+        status,
+        statusText: 'Service Unavailable'
+      });
+    }
 
     it('creates a fresh request for each connectViaFetch retry', async () => {
       vi.useFakeTimers();
@@ -794,10 +755,7 @@ describe('WebSocketTransport', () => {
             .fn<(request: Request) => Promise<Response>>()
             .mockImplementationOnce(async (request) => {
               requests.push(request);
-              return new Response('Container is starting.', {
-                status: 503,
-                statusText: 'Service Unavailable'
-              });
+              return makeUpgradeFailure(503);
             })
             .mockImplementationOnce(async (request) => {
               requests.push(request);
@@ -818,12 +776,11 @@ describe('WebSocketTransport', () => {
           wsUrl: 'ws://localhost:8671/ws',
           stub,
           connectTimeoutMs: 1,
-          retryTimeoutMs: 20_000
+          retryTimeoutMs: 1_000
         });
+        transport.setRetryTimeoutMs(20_000);
 
-        const connectPromise = (
-          transport as unknown as { connectViaFetch: () => Promise<void> }
-        ).connectViaFetch();
+        const connectPromise = transport.connect();
 
         await vi.advanceTimersByTimeAsync(0);
         expect(stub.fetch).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
The Sandbox DO opens a WebSocket control-plane connection to the container. Until now, only HTTP 503 on the upgrade was treated as transient — every other 5xx terminated the connect attempt, even when the container was healthy and would have accepted the next attempt.

This widens the retry policy on the WebSocket upgrade leg only:

- 500/502/503/504 are retried against the existing 2-minute budget with exponential backoff.
- 400/401/403/404 stay terminal so client/validation errors fail fast.
- HTTP startup retry is unchanged — `BaseTransport` still only retries 503.
- The container runtime now returns 503 (instead of 500) when `server.upgrade()` itself fails, so producer and consumer agree a failed upgrade is retryable.

The asymmetry is deliberate: a 5xx on the WebSocket upgrade means we never established the channel and no application code ran, so retrying is safe. A 5xx on a normal HTTP request means the container actually attempted the work, so blindly retrying could double-execute. 503 is the one HTTP status that carries the specific "container still starting, no handler mounted" meaning.

The retry loop that previously lived inline in both upgrade paths is now a single internal helper, reused by the HTTP 503 startup path as well.

Out of scope: thrown fetch errors on the upgrade leg (abort/timeout before a Response) are not retried here, and no automatic `ctx.abort()` is added. Those belong to a follow-up control-plane liveness pass if persistent wedges remain after this change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->