### PR TITLE
Remove E2E transport matrix

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -43,13 +43,11 @@ jobs:
           PR=${{ github.event.pull_request.number }}
           CONTAINERS=$(wrangler containers list --json 2>/dev/null || echo "[]")
 
-          for suffix in "-http" "-websocket"; do
-            WORKER="sandbox-e2e-test-worker-pr-${PR}${suffix}"
-            IDS=$(echo "$CONTAINERS" | jq -r ".[] | select(.name | startswith(\"$WORKER\")) | .id" 2>/dev/null)
-            wrangler delete --name "$WORKER" 2>/dev/null || true
-            for id in $IDS; do
-              wrangler containers delete "$id" 2>/dev/null || true
-            done
+          WORKER="sandbox-e2e-test-worker-pr-${PR}"
+          IDS=$(echo "$CONTAINERS" | jq -r ".[] | select(.name | startswith(\"$WORKER\")) | .id" 2>/dev/null)
+          wrangler delete --name "$WORKER" 2>/dev/null || true
+          for id in $IDS; do
+            wrangler containers delete "$id" 2>/dev/null || true
           done
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -121,13 +119,11 @@ jobs:
           for PR in $PR_NUMBERS; do
             if [ "${SHOULD_CLEAN[$PR]}" = "true" ]; then
               echo "PR #$PR is stale — cleaning up"
-              for suffix in "-http" "-websocket"; do
-                WORKER="sandbox-e2e-test-worker-pr-${PR}${suffix}"
-                IDS=$(echo "$CONTAINERS" | jq -r ".[] | select(.name | startswith(\"$WORKER\")) | .id" 2>/dev/null)
-                wrangler delete --name "$WORKER" 2>/dev/null || true
-                for id in $IDS; do
-                  wrangler containers delete "$id" 2>/dev/null || true
-                done
+              WORKER="sandbox-e2e-test-worker-pr-${PR}"
+              IDS=$(echo "$CONTAINERS" | jq -r ".[] | select(.name | startswith(\"$WORKER\")) | .id" 2>/dev/null)
+              wrangler delete --name "$WORKER" 2>/dev/null || true
+              for id in $IDS; do
+                wrangler containers delete "$id" 2>/dev/null || true
               done
               # Delete pr-* images for closed/stale PRs. These tags are no
               # longer referenced by any active CI run. Note: if the CF

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -44,7 +44,7 @@ jobs:
           CONTAINERS=$(wrangler containers list --json 2>/dev/null || echo "[]")
 
           WORKER="sandbox-e2e-test-worker-pr-${PR}"
-          IDS=$(echo "$CONTAINERS" | jq -r ".[] | select(.name | startswith(\"$WORKER\")) | .id" 2>/dev/null)
+          IDS=$(echo "$CONTAINERS" | jq -r ".[] | select(.name == \"$WORKER\" or (.name | startswith(\"$WORKER-\"))) | .id" 2>/dev/null)
           wrangler delete --name "$WORKER" 2>/dev/null || true
           for id in $IDS; do
             wrangler containers delete "$id" 2>/dev/null || true
@@ -120,7 +120,7 @@ jobs:
             if [ "${SHOULD_CLEAN[$PR]}" = "true" ]; then
               echo "PR #$PR is stale — cleaning up"
               WORKER="sandbox-e2e-test-worker-pr-${PR}"
-              IDS=$(echo "$CONTAINERS" | jq -r ".[] | select(.name | startswith(\"$WORKER\")) | .id" 2>/dev/null)
+              IDS=$(echo "$CONTAINERS" | jq -r ".[] | select(.name == \"$WORKER\" or (.name | startswith(\"$WORKER-\"))) | .id" 2>/dev/null)
               wrangler delete --name "$WORKER" 2>/dev/null || true
               for id in $IDS; do
                 wrangler containers delete "$id" 2>/dev/null || true

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -314,6 +314,7 @@ jobs:
         env:
           TEST_WORKER_URL: ${{ needs.deploy.outputs.worker-url }}
           TEST_SANDBOX_ID: e2e-test-${{ github.run_id }}
+          TEST_TRANSPORT: rpc
           CI: true
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -272,13 +272,6 @@ jobs:
     needs: deploy
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - transport: http
-          - transport: websocket
-          - transport: rpc
     steps:
       - uses: actions/checkout@v6
         with:
@@ -316,12 +309,11 @@ jobs:
         with:
           name: build-${{ github.sha }}
           path: packages
-      - name: E2E tests (${{ matrix.transport }} transport)
+      - name: E2E tests
         run: npx vitest run --config vitest.e2e.config.ts
         env:
           TEST_WORKER_URL: ${{ needs.deploy.outputs.worker-url }}
           TEST_SANDBOX_ID: e2e-test-${{ github.run_id }}
-          TEST_TRANSPORT: ${{ matrix.transport }}
           CI: true
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -407,7 +399,6 @@ jobs:
         run: npx playwright test --config tests/e2e/browser/playwright.config.ts
         env:
           TEST_WORKER_URL: ${{ needs.deploy.outputs.worker-url }}
-          TEST_TRANSPORT: http
           TEST_SANDBOX_ID: browser-test-${{ github.run_id }}
           CI: true
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/turbo.json
+++ b/turbo.json
@@ -84,7 +84,7 @@
         "vitest.e2e.config.ts",
         "packages/sandbox/Dockerfile"
       ],
-      "passThroughEnv": ["TEST_TRANSPORT", "TEST_WORKER_URL"]
+      "passThroughEnv": ["TEST_WORKER_URL"]
     },
     "test:perf": {
       "dependsOn": ["^build", "docker:local"],

--- a/turbo.json
+++ b/turbo.json
@@ -84,7 +84,7 @@
         "vitest.e2e.config.ts",
         "packages/sandbox/Dockerfile"
       ],
-      "passThroughEnv": ["TEST_WORKER_URL"]
+      "passThroughEnv": ["TEST_TRANSPORT", "TEST_WORKER_URL"]
     },
     "test:perf": {
       "dependsOn": ["^build", "docker:local"],


### PR DESCRIPTION
Once #750 lands, there will only be one transport so CI no longer needs to run the same Vitest E2E suite once per legacy transport label. But this change needs to be merged first because we use the main version of the workflow config even on PRs for safety reasons, but that means running the obsolete matrix on #750 creates duplicate privileged E2E jobs against the same PR worker and causes contention in downstream sandbox initialization and just fails the whole pipeline for unrelated reasons to the actual change.

This removes the `http` / `websocket` / `rpc` matrix from the reusable E2E workflow, stops passing `TEST_TRANSPORT` to Vitest and browser E2E jobs, drops the stale Turbo env passthrough, and updates cleanup to target the current unsuffixed PR worker name.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->