### PR TITLE
Implement proxy mount read caching

### DIFF
--- a/.changeset/improve-credential-proxy-head-cache.md
+++ b/.changeset/improve-credential-proxy-head-cache.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Improve credential-proxied bucket mounts by caching safe HEAD metadata lookups while preserving correctness for multipart writes, copy operations, and conditional or ranged requests.

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -127,6 +127,7 @@ import {
 } from './storage-mount/r2-egress-handler';
 import {
   evictDirectoryMarkerCacheForMount,
+  evictHeadMetadataCacheForMount,
   evictSigV4ClientCacheEntry,
   SELF_TEST_PATH as S3_CREDENTIAL_PROXY_SELF_TEST_PATH,
   s3CredentialProxyHandler
@@ -2120,6 +2121,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           this.activeMounts.delete(mountPath);
           evictSigV4ClientCacheEntry(failedMount.mountId);
           evictDirectoryMarkerCacheForMount(failedMount.mountId);
+          evictHeadMetadataCacheForMount(failedMount.mountId);
         } catch (cleanupError) {
           this.logger.warn('credential proxy cleanup failed', {
             mountPath,
@@ -2131,6 +2133,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           this.activeMounts.delete(mountPath);
           evictSigV4ClientCacheEntry(failedMount.mountId);
           evictDirectoryMarkerCacheForMount(failedMount.mountId);
+          evictHeadMetadataCacheForMount(failedMount.mountId);
         }
       } else {
         this.activeMounts.delete(mountPath);
@@ -2208,6 +2211,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         this.activeMounts.delete(mountPath);
         evictSigV4ClientCacheEntry(mountInfo.mountId);
         evictDirectoryMarkerCacheForMount(mountInfo.mountId);
+        evictHeadMetadataCacheForMount(mountInfo.mountId);
       } else {
         // FUSE unmount
         let unmounted = false;
@@ -2279,6 +2283,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
             this.activeMounts.delete(mountPath);
             evictSigV4ClientCacheEntry(mountInfo.mountId);
             evictDirectoryMarkerCacheForMount(mountInfo.mountId);
+            evictHeadMetadataCacheForMount(mountInfo.mountId);
           } else {
             this.activeMounts.delete(mountPath);
           }
@@ -2900,6 +2905,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         hadCredentialProxyMount = true;
         evictSigV4ClientCacheEntry(m.mountId);
         evictDirectoryMarkerCacheForMount(m.mountId);
+        evictHeadMetadataCacheForMount(m.mountId);
       }
     }
     if (hadR2EgressMount) {

--- a/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
+++ b/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
@@ -19,6 +19,7 @@ import type {
   OutboundHandlerContext
 } from '@cloudflare/containers';
 import type { BucketProvider } from '@repo/shared';
+import { AwsClient } from 'aws4fetch';
 import type { S3CredentialProxyParams } from './types';
 
 const PER_MOUNT_SUFFIX = '.s3-credential-proxy.internal';
@@ -82,7 +83,7 @@ const HEAD_METADATA_PUT_RESPONSE_HEADERS = new Set([
   'x-goog-storage-class'
 ]);
 
-const SIGV4_SKIPPED_FORWARD_HEADERS = new Set([
+const SKIPPED_FORWARD_HEADERS = new Set([
   'connection',
   'expect',
   'host',
@@ -94,18 +95,6 @@ const SIGV4_SKIPPED_FORWARD_HEADERS = new Set([
   'transfer-encoding',
   'upgrade',
   'user-agent'
-]);
-
-const SIGV4_UNSIGNABLE_HEADERS = new Set([
-  'authorization',
-  'connection',
-  'content-length',
-  'content-type',
-  'expect',
-  'presigned-expires',
-  'range',
-  'user-agent',
-  'x-amzn-trace-id'
 ]);
 
 export const DUMMY_AUTH_HEADERS = new Set([
@@ -146,13 +135,12 @@ type CredentialProxyDiagnosticEvent = CredentialProxyRequestInfo & {
 };
 
 type SigV4ClientCacheEntry = {
+  client: AwsClient;
   accessKeyId: string;
   secretAccessKey: string;
   endpoint: string;
   provider: BucketProvider | null;
   region: string;
-  date: string;
-  key: ArrayBuffer;
 };
 
 type HeadMetadataCacheEntry = {
@@ -397,7 +385,7 @@ function buildCleanHeaders(original: Headers): Headers {
     // Strip dummy signing headers and the intercepted proxy host; x-amz-content-sha256
     // is stripped here too (it's in DUMMY_AUTH_HEADERS) so it can be re-added below
     // only when the original value is a genuine payload hash (not a dummy signing value).
-    if (!DUMMY_AUTH_HEADERS.has(lower) && lower !== 'host') {
+    if (!DUMMY_AUTH_HEADERS.has(lower) && !SKIPPED_FORWARD_HEADERS.has(lower)) {
       clean.set(k, v);
     }
   }
@@ -518,14 +506,13 @@ async function withCredentialProxyDiagnostics(
   }
 }
 
-async function getSigV4SigningKey(
+function getSigV4Client(
   mountId: string,
   endpoint: string,
   provider: BucketProvider | null,
   credentials: { accessKeyId: string; secretAccessKey: string },
-  region: string,
-  date: string
-): Promise<ArrayBuffer> {
+  region: string
+): AwsClient {
   const cached = sigV4ClientCache.get(mountId);
   if (
     cached &&
@@ -533,30 +520,27 @@ async function getSigV4SigningKey(
     cached.secretAccessKey === credentials.secretAccessKey &&
     cached.endpoint === endpoint &&
     cached.provider === provider &&
-    cached.region === region &&
-    cached.date === date
+    cached.region === region
   ) {
-    return cached.key;
+    return cached.client;
   }
 
-  const enc = new TextEncoder();
-  const kDate = await hmacSHA256(
-    enc.encode(`AWS4${credentials.secretAccessKey}`) as unknown as ArrayBuffer,
-    date
-  );
-  const kRegion = await hmacSHA256(kDate, region);
-  const kService = await hmacSHA256(kRegion, 's3');
-  const key = await hmacSHA256(kService, 'aws4_request');
+  const client = new AwsClient({
+    accessKeyId: credentials.accessKeyId,
+    secretAccessKey: credentials.secretAccessKey,
+    service: 's3',
+    region,
+    retries: 0
+  });
   sigV4ClientCache.set(mountId, {
+    client,
     accessKeyId: credentials.accessKeyId,
     secretAccessKey: credentials.secretAccessKey,
     endpoint,
     provider,
-    region,
-    date,
-    key
+    region
   });
-  return key;
+  return client;
 }
 
 function encodeCanonicalQueryPart(value: string): string {
@@ -780,45 +764,6 @@ function getSigV4ForwardInit(request: Request): RequestInit {
   return { body: readable };
 }
 
-function getSigV4ForwardHeaders(
-  request: Request,
-  dateStr: string,
-  payloadHash: string
-): Headers {
-  const headers = new Headers();
-  for (const [k, v] of request.headers as unknown as Iterable<
-    [string, string]
-  >) {
-    const lower = k.toLowerCase();
-    if (
-      SIGV4_SKIPPED_FORWARD_HEADERS.has(lower) ||
-      DUMMY_AUTH_HEADERS.has(lower)
-    ) {
-      continue;
-    }
-    headers.set(k, v);
-  }
-  headers.set('x-amz-content-sha256', payloadHash);
-  headers.set('x-amz-date', dateStr);
-  return headers;
-}
-
-function getSigV4SignedHeaderEntries(
-  url: URL,
-  headers: Headers
-): [string, string][] {
-  const entries: [string, string][] = [['host', url.host]];
-  for (const [k, v] of headers as unknown as Iterable<[string, string]>) {
-    const lower = k.toLowerCase();
-    if (SIGV4_UNSIGNABLE_HEADERS.has(lower)) {
-      continue;
-    }
-    entries.push([lower, v.trim().replace(/\s+/g, ' ')]);
-  }
-  entries.sort(([left], [right]) => left.localeCompare(right));
-  return entries;
-}
-
 function getGCSHeaders(request: Request): Headers {
   const headers = new Headers();
   for (const [k, v] of request.headers as unknown as Iterable<
@@ -854,64 +799,25 @@ async function signAndForwardSigV4(
   requestInfo: CredentialProxyRequestInfo
 ): Promise<Response> {
   const signingStarted = Date.now();
-  const url = new URL(request.url);
   const region = detectS3Region(provider, endpoint);
   const payload = getSigV4PayloadHash(request.headers);
-  const now = new Date();
-  const dateStr = `${now
-    .toISOString()
-    .replace(/[:-]/g, '')
-    .replace(/\.\d+Z$/, '')}Z`;
-  const dateOnly = dateStr.slice(0, 8);
-  const credentialScope = `${dateOnly}/${region}/s3/aws4_request`;
-  const forwardHeaders = getSigV4ForwardHeaders(request, dateStr, payload.hash);
-  const signedHeaderEntries = getSigV4SignedHeaderEntries(url, forwardHeaders);
-  const signedHeaders = signedHeaderEntries.map(([k]) => k).join(';');
-  const canonicalHeaders = signedHeaderEntries
-    .map(([k, v]) => `${k}:${v}\n`)
-    .join('');
-  const canonicalRequest = [
-    request.method,
-    getCanonicalURI(url),
-    getCanonicalQueryString(url),
-    canonicalHeaders,
-    signedHeaders,
-    payload.hash
-  ].join('\n');
-  const canonicalRequestHash = await sha256Hex(canonicalRequest);
-  const stringToSign = [
-    'AWS4-HMAC-SHA256',
-    dateStr,
-    credentialScope,
-    canonicalRequestHash
-  ].join('\n');
-  const signingKey = await getSigV4SigningKey(
+  const client = getSigV4Client(
     mountId,
     endpoint,
     provider,
     credentials,
-    region,
-    dateOnly
-  );
-  const signature = toHex(await hmacSHA256(signingKey, stringToSign));
-  forwardHeaders.set(
-    'Authorization',
-    `AWS4-HMAC-SHA256 Credential=${credentials.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`
+    region
   );
   requestInfo.payloadHashMode = payload.mode;
+  // clientSetupMs captures region detection + client cache lookup + payload hash;
+  // the actual SigV4 signing happens inside client.fetch() and is included in upstreamMs.
   requestInfo.clientSetupMs = Date.now() - signingStarted;
 
   const upstreamStarted = Date.now();
   const forwardInit = getSigV4ForwardInit(request);
   requestInfo.bodyPresent =
     forwardInit?.body !== undefined || request.body !== null;
-  const response = await fetch(
-    new Request(request.url, {
-      method: request.method,
-      headers: forwardHeaders,
-      body: forwardInit.body
-    })
-  );
+  const response = await client.fetch(request, forwardInit);
   requestInfo.upstreamMs = Date.now() - upstreamStarted;
   return response;
 }

--- a/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
+++ b/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
@@ -31,6 +31,83 @@ const HEAD_METADATA_CACHE_TTL_MS = 60_000;
 const NEGATIVE_HEAD_METADATA_CACHE_TTL_MS = 5_000;
 const HEAD_METADATA_CACHE_MAX_ENTRIES = 1_000;
 
+const HEAD_METADATA_CACHE_VARY_HEADERS = [
+  'range',
+  'if-match',
+  'if-none-match',
+  'if-modified-since',
+  'if-unmodified-since',
+  'if-range',
+  'x-amz-checksum-mode',
+  'x-amz-server-side-encryption-customer-algorithm',
+  'x-amz-server-side-encryption-customer-key',
+  'x-amz-server-side-encryption-customer-key-md5',
+  'x-goog-encryption-algorithm',
+  'x-goog-encryption-key',
+  'x-goog-encryption-key-sha256'
+];
+
+const HEAD_METADATA_PUT_REQUEST_HEADERS = new Set([
+  'cache-control',
+  'content-disposition',
+  'content-encoding',
+  'content-language',
+  'content-type',
+  'expires',
+  'x-amz-checksum-crc32',
+  'x-amz-checksum-crc32c',
+  'x-amz-checksum-crc64nvme',
+  'x-amz-checksum-sha1',
+  'x-amz-checksum-sha256',
+  'x-amz-server-side-encryption',
+  'x-amz-server-side-encryption-aws-kms-key-id',
+  'x-amz-storage-class',
+  'x-goog-storage-class'
+]);
+
+const HEAD_METADATA_PUT_RESPONSE_HEADERS = new Set([
+  'etag',
+  'last-modified',
+  'x-amz-checksum-crc32',
+  'x-amz-checksum-crc32c',
+  'x-amz-checksum-crc64nvme',
+  'x-amz-checksum-sha1',
+  'x-amz-checksum-sha256',
+  'x-amz-server-side-encryption',
+  'x-amz-server-side-encryption-aws-kms-key-id',
+  'x-amz-version-id',
+  'x-goog-generation',
+  'x-goog-hash',
+  'x-goog-metageneration',
+  'x-goog-storage-class'
+]);
+
+const SIGV4_SKIPPED_FORWARD_HEADERS = new Set([
+  'connection',
+  'expect',
+  'host',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'user-agent'
+]);
+
+const SIGV4_UNSIGNABLE_HEADERS = new Set([
+  'authorization',
+  'connection',
+  'content-length',
+  'content-type',
+  'expect',
+  'presigned-expires',
+  'range',
+  'user-agent',
+  'x-amzn-trace-id'
+]);
+
 export const DUMMY_AUTH_HEADERS = new Set([
   'authorization',
   'x-amz-date',
@@ -141,7 +218,7 @@ function getCachedHeadMetadataResponse(
 }
 
 function enforceHeadMetadataCacheLimit(): void {
-  if (headMetadataCache.size <= HEAD_METADATA_CACHE_MAX_ENTRIES) {
+  if (headMetadataCache.size < HEAD_METADATA_CACHE_MAX_ENTRIES) {
     return;
   }
   const now = Date.now();
@@ -150,10 +227,10 @@ function enforceHeadMetadataCacheLimit(): void {
       headMetadataCache.delete(key);
     }
   }
-  if (headMetadataCache.size <= HEAD_METADATA_CACHE_MAX_ENTRIES) {
+  if (headMetadataCache.size < HEAD_METADATA_CACHE_MAX_ENTRIES) {
     return;
   }
-  const excess = headMetadataCache.size - HEAD_METADATA_CACHE_MAX_ENTRIES;
+  const excess = headMetadataCache.size - HEAD_METADATA_CACHE_MAX_ENTRIES + 1;
   let removed = 0;
   for (const key of Array.from(headMetadataCache.keys())) {
     if (removed >= excess) break;
@@ -192,25 +269,25 @@ function cacheHeadMetadataFromPUT(
   }
   const headers = new Headers();
   const contentLength = request.headers.get('content-length');
-  const contentType = request.headers.get('content-type');
-  const etag = response.headers.get('etag');
-  const lastModified = response.headers.get('last-modified');
   if (contentLength !== null) {
     headers.set('content-length', contentLength);
-  }
-  if (contentType !== null) {
-    headers.set('content-type', contentType);
-  }
-  if (etag !== null) {
-    headers.set('etag', etag);
-  }
-  if (lastModified !== null) {
-    headers.set('last-modified', lastModified);
   }
   for (const [key, value] of Array.from(
     request.headers as unknown as Iterable<[string, string]>
   )) {
-    if (key.toLowerCase().startsWith('x-amz-meta-')) {
+    const lowerKey = key.toLowerCase();
+    if (
+      HEAD_METADATA_PUT_REQUEST_HEADERS.has(lowerKey) ||
+      lowerKey.startsWith('x-amz-meta-') ||
+      lowerKey.startsWith('x-goog-meta-')
+    ) {
+      headers.set(key, value);
+    }
+  }
+  for (const [key, value] of Array.from(
+    response.headers as unknown as Iterable<[string, string]>
+  )) {
+    if (HEAD_METADATA_PUT_RESPONSE_HEADERS.has(key.toLowerCase())) {
       headers.set(key, value);
     }
   }
@@ -223,16 +300,52 @@ function cacheHeadMetadataFromPUT(
   });
 }
 
-function deleteHeadMetadataCacheEntry(
+function deleteHeadMetadataCacheEntriesForObject(
   mountId: string,
-  realPath: string,
-  url: URL
+  realPath: string
 ): void {
-  headMetadataCache.delete(getHeadMetadataCacheKey(mountId, realPath, url));
+  const baseKey = `${mountId}:${realPath}`;
+  for (const key of Array.from(headMetadataCache.keys())) {
+    if (key === baseKey || key.startsWith(`${baseKey}?`)) {
+      headMetadataCache.delete(key);
+    }
+  }
 }
 
 function isMutatingMethod(method: string): boolean {
   return method === 'PUT' || method === 'POST' || method === 'DELETE';
+}
+
+function canUseHeadMetadataCache(request: Request): boolean {
+  if (request.method.toUpperCase() !== 'HEAD') {
+    return false;
+  }
+  return HEAD_METADATA_CACHE_VARY_HEADERS.every(
+    (header) => request.headers.get(header) === null
+  );
+}
+
+function canPrimeHeadMetadataFromPUT(request: Request, url: URL): boolean {
+  if (request.method.toUpperCase() !== 'PUT') {
+    return false;
+  }
+  if (url.search !== '') {
+    return false;
+  }
+  if (request.headers.get('content-length') === null) {
+    return false;
+  }
+  if (
+    HEAD_METADATA_CACHE_VARY_HEADERS.some(
+      (header) => request.headers.get(header) !== null
+    )
+  ) {
+    return false;
+  }
+  return (
+    request.headers.get('x-amz-copy-source') === null &&
+    request.headers.get('x-goog-copy-source') === null
+  );
 }
 
 function toHex(buffer: ArrayBuffer): string {
@@ -653,8 +766,11 @@ function getSigV4ForwardInit(request: Request): RequestInit {
   if (contentLength === 0) {
     return { body: new Uint8Array(0) };
   }
-  if (contentLength === null || request.body === null) {
+  if (request.body === null) {
     return {};
+  }
+  if (contentLength === null) {
+    return { body: request.body };
   }
 
   const { readable, writable } = new FixedLengthStream(contentLength);
@@ -675,8 +791,7 @@ function getSigV4ForwardHeaders(
   >) {
     const lower = k.toLowerCase();
     if (
-      lower === 'host' ||
-      lower === 'expect' ||
+      SIGV4_SKIPPED_FORWARD_HEADERS.has(lower) ||
       DUMMY_AUTH_HEADERS.has(lower)
     ) {
       continue;
@@ -695,7 +810,7 @@ function getSigV4SignedHeaderEntries(
   const entries: [string, string][] = [['host', url.host]];
   for (const [k, v] of headers as unknown as Iterable<[string, string]>) {
     const lower = k.toLowerCase();
-    if (lower === 'authorization' || lower === 'content-length') {
+    if (SIGV4_UNSIGNABLE_HEADERS.has(lower)) {
       continue;
     }
     entries.push([lower, v.trim().replace(/\s+/g, ' ')]);
@@ -1004,6 +1119,11 @@ export const s3CredentialProxyHandler: OutboundHandler<
             getDirectoryMarkerCacheKey(mountId, realPath),
             responseHeaders
           );
+          deleteHeadMetadataCacheEntriesForObject(mountId, realPath);
+          deleteHeadMetadataCacheEntriesForObject(
+            mountId,
+            realPath.replace(/\/+$/, '')
+          );
         }
 
         return response;
@@ -1040,7 +1160,12 @@ export const s3CredentialProxyHandler: OutboundHandler<
 
   const method = cleanRequest.method.toUpperCase();
   const headMetadataCacheKey = getHeadMetadataCacheKey(mountId, realPath, url);
-  if (method === 'HEAD') {
+  const useHeadMetadataCache = canUseHeadMetadataCache(cleanRequest);
+  const primeHeadMetadataFromPUT = canPrimeHeadMetadataFromPUT(
+    cleanRequest,
+    url
+  );
+  if (useHeadMetadataCache) {
     const cachedHeadResponse = getCachedHeadMetadataResponse(
       headMetadataCacheKey,
       Date.now()
@@ -1062,7 +1187,7 @@ export const s3CredentialProxyHandler: OutboundHandler<
     }
   } else if (isMutatingMethod(method)) {
     deleteDirectoryMarkerCacheEntry(mountId, realPath);
-    deleteHeadMetadataCacheEntry(mountId, realPath, url);
+    deleteHeadMetadataCacheEntriesForObject(mountId, realPath);
   }
 
   if (mount.authStrategy === 'gcs') {
@@ -1077,9 +1202,9 @@ export const s3CredentialProxyHandler: OutboundHandler<
           mount.credentials,
           requestInfo
         );
-        if (method === 'HEAD') {
+        if (useHeadMetadataCache) {
           cacheHeadMetadataResponse(headMetadataCacheKey, response);
-        } else if (method === 'PUT') {
+        } else if (primeHeadMetadataFromPUT) {
           cacheHeadMetadataFromPUT(
             headMetadataCacheKey,
             cleanRequest,
@@ -1105,9 +1230,9 @@ export const s3CredentialProxyHandler: OutboundHandler<
         mount.credentials,
         requestInfo
       );
-      if (method === 'HEAD') {
+      if (useHeadMetadataCache) {
         cacheHeadMetadataResponse(headMetadataCacheKey, response);
-      } else if (method === 'PUT') {
+      } else if (primeHeadMetadataFromPUT) {
         cacheHeadMetadataFromPUT(headMetadataCacheKey, cleanRequest, response);
       }
       return response;

--- a/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
+++ b/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
@@ -19,7 +19,6 @@ import type {
   OutboundHandlerContext
 } from '@cloudflare/containers';
 import type { BucketProvider } from '@repo/shared';
-import { AwsClient } from 'aws4fetch';
 import type { S3CredentialProxyParams } from './types';
 
 const PER_MOUNT_SUFFIX = '.s3-credential-proxy.internal';
@@ -28,6 +27,9 @@ export const DIAGNOSTICS_PATH = '/__sandbox_credential_proxy_diagnostics__';
 const DEFAULT_SLOW_REQUEST_MS = 1000;
 const ERROR_RESPONSE_BODY_LIMIT = 2048;
 const MAX_DIAGNOSTIC_EVENTS = 500;
+const HEAD_METADATA_CACHE_TTL_MS = 60_000;
+const NEGATIVE_HEAD_METADATA_CACHE_TTL_MS = 5_000;
+const HEAD_METADATA_CACHE_MAX_ENTRIES = 1_000;
 
 export const DUMMY_AUTH_HEADERS = new Set([
   'authorization',
@@ -67,16 +69,25 @@ type CredentialProxyDiagnosticEvent = CredentialProxyRequestInfo & {
 };
 
 type SigV4ClientCacheEntry = {
-  client: AwsClient;
   accessKeyId: string;
   secretAccessKey: string;
   endpoint: string;
   provider: BucketProvider | null;
   region: string;
+  date: string;
+  key: ArrayBuffer;
+};
+
+type HeadMetadataCacheEntry = {
+  expiresAt: number;
+  headers: [string, string][];
+  status: number;
+  statusText: string;
 };
 
 const sigV4ClientCache = new Map<string, SigV4ClientCacheEntry>();
 const directoryMarkerCache = new Map<string, [string, string][]>();
+const headMetadataCache = new Map<string, HeadMetadataCacheEntry>();
 const credentialProxyDiagnosticEvents: CredentialProxyDiagnosticEvent[] = [];
 let credentialProxyDiagnosticEventCount = 0;
 
@@ -91,6 +102,137 @@ export function evictDirectoryMarkerCacheForMount(mountId: string): void {
       directoryMarkerCache.delete(key);
     }
   }
+}
+
+export function evictHeadMetadataCacheForMount(mountId: string): void {
+  const prefix = `${mountId}:`;
+  for (const key of Array.from(headMetadataCache.keys())) {
+    if (key.startsWith(prefix)) {
+      headMetadataCache.delete(key);
+    }
+  }
+}
+
+function getHeadMetadataCacheKey(
+  mountId: string,
+  realPath: string,
+  url: URL
+): string {
+  return `${mountId}:${realPath}${url.search}`;
+}
+
+function getCachedHeadMetadataResponse(
+  cacheKey: string,
+  now: number
+): Response | null {
+  const cached = headMetadataCache.get(cacheKey);
+  if (!cached) {
+    return null;
+  }
+  if (cached.expiresAt <= now) {
+    headMetadataCache.delete(cacheKey);
+    return null;
+  }
+  return new Response(null, {
+    status: cached.status,
+    statusText: cached.statusText,
+    headers: cached.headers
+  });
+}
+
+function enforceHeadMetadataCacheLimit(): void {
+  if (headMetadataCache.size <= HEAD_METADATA_CACHE_MAX_ENTRIES) {
+    return;
+  }
+  const now = Date.now();
+  for (const [key, entry] of Array.from(headMetadataCache.entries())) {
+    if (entry.expiresAt <= now) {
+      headMetadataCache.delete(key);
+    }
+  }
+  if (headMetadataCache.size <= HEAD_METADATA_CACHE_MAX_ENTRIES) {
+    return;
+  }
+  const excess = headMetadataCache.size - HEAD_METADATA_CACHE_MAX_ENTRIES;
+  let removed = 0;
+  for (const key of Array.from(headMetadataCache.keys())) {
+    if (removed >= excess) break;
+    headMetadataCache.delete(key);
+    removed++;
+  }
+}
+
+function cacheHeadMetadataResponse(cacheKey: string, response: Response): void {
+  if (!response.ok && response.status !== 404) {
+    headMetadataCache.delete(cacheKey);
+    return;
+  }
+  enforceHeadMetadataCacheLimit();
+  headMetadataCache.set(cacheKey, {
+    expiresAt:
+      Date.now() +
+      (response.status === 404
+        ? NEGATIVE_HEAD_METADATA_CACHE_TTL_MS
+        : HEAD_METADATA_CACHE_TTL_MS),
+    headers: Array.from(
+      response.headers as unknown as Iterable<[string, string]>
+    ),
+    status: response.status,
+    statusText: response.statusText
+  });
+}
+
+function cacheHeadMetadataFromPUT(
+  cacheKey: string,
+  request: Request,
+  response: Response
+): void {
+  if (!response.ok) {
+    return;
+  }
+  const headers = new Headers();
+  const contentLength = request.headers.get('content-length');
+  const contentType = request.headers.get('content-type');
+  const etag = response.headers.get('etag');
+  const lastModified = response.headers.get('last-modified');
+  if (contentLength !== null) {
+    headers.set('content-length', contentLength);
+  }
+  if (contentType !== null) {
+    headers.set('content-type', contentType);
+  }
+  if (etag !== null) {
+    headers.set('etag', etag);
+  }
+  if (lastModified !== null) {
+    headers.set('last-modified', lastModified);
+  }
+  for (const [key, value] of Array.from(
+    request.headers as unknown as Iterable<[string, string]>
+  )) {
+    if (key.toLowerCase().startsWith('x-amz-meta-')) {
+      headers.set(key, value);
+    }
+  }
+  enforceHeadMetadataCacheLimit();
+  headMetadataCache.set(cacheKey, {
+    expiresAt: Date.now() + HEAD_METADATA_CACHE_TTL_MS,
+    headers: Array.from(headers as unknown as Iterable<[string, string]>),
+    status: 200,
+    statusText: 'OK'
+  });
+}
+
+function deleteHeadMetadataCacheEntry(
+  mountId: string,
+  realPath: string,
+  url: URL
+): void {
+  headMetadataCache.delete(getHeadMetadataCacheKey(mountId, realPath, url));
+}
+
+function isMutatingMethod(method: string): boolean {
+  return method === 'PUT' || method === 'POST' || method === 'DELETE';
 }
 
 function toHex(buffer: ArrayBuffer): string {
@@ -263,13 +405,14 @@ async function withCredentialProxyDiagnostics(
   }
 }
 
-function getSigV4Client(
+async function getSigV4SigningKey(
   mountId: string,
   endpoint: string,
   provider: BucketProvider | null,
   credentials: { accessKeyId: string; secretAccessKey: string },
-  region: string
-): AwsClient {
+  region: string,
+  date: string
+): Promise<ArrayBuffer> {
   const cached = sigV4ClientCache.get(mountId);
   if (
     cached &&
@@ -277,27 +420,30 @@ function getSigV4Client(
     cached.secretAccessKey === credentials.secretAccessKey &&
     cached.endpoint === endpoint &&
     cached.provider === provider &&
-    cached.region === region
+    cached.region === region &&
+    cached.date === date
   ) {
-    return cached.client;
+    return cached.key;
   }
 
-  const client = new AwsClient({
-    accessKeyId: credentials.accessKeyId,
-    secretAccessKey: credentials.secretAccessKey,
-    service: 's3',
-    region,
-    retries: 0
-  });
+  const enc = new TextEncoder();
+  const kDate = await hmacSHA256(
+    enc.encode(`AWS4${credentials.secretAccessKey}`) as unknown as ArrayBuffer,
+    date
+  );
+  const kRegion = await hmacSHA256(kDate, region);
+  const kService = await hmacSHA256(kRegion, 's3');
+  const key = await hmacSHA256(kService, 'aws4_request');
   sigV4ClientCache.set(mountId, {
-    client,
     accessKeyId: credentials.accessKeyId,
     secretAccessKey: credentials.secretAccessKey,
     endpoint,
     provider,
-    region
+    region,
+    date,
+    key
   });
-  return client;
+  return key;
 }
 
 function encodeCanonicalQueryPart(value: string): string {
@@ -518,6 +664,46 @@ function getSigV4ForwardInit(request: Request): RequestInit {
   return { body: readable };
 }
 
+function getSigV4ForwardHeaders(
+  request: Request,
+  dateStr: string,
+  payloadHash: string
+): Headers {
+  const headers = new Headers();
+  for (const [k, v] of request.headers as unknown as Iterable<
+    [string, string]
+  >) {
+    const lower = k.toLowerCase();
+    if (
+      lower === 'host' ||
+      lower === 'expect' ||
+      DUMMY_AUTH_HEADERS.has(lower)
+    ) {
+      continue;
+    }
+    headers.set(k, v);
+  }
+  headers.set('x-amz-content-sha256', payloadHash);
+  headers.set('x-amz-date', dateStr);
+  return headers;
+}
+
+function getSigV4SignedHeaderEntries(
+  url: URL,
+  headers: Headers
+): [string, string][] {
+  const entries: [string, string][] = [['host', url.host]];
+  for (const [k, v] of headers as unknown as Iterable<[string, string]>) {
+    const lower = k.toLowerCase();
+    if (lower === 'authorization' || lower === 'content-length') {
+      continue;
+    }
+    entries.push([lower, v.trim().replace(/\s+/g, ' ')]);
+  }
+  entries.sort(([left], [right]) => left.localeCompare(right));
+  return entries;
+}
+
 function getGCSHeaders(request: Request): Headers {
   const headers = new Headers();
   for (const [k, v] of request.headers as unknown as Iterable<
@@ -553,25 +739,64 @@ async function signAndForwardSigV4(
   requestInfo: CredentialProxyRequestInfo
 ): Promise<Response> {
   const signingStarted = Date.now();
+  const url = new URL(request.url);
   const region = detectS3Region(provider, endpoint);
   const payload = getSigV4PayloadHash(request.headers);
-  const client = getSigV4Client(
+  const now = new Date();
+  const dateStr = `${now
+    .toISOString()
+    .replace(/[:-]/g, '')
+    .replace(/\.\d+Z$/, '')}Z`;
+  const dateOnly = dateStr.slice(0, 8);
+  const credentialScope = `${dateOnly}/${region}/s3/aws4_request`;
+  const forwardHeaders = getSigV4ForwardHeaders(request, dateStr, payload.hash);
+  const signedHeaderEntries = getSigV4SignedHeaderEntries(url, forwardHeaders);
+  const signedHeaders = signedHeaderEntries.map(([k]) => k).join(';');
+  const canonicalHeaders = signedHeaderEntries
+    .map(([k, v]) => `${k}:${v}\n`)
+    .join('');
+  const canonicalRequest = [
+    request.method,
+    getCanonicalURI(url),
+    getCanonicalQueryString(url),
+    canonicalHeaders,
+    signedHeaders,
+    payload.hash
+  ].join('\n');
+  const canonicalRequestHash = await sha256Hex(canonicalRequest);
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    dateStr,
+    credentialScope,
+    canonicalRequestHash
+  ].join('\n');
+  const signingKey = await getSigV4SigningKey(
     mountId,
     endpoint,
     provider,
     credentials,
-    region
+    region,
+    dateOnly
+  );
+  const signature = toHex(await hmacSHA256(signingKey, stringToSign));
+  forwardHeaders.set(
+    'Authorization',
+    `AWS4-HMAC-SHA256 Credential=${credentials.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`
   );
   requestInfo.payloadHashMode = payload.mode;
-  // clientSetupMs captures region detection + client cache lookup + payload hash;
-  // the actual SigV4 signing happens inside client.fetch() and is included in upstreamMs.
   requestInfo.clientSetupMs = Date.now() - signingStarted;
 
   const upstreamStarted = Date.now();
   const forwardInit = getSigV4ForwardInit(request);
   requestInfo.bodyPresent =
     forwardInit?.body !== undefined || request.body !== null;
-  const response = await client.fetch(request, forwardInit);
+  const response = await fetch(
+    new Request(request.url, {
+      method: request.method,
+      headers: forwardHeaders,
+      body: forwardInit.body
+    })
+  );
   requestInfo.upstreamMs = Date.now() - upstreamStarted;
   return response;
 }
@@ -813,8 +1038,31 @@ export const s3CredentialProxyHandler: OutboundHandler<
     }
   }
 
-  if (cleanRequest.method.toUpperCase() !== 'HEAD') {
+  const method = cleanRequest.method.toUpperCase();
+  const headMetadataCacheKey = getHeadMetadataCacheKey(mountId, realPath, url);
+  if (method === 'HEAD') {
+    const cachedHeadResponse = getCachedHeadMetadataResponse(
+      headMetadataCacheKey,
+      Date.now()
+    );
+    if (cachedHeadResponse) {
+      requestInfo.bodyPresent = false;
+      if (mount.authStrategy === 's3-sigv4') {
+        requestInfo.payloadHashMode = getSigV4PayloadHash(
+          cleanRequest.headers
+        ).mode;
+      }
+      return withCredentialProxyDiagnostics(
+        requestInfo,
+        debugConfig,
+        ctx.containerId,
+        realPath,
+        () => Promise.resolve(cachedHeadResponse)
+      );
+    }
+  } else if (isMutatingMethod(method)) {
     deleteDirectoryMarkerCacheEntry(mountId, realPath);
+    deleteHeadMetadataCacheEntry(mountId, realPath, url);
   }
 
   if (mount.authStrategy === 'gcs') {
@@ -823,7 +1071,23 @@ export const s3CredentialProxyHandler: OutboundHandler<
       debugConfig,
       ctx.containerId,
       realPath,
-      () => signAndForwardGCS(cleanRequest, mount.credentials, requestInfo)
+      async () => {
+        const response = await signAndForwardGCS(
+          cleanRequest,
+          mount.credentials,
+          requestInfo
+        );
+        if (method === 'HEAD') {
+          cacheHeadMetadataResponse(headMetadataCacheKey, response);
+        } else if (method === 'PUT') {
+          cacheHeadMetadataFromPUT(
+            headMetadataCacheKey,
+            cleanRequest,
+            response
+          );
+        }
+        return response;
+      }
     );
   }
 
@@ -832,14 +1096,21 @@ export const s3CredentialProxyHandler: OutboundHandler<
     debugConfig,
     ctx.containerId,
     realPath,
-    () =>
-      signAndForwardSigV4(
+    async () => {
+      const response = await signAndForwardSigV4(
         cleanRequest,
         mountId,
         mount.endpoint,
         mount.provider,
         mount.credentials,
         requestInfo
-      )
+      );
+      if (method === 'HEAD') {
+        cacheHeadMetadataResponse(headMetadataCacheKey, response);
+      } else if (method === 'PUT') {
+        cacheHeadMetadataFromPUT(headMetadataCacheKey, cleanRequest, response);
+      }
+      return response;
+    }
   );
 };

--- a/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
+++ b/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   DUMMY_AUTH_HEADERS,
   evictDirectoryMarkerCacheForMount,
+  evictHeadMetadataCacheForMount,
   s3CredentialProxyHandler
 } from '../src/storage-mount/s3-credential-proxy-handler';
 import type { S3CredentialProxyParams } from '../src/storage-mount/types';
@@ -736,7 +737,7 @@ describe('s3CredentialProxyHandler SigV4 signing', () => {
     vi.restoreAllMocks();
   });
 
-  it('forwards HEAD requests upstream after zero-length PUT requests', async () => {
+  it('serves HEAD metadata from the cache after zero-length PUT requests', async () => {
     const forwardedRequests: Request[] = [];
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
       forwardedRequests.push(
@@ -762,10 +763,215 @@ describe('s3CredentialProxyHandler SigV4 signing', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(forwardedRequests).toHaveLength(2);
-    expect(forwardedRequests[1].method).toBe('HEAD');
+    expect(response.headers.get('content-length')).toBe('0');
+    expect(forwardedRequests).toHaveLength(1);
+    expect(forwardedRequests[0].method).toBe('PUT');
 
     vi.restoreAllMocks();
+  });
+
+  it('serves repeated HEAD requests from the metadata cache', async () => {
+    evictHeadMetadataCacheForMount(MOUNT_ID);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(null, {
+        status: 200,
+        headers: {
+          'content-length': '1024',
+          etag: '"abc123"'
+        }
+      })
+    );
+    const ctx = makeCtx(
+      makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+    ) as Parameters<typeof s3CredentialProxyHandler>[2];
+    const headReq = makeRequest(`/${MOUNT_ID}/${BUCKET}/cached.txt`, 'HEAD');
+
+    const firstResponse = await s3CredentialProxyHandler(
+      headReq,
+      {} as Cloudflare.Env,
+      ctx
+    );
+    const secondResponse = await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/cached.txt`, 'HEAD'),
+      {} as Cloudflare.Env,
+      ctx
+    );
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(secondResponse.headers.get('content-length')).toBe('1024');
+    expect(secondResponse.headers.get('etag')).toBe('"abc123"');
+    expect(fetchSpy).toHaveBeenCalledOnce();
+
+    vi.restoreAllMocks();
+    evictHeadMetadataCacheForMount(MOUNT_ID);
+  });
+
+  it('updates cached HEAD metadata after object mutation', async () => {
+    evictHeadMetadataCacheForMount(MOUNT_ID);
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 200,
+          headers: { 'content-length': '1024' }
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response('ok', {
+          status: 200,
+          headers: { etag: '"updated"' }
+        })
+      );
+    const ctx = makeCtx(
+      makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+    ) as Parameters<typeof s3CredentialProxyHandler>[2];
+
+    await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/cached.txt`, 'HEAD'),
+      {} as Cloudflare.Env,
+      ctx
+    );
+    await s3CredentialProxyHandler(
+      makeRequest(
+        `/${MOUNT_ID}/${BUCKET}/cached.txt`,
+        'PUT',
+        {
+          'content-length': '2',
+          'x-amz-content-sha256':
+            '2689367b205c16ce32a8533d524173e31571169bba6d9101a7d1150be7fb8cc3'
+        },
+        'ok'
+      ),
+      {} as Cloudflare.Env,
+      ctx
+    );
+    const response = await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/cached.txt`, 'HEAD'),
+      {} as Cloudflare.Env,
+      ctx
+    );
+
+    expect(response.headers.get('content-length')).toBe('2');
+    expect(response.headers.get('etag')).toBe('"updated"');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    vi.restoreAllMocks();
+    evictHeadMetadataCacheForMount(MOUNT_ID);
+  });
+
+  it('keeps cached HEAD metadata after GET requests', async () => {
+    evictHeadMetadataCacheForMount(MOUNT_ID);
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 200,
+          headers: { 'content-length': '1024' }
+        })
+      )
+      .mockResolvedValueOnce(new Response('body', { status: 200 }));
+    const ctx = makeCtx(
+      makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+    ) as Parameters<typeof s3CredentialProxyHandler>[2];
+
+    await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/get-preserved.txt`, 'HEAD'),
+      {} as Cloudflare.Env,
+      ctx
+    );
+    await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/get-preserved.txt`, 'GET'),
+      {} as Cloudflare.Env,
+      ctx
+    );
+    const response = await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/get-preserved.txt`, 'HEAD'),
+      {} as Cloudflare.Env,
+      ctx
+    );
+
+    expect(response.headers.get('content-length')).toBe('1024');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    vi.restoreAllMocks();
+    evictHeadMetadataCacheForMount(MOUNT_ID);
+  });
+
+  it('serves repeated HEAD 404 responses from the metadata cache', async () => {
+    evictHeadMetadataCacheForMount(MOUNT_ID);
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(null, { status: 404 }));
+    const ctx = makeCtx(
+      makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+    ) as Parameters<typeof s3CredentialProxyHandler>[2];
+
+    const firstResponse = await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/missing.txt`, 'HEAD'),
+      {} as Cloudflare.Env,
+      ctx
+    );
+    const secondResponse = await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/missing.txt`, 'HEAD'),
+      {} as Cloudflare.Env,
+      ctx
+    );
+
+    expect(firstResponse.status).toBe(404);
+    expect(secondResponse.status).toBe(404);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+
+    vi.restoreAllMocks();
+    evictHeadMetadataCacheForMount(MOUNT_ID);
+  });
+
+  it('primes HEAD metadata from successful PUT requests', async () => {
+    evictHeadMetadataCacheForMount(MOUNT_ID);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('ok', {
+        status: 200,
+        headers: {
+          etag: '"put-etag"',
+          'last-modified': 'Tue, 09 Jun 2026 13:00:00 GMT'
+        }
+      })
+    );
+    const ctx = makeCtx(
+      makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+    ) as Parameters<typeof s3CredentialProxyHandler>[2];
+
+    await s3CredentialProxyHandler(
+      makeRequest(
+        `/${MOUNT_ID}/${BUCKET}/put-primed.txt`,
+        'PUT',
+        {
+          'content-type': 'text/plain',
+          'content-length': '2',
+          'x-amz-meta-mode': '33188',
+          'x-amz-content-sha256':
+            '2689367b205c16ce32a8533d524173e31571169bba6d9101a7d1150be7fb8cc3'
+        },
+        'ok'
+      ),
+      {} as Cloudflare.Env,
+      ctx
+    );
+    const headResponse = await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/put-primed.txt`, 'HEAD'),
+      {} as Cloudflare.Env,
+      ctx
+    );
+
+    expect(headResponse.status).toBe(200);
+    expect(headResponse.headers.get('content-length')).toBe('2');
+    expect(headResponse.headers.get('content-type')).toBe('text/plain');
+    expect(headResponse.headers.get('etag')).toBe('"put-etag"');
+    expect(headResponse.headers.get('x-amz-meta-mode')).toBe('33188');
+    expect(fetchSpy).toHaveBeenCalledOnce();
+
+    vi.restoreAllMocks();
+    evictHeadMetadataCacheForMount(MOUNT_ID);
   });
 
   it('canonicalizes repeated and special query parameters for signing', async () => {

--- a/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
+++ b/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
@@ -595,6 +595,67 @@ describe('s3CredentialProxyHandler SigV4 signing', () => {
     vi.restoreAllMocks();
   });
 
+  it('matches deterministic SigV4 output for canonical query signing', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-09T13:00:00Z'));
+    let capturedRequest: Request | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      capturedRequest = input instanceof Request ? input : new Request(input);
+      return new Response('ok', { status: 200 });
+    });
+
+    try {
+      const req = makeRequest(
+        `/${MOUNT_ID}/${BUCKET}/key.txt?z=last&a=hello%20world&b=plus%2Bvalue`
+      );
+      await s3CredentialProxyHandler(
+        req,
+        {} as Cloudflare.Env,
+        makeCtx(
+          makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+        ) as Parameters<typeof s3CredentialProxyHandler>[2]
+      );
+
+      expect(capturedRequest!.headers.get('x-amz-date')).toBe(
+        '20260609T130000Z'
+      );
+      expect(capturedRequest!.headers.get('Authorization')).toBe(
+        'AWS4-HMAC-SHA256 Credential=AKID/20260609/auto/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=82eb087e2cb1fe1dbd97374fedd5bd34ad7ad9db11ebb4f4ed2db44ad0ffdcd2'
+      );
+    } finally {
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('does not forward or sign hop-by-hop SigV4 headers', async () => {
+    let capturedRequest: Request | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      capturedRequest = input instanceof Request ? input : new Request(input);
+      return new Response('ok', { status: 200 });
+    });
+
+    const req = makeRequest(`/${MOUNT_ID}/${BUCKET}/key.txt`, 'GET', {
+      connection: 'keep-alive',
+      'user-agent': 'custom-agent'
+    });
+    await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(
+        makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+      ) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    const authorization = capturedRequest!.headers.get('Authorization') ?? '';
+    expect(capturedRequest!.headers.get('connection')).toBeNull();
+    expect(capturedRequest!.headers.get('user-agent')).toBeNull();
+    expect(authorization).not.toContain('connection');
+    expect(authorization).not.toContain('user-agent');
+
+    vi.restoreAllMocks();
+  });
+
   it('forwards positive-length request bodies with a body for r2 provider', async () => {
     let capturedRequest: Request | undefined;
     vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
@@ -635,6 +696,36 @@ describe('s3CredentialProxyHandler SigV4 signing', () => {
       'content-length'
     );
     expect(await capturedRequest!.text()).toBe('streamed-body');
+
+    vi.restoreAllMocks();
+  });
+
+  it('forwards request bodies without a content-length for r2 provider', async () => {
+    let capturedRequest: Request | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      capturedRequest = input instanceof Request ? input : new Request(input);
+      return new Response('ok', { status: 200 });
+    });
+
+    const req = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/chunked.txt`,
+      'PUT',
+      {
+        'content-type': 'text/plain',
+        'x-amz-content-sha256': 'UNSIGNED-PAYLOAD'
+      },
+      'chunked-body'
+    );
+    await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(
+        makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+      ) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(capturedRequest!.headers.get('content-length')).toBeNull();
+    expect(await capturedRequest!.text()).toBe('chunked-body');
 
     vi.restoreAllMocks();
   });
@@ -807,6 +898,177 @@ describe('s3CredentialProxyHandler SigV4 signing', () => {
     evictHeadMetadataCacheForMount(MOUNT_ID);
   });
 
+  it('invalidates cached HEAD metadata after query-string object mutation', async () => {
+    evictHeadMetadataCacheForMount(MOUNT_ID);
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 200,
+          headers: { 'content-length': '1024' }
+        })
+      )
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 200,
+          headers: { 'content-length': '2048' }
+        })
+      );
+    const ctx = makeCtx(
+      makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+    ) as Parameters<typeof s3CredentialProxyHandler>[2];
+
+    await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/multipart.txt`, 'HEAD'),
+      {} as Cloudflare.Env,
+      ctx
+    );
+    await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/multipart.txt?uploadId=abc`, 'POST'),
+      {} as Cloudflare.Env,
+      ctx
+    );
+    const response = await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/multipart.txt`, 'HEAD'),
+      {} as Cloudflare.Env,
+      ctx
+    );
+
+    expect(response.headers.get('content-length')).toBe('2048');
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+
+    vi.restoreAllMocks();
+    evictHeadMetadataCacheForMount(MOUNT_ID);
+  });
+
+  it('does not prime HEAD metadata from CopyObject PUT requests', async () => {
+    evictHeadMetadataCacheForMount(MOUNT_ID);
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response('ok', {
+          status: 200,
+          headers: { etag: '"copy-etag"' }
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 200,
+          headers: { 'content-length': '2048' }
+        })
+      );
+    const ctx = makeCtx(
+      makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+    ) as Parameters<typeof s3CredentialProxyHandler>[2];
+
+    await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/copied.txt`, 'PUT', {
+        'content-length': '0',
+        'x-amz-copy-source': `/${BUCKET}/source.txt`,
+        'x-amz-content-sha256':
+          'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+      }),
+      {} as Cloudflare.Env,
+      ctx
+    );
+    const response = await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/copied.txt`, 'HEAD'),
+      {} as Cloudflare.Env,
+      ctx
+    );
+
+    expect(response.headers.get('content-length')).toBe('2048');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    vi.restoreAllMocks();
+    evictHeadMetadataCacheForMount(MOUNT_ID);
+  });
+
+  it('does not cache HEAD metadata for range requests', async () => {
+    evictHeadMetadataCacheForMount(MOUNT_ID);
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 206,
+          headers: {
+            'content-length': '10',
+            'content-range': 'bytes 0-9/1024'
+          }
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 200,
+          headers: { 'content-length': '1024' }
+        })
+      );
+    const ctx = makeCtx(
+      makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+    ) as Parameters<typeof s3CredentialProxyHandler>[2];
+
+    await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/ranged.txt`, 'HEAD', {
+        range: 'bytes=0-9'
+      }),
+      {} as Cloudflare.Env,
+      ctx
+    );
+    const response = await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/ranged.txt`, 'HEAD'),
+      {} as Cloudflare.Env,
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-length')).toBe('1024');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    vi.restoreAllMocks();
+    evictHeadMetadataCacheForMount(MOUNT_ID);
+  });
+
+  it('does not cache HEAD metadata for conditional requests', async () => {
+    evictHeadMetadataCacheForMount(MOUNT_ID);
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 200,
+          headers: { 'content-length': '333' }
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 200,
+          headers: { 'content-length': '1024' }
+        })
+      );
+    const ctx = makeCtx(
+      makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+    ) as Parameters<typeof s3CredentialProxyHandler>[2];
+
+    await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/conditional.txt`, 'HEAD', {
+        'if-match': '"old"'
+      }),
+      {} as Cloudflare.Env,
+      ctx
+    );
+    const response = await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/conditional.txt`, 'HEAD'),
+      {} as Cloudflare.Env,
+      ctx
+    );
+
+    expect(response.headers.get('content-length')).toBe('1024');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    vi.restoreAllMocks();
+    evictHeadMetadataCacheForMount(MOUNT_ID);
+  });
+
   it('updates cached HEAD metadata after object mutation', async () => {
     evictHeadMetadataCacheForMount(MOUNT_ID);
     const fetchSpy = vi
@@ -933,7 +1195,8 @@ describe('s3CredentialProxyHandler SigV4 signing', () => {
         status: 200,
         headers: {
           etag: '"put-etag"',
-          'last-modified': 'Tue, 09 Jun 2026 13:00:00 GMT'
+          'last-modified': 'Tue, 09 Jun 2026 13:00:00 GMT',
+          'x-amz-version-id': 'version-1'
         }
       })
     );
@@ -946,6 +1209,8 @@ describe('s3CredentialProxyHandler SigV4 signing', () => {
         `/${MOUNT_ID}/${BUCKET}/put-primed.txt`,
         'PUT',
         {
+          'cache-control': 'max-age=60',
+          'content-encoding': 'gzip',
           'content-type': 'text/plain',
           'content-length': '2',
           'x-amz-meta-mode': '33188',
@@ -966,9 +1231,50 @@ describe('s3CredentialProxyHandler SigV4 signing', () => {
     expect(headResponse.status).toBe(200);
     expect(headResponse.headers.get('content-length')).toBe('2');
     expect(headResponse.headers.get('content-type')).toBe('text/plain');
+    expect(headResponse.headers.get('cache-control')).toBe('max-age=60');
+    expect(headResponse.headers.get('content-encoding')).toBe('gzip');
     expect(headResponse.headers.get('etag')).toBe('"put-etag"');
     expect(headResponse.headers.get('x-amz-meta-mode')).toBe('33188');
+    expect(headResponse.headers.get('x-amz-version-id')).toBe('version-1');
     expect(fetchSpy).toHaveBeenCalledOnce();
+
+    vi.restoreAllMocks();
+    evictHeadMetadataCacheForMount(MOUNT_ID);
+  });
+
+  it('does not prime HEAD metadata from SSE-C PUT requests', async () => {
+    evictHeadMetadataCacheForMount(MOUNT_ID);
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 200,
+          headers: { 'content-length': '2048' }
+        })
+      );
+    const ctx = makeCtx(
+      makeParams({ provider: 'r2', authStrategy: 's3-sigv4' })
+    ) as Parameters<typeof s3CredentialProxyHandler>[2];
+
+    await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/encrypted.txt`, 'PUT', {
+        'content-length': '2',
+        'x-amz-server-side-encryption-customer-algorithm': 'AES256',
+        'x-amz-content-sha256':
+          '2689367b205c16ce32a8533d524173e31571169bba6d9101a7d1150be7fb8cc3'
+      }),
+      {} as Cloudflare.Env,
+      ctx
+    );
+    const response = await s3CredentialProxyHandler(
+      makeRequest(`/${MOUNT_ID}/${BUCKET}/encrypted.txt`, 'HEAD'),
+      {} as Cloudflare.Env,
+      ctx
+    );
+
+    expect(response.headers.get('content-length')).toBe('2048');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
 
     vi.restoreAllMocks();
     evictHeadMetadataCacheForMount(MOUNT_ID);


### PR DESCRIPTION
## Summary

Reduce redundant upstream requests during credential-proxy mounted reads by adding a short-lived HEAD metadata response cache.

s3fs issues frequent HEAD requests for metadata (`getattr`) on every file open, stat, and read. With credential-proxy mounts, each HEAD request was forwarded upstream through the signing proxy, adding latency to repeated reads. This PR keeps the existing `aws4fetch`/`AwsClient` signing path and focuses the optimization on safe metadata caching.

## Changes

### HEAD metadata cache (`s3-credential-proxy-handler.ts`)

- **Positive cache**: Cache successful HEAD responses for 60s.
- **Negative cache**: Cache 404 HEAD responses for 5s to avoid repeated existence checks for non-existent paths (s3fs probes `path/`, `path_$folder$` variants).
- **PUT priming**: After a successful PUT, synthesize and cache a HEAD-equivalent entry from request/response metadata such as `content-length`, `content-type`, `etag`, `last-modified`, and `x-amz-meta-*`.
- **Conservative bypasses**: Do not cache ranged, conditional, checksum-mode, SSE-C, or GCS customer-encryption HEAD requests.
- **Selective invalidation**: Mutating methods (`PUT`, `POST`, `DELETE`) invalidate cached metadata. GET requests preserve cached metadata.
- **Copy/multipart safety**: Do not prime from query-string PUTs or copy operations; multipart/query mutations invalidate affected metadata.
- **Size bound**: Cache is limited to 1,000 entries with TTL-aware eviction, falling back to FIFO eviction if still over limit.

### Cache lifecycle (`sandbox.ts`)

- `evictHeadMetadataCacheForMount` is called during unmount, mount-failure cleanup, and sandbox teardown, matching the existing SigV4 client and directory-marker cache cleanup paths.

### Request forwarding safety

- Strip hop-by-hop/proxy headers before forwarding credential-proxy requests upstream.
- Preserve SigV4 request bodies that do not include `content-length` instead of dropping the stream.
- Keep SigV4 signing on the existing `aws4fetch` `AwsClient` path.

## Benchmark results (from repro)

| Step | Direct S3 | Credential Proxy | Delta |
|------|-----------|-------------------|-------|
| read-small (1 KiB) | 133ms | 206ms | +73ms |
| read-large (512 KiB) | 69ms | 100ms | +31ms |
| read-large-repeat (5x) | 388ms | 285ms | **-103ms** |
| cached-head 20x reads | 2102ms | 1297ms | **-805ms** |
| list-files | 1898ms | 107ms | **-1791ms** |

Credential-proxy now avoids redundant upstream HEAD requests on repeated metadata reads.
