### PR TITLE
Ignore exec AbortSignal when RPC flag is unset

### DIFF
--- a/.changeset/exec-abortsignal-rpc.md
+++ b/.changeset/exec-abortsignal-rpc.md
@@ -1,0 +1,19 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Stop `exec()` from throwing when passed an `AbortSignal` without the
+`enable_abortsignal_rpc` compatibility flag. Previously this failed with
+`DataCloneError: AbortSignal serialization is not enabled.` because the signal
+could not cross the Worker → Durable Object boundary. The command now runs and
+a one-time warning explains how to enable cancellation:
+
+```jsonc
+// wrangler.jsonc
+{
+  "compatibility_flags": ["enable_abortsignal_rpc"]
+}
+```
+
+With the flag set, the signal is honored as before; without it, the signal is
+ignored instead of breaking the call.

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -619,6 +619,68 @@ function applySandboxConfiguration(
   return Promise.all(operations).then(() => undefined);
 }
 
+/**
+ * Tracks whether the AbortSignal-not-serializable warning has already been
+ * emitted in this isolate, so we warn once per isolate rather than on every
+ * call. The compatibility flag is fixed for the isolate's lifetime, so a
+ * single notice is enough.
+ */
+let warnedAboutAbortSignalRPC = false;
+
+/**
+ * Detects whether an `AbortSignal` can cross the Worker -> Durable Object RPC
+ * boundary. Without the `enable_abortsignal_rpc` compatibility flag, the
+ * structured clone used for RPC arguments throws
+ * `DataCloneError: AbortSignal serialization is not enabled.` We probe this
+ * locally with `structuredClone` so we can react *before* the actual RPC call,
+ * which would otherwise reject (and leave an unhandled rejection inside
+ * workerd's RPC machinery).
+ */
+function isAbortSignalRPCDisabled(signal: AbortSignal): boolean {
+  try {
+    structuredClone(signal);
+    return false;
+  } catch (error) {
+    // Flag off: "AbortSignal serialization is not enabled."
+    // Flag on:  "AbortSignal can only be serialized for RPC." (RPC works)
+    // Only the former means the signal cannot cross the RPC boundary.
+    return (
+      error instanceof Error &&
+      /AbortSignal serialization is not enabled/i.test(error.message)
+    );
+  }
+}
+
+/**
+ * Returns `execOptions` with any `signal` removed when the
+ * `enable_abortsignal_rpc` compatibility flag is not set, warning the user
+ * once. This keeps `exec()` from throwing a `DataCloneError` across the RPC
+ * boundary (issue #764): the command still runs, but cancellation via the
+ * signal becomes a no-op until the flag is enabled.
+ */
+function stripUnsupportedSignal<O extends { signal?: AbortSignal }>(
+  options: O | undefined,
+  logger: ReturnType<typeof createLogger>
+): O | undefined {
+  if (!options?.signal || !isAbortSignalRPCDisabled(options.signal)) {
+    return options;
+  }
+
+  if (!warnedAboutAbortSignalRPC) {
+    warnedAboutAbortSignalRPC = true;
+    logger.warn(
+      'An AbortSignal was passed to exec(), but AbortSignal cannot cross the ' +
+        'Worker -> Durable Object boundary unless the `enable_abortsignal_rpc` ' +
+        'compatibility flag is enabled. The signal is being ignored so the ' +
+        'command can run. Add "enable_abortsignal_rpc" to compatibility_flags ' +
+        'in your Wrangler config to enable cancellation.'
+    );
+  }
+
+  const { signal: _signal, ...rest } = options;
+  return rest as O;
+}
+
 export function getSandbox<T extends Sandbox<any>>(
   ns: DurableObjectNamespace<T>,
   id: string,
@@ -671,19 +733,22 @@ export function getSandbox<T extends Sandbox<any>>(
 
   const defaultSessionId = `sandbox-${effectiveId}`;
   const useDefaultSession = options?.enableDefaultSession !== false;
+  const clientLogger = createLogger({ component: 'sandbox-do' });
 
   // IMPORTANT: Any method that returns ExecutionSession must be listed here
   // to ensure the returned session uses proxyTerminal instead of RPC's terminal.
   const enhancedMethods = {
     fetch: (request: Request) => stub.fetch(request),
-    exec: (command: string, execOptions?: ExecOptions) =>
-      useDefaultSession
-        ? stub.exec(command, execOptions)
+    exec: (command: string, execOptions?: ExecOptions) => {
+      const safeOptions = stripUnsupportedSignal(execOptions, clientLogger);
+      return useDefaultSession
+        ? stub.exec(command, safeOptions)
         : stub.execWithSessionToken(
             command,
             DISABLE_SESSION_TOKEN,
-            execOptions
-          ),
+            safeOptions
+          );
+    },
     startProcess: (command: string, processOptions?: ProcessOptions) =>
       useDefaultSession || processOptions?.sessionId !== undefined
         ? stub.startProcess(command, processOptions)
@@ -700,14 +765,15 @@ export function getSandbox<T extends Sandbox<any>>(
         ? stub.getProcess(id, sessionId)
         : stub.getProcess(id, DISABLE_SESSION_TOKEN),
     execStream: (command: string, streamOptions?: StreamOptions) => {
-      if (useDefaultSession || streamOptions?.sessionId !== undefined) {
-        return stub.execStream(command, streamOptions);
+      const safeOptions = stripUnsupportedSignal(streamOptions, clientLogger);
+      if (useDefaultSession || safeOptions?.sessionId !== undefined) {
+        return stub.execStream(command, safeOptions);
       }
 
       return stub.execStreamWithSessionToken(
         command,
         DISABLE_SESSION_TOKEN,
-        streamOptions
+        safeOptions
       );
     },
     writeFile: (

--- a/packages/sandbox/tests/abortsignal-rpc.test.ts
+++ b/packages/sandbox/tests/abortsignal-rpc.test.ts
@@ -1,0 +1,140 @@
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+import { env } from 'cloudflare:test';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getSandbox, type Sandbox } from '../src/sandbox';
+
+/**
+ * The two regression projects inject the Sandbox DO namespace and the
+ * `ABORTSIGNAL_RPC_ENABLED` flag binding. `cloudflare:test` types `env` as the
+ * shared (empty) `Cloudflare.Env`, so we narrow it locally rather than
+ * augmenting the global `Env` used throughout the SDK source.
+ */
+const testEnv = env as unknown as {
+  Sandbox: DurableObjectNamespace<Sandbox>;
+  ABORTSIGNAL_RPC_ENABLED: boolean;
+};
+
+/**
+ * Regression tests for https://github.com/cloudflare/sandbox-sdk/issues/764
+ *
+ * `ExecOptions` accepts `signal?: AbortSignal`, but the options object is
+ * structured-cloned across the Worker -> Durable Object RPC boundary. An
+ * `AbortSignal` is not cloneable unless the `enable_abortsignal_rpc`
+ * compatibility flag is set, so passing one straight to the DO stub throws
+ *
+ *   DataCloneError: AbortSignal serialization is not enabled.
+ *
+ * before the command ever runs.
+ *
+ * Compatibility flags are fixed per workerd isolate at startup, so a single
+ * test run cannot toggle the flag. Instead this file runs under two Vitest
+ * projects (see vitest.config.ts):
+ *
+ *   - `sandbox-abortsignal-rpc-disabled`: boots the pool WITHOUT the flag
+ *     (ABORTSIGNAL_RPC_ENABLED = false).
+ *   - `sandbox-abortsignal-rpc-enabled`: boots the pool WITH the flag
+ *     (ABORTSIGNAL_RPC_ENABLED = true).
+ *
+ * The `ABORTSIGNAL_RPC_ENABLED` binding tells each test which mode it runs
+ * under, so the same assertions capture both directions.
+ *
+ * The serialization happens while marshalling the call arguments — i.e.
+ * before the container is contacted — so the results are meaningful even
+ * though no container runs in the unit-test environment. A later, unrelated
+ * "Containers have not been enabled" error is expected once a call gets past
+ * the boundary and proves the AbortSignal serialized fine.
+ */
+function isAbortSignalCloneError(thrown: unknown): boolean {
+  const message = thrown instanceof Error ? thrown.message : String(thrown);
+  return (
+    (thrown instanceof Error && thrown.name === 'DataCloneError') ||
+    /AbortSignal serialization is not enabled/i.test(message)
+  );
+}
+
+const flagEnabled = testEnv.ABORTSIGNAL_RPC_ENABLED;
+
+describe('AbortSignal across the raw DO stub (issue #764)', () => {
+  it('matches enable_abortsignal_rpc when a signal is passed to the stub', async () => {
+    const id = testEnv.Sandbox.idFromName('abortsignal-rpc-raw');
+    const stub = testEnv.Sandbox.get(id);
+
+    const controller = new AbortController();
+
+    let thrown: unknown;
+    try {
+      await stub.exec('echo hi', { signal: controller.signal });
+    } catch (error) {
+      thrown = error;
+    }
+
+    const cloneError = isAbortSignalCloneError(thrown);
+    const message = thrown instanceof Error ? thrown.message : String(thrown);
+
+    if (flagEnabled) {
+      expect(
+        cloneError,
+        `With enable_abortsignal_rpc set, a raw stub call must not throw a ` +
+          `structured-clone error. Got: ${message}`
+      ).toBe(false);
+    } else {
+      // The raw, unguarded boundary still throws — this is the bug the SDK
+      // proxy guards against below.
+      expect(
+        cloneError,
+        `Without enable_abortsignal_rpc, a raw stub call is expected to throw ` +
+          `the structured-clone error. Got: ${message}`
+      ).toBe(true);
+    }
+  });
+});
+
+describe('getSandbox().exec() with an AbortSignal (issue #764 fix)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not throw a structured-clone error and warns when the flag is off', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const sandbox = getSandbox(testEnv.Sandbox, 'abortsignal-rpc-sdk');
+    const controller = new AbortController();
+
+    let thrown: unknown;
+    try {
+      await sandbox.exec('echo hi', { signal: controller.signal });
+    } catch (error) {
+      thrown = error;
+    }
+
+    const message = thrown instanceof Error ? thrown.message : String(thrown);
+
+    // Regardless of the flag, the SDK must never surface the AbortSignal
+    // structured-clone error to the caller.
+    expect(
+      isAbortSignalCloneError(thrown),
+      `getSandbox().exec() must not surface the AbortSignal clone error. ` +
+        `Got: ${message}`
+    ).toBe(false);
+
+    // The logger emits structured records (objects), so match against the
+    // serialized call arguments rather than assuming a string first arg.
+    const warnedAboutFlag = warn.mock.calls.some((call) =>
+      /enable_abortsignal_rpc/i.test(
+        call.map((arg) => JSON.stringify(arg)).join(' ')
+      )
+    );
+
+    if (flagEnabled) {
+      // Flag on: the signal serializes, so no warning is emitted.
+      expect(warnedAboutFlag).toBe(false);
+    } else {
+      // Flag off: the signal is stripped and the user is told to set the flag.
+      expect(
+        warnedAboutFlag,
+        'Expected a warning mentioning enable_abortsignal_rpc when the flag ' +
+          'is off and a signal is passed.'
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/sandbox/tests/src/index.ts
+++ b/packages/sandbox/tests/src/index.ts
@@ -1,0 +1,9 @@
+import { Sandbox } from '../../src/sandbox';
+
+export { Sandbox };
+
+export default {
+  async fetch(): Promise<Response> {
+    return new Response('test worker');
+  }
+};

--- a/packages/sandbox/vitest.config.ts
+++ b/packages/sandbox/vitest.config.ts
@@ -8,23 +8,88 @@ import { defineConfig } from 'vitest/config';
  * Uses @cloudflare/vitest-pool-workers to run tests in workerd runtime.
  *
  * Run with: npm test
+ *
+ * Compatibility flags are fixed per workerd isolate at startup, so a single
+ * isolate cannot toggle `enable_abortsignal_rpc` mid-run. To exercise both
+ * sides of issue #764, the AbortSignal regression test runs under two extra
+ * projects that boot the pool with different compatibility flags. The
+ * `ABORTSIGNAL_RPC_ENABLED` binding tells that test which mode it is running
+ * under so it can assert the matching behaviour.
  */
+const baseWrangler = {
+  configPath: './tests/wrangler.jsonc'
+} as const;
+
+const abortSignalTest = 'tests/abortsignal-rpc.test.ts';
+
 export default defineConfig({
-  plugins: [
-    cloudflareTest({
-      wrangler: {
-        configPath: './tests/wrangler.jsonc'
-      }
-    })
-  ],
   test: {
     globals: true,
-    include: ['tests/**/*.test.ts'],
     testTimeout: 10000,
     hookTimeout: 10000,
-    teardownTimeout: 10000
-  },
-  esbuild: {
-    target: 'esnext'
+    teardownTimeout: 10000,
+    // The issue #764 flag-off project intentionally triggers a
+    // DataCloneError for the AbortSignal. workerd's RPC layer rejects an
+    // internal promise with that error in addition to the one the test
+    // awaits, and that internal rejection is unreachable from test code.
+    // Drop only that specific error so the deliberate repro doesn't fail the
+    // run; every other unhandled error still does.
+    onUnhandledError(error) {
+      const isAbortSignalCloneError =
+        error.name === 'DataCloneError' &&
+        /AbortSignal serialization is not enabled/i.test(error.message ?? '');
+      if (isAbortSignalCloneError) return false;
+    },
+    projects: [
+      {
+        // Main suite. Keeps strict unhandled-error checking; the AbortSignal
+        // regression file is exercised by the two dedicated projects below.
+        plugins: [cloudflareTest({ wrangler: baseWrangler })],
+        test: {
+          name: 'sandbox',
+          globals: true,
+          include: ['tests/**/*.test.ts'],
+          exclude: [abortSignalTest]
+        },
+        esbuild: { target: 'esnext' }
+      },
+      {
+        // Issue #764, flag OFF: passing an AbortSignal must throw the
+        // structured-clone error.
+        plugins: [
+          cloudflareTest({
+            wrangler: baseWrangler,
+            miniflare: {
+              bindings: { ABORTSIGNAL_RPC_ENABLED: false }
+            }
+          })
+        ],
+        test: {
+          name: 'sandbox-abortsignal-rpc-disabled',
+          globals: true,
+          include: [abortSignalTest]
+        },
+        esbuild: { target: 'esnext' }
+      },
+      {
+        // Issue #764, flag ON: the AbortSignal serializes and the call gets
+        // past the RPC boundary without a structured-clone error.
+        plugins: [
+          cloudflareTest({
+            wrangler: baseWrangler,
+            miniflare: {
+              compatibilityFlags: ['enable_abortsignal_rpc'],
+              bindings: { ABORTSIGNAL_RPC_ENABLED: true }
+            }
+          })
+        ],
+        test: {
+          name: 'sandbox-abortsignal-rpc-enabled',
+          globals: true,
+          include: [abortSignalTest]
+        },
+        esbuild: { target: 'esnext' }
+      }
+    ]
   }
 });


### PR DESCRIPTION
Fixes https://github.com/cloudflare/sandbox-sdk/issues/764

Calling `exec()` with an abort signal threw before the command ever ran:

```ts
const sandbox = getSandbox(env.Sandbox, 'repro');
const controller = new AbortController();
await sandbox.exec('echo hi', { signal: controller.signal });
// -> DataCloneError: AbortSignal serialization is not enabled.
```

The options object is structured-cloned when it crosses from the Worker into
the Durable Object. An `AbortSignal` is only cloneable when the
`enable_abortsignal_rpc` compatibility flag is set, so without that flag the
call failed instead of either honoring the signal or ignoring it. This is
[issue #764](https://github.com/cloudflare/sandbox-sdk/issues/764).

**The fix**

Before the call crosses the boundary, the software development kit now checks
whether an abort signal can actually be serialized. It does this with a local
`structuredClone` probe rather than letting the real call fail, because a
failed call also leaves an unhandled rejection inside the runtime's remote
procedure call machinery that the caller cannot reach.

When the flag is missing, the signal is dropped so the command still runs, and
a single warning explains how to turn cancellation on. When the flag is set,
the signal is passed through and honored exactly as before. The same guard is
applied to `execStream()`, which accepts a signal through the same options
shape. The warning fires once per isolate, since the flag cannot change while
the isolate is alive.

**How to verify**

With the flag enabled, cancellation works as expected:

```jsonc
// wrangler.jsonc
{
  "compatibility_flags": ["enable_abortsignal_rpc"]
}
```

Without the flag, the previously broken snippet from the issue now completes
instead of throwing, and the logs contain a one-time warning pointing at the
flag.

**Testing**

Compatibility flags are fixed for the lifetime of an isolate, so a single test
run cannot toggle the flag on and off. To cover both states, the regression
test runs under two test projects in the same suite: one boots the pool without
`enable_abortsignal_rpc` and one boots it with the flag. A binding tells each
run which state it is in so the same assertions describe both directions.

The test confirms three things. The raw, unguarded boundary still throws when
the flag is off, which documents the underlying issue. Going through
`getSandbox().exec()` never surfaces the clone error to the caller. And the
warning about the flag is emitted only when the flag is off.

A deliberate side effect of the flag-off case is an internal rejected promise
created by the runtime that no test code can await. The suite drops only that
exact error through the `onUnhandledError` hook, so every other unhandled
error across the whole suite still fails the run.
