### PR TITLE
Allow next release E2E permissions

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  actions: read
   packages: write
 
 jobs:


### PR DESCRIPTION
Allow the next prerelease workflow to start nested E2E jobs.

The `release-next.yml` workflow calls reusable prerelease automation, which then calls the reusable E2E workflow. GitHub caps nested workflow permissions at the top-level caller, so the caller must grant `actions: read` before the E2E job can request it.

Validation:

- `actionlint .github/workflows/release-next.yml .github/workflows/reusable-prerelease.yml`
- pre-push `npm run typecheck`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->