### PR TITLE
Recover from sandbox runtime replacement on stable

### DIFF
--- a/.changeset/stable-runtime-recovery.md
+++ b/.changeset/stable-runtime-recovery.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Improve recovery when a sandbox runtime is replaced during active work, reducing transient failures for stable SDK users.

--- a/packages/sandbox-container/src/control-plane/api.ts
+++ b/packages/sandbox-container/src/control-plane/api.ts
@@ -1,6 +1,8 @@
 import type {
   CheckChangesRequest,
   CheckChangesResult,
+  EnsureTunnelRunRequest,
+  EnsureTunnelRunResult,
   ExecutionError,
   FileEncoding,
   FileInfo,
@@ -9,6 +11,8 @@ import type {
   OutputMessage,
   Result,
   SandboxAPI,
+  StopTunnelRunRequest,
+  StopTunnelRunResult,
   TunnelInfo,
   WatchRequest
 } from '@repo/shared';
@@ -1127,5 +1131,19 @@ class TunnelsRPCAPI extends RpcTarget {
 
   async listTunnels(): Promise<TunnelInfo[]> {
     return this.#svc.list();
+  }
+
+  async ensureTunnelRun(
+    request: EnsureTunnelRunRequest
+  ): Promise<EnsureTunnelRunResult> {
+    const result = await this.#svc.ensureTunnelRun(request);
+    return extractData<EnsureTunnelRunResult>(result);
+  }
+
+  async stopTunnelRun(
+    request: StopTunnelRunRequest
+  ): Promise<StopTunnelRunResult> {
+    const result = await this.#svc.stopTunnelRun(request);
+    return extractData<StopTunnelRunResult>(result);
   }
 }

--- a/packages/sandbox-container/src/services/tunnel-service.ts
+++ b/packages/sandbox-container/src/services/tunnel-service.ts
@@ -41,8 +41,23 @@ interface TunnelRecord {
 /** Runtime-run registry entry for ensureTunnelRun/stopTunnelRun paths. */
 interface TunnelRunRecord {
   request: EnsureTunnelRunRequest;
-  snapshot: TunnelRunSnapshot;
   manager: TunnelManager;
+  result: Promise<ServiceResult<EnsureTunnelRunResult>>;
+}
+
+function tunnelRunRequestsMatch(
+  left: EnsureTunnelRunRequest,
+  right: EnsureTunnelRunRequest
+): boolean {
+  return (
+    left.tunnelId === right.tunnelId &&
+    left.runId === right.runId &&
+    left.mode === right.mode &&
+    left.port === right.port &&
+    (left.mode !== 'named' ||
+      right.mode !== 'named' ||
+      left.token === right.token)
+  );
 }
 
 export class TunnelService {
@@ -222,25 +237,20 @@ export class TunnelService {
   ): Promise<ServiceResult<EnsureTunnelRunResult>> {
     const { tunnelId, runId, mode, port } = request;
 
-    // Idempotent replay: same runId already running.
     const existing = this.tunnelRuns.get(runId);
     if (existing) {
-      const prev = existing.request;
-      if (
-        prev.tunnelId !== tunnelId ||
-        prev.mode !== mode ||
-        prev.port !== port
-      ) {
+      if (!tunnelRunRequestsMatch(existing.request, request)) {
         return serviceError({
           message: `Run ${runId} already active with different params`,
           code: 'TUNNEL_RUN_CONFLICT',
           details: { runId, tunnelId, port }
         });
       }
-      return serviceSuccess({ run: existing.snapshot, started: false });
+      const result = await existing.result;
+      if (!result.success) return result;
+      return serviceSuccess({ run: result.data.run, started: false });
     }
 
-    // Conflict: different runId on the same port.
     for (const rec of this.tunnelRuns.values()) {
       if (rec.request.port === port) {
         return serviceError({
@@ -277,6 +287,16 @@ export class TunnelService {
       }
     });
 
+    const result = this.startTunnelRun(request, manager);
+    this.tunnelRuns.set(runId, { request, manager, result });
+    return await result;
+  }
+
+  private async startTunnelRun(
+    request: EnsureTunnelRunRequest,
+    manager: TunnelManager
+  ): Promise<ServiceResult<EnsureTunnelRunResult>> {
+    const { tunnelId, runId, mode, port } = request;
     try {
       const startResult = await manager.start();
       const snapshot: TunnelRunSnapshot = {
@@ -292,10 +312,10 @@ export class TunnelService {
             }
           : {})
       };
-      this.tunnelRuns.set(runId, { request, snapshot, manager });
       this.logger.info('Tunnel run started', { tunnelId, runId, mode, port });
       return serviceSuccess({ run: snapshot, started: true });
     } catch (err) {
+      this.tunnelRuns.delete(runId);
       await manager.stop().catch(() => {});
       if (err instanceof CloudflaredNotFoundError) {
         return serviceError({
@@ -360,7 +380,14 @@ export class TunnelService {
 
   /** Stop every tunnel. Called on container shutdown. */
   async destroyAll(): Promise<void> {
-    const ids = Array.from(this.tunnels.keys());
-    await Promise.all(ids.map((id) => this.destroyTunnel(id)));
+    const legacyIds = Array.from(this.tunnels.keys());
+    const runRefs = Array.from(this.tunnelRuns.values()).map(({ request }) => ({
+      tunnelId: request.tunnelId,
+      runId: request.runId
+    }));
+    await Promise.all([
+      ...legacyIds.map((id) => this.destroyTunnel(id)),
+      ...runRefs.map((ref) => this.stopTunnelRun(ref))
+    ]);
   }
 }

--- a/packages/sandbox-container/src/services/tunnel-service.ts
+++ b/packages/sandbox-container/src/services/tunnel-service.ts
@@ -9,7 +9,16 @@
  * id without waiting for the create round-trip to resolve.
  */
 
-import type { Logger, SandboxControlCallback, TunnelInfo } from '@repo/shared';
+import type {
+  EnsureTunnelRunRequest,
+  EnsureTunnelRunResult,
+  Logger,
+  SandboxControlCallback,
+  StopTunnelRunRequest,
+  StopTunnelRunResult,
+  TunnelInfo,
+  TunnelRunSnapshot
+} from '@repo/shared';
 import type { ServiceResult } from '../core/types';
 import { serviceError, serviceSuccess } from '../core/types';
 import {
@@ -29,8 +38,17 @@ interface TunnelRecord {
   manager: TunnelManager;
 }
 
+/** Runtime-run registry entry for ensureTunnelRun/stopTunnelRun paths. */
+interface TunnelRunRecord {
+  request: EnsureTunnelRunRequest;
+  snapshot: TunnelRunSnapshot;
+  manager: TunnelManager;
+}
+
 export class TunnelService {
   private readonly tunnels = new Map<string, TunnelRecord>();
+  /** Keyed by `runId`. Separate from legacy `tunnels` so list() behavior is unchanged. */
+  private readonly tunnelRuns = new Map<string, TunnelRunRecord>();
 
   /**
    * @param logger Child logger for tunnel-service log lines.
@@ -191,6 +209,131 @@ export class TunnelService {
         details: { tunnelId: id, port }
       });
     }
+  }
+
+  /**
+   * Start or replay a cloudflared run identified by `(tunnelId, runId)`.
+   * Idempotent: same request replays with `started: false`. Conflict:
+   * different params for same runId, or different active run on same
+   * port/tunnelId, returns `TUNNEL_RUN_CONFLICT`.
+   */
+  async ensureTunnelRun(
+    request: EnsureTunnelRunRequest
+  ): Promise<ServiceResult<EnsureTunnelRunResult>> {
+    const { tunnelId, runId, mode, port } = request;
+
+    // Idempotent replay: same runId already running.
+    const existing = this.tunnelRuns.get(runId);
+    if (existing) {
+      const prev = existing.request;
+      if (
+        prev.tunnelId !== tunnelId ||
+        prev.mode !== mode ||
+        prev.port !== port
+      ) {
+        return serviceError({
+          message: `Run ${runId} already active with different params`,
+          code: 'TUNNEL_RUN_CONFLICT',
+          details: { runId, tunnelId, port }
+        });
+      }
+      return serviceSuccess({ run: existing.snapshot, started: false });
+    }
+
+    // Conflict: different runId on the same port.
+    for (const rec of this.tunnelRuns.values()) {
+      if (rec.request.port === port) {
+        return serviceError({
+          message: `Port ${port} already active under run ${rec.request.runId}`,
+          code: 'TUNNEL_RUN_CONFLICT',
+          details: { runId, port, activeRunId: rec.request.runId }
+        });
+      }
+      if (rec.request.tunnelId === tunnelId) {
+        return serviceError({
+          message: `Tunnel ${tunnelId} already active under run ${rec.request.runId}`,
+          code: 'TUNNEL_RUN_CONFLICT',
+          details: { tunnelId, runId, activeRunId: rec.request.runId }
+        });
+      }
+    }
+
+    const token = mode === 'named' ? request.token : undefined;
+    const manager = new TunnelManager({
+      port,
+      token,
+      logger: this.logger,
+      onExit: (code) => {
+        this.tunnelRuns.delete(runId);
+        const cb = this.getControlCallback();
+        if (!cb) return;
+        cb.onTunnelExit(tunnelId, port, code, runId).catch((err) => {
+          this.logger.warn('onTunnelExit RPC failed (runtime-run)', {
+            tunnelId,
+            runId,
+            error: err instanceof Error ? err.message : String(err)
+          });
+        });
+      }
+    });
+
+    try {
+      const startResult = await manager.start();
+      const snapshot: TunnelRunSnapshot = {
+        tunnelId,
+        runId,
+        mode,
+        port,
+        startedAt: new Date().toISOString(),
+        ...(mode === 'quick' && startResult.url
+          ? {
+              url: startResult.url,
+              hostname: new URL(startResult.url).hostname
+            }
+          : {})
+      };
+      this.tunnelRuns.set(runId, { request, snapshot, manager });
+      this.logger.info('Tunnel run started', { tunnelId, runId, mode, port });
+      return serviceSuccess({ run: snapshot, started: true });
+    } catch (err) {
+      await manager.stop().catch(() => {});
+      if (err instanceof CloudflaredNotFoundError) {
+        return serviceError({
+          message: err.message,
+          code: 'CLOUDFLARED_NOT_FOUND',
+          details: { tunnelId, runId, port, binary: err.binary }
+        });
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      return serviceError({
+        message: `Failed to start tunnel run: ${message}`,
+        code: 'TUNNEL_START_ERROR',
+        details: { tunnelId, runId, port }
+      });
+    }
+  }
+
+  /**
+   * Stop the cloudflared process identified by the exact `(tunnelId, runId)` pair.
+   * Returns `{ stopped: true }` when found and stopped; `{ stopped: false }` when
+   * no matching run is active. A non-matching runId for a known tunnelId also
+   * returns `{ stopped: false }`; exact run identity is required for stop.
+   */
+  async stopTunnelRun(
+    request: StopTunnelRunRequest
+  ): Promise<ServiceResult<StopTunnelRunResult>> {
+    const { tunnelId, runId } = request;
+    const rec = this.tunnelRuns.get(runId);
+    if (!rec || rec.request.tunnelId !== tunnelId) {
+      return serviceSuccess({ stopped: false });
+    }
+    try {
+      await rec.manager.stop();
+    } finally {
+      this.tunnelRuns.delete(runId);
+    }
+    this.logger.info('Tunnel run stopped', { tunnelId, runId });
+    return serviceSuccess({ stopped: true });
   }
 
   async destroyTunnel(id: string): Promise<ServiceResult<void>> {

--- a/packages/sandbox-container/tests/rpc/sandbox-api-utils.test.ts
+++ b/packages/sandbox-container/tests/rpc/sandbox-api-utils.test.ts
@@ -138,3 +138,15 @@ describe('SandboxControlAPI utils.createSession', () => {
     expect(err.details?.containerPlacementId).toBeUndefined();
   });
 });
+
+describe('SandboxControlAPI tunnels.ensureTunnelRun and stopTunnelRun', () => {
+  it('exposes ensureTunnelRun on the tunnels sub-stub', () => {
+    const api = buildApi({} as unknown as SessionManager);
+    expect(typeof api.tunnels.ensureTunnelRun).toBe('function');
+  });
+
+  it('exposes stopTunnelRun on the tunnels sub-stub', () => {
+    const api = buildApi({} as unknown as SessionManager);
+    expect(typeof api.tunnels.stopTunnelRun).toBe('function');
+  });
+});

--- a/packages/sandbox-container/tests/services/tunnel-service.test.ts
+++ b/packages/sandbox-container/tests/services/tunnel-service.test.ts
@@ -643,7 +643,6 @@ describe('TunnelService > runNamedTunnel', () => {
   });
 });
 
-
 // ---------------------------------------------------------------------------
 // Missing cloudflared binary
 // ---------------------------------------------------------------------------
@@ -712,5 +711,218 @@ describe('TunnelService > cloudflared binary missing', () => {
     expect(result.success).toBe(false);
     if (result.success) return;
     expect(result.error.code).toBe('TUNNEL_START_ERROR');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runtime-run API (ensureTunnelRun / stopTunnelRun)
+// ---------------------------------------------------------------------------
+
+describe('TunnelService > ensureTunnelRun', () => {
+  it('starts a quick run and returns the snapshot with started: true', async () => {
+    const service = new TunnelService(mockLogger);
+
+    let result!: Awaited<ReturnType<typeof service.ensureTunnelRun>>;
+    await withFakeCloudflared(QUICK_BANNER, async () => {
+      result = await service.ensureTunnelRun({
+        tunnelId: 'tid-1',
+        runId: 'rid-1',
+        mode: 'quick',
+        port: 8080
+      });
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.started).toBe(true);
+    expect(result.data.run.tunnelId).toBe('tid-1');
+    expect(result.data.run.runId).toBe('rid-1');
+    expect(result.data.run.mode).toBe('quick');
+    expect(result.data.run.port).toBe(8080);
+    expect(typeof result.data.run.url).toBe('string');
+    expect(result.data.run.url).toBeTruthy();
+    expect(typeof result.data.run.hostname).toBe('string');
+    expect(result.data.run.hostname).toBeTruthy();
+  });
+
+  it('replays the same runId + same params with started: false', async () => {
+    const service = new TunnelService(mockLogger);
+
+    await withFakeCloudflared(QUICK_BANNER, async () => {
+      await service.ensureTunnelRun({
+        tunnelId: 'tid-2',
+        runId: 'rid-2',
+        mode: 'quick',
+        port: 8080
+      });
+    });
+
+    // Replay — no new cloudflared should spawn
+    const result = await service.ensureTunnelRun({
+      tunnelId: 'tid-2',
+      runId: 'rid-2',
+      mode: 'quick',
+      port: 8080
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.started).toBe(false);
+    expect(result.data.run.runId).toBe('rid-2');
+    // Only one cloudflared was spawned across both calls
+    expect(fakeProcs).toHaveLength(1);
+  });
+
+  it('returns TUNNEL_RUN_CONFLICT for same runId with different params', async () => {
+    const service = new TunnelService(mockLogger);
+
+    await withFakeCloudflared(QUICK_BANNER, async () => {
+      await service.ensureTunnelRun({
+        tunnelId: 'tid-3',
+        runId: 'rid-3',
+        mode: 'quick',
+        port: 8080
+      });
+    });
+
+    const result = await service.ensureTunnelRun({
+      tunnelId: 'tid-3',
+      runId: 'rid-3',
+      mode: 'quick',
+      port: 9090 // different port
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('TUNNEL_RUN_CONFLICT');
+  });
+
+  it('returns TUNNEL_RUN_CONFLICT for different runId on same port', async () => {
+    const service = new TunnelService(mockLogger);
+
+    await withFakeCloudflared(QUICK_BANNER, async () => {
+      await service.ensureTunnelRun({
+        tunnelId: 'tid-4',
+        runId: 'rid-4a',
+        mode: 'quick',
+        port: 8080
+      });
+    });
+
+    const result = await service.ensureTunnelRun({
+      tunnelId: 'tid-5', // different tunnelId
+      runId: 'rid-4b', // different runId
+      mode: 'quick',
+      port: 8080 // same port
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('TUNNEL_RUN_CONFLICT');
+  });
+
+  it('returns TUNNEL_RUN_CONFLICT for different runId on same tunnelId', async () => {
+    const service = new TunnelService(mockLogger);
+
+    await withFakeCloudflared(QUICK_BANNER, async () => {
+      await service.ensureTunnelRun({
+        tunnelId: 'tid-6',
+        runId: 'rid-6a',
+        mode: 'quick',
+        port: 8080
+      });
+    });
+
+    const result = await service.ensureTunnelRun({
+      tunnelId: 'tid-6', // same tunnelId
+      runId: 'rid-6b', // different runId
+      mode: 'quick',
+      port: 9090
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('TUNNEL_RUN_CONFLICT');
+  });
+});
+
+describe('TunnelService > stopTunnelRun', () => {
+  it('stops the exact matching run and returns stopped: true', async () => {
+    const service = new TunnelService(mockLogger);
+
+    await withFakeCloudflared(QUICK_BANNER, async () => {
+      await service.ensureTunnelRun({
+        tunnelId: 'tid-s1',
+        runId: 'rid-s1',
+        mode: 'quick',
+        port: 8080
+      });
+    });
+
+    const stopPromise = service.stopTunnelRun({
+      tunnelId: 'tid-s1',
+      runId: 'rid-s1'
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    fakeProcs[0].resolveExit(0);
+    const result = await stopPromise;
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.stopped).toBe(true);
+    expect(fakeProcs[0].kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('returns stopped: false for a non-existent runId without error', async () => {
+    const service = new TunnelService(mockLogger);
+
+    const result = await service.stopTunnelRun({
+      tunnelId: 'tid-ghost',
+      runId: 'rid-ghost'
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.stopped).toBe(false);
+  });
+
+  it('returns stopped: false when tunnelId matches but runId differs', async () => {
+    const service = new TunnelService(mockLogger);
+
+    await withFakeCloudflared(QUICK_BANNER, async () => {
+      await service.ensureTunnelRun({
+        tunnelId: 'tid-s2',
+        runId: 'rid-s2',
+        mode: 'quick',
+        port: 8080
+      });
+    });
+
+    const result = await service.stopTunnelRun({
+      tunnelId: 'tid-s2',
+      runId: 'rid-s2-different'
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.stopped).toBe(false);
+    // Original process still running — no kill called for this attempt
+    expect(fakeProcs[0].kill).not.toHaveBeenCalled();
+  });
+
+  it('runtime-run records do not appear in legacy list()', async () => {
+    const service = new TunnelService(mockLogger);
+
+    await withFakeCloudflared(QUICK_BANNER, async () => {
+      await service.ensureTunnelRun({
+        tunnelId: 'tid-list',
+        runId: 'rid-list',
+        mode: 'quick',
+        port: 8080
+      });
+    });
+
+    // Legacy list() should be empty — runtime-run records are separate
+    expect(service.list()).toHaveLength(0);
   });
 });

--- a/packages/sandbox-container/tests/services/tunnel-service.test.ts
+++ b/packages/sandbox-container/tests/services/tunnel-service.test.ts
@@ -773,6 +773,69 @@ describe('TunnelService > ensureTunnelRun', () => {
     expect(fakeProcs).toHaveLength(1);
   });
 
+  it('replays the same inflight runId without spawning another process', async () => {
+    const service = new TunnelService(mockLogger);
+
+    const first = service.ensureTunnelRun({
+      tunnelId: 'tid-inflight',
+      runId: 'rid-inflight',
+      mode: 'quick',
+      port: 8080
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fakeProcs).toHaveLength(1);
+
+    const replay = service.ensureTunnelRun({
+      tunnelId: 'tid-inflight',
+      runId: 'rid-inflight',
+      mode: 'quick',
+      port: 8080
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fakeProcs).toHaveLength(1);
+
+    fakeProcs[0].stderr.write(QUICK_BANNER);
+    await new Promise((r) => setTimeout(r, 30));
+    fetchHandler.ready = true;
+
+    const [firstResult, replayResult] = await Promise.all([first, replay]);
+    expect(firstResult.success).toBe(true);
+    expect(replayResult.success).toBe(true);
+    if (!replayResult.success) return;
+    expect(replayResult.data.started).toBe(false);
+    expect(replayResult.data.run.runId).toBe('rid-inflight');
+  });
+
+  it('rejects a different run on the same port while the first run is starting', async () => {
+    const service = new TunnelService(mockLogger);
+
+    const first = service.ensureTunnelRun({
+      tunnelId: 'tid-starting-a',
+      runId: 'rid-starting-a',
+      mode: 'quick',
+      port: 8080
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fakeProcs).toHaveLength(1);
+
+    const second = await service.ensureTunnelRun({
+      tunnelId: 'tid-starting-b',
+      runId: 'rid-starting-b',
+      mode: 'quick',
+      port: 8080
+    });
+
+    expect(second.success).toBe(false);
+    if (second.success) return;
+    expect(second.error.code).toBe('TUNNEL_RUN_CONFLICT');
+    expect(fakeProcs).toHaveLength(1);
+
+    fakeProcs[0].stderr.write(QUICK_BANNER);
+    await new Promise((r) => setTimeout(r, 30));
+    fetchHandler.ready = true;
+    expect((await first).success).toBe(true);
+  });
+
   it('returns TUNNEL_RUN_CONFLICT for same runId with different params', async () => {
     const service = new TunnelService(mockLogger);
 

--- a/packages/sandbox/src/backup/restore-lifecycle.ts
+++ b/packages/sandbox/src/backup/restore-lifecycle.ts
@@ -1,0 +1,459 @@
+import type {
+  CurrentRuntimeIdentity,
+  RuntimeIdentity
+} from '../current-runtime-identity';
+import { RuntimeIdentityInactiveError } from '../current-runtime-identity';
+import {
+  ErrorCode,
+  OperationInterruptedError,
+  RPCTransportError
+} from '../errors';
+import type {
+  CurrentSandboxLifetime,
+  SandboxLifetime
+} from '../sandbox-lifetime';
+import { SandboxLifetimeChangedError } from '../sandbox-lifetime';
+import {
+  type BackupRestoreOperationPhase,
+  type BackupRestoreOperationRecord,
+  type BackupRestoreOperationResult,
+  BackupRestoreOperationStore,
+  createBackupRestoreOperationRecord
+} from './restore-operation-store';
+
+const BACKUP_RESTORE_MAX_RECOVERY_ATTEMPTS = 2;
+
+type RestoreLifecycleDeps = {
+  storage: DurableObjectStorage;
+  currentRuntime: CurrentRuntimeIdentity;
+  currentLifetime: CurrentSandboxLifetime;
+};
+
+export type RestoreLifecycleContext = {
+  lifetime: SandboxLifetime;
+  runtimeReady: (archiveSize?: number) => Promise<{
+    runtime: RuntimeIdentity;
+    operation: BackupRestoreOperationRecord;
+  }>;
+  archiveReady: (archiveSize?: number) => Promise<{
+    runtime: RuntimeIdentity;
+    operation: BackupRestoreOperationRecord;
+  }>;
+  verify: (
+    result: BackupRestoreOperationResult,
+    archiveSize?: number
+  ) => Promise<BackupRestoreOperationRecord>;
+};
+
+export class RestoreLifecycleRunner {
+  private readonly operationRecords: BackupRestoreOperationStore;
+
+  constructor(private readonly deps: RestoreLifecycleDeps) {
+    this.operationRecords = new BackupRestoreOperationStore(deps.storage);
+  }
+
+  async execute(params: {
+    backupId: string;
+    dir: string;
+    attempt: (
+      context: RestoreLifecycleContext
+    ) => Promise<BackupRestoreOperationResult>;
+  }): Promise<BackupRestoreOperationResult> {
+    return await this.runWithRecovery(async () => {
+      const { lifetime, operation } = await this.startOperation(
+        params.backupId,
+        params.dir
+      );
+      let currentOperation = operation;
+      let runtime: RuntimeIdentity | undefined;
+
+      const context: RestoreLifecycleContext = {
+        lifetime,
+        runtimeReady: async (archiveSize) => {
+          try {
+            runtime = await this.captureRuntime();
+            await this.deps.currentLifetime.assertCurrent(lifetime);
+          } catch (error) {
+            const interrupted = await this.translateFenceError(
+              error,
+              currentOperation,
+              'validating',
+              'unknown'
+            );
+            throw interrupted ?? error;
+          }
+
+          currentOperation = await this.markRuntimeReady(
+            currentOperation,
+            runtime,
+            archiveSize
+          );
+          return { runtime, operation: currentOperation };
+        },
+        archiveReady: async (archiveSize) => {
+          if (!runtime) {
+            throw new Error(
+              'Backup restore archiveReady requires runtimeReady()'
+            );
+          }
+
+          try {
+            await this.assertFences(runtime, lifetime);
+          } catch (error) {
+            const interrupted = await this.translateFenceError(
+              error,
+              currentOperation,
+              currentOperation.phase,
+              true
+            );
+            throw interrupted ?? error;
+          }
+
+          currentOperation = await this.markArchiveReady(
+            currentOperation,
+            runtime,
+            archiveSize
+          );
+          return { runtime, operation: currentOperation };
+        },
+        verify: async (result, archiveSize) => {
+          if (!runtime) {
+            throw new Error(
+              'Backup restore verification requires runtimeReady()'
+            );
+          }
+
+          try {
+            await this.assertFences(runtime, lifetime);
+          } catch (error) {
+            const interrupted = await this.translateFenceError(
+              error,
+              currentOperation,
+              'archive_ready',
+              true
+            );
+            throw interrupted ?? error;
+          }
+
+          currentOperation = await this.markVerified(
+            currentOperation,
+            runtime,
+            result,
+            archiveSize
+          );
+          return currentOperation;
+        }
+      };
+
+      try {
+        return await params.attempt(context);
+      } catch (error) {
+        const translatedRPC = await this.translateRPCError(
+          error,
+          currentOperation
+        );
+        if (translatedRPC) {
+          throw translatedRPC;
+        }
+
+        const translatedFence = await this.translateFenceError(
+          error,
+          currentOperation,
+          currentOperation.phase,
+          'unknown'
+        );
+        if (translatedFence) {
+          throw translatedFence;
+        }
+
+        if (!(error instanceof OperationInterruptedError)) {
+          await this.markFailed(currentOperation, error);
+        }
+        throw error;
+      }
+    });
+  }
+
+  private async runWithRecovery<T>(attempt: () => Promise<T>): Promise<T> {
+    let recoveryAttempts = 0;
+
+    while (true) {
+      try {
+        return await attempt();
+      } catch (error) {
+        if (!(error instanceof OperationInterruptedError)) {
+          throw error;
+        }
+
+        if (!error.context.retryable) {
+          throw error;
+        }
+
+        if (recoveryAttempts >= BACKUP_RESTORE_MAX_RECOVERY_ATTEMPTS) {
+          throw this.createRecoveryExhaustedError(error, recoveryAttempts);
+        }
+
+        recoveryAttempts++;
+      }
+    }
+  }
+
+  private async startOperation(
+    backupId: string,
+    dir: string
+  ): Promise<{
+    lifetime: SandboxLifetime;
+    operation: BackupRestoreOperationRecord;
+  }> {
+    const lifetime = await this.deps.currentLifetime.getOrCreate();
+    const operation = createBackupRestoreOperationRecord({
+      operationId: crypto.randomUUID(),
+      sandboxLifetimeID: lifetime.id,
+      backupId,
+      dir,
+      now: new Date().toISOString()
+    });
+    await this.operationRecords.put(operation);
+    return { lifetime, operation };
+  }
+
+  private async captureRuntime(): Promise<RuntimeIdentity> {
+    const runtime =
+      (await this.deps.currentRuntime.get()) ??
+      (await this.deps.currentRuntime.markStarted());
+    await this.deps.currentRuntime.assertActive(runtime);
+    return runtime;
+  }
+
+  private async assertFences(
+    runtime: RuntimeIdentity,
+    lifetime: SandboxLifetime
+  ): Promise<void> {
+    await this.deps.currentRuntime.assertActive(runtime);
+    await this.deps.currentLifetime.assertCurrent(lifetime);
+  }
+
+  private async markRuntimeReady(
+    operation: BackupRestoreOperationRecord,
+    runtime: RuntimeIdentity,
+    archiveSize?: number
+  ): Promise<BackupRestoreOperationRecord> {
+    const next: BackupRestoreOperationRecord = {
+      ...operation,
+      phase: 'runtime_ready',
+      runtimeIdentityID: runtime.id,
+      payload: {
+        ...operation.payload,
+        ...(archiveSize !== undefined && { archiveSize })
+      },
+      updatedAt: new Date().toISOString()
+    };
+    await this.operationRecords.put(next);
+    return next;
+  }
+
+  private async markArchiveReady(
+    operation: BackupRestoreOperationRecord,
+    runtime: RuntimeIdentity,
+    archiveSize?: number
+  ): Promise<BackupRestoreOperationRecord> {
+    const next: BackupRestoreOperationRecord = {
+      ...operation,
+      phase: 'archive_ready',
+      runtimeIdentityID: runtime.id,
+      payload: {
+        ...operation.payload,
+        ...(archiveSize !== undefined && { archiveSize })
+      },
+      updatedAt: new Date().toISOString()
+    };
+    await this.operationRecords.put(next);
+    return next;
+  }
+
+  private async markVerified(
+    operation: BackupRestoreOperationRecord,
+    runtime: RuntimeIdentity,
+    result: BackupRestoreOperationResult,
+    archiveSize?: number
+  ): Promise<BackupRestoreOperationRecord> {
+    const completedAt = new Date().toISOString();
+    const next: BackupRestoreOperationRecord = {
+      ...operation,
+      phase: 'verified',
+      status: 'committed',
+      runtimeIdentityID: runtime.id,
+      payload: {
+        ...operation.payload,
+        ...(archiveSize !== undefined && { archiveSize })
+      },
+      result,
+      completedAt,
+      updatedAt: completedAt
+    };
+    await this.operationRecords.put(next);
+    return next;
+  }
+
+  private async markFailed(
+    operation: BackupRestoreOperationRecord,
+    error: unknown
+  ): Promise<BackupRestoreOperationRecord> {
+    const completedAt = new Date().toISOString();
+    const message = error instanceof Error ? error.message : String(error);
+    const code =
+      error instanceof Error &&
+      'code' in error &&
+      typeof error.code === 'string'
+        ? error.code
+        : 'UNKNOWN';
+    const next: BackupRestoreOperationRecord = {
+      ...operation,
+      phase: 'failed',
+      status: 'failed',
+      error: {
+        code,
+        message,
+        retryable: false
+      },
+      completedAt,
+      updatedAt: completedAt
+    };
+    await this.operationRecords.put(next);
+    return next;
+  }
+
+  private async markInterrupted(
+    operation: BackupRestoreOperationRecord,
+    message: string,
+    retryable: boolean
+  ): Promise<BackupRestoreOperationRecord> {
+    const next: BackupRestoreOperationRecord = {
+      ...operation,
+      phase: 'interrupted',
+      status: 'interrupted',
+      error: {
+        code: ErrorCode.OPERATION_INTERRUPTED,
+        message,
+        retryable
+      },
+      updatedAt: new Date().toISOString()
+    };
+    await this.operationRecords.put(next);
+    return next;
+  }
+
+  private async translateFenceError(
+    error: unknown,
+    operation: BackupRestoreOperationRecord,
+    phase: BackupRestoreOperationPhase,
+    admitted: boolean | 'unknown'
+  ): Promise<OperationInterruptedError | null> {
+    if (
+      !(
+        error instanceof RuntimeIdentityInactiveError ||
+        error instanceof SandboxLifetimeChangedError
+      )
+    ) {
+      return null;
+    }
+
+    const reason =
+      error instanceof RuntimeIdentityInactiveError
+        ? 'runtime_replaced'
+        : 'sandbox_lifetime_changed';
+    const retryable = reason !== 'sandbox_lifetime_changed';
+    const message =
+      'Backup restore was interrupted before completion could be verified';
+    const interrupted = await this.markInterrupted(
+      operation,
+      message,
+      retryable
+    );
+    return this.createInterruptedError({
+      reason,
+      phase,
+      admitted,
+      retryable,
+      message,
+      operation: interrupted
+    });
+  }
+
+  private async translateRPCError(
+    error: unknown,
+    operation: BackupRestoreOperationRecord
+  ): Promise<OperationInterruptedError | null> {
+    if (!(error instanceof RPCTransportError)) {
+      return null;
+    }
+
+    const message =
+      'Backup restore was interrupted before completion could be verified';
+    const interruptedPhase = operation.phase;
+    const interrupted = await this.markInterrupted(operation, message, true);
+    return this.createInterruptedError({
+      reason: 'transport_disposed',
+      phase: interruptedPhase,
+      admitted: 'unknown',
+      retryable: true,
+      message,
+      operation: interrupted
+    });
+  }
+
+  private createInterruptedError(params: {
+    reason:
+      | 'runtime_replaced'
+      | 'transport_disposed'
+      | 'sandbox_lifetime_changed';
+    phase: BackupRestoreOperationPhase;
+    admitted: boolean | 'unknown';
+    retryable: boolean;
+    message: string;
+    operation: BackupRestoreOperationRecord;
+  }): OperationInterruptedError {
+    return new OperationInterruptedError({
+      message: params.message,
+      code: ErrorCode.OPERATION_INTERRUPTED,
+      httpStatus: 409,
+      context: {
+        reason: params.reason,
+        operation: 'backup.restore',
+        phase: params.phase,
+        admitted: params.admitted,
+        retryable: params.retryable
+      },
+      timestamp: new Date().toISOString(),
+      suggestion: this.suggestionFor(params.retryable)
+    });
+  }
+
+  private createRecoveryExhaustedError(
+    error: OperationInterruptedError,
+    recoveryAttempts: number
+  ): OperationInterruptedError {
+    return new OperationInterruptedError({
+      message: 'Backup restore recovery attempts were exhausted',
+      code: ErrorCode.OPERATION_INTERRUPTED,
+      httpStatus: 409,
+      context: {
+        reason: 'recovery_exhausted',
+        operation: error.context.operation,
+        phase: 'interrupted',
+        admitted: error.context.admitted,
+        retryable: false,
+        recoveryAttempts,
+        maxRecoveryAttempts: BACKUP_RESTORE_MAX_RECOVERY_ATTEMPTS
+      },
+      timestamp: new Date().toISOString(),
+      suggestion: this.suggestionFor(false)
+    });
+  }
+
+  private suggestionFor(retryable: boolean): string {
+    return retryable
+      ? 'Retry restoreBackup() with the same backup handle so the SDK can reconcile the restore operation.'
+      : 'Start a new restoreBackup() call only if restoring this backup is still desired for the current sandbox.';
+  }
+}

--- a/packages/sandbox/src/backup/restore-lifecycle.ts
+++ b/packages/sandbox/src/backup/restore-lifecycle.ts
@@ -31,7 +31,7 @@ type RestoreLifecycleDeps = {
 
 export type RestoreLifecycleContext = {
   lifetime: SandboxLifetime;
-  runtimeReady: (archiveSize?: number) => Promise<{
+  runtimeReady: () => Promise<{
     runtime: RuntimeIdentity;
     operation: BackupRestoreOperationRecord;
   }>;
@@ -40,8 +40,7 @@ export type RestoreLifecycleContext = {
     operation: BackupRestoreOperationRecord;
   }>;
   verify: (
-    result: BackupRestoreOperationResult,
-    archiveSize?: number
+    result: BackupRestoreOperationResult
   ) => Promise<BackupRestoreOperationRecord>;
 };
 
@@ -69,7 +68,7 @@ export class RestoreLifecycleRunner {
 
       const context: RestoreLifecycleContext = {
         lifetime,
-        runtimeReady: async (archiveSize) => {
+        runtimeReady: async () => {
           try {
             runtime = await this.captureRuntime();
             await this.deps.currentLifetime.assertCurrent(lifetime);
@@ -85,8 +84,7 @@ export class RestoreLifecycleRunner {
 
           currentOperation = await this.markRuntimeReady(
             currentOperation,
-            runtime,
-            archiveSize
+            runtime
           );
           return { runtime, operation: currentOperation };
         },
@@ -116,7 +114,7 @@ export class RestoreLifecycleRunner {
           );
           return { runtime, operation: currentOperation };
         },
-        verify: async (result, archiveSize) => {
+        verify: async (result) => {
           if (!runtime) {
             throw new Error(
               'Backup restore verification requires runtimeReady()'
@@ -138,8 +136,7 @@ export class RestoreLifecycleRunner {
           currentOperation = await this.markVerified(
             currentOperation,
             runtime,
-            result,
-            archiveSize
+            result
           );
           return currentOperation;
         }
@@ -207,7 +204,6 @@ export class RestoreLifecycleRunner {
   }> {
     const lifetime = await this.deps.currentLifetime.getOrCreate();
     const operation = createBackupRestoreOperationRecord({
-      operationId: crypto.randomUUID(),
       sandboxLifetimeID: lifetime.id,
       backupId,
       dir,
@@ -235,17 +231,12 @@ export class RestoreLifecycleRunner {
 
   private async markRuntimeReady(
     operation: BackupRestoreOperationRecord,
-    runtime: RuntimeIdentity,
-    archiveSize?: number
+    runtime: RuntimeIdentity
   ): Promise<BackupRestoreOperationRecord> {
     const next: BackupRestoreOperationRecord = {
       ...operation,
       phase: 'runtime_ready',
       runtimeIdentityID: runtime.id,
-      payload: {
-        ...operation.payload,
-        ...(archiveSize !== undefined && { archiveSize })
-      },
       updatedAt: new Date().toISOString()
     };
     await this.operationRecords.put(next);
@@ -274,8 +265,7 @@ export class RestoreLifecycleRunner {
   private async markVerified(
     operation: BackupRestoreOperationRecord,
     runtime: RuntimeIdentity,
-    result: BackupRestoreOperationResult,
-    archiveSize?: number
+    result: BackupRestoreOperationResult
   ): Promise<BackupRestoreOperationRecord> {
     const completedAt = new Date().toISOString();
     const next: BackupRestoreOperationRecord = {
@@ -283,10 +273,6 @@ export class RestoreLifecycleRunner {
       phase: 'verified',
       status: 'committed',
       runtimeIdentityID: runtime.id,
-      payload: {
-        ...operation.payload,
-        ...(archiveSize !== undefined && { archiveSize })
-      },
       result,
       completedAt,
       updatedAt: completedAt

--- a/packages/sandbox/src/backup/restore-operation-store.ts
+++ b/packages/sandbox/src/backup/restore-operation-store.ts
@@ -34,7 +34,6 @@ export type BackupRestoreOperationResult = {
 };
 
 export type BackupRestoreOperationRecord = {
-  operationId: string;
   operationKey: string;
   kind: 'backup.restore';
   sandboxLifetimeID: SandboxLifetimeID;
@@ -61,14 +60,12 @@ export function backupRestoreOperationKey(
 }
 
 export function createBackupRestoreOperationRecord(params: {
-  operationId: string;
   sandboxLifetimeID: SandboxLifetimeID;
   backupId: string;
   dir: string;
   now: string;
 }): BackupRestoreOperationRecord {
   return {
-    operationId: params.operationId,
     operationKey: backupRestoreOperationKey(params.backupId, params.dir),
     kind: 'backup.restore',
     sandboxLifetimeID: params.sandboxLifetimeID,

--- a/packages/sandbox/src/backup/restore-operation-store.ts
+++ b/packages/sandbox/src/backup/restore-operation-store.ts
@@ -1,0 +1,106 @@
+import type { RuntimeIdentityID } from '../current-runtime-identity';
+import type { SandboxLifetimeID } from '../sandbox-lifetime';
+
+export type BackupRestoreOperationStatus =
+  | 'running'
+  | 'committed'
+  | 'failed'
+  | 'interrupted';
+
+export type BackupRestoreOperationPhase =
+  | 'validating'
+  | 'runtime_ready'
+  | 'archive_ready'
+  | 'verified'
+  | 'failed'
+  | 'interrupted';
+
+export type BackupRestoreOperationError = {
+  code: string;
+  message: string;
+  retryable: boolean;
+};
+
+export type BackupRestoreOperationPayload = {
+  backupId: string;
+  dir: string;
+  archiveSize?: number;
+};
+
+export type BackupRestoreOperationResult = {
+  success: true;
+  id: string;
+  dir: string;
+};
+
+export type BackupRestoreOperationRecord = {
+  operationId: string;
+  operationKey: string;
+  kind: 'backup.restore';
+  sandboxLifetimeID: SandboxLifetimeID;
+  phase: BackupRestoreOperationPhase;
+  status: BackupRestoreOperationStatus;
+  runtimeIdentityID?: RuntimeIdentityID;
+  payload: BackupRestoreOperationPayload;
+  result?: BackupRestoreOperationResult;
+  error?: BackupRestoreOperationError;
+  createdAt: string;
+  updatedAt: string;
+  completedAt?: string;
+};
+
+type OperationRecordStorage = Pick<DurableObjectStorage, 'get' | 'put'>;
+
+const OPERATION_STORAGE_PREFIX = 'operations:';
+
+export function backupRestoreOperationKey(
+  backupId: string,
+  dir: string
+): string {
+  return `restore:${backupId}:${dir}`;
+}
+
+export function createBackupRestoreOperationRecord(params: {
+  operationId: string;
+  sandboxLifetimeID: SandboxLifetimeID;
+  backupId: string;
+  dir: string;
+  now: string;
+}): BackupRestoreOperationRecord {
+  return {
+    operationId: params.operationId,
+    operationKey: backupRestoreOperationKey(params.backupId, params.dir),
+    kind: 'backup.restore',
+    sandboxLifetimeID: params.sandboxLifetimeID,
+    phase: 'validating',
+    status: 'running',
+    payload: {
+      backupId: params.backupId,
+      dir: params.dir
+    },
+    createdAt: params.now,
+    updatedAt: params.now
+  };
+}
+
+export class BackupRestoreOperationStore {
+  constructor(private readonly storage: OperationRecordStorage) {}
+
+  async get(
+    operationKey: string
+  ): Promise<BackupRestoreOperationRecord | null> {
+    return (
+      (await this.storage.get<BackupRestoreOperationRecord>(
+        this.storageKey(operationKey)
+      )) ?? null
+    );
+  }
+
+  async put(record: BackupRestoreOperationRecord): Promise<void> {
+    await this.storage.put(this.storageKey(record.operationKey), record);
+  }
+
+  storageKey(operationKey: string): string {
+    return `${OPERATION_STORAGE_PREFIX}${operationKey}`;
+  }
+}

--- a/packages/sandbox/src/container-control/client.ts
+++ b/packages/sandbox/src/container-control/client.ts
@@ -94,6 +94,7 @@ import {
 } from '@repo/shared/errors';
 import type { SandboxClient } from '../clients/sandbox-client';
 import { createErrorFromResponse } from '../errors/adapter';
+import { SandboxError } from '../errors/classes';
 import {
   ContainerControlConnection,
   type ContainerControlConnectionOptions
@@ -163,6 +164,12 @@ interface RPCErrorPayload {
  * no longer in service.
  */
 export function translateRPCError(error: unknown): never {
+  // Preserve locally-created SDK errors. These already carry the correct
+  // code, context, and HTTP status. Re-wrapping them would create a new
+  // instance with an empty context (no `details` property) and lose the
+  // original structured information.
+  if (error instanceof SandboxError) throw error;
+
   if (error instanceof Error) {
     // Format (1): propagated error properties. Distinguish from arbitrary
     // Node/system errors (e.g. `Error.code === 'ENOENT'`) by checking the

--- a/packages/sandbox/src/container-control/connection.ts
+++ b/packages/sandbox/src/container-control/connection.ts
@@ -58,18 +58,27 @@ async function tryParseContainerUnavailable(
     const body = (await response.clone().json()) as StructuredErrorBody;
     if (body.code !== ErrorCode.CONTAINER_UNAVAILABLE) return null;
 
+    const reason =
+      body.context?.reason === 'container_starting' ||
+      body.context?.reason === 'container_unhealthy' ||
+      body.context?.reason === 'container_replaced' ||
+      body.context?.reason === 'rpc_upgrade_failed'
+        ? body.context.reason
+        : 'container_replaced';
+    const context = {
+      reason,
+      retryable: true as const,
+      ...(typeof body.context?.retryAfterMs === 'number' && {
+        retryAfterMs: body.context.retryAfterMs
+      })
+    };
+
     return createErrorFromResponse({
       code: ErrorCode.CONTAINER_UNAVAILABLE,
       message: body.message ?? 'Container is unavailable',
-      context: body.context ?? {
-        reason: 'container_replaced',
-        retryable: true
-      },
+      context,
       httpStatus: getHttpStatus(ErrorCode.CONTAINER_UNAVAILABLE),
-      suggestion: getSuggestion(
-        ErrorCode.CONTAINER_UNAVAILABLE,
-        body.context ?? ({} as Record<string, unknown>)
-      ),
+      suggestion: getSuggestion(ErrorCode.CONTAINER_UNAVAILABLE, context),
       timestamp: new Date().toISOString()
     });
   } catch {

--- a/packages/sandbox/src/container-control/connection.ts
+++ b/packages/sandbox/src/container-control/connection.ts
@@ -20,11 +20,62 @@ import type {
   SandboxWatchAPI
 } from '@repo/shared';
 import { createNoOpLogger } from '@repo/shared';
+import { ErrorCode, getHttpStatus, getSuggestion } from '@repo/shared/errors';
 import { RpcSession, type RpcStub, type RpcTransport } from 'capnweb';
+import { createErrorFromResponse } from '../errors/adapter';
 import {
   fetchWithResponseRetry,
   isRetryableWebSocketUpgradeResponse
 } from '../response-retry';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Wire shape used by the container and by SDK-internal throws. */
+interface StructuredErrorBody {
+  code?: string;
+  message?: string;
+  context?: Record<string, unknown>;
+}
+
+/**
+ * Attempt to parse a structured CONTAINER_UNAVAILABLE JSON body from a
+ * non-101 upgrade response. Returns a typed ContainerUnavailableError when
+ * the body contains a recognized code, or null if the response is not
+ * JSON / not a container availability error.
+ *
+ * The response body is consumed only once via `clone()` so the caller still
+ * holds the original Response.
+ */
+async function tryParseContainerUnavailable(
+  response: Response
+): Promise<Error | null> {
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) return null;
+
+  try {
+    const body = (await response.clone().json()) as StructuredErrorBody;
+    if (body.code !== ErrorCode.CONTAINER_UNAVAILABLE) return null;
+
+    return createErrorFromResponse({
+      code: ErrorCode.CONTAINER_UNAVAILABLE,
+      message: body.message ?? 'Container is unavailable',
+      context: body.context ?? {
+        reason: 'container_replaced',
+        retryable: true
+      },
+      httpStatus: getHttpStatus(ErrorCode.CONTAINER_UNAVAILABLE),
+      suggestion: getSuggestion(
+        ErrorCode.CONTAINER_UNAVAILABLE,
+        body.context ?? ({} as Record<string, unknown>)
+      ),
+      timestamp: new Date().toISOString()
+    });
+  } catch {
+    return null;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Connection manager
@@ -58,14 +109,12 @@ export interface ContainerControlConnectionOptions {
    */
   localMain?: any;
   /**
-   * Invoked when an active WebSocket transitions to closed/errored.
-   * Fired at most once per successful connection from the WS event
-   * handlers in `doConnect`. Gives owners a synchronous teardown
-   * signal so recovery doesn't depend on a periodic poller running
-   * inside what may be an idle isolate.
+   * Invoked when connection setup fails or an active WebSocket transitions
+   * to closed/errored. Fired at most once per connection attempt. Gives
+   * owners a synchronous teardown signal so recovery doesn't depend on a
+   * periodic poller running inside what may be an idle isolate.
    *
-   * Not fired for `doConnect` failures (the rejected `connect()`
-   * promise is the signal in that case) nor for `disconnect()`.
+   * Not fired for `disconnect()`.
    */
   onClose?: () => void;
 }
@@ -231,6 +280,28 @@ export class ContainerControlConnection {
       const response = await this.fetchUpgradeWithRetry();
 
       if (response.status !== 101) {
+        // Try to surface a structured ContainerUnavailableError from the
+        // response body so callers get typed context rather than a generic
+        // upgrade_failed RPCTransportError.
+        const structured = await tryParseContainerUnavailable(response);
+        if (structured) throw structured;
+
+        // No structured body. If the status was retryable, we exhausted the
+        // retry budget without the container becoming available.
+        if (isRetryableWebSocketUpgradeResponse(response)) {
+          throw createErrorFromResponse({
+            code: ErrorCode.CONTAINER_UNAVAILABLE,
+            message: `Container was unavailable after exhausting upgrade retry budget (status ${response.status})`,
+            context: { reason: 'rpc_upgrade_failed', retryable: true },
+            httpStatus: getHttpStatus(ErrorCode.CONTAINER_UNAVAILABLE),
+            suggestion: getSuggestion(
+              ErrorCode.CONTAINER_UNAVAILABLE,
+              {} as Record<string, unknown>
+            ),
+            timestamp: new Date().toISOString()
+          });
+        }
+
         throw new Error(
           `WebSocket upgrade failed: ${response.status} ${response.statusText}`
         );
@@ -259,6 +330,11 @@ export class ContainerControlConnection {
     } catch (error) {
       this.connected = false;
       this.transport.abort(error);
+      // Signal the client to discard this connection. The transport is now
+      // permanently aborted; any in-flight or future stub calls would fail
+      // immediately. Firing onClose here lets the client null out its
+      // reference so the next RPC attempt creates a fresh connection.
+      this.fireOnClose();
       this.logger.error(
         'ContainerControlConnection failed',
         error instanceof Error ? error : new Error(String(error))

--- a/packages/sandbox/src/errors/adapter.ts
+++ b/packages/sandbox/src/errors/adapter.ts
@@ -28,6 +28,7 @@ import type {
   InterpreterNotReadyContext,
   InvalidBackupConfigContext,
   InvalidPortContext,
+  OperationInterruptedContext,
   PortAlreadyExposedContext,
   PortErrorContext,
   PortNotExposedContext,
@@ -67,6 +68,7 @@ import {
   InvalidBackupConfigError,
   InvalidGitUrlError,
   InvalidPortError,
+  OperationInterruptedError,
   PermissionDeniedError,
   PortAlreadyExposedError,
   PortError,
@@ -287,6 +289,13 @@ export function createErrorFromResponse(
     case ErrorCode.CODE_EXECUTION_ERROR:
       return new CodeExecutionError(
         errorResponse as unknown as ErrorResponse<CodeExecutionContext>
+      );
+
+    // Operation lifecycle errors — raised by the SDK when a sandbox-owned
+    // operation is interrupted by a runtime replacement or lifetime change.
+    case ErrorCode.OPERATION_INTERRUPTED:
+      return new OperationInterruptedError(
+        errorResponse as unknown as ErrorResponse<OperationInterruptedContext>
       );
 
     // Container availability errors (SDK-side, raised when the sandbox

--- a/packages/sandbox/src/errors/adapter.ts
+++ b/packages/sandbox/src/errors/adapter.ts
@@ -13,6 +13,7 @@ import type {
   CodeExecutionContext,
   CommandErrorContext,
   CommandNotFoundContext,
+  ContainerUnavailableContext,
   ContextNotFoundContext,
   ErrorResponse,
   FileExistsContext,
@@ -48,6 +49,7 @@ import {
   CodeExecutionError,
   CommandError,
   CommandNotFoundError,
+  ContainerUnavailableError,
   ContextNotFoundError,
   CustomDomainRequiredError,
   FileExistsError,
@@ -285,6 +287,13 @@ export function createErrorFromResponse(
     case ErrorCode.CODE_EXECUTION_ERROR:
       return new CodeExecutionError(
         errorResponse as unknown as ErrorResponse<CodeExecutionContext>
+      );
+
+    // Container availability errors (SDK-side, raised when the sandbox
+    // container cannot accept the incoming RPC connection).
+    case ErrorCode.CONTAINER_UNAVAILABLE:
+      return new ContainerUnavailableError(
+        errorResponse as unknown as ErrorResponse<ContainerUnavailableContext>
       );
 
     // RPC Transport Errors (SDK-side, raised by translateRPCError on

--- a/packages/sandbox/src/errors/classes.ts
+++ b/packages/sandbox/src/errors/classes.ts
@@ -28,6 +28,7 @@ import type {
   InterpreterNotReadyContext,
   InvalidBackupConfigContext,
   InvalidPortContext,
+  OperationInterruptedContext,
   PortAlreadyExposedContext,
   PortErrorContext,
   PortNotExposedContext,
@@ -883,5 +884,25 @@ export class RPCTransportError extends SandboxError<RPCTransportContext> {
 
   get originalMessage(): string {
     return this.errorResponse.context.originalMessage;
+  }
+}
+
+// ============================================================================
+// Operation Lifecycle Errors
+// ============================================================================
+
+/**
+ * Raised when a sandbox-owned operation was interrupted by a runtime
+ * replacement or sandbox lifetime change after the operation was admitted.
+ * The caller can retry the full operation when `context.retryable` is true.
+ */
+export class OperationInterruptedError extends SandboxError<OperationInterruptedContext> {
+  constructor(errorResponse: ErrorResponse<OperationInterruptedContext>) {
+    super(errorResponse);
+    this.name = 'OperationInterruptedError';
+  }
+
+  get reason(): OperationInterruptedContext['reason'] {
+    return this.context.reason;
   }
 }

--- a/packages/sandbox/src/errors/classes.ts
+++ b/packages/sandbox/src/errors/classes.ts
@@ -13,6 +13,7 @@ import type {
   CodeExecutionContext,
   CommandErrorContext,
   CommandNotFoundContext,
+  ContainerUnavailableContext,
   ContextNotFoundContext,
   ErrorResponse,
   FileExistsContext,
@@ -821,6 +822,33 @@ export class BackupRestoreError extends SandboxError<BackupRestoreContext> {
   }
   get backupId() {
     return this.context.backupId;
+  }
+}
+
+// ============================================================================
+// Container Availability Errors (SDK-side)
+// ============================================================================
+
+/**
+ * Raised when the sandbox container cannot accept an incoming RPC connection.
+ * The container may be starting up, temporarily unhealthy, or was replaced
+ * while the connection attempt was in progress.
+ *
+ * Always retryable: the operation that triggered the connection attempt can
+ * be retried once the container is ready.
+ */
+export class ContainerUnavailableError extends SandboxError<ContainerUnavailableContext> {
+  constructor(errorResponse: ErrorResponse<ContainerUnavailableContext>) {
+    super(errorResponse);
+    this.name = 'ContainerUnavailableError';
+  }
+
+  get reason(): ContainerUnavailableContext['reason'] {
+    return this.context.reason;
+  }
+
+  get retryAfterMs(): number | undefined {
+    return this.context.retryAfterMs;
   }
 }
 

--- a/packages/sandbox/src/errors/index.ts
+++ b/packages/sandbox/src/errors/index.ts
@@ -62,6 +62,8 @@ export type {
   InterpreterNotReadyContext,
   InvalidBackupConfigContext,
   InvalidPortContext,
+  OperationInterruptedContext,
+  OperationInterruptedReason,
   OperationType,
   PortAlreadyExposedContext,
   PortErrorContext,
@@ -114,6 +116,8 @@ export {
   InvalidBackupConfigError,
   InvalidGitUrlError,
   InvalidPortError,
+  // Operation Lifecycle Errors
+  OperationInterruptedError,
   PermissionDeniedError,
   // Port Errors
   PortAlreadyExposedError,

--- a/packages/sandbox/src/errors/index.ts
+++ b/packages/sandbox/src/errors/index.ts
@@ -47,6 +47,7 @@ export type {
   CodeExecutionContext,
   CommandErrorContext,
   CommandNotFoundContext,
+  ContainerUnavailableContext,
   ContextNotFoundContext,
   ErrorCodeType,
   ErrorResponse,
@@ -91,6 +92,8 @@ export {
   CommandError,
   // Command Errors
   CommandNotFoundError,
+  // Container Availability Errors (SDK-side)
+  ContainerUnavailableError,
   ContextNotFoundError,
   CustomDomainRequiredError,
   FileExistsError,

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -110,6 +110,8 @@ export type {
 } from './clients/interpreter-client.js';
 export type {
   ContainerUnavailableContext,
+  OperationInterruptedContext,
+  OperationInterruptedReason,
   RPCTransportContext,
   RPCTransportErrorKind
 } from './errors';
@@ -123,6 +125,9 @@ export {
   // yet ready to accept requests or was replaced during a connection attempt)
   ContainerUnavailableError,
   InvalidBackupConfigError,
+  // Operation lifecycle error (raised when a sandbox-owned operation is
+  // interrupted by a runtime replacement or sandbox lifetime change)
+  OperationInterruptedError,
   ProcessExitedBeforeReadyError,
   ProcessReadyTimeoutError,
   // RPC transport error (raised on capnweb WebSocket session failures)

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -108,13 +108,20 @@ export type {
   ExecutionCallbacks,
   InterpreterClient
 } from './clients/interpreter-client.js';
-export type { RPCTransportContext, RPCTransportErrorKind } from './errors';
+export type {
+  ContainerUnavailableContext,
+  RPCTransportContext,
+  RPCTransportErrorKind
+} from './errors';
 // Export backup and process readiness errors
 export {
   BackupCreateError,
   BackupExpiredError,
   BackupNotFoundError,
   BackupRestoreError,
+  // Container availability error (raised when the sandbox container is not
+  // yet ready to accept requests or was replaced during a connection attempt)
+  ContainerUnavailableError,
   InvalidBackupConfigError,
   ProcessExitedBeforeReadyError,
   ProcessReadyTimeoutError,

--- a/packages/sandbox/src/sandbox-lifetime.ts
+++ b/packages/sandbox/src/sandbox-lifetime.ts
@@ -1,0 +1,129 @@
+/**
+ * Sandbox logical lifetime tracking.
+ *
+ * A sandbox lifetime represents the logical existence of a sandbox across
+ * container start/stop cycles. It changes only when the sandbox is explicitly
+ * destroyed via `sandbox.destroy()`. Restore and tunnel operations use the
+ * lifetime id as a fence so operations that started before `destroy()` do
+ * not recover into a new sandbox lifetime.
+ */
+
+type SandboxLifetimeStorage = Pick<
+  DurableObjectStorage | DurableObjectTransaction,
+  'get' | 'put'
+>;
+
+export type SandboxLifetimeID = string & {
+  readonly __sandboxLifetimeID: unique symbol;
+};
+
+export type SandboxLifetimeRecord = {
+  id: SandboxLifetimeID;
+  generation: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const SANDBOX_LIFETIME_STORAGE_KEY = 'sandbox:lifetime';
+
+export class SandboxLifetimeChangedError extends Error {
+  constructor() {
+    super('Sandbox lifetime is no longer current');
+    this.name = 'SandboxLifetimeChangedError';
+  }
+}
+
+export class SandboxLifetime {
+  readonly id: SandboxLifetimeID;
+  readonly generation: number;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+
+  constructor(readonly record: SandboxLifetimeRecord) {
+    this.id = record.id;
+    this.generation = record.generation;
+    this.createdAt = record.createdAt;
+    this.updatedAt = record.updatedAt;
+  }
+
+  owns(record: { readonly sandboxLifetimeID: SandboxLifetimeID }): boolean {
+    return record.sandboxLifetimeID === this.id;
+  }
+
+  scope<T extends object>(
+    value: T
+  ): T & { sandboxLifetimeID: SandboxLifetimeID } {
+    return {
+      ...value,
+      sandboxLifetimeID: this.id
+    };
+  }
+}
+
+export class CurrentSandboxLifetime {
+  constructor(private readonly storage: SandboxLifetimeStorage) {}
+
+  async get(): Promise<SandboxLifetime | null> {
+    const record =
+      (await this.storage.get<SandboxLifetimeRecord>(
+        SANDBOX_LIFETIME_STORAGE_KEY
+      )) ?? null;
+    return record ? new SandboxLifetime(record) : null;
+  }
+
+  /**
+   * Returns the current lifetime if one exists, or creates and persists a new
+   * one. The id is stable for the lifetime of the sandbox — it only changes
+   * when `rotate()` is called (on `destroy()`).
+   */
+  async getOrCreate(): Promise<SandboxLifetime> {
+    const existing = await this.get();
+    if (existing) {
+      return existing;
+    }
+
+    const now = new Date().toISOString();
+    const record: SandboxLifetimeRecord = {
+      id: crypto.randomUUID() as SandboxLifetimeID,
+      generation: 1,
+      createdAt: now,
+      updatedAt: now
+    };
+    await this.storage.put(SANDBOX_LIFETIME_STORAGE_KEY, record);
+    return new SandboxLifetime(record);
+  }
+
+  /**
+   * Creates and persists a new lifetime id, incrementing the generation
+   * counter. Called during `sandbox.destroy()` before runtime state is
+   * cleared so in-flight operations can detect the lifetime change.
+   */
+  async rotate(): Promise<SandboxLifetime> {
+    const existing = await this.get();
+    const now = new Date().toISOString();
+    const record: SandboxLifetimeRecord = {
+      id: crypto.randomUUID() as SandboxLifetimeID,
+      generation: (existing?.generation ?? 0) + 1,
+      createdAt: now,
+      updatedAt: now
+    };
+    await this.storage.put(SANDBOX_LIFETIME_STORAGE_KEY, record);
+    return new SandboxLifetime(record);
+  }
+
+  async isCurrent(lifetime: SandboxLifetime): Promise<boolean> {
+    const current = await this.get();
+    return current?.id === lifetime.id;
+  }
+
+  /**
+   * Throws `SandboxLifetimeChangedError` if the given lifetime is no longer
+   * the current one. Used by operation runners to abort operations that
+   * started before a `destroy()` call.
+   */
+  async assertCurrent(lifetime: SandboxLifetime): Promise<void> {
+    if (!(await this.isCurrent(lifetime))) {
+      throw new SandboxLifetimeChangedError();
+    }
+  }
+}

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -108,6 +108,10 @@ import {
   sanitizeSandboxId,
   validatePort
 } from './security';
+import {
+  isSessionInitInvalidated,
+  SessionInitInvalidatedError
+} from './session-init';
 import { parseSSEStream } from './sse-parser';
 import {
   buildS3fsSource,
@@ -324,22 +328,6 @@ function isFetcher(value: unknown): value is Fetcher {
     value !== null &&
     'fetch' in value &&
     typeof value.fetch === 'function'
-  );
-}
-
-/**
- * Returns true when an error thrown by `initializeDefaultSession` carries
- * the specific message that signals a container generation change while the
- * createSession RPC was in flight. Only this message triggers the single-shot
- * retry in `ensureDefaultSession`.
- */
-function isSessionInitInvalidated(err: unknown): boolean {
-  return (
-    err !== null &&
-    typeof err === 'object' &&
-    'message' in err &&
-    (err as { message: unknown }).message ===
-      'Default session initialization was invalidated by a container stop'
   );
 }
 
@@ -3618,9 +3606,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     // Fail the attempt so the next caller starts fresh against the new
     // container.
     if (generation !== this.containerGeneration) {
-      throw new Error(
-        'Default session initialization was invalidated by a container stop'
-      );
+      throw new SessionInitInvalidatedError();
     }
 
     // Durable storage is the cross-eviction source of truth for the default
@@ -7070,9 +7056,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         });
       }
 
-      await lifecycle.runtimeReady(archiveHead.size);
-
       backupSession = await this.ensureBackupSession();
+      await lifecycle.runtimeReady();
       const archivePath = `${BACKUP_CONTAINER_DIR}/${id}.sqsh`;
 
       // Step 3: Tear down existing FUSE mounts before overwriting the archive.
@@ -7140,7 +7125,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         dir,
         id
       };
-      await lifecycle.verify(result, archiveHead.size);
+      await lifecycle.verify(result);
 
       outcome = 'success';
 
@@ -7291,9 +7276,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         });
       }
       const archiveSize = metadata.sizeBytes;
-      await lifecycle.runtimeReady(archiveSize);
 
       backupSession = await this.ensureBackupSession();
+      await lifecycle.runtimeReady();
       const archivePath = `${BACKUP_CONTAINER_DIR}/${id}.sqsh`;
 
       // Ensure backup directory exists
@@ -7377,7 +7362,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         dir,
         id
       };
-      await lifecycle.verify(result, archiveSize);
+      await lifecycle.verify(result);
 
       // Clean up archive after extraction (no FUSE mount holds it open)
       await this.execWithSession(

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -323,6 +323,22 @@ function isFetcher(value: unknown): value is Fetcher {
   );
 }
 
+/**
+ * Returns true when an error thrown by `initializeDefaultSession` carries
+ * the specific message that signals a container generation change while the
+ * createSession RPC was in flight. Only this message triggers the single-shot
+ * retry in `ensureDefaultSession`.
+ */
+function isSessionInitInvalidated(err: unknown): boolean {
+  return (
+    err !== null &&
+    typeof err === 'object' &&
+    'message' in err &&
+    (err as { message: unknown }).message ===
+      'Default session initialization was invalidated by a container stop'
+  );
+}
+
 type ConfigurableSandboxStub = {
   configure?: (configuration: SandboxConfiguration) => Promise<void>;
   setSandboxName?: (name: string, normalizeId?: boolean) => Promise<void>;
@@ -3522,6 +3538,36 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     this.defaultSessionInit = init;
     try {
       return await promise;
+    } catch (err) {
+      // Retry once when the container generation was advanced (by onStop)
+      // while the initial createSession RPC was in flight. The fresh
+      // generation is captured after the failed attempt so the retry
+      // targets the new container.
+      if (isSessionInitInvalidated(err)) {
+        // Fast path: a concurrent caller may have already initialized the
+        // session by the time we get here.
+        if (this.defaultSession === sessionId) return this.defaultSession;
+        // Join an in-flight init for the current generation that was started
+        // by a concurrent caller rather than starting a parallel one. The guard
+        // `freshPending !== init` prevents joining the same slot that just
+        // failed (which would return an already-rejected promise).
+        const freshPending = this.defaultSessionInit;
+        if (
+          freshPending != null &&
+          freshPending !== init &&
+          freshPending.sessionId === sessionId &&
+          freshPending.generation === this.containerGeneration
+        ) {
+          return freshPending.promise;
+        }
+        // No concurrent init exists: start a fresh one with the current
+        // generation.
+        return await this.initializeDefaultSession(
+          sessionId,
+          this.containerGeneration
+        );
+      }
+      throw err;
     } finally {
       // Identity guard: only clear the slot if it still holds this
       // attempt. A newer mismatching caller or an onStop may have

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -5137,6 +5137,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       storage: this.ctx.storage,
       logger: this.logger,
       sandboxId: this.ctx.id.toString(),
+      currentRuntime: this.currentRuntime,
+      currentLifetime: this.currentLifetime,
       getNamedTunnelConfig: async () => {
         const envObj = this.env as Record<string, unknown>;
         const token = getEnvString(envObj, 'CLOUDFLARE_API_TOKEN');

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -61,6 +61,9 @@ import {
 } from '@repo/shared/backup';
 import { DISABLE_SESSION_TOKEN } from '@repo/shared/internal';
 import { AwsClient } from 'aws4fetch';
+import type { RestoreLifecycleContext } from './backup/restore-lifecycle';
+import { RestoreLifecycleRunner } from './backup/restore-lifecycle';
+import type { BackupRestoreOperationResult } from './backup/restore-operation-store';
 import { type ExecuteResponse, SandboxClient } from './clients';
 import { ContainerControlClient } from './container-control';
 import {
@@ -99,6 +102,7 @@ import {
 } from './preview-proxy-protocol';
 import { isLocalhostPattern } from './preview-url';
 import { proxyTerminal } from './pty';
+import { CurrentSandboxLifetime } from './sandbox-lifetime';
 import {
   SandboxSecurityError,
   sanitizeSandboxId,
@@ -919,6 +923,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   private activeMounts: Map<string, MountInfo> = new Map();
   private mountOperationQueue: Promise<void> = Promise.resolve();
   private currentRuntime: CurrentRuntimeIdentity;
+  private currentLifetime: CurrentSandboxLifetime;
   private transport: SandboxTransport = 'http';
 
   /**
@@ -1140,6 +1145,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       () => this.getState(),
       () => this.ctx.container?.running === true
     );
+
+    this.currentLifetime = new CurrentSandboxLifetime(this.ctx.storage);
 
     // Read transport setting from env var
     const transportEnv = envObj?.SANDBOX_TRANSPORT;
@@ -2649,6 +2656,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       // the container.
       await this.ctx.storage.delete(PORT_TOKENS_STORAGE_KEY);
       await this.clearActivePreviewPorts();
+      // Rotate sandbox lifetime before clearing runtime state so that
+      // in-flight operations can detect the lifetime change and abort.
+      await this.currentLifetime.rotate();
       await this.currentRuntime.clear();
 
       // Unmount all mounted buckets and cleanup (requires an active connection
@@ -6928,18 +6938,39 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    * Concurrent backup/restore calls on the same sandbox are serialized.
    */
   async restoreBackup(backup: DirectoryBackup): Promise<RestoreBackupResult> {
-    if (backup.localBucket) {
-      return await this.enqueueBackupOp(() =>
-        this.doRestoreBackupLocal(backup)
-      );
+    if (!backup.localBucket) {
+      this.requireBackupBucket();
     }
-    this.requireBackupBucket();
-    return await this.enqueueBackupOp(() => this.doRestoreBackup(backup));
+    return await this.enqueueBackupOp(() =>
+      this.doRestoreBackupWithRecovery(backup)
+    );
+  }
+
+  private async doRestoreBackupWithRecovery(
+    backup: DirectoryBackup
+  ): Promise<BackupRestoreOperationResult> {
+    const runner = new RestoreLifecycleRunner({
+      storage: this.ctx.storage,
+      currentRuntime: this.currentRuntime,
+      currentLifetime: this.currentLifetime
+    });
+
+    return await runner.execute({
+      backupId: backup.id,
+      dir: backup.dir,
+      attempt: async (lifecycle) => {
+        if (backup.localBucket) {
+          return await this.doRestoreBackupLocal(backup, lifecycle);
+        }
+        return await this.doRestoreBackup(backup, lifecycle);
+      }
+    });
   }
 
   private async doRestoreBackup(
-    backup: DirectoryBackup
-  ): Promise<RestoreBackupResult> {
+    backup: DirectoryBackup,
+    lifecycle: RestoreLifecycleContext
+  ): Promise<BackupRestoreOperationResult> {
     const restoreStartTime = Date.now();
     const bucket = this.requireBackupBucket();
     this.requirePresignedURLSupport();
@@ -7037,6 +7068,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         });
       }
 
+      await lifecycle.runtimeReady(archiveHead.size);
+
       backupSession = await this.ensureBackupSession();
       const archivePath = `${BACKUP_CONTAINER_DIR}/${id}.sqsh`;
 
@@ -7082,6 +7115,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         );
       }
 
+      await lifecycle.archiveReady(archiveHead.size);
+
       const restoreResult = await this.client.backup.restoreArchive(
         dir,
         archivePath,
@@ -7098,13 +7133,16 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         });
       }
 
-      outcome = 'success';
-
-      return {
-        success: true,
+      const result = {
+        success: true as const,
         dir,
         id
       };
+      await lifecycle.verify(result, archiveHead.size);
+
+      outcome = 'success';
+
+      return result;
     } catch (error) {
       caughtError = error instanceof Error ? error : new Error(String(error));
       if (id && backupSession) {
@@ -7137,8 +7175,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    * unsquashfs for extraction instead of squashfuse + fuse-overlayfs.
    */
   private async doRestoreBackupLocal(
-    backup: DirectoryBackup
-  ): Promise<RestoreBackupResult> {
+    backup: DirectoryBackup,
+    lifecycle: RestoreLifecycleContext
+  ): Promise<BackupRestoreOperationResult> {
     const restoreStartTime = Date.now();
     const { id, dir } = backup;
 
@@ -7203,6 +7242,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         ttl: number;
         createdAt: string;
         dir: string;
+        sizeBytes?: number;
       }>();
 
       // Check TTL with 60-second buffer
@@ -7248,6 +7288,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           timestamp: new Date().toISOString()
         });
       }
+      const archiveSize = metadata.sizeBytes;
+      await lifecycle.runtimeReady(archiveSize);
 
       backupSession = await this.ensureBackupSession();
       const archivePath = `${BACKUP_CONTAINER_DIR}/${id}.sqsh`;
@@ -7309,6 +7351,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         }
       }
 
+      await lifecycle.archiveReady(archiveSize);
+
       // Step 3: Extract archive using unsquashfs (no FUSE needed)
       const extractResult = await this.execWithSession(
         `/usr/bin/unsquashfs -f -d ${shellEscape(dir)} ${shellEscape(archivePath)}`,
@@ -7326,6 +7370,13 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         });
       }
 
+      const result = {
+        success: true as const,
+        dir,
+        id
+      };
+      await lifecycle.verify(result, archiveSize);
+
       // Clean up archive after extraction (no FUSE mount holds it open)
       await this.execWithSession(
         `rm -f ${shellEscape(archivePath)}`,
@@ -7335,11 +7386,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
       outcome = 'success';
 
-      return {
-        success: true,
-        dir,
-        id
-      };
+      return result;
     } catch (error) {
       caughtError = error instanceof Error ? error : new Error(String(error));
       if (id && backupSession) {

--- a/packages/sandbox/src/session-init.ts
+++ b/packages/sandbox/src/session-init.ts
@@ -1,0 +1,12 @@
+export class SessionInitInvalidatedError extends Error {
+  constructor() {
+    super('Default session initialization was invalidated by a container stop');
+    this.name = 'SessionInitInvalidatedError';
+  }
+}
+
+export function isSessionInitInvalidated(
+  error: unknown
+): error is SessionInitInvalidatedError {
+  return error instanceof SessionInitInvalidatedError;
+}

--- a/packages/sandbox/src/tunnels/lifecycle.ts
+++ b/packages/sandbox/src/tunnels/lifecycle.ts
@@ -1,0 +1,84 @@
+import type { OperationInterruptedReason } from '@repo/shared/errors';
+import { RuntimeIdentityInactiveError } from '../current-runtime-identity';
+import {
+  ErrorCode,
+  OperationInterruptedError,
+  RPCTransportError
+} from '../errors';
+import { SandboxLifetimeChangedError } from '../sandbox-lifetime';
+
+export const TUNNEL_GET_MAX_RECOVERY_ATTEMPTS = 2;
+
+export function runtimeRunId(): string {
+  return `run-${crypto.randomUUID()}`;
+}
+
+export function createTunnelInterruptedError(params: {
+  reason: OperationInterruptedReason;
+  phase: string;
+  admitted: boolean | 'unknown';
+  retryable: boolean;
+  recoveryAttempts?: number;
+  maxRecoveryAttempts?: number;
+}): OperationInterruptedError {
+  return new OperationInterruptedError({
+    message:
+      params.reason === 'recovery_exhausted'
+        ? 'Tunnel recovery attempts were exhausted'
+        : 'Tunnel operation was interrupted by a sandbox runtime change',
+    code: ErrorCode.OPERATION_INTERRUPTED,
+    httpStatus: 409,
+    context: {
+      reason: params.reason,
+      operation: 'tunnel.get',
+      phase: params.phase,
+      admitted: params.admitted,
+      retryable: params.retryable,
+      ...(params.recoveryAttempts !== undefined && {
+        recoveryAttempts: params.recoveryAttempts
+      }),
+      ...(params.maxRecoveryAttempts !== undefined && {
+        maxRecoveryAttempts: params.maxRecoveryAttempts
+      })
+    },
+    timestamp: new Date().toISOString(),
+    suggestion: params.retryable
+      ? 'Retry tunnels.get() for the same port so the SDK can establish a fresh tunnel run.'
+      : 'Start a new tunnels.get() call only if this tunnel is still desired for the current sandbox.'
+  });
+}
+
+export function translateTunnelInterruption(
+  error: unknown,
+  phase: string,
+  admitted: boolean | 'unknown'
+): OperationInterruptedError | null {
+  if (error instanceof OperationInterruptedError) {
+    return error;
+  }
+  if (error instanceof RuntimeIdentityInactiveError) {
+    return createTunnelInterruptedError({
+      reason: 'runtime_replaced',
+      phase,
+      admitted,
+      retryable: true
+    });
+  }
+  if (error instanceof SandboxLifetimeChangedError) {
+    return createTunnelInterruptedError({
+      reason: 'sandbox_lifetime_changed',
+      phase,
+      admitted,
+      retryable: false
+    });
+  }
+  if (error instanceof RPCTransportError) {
+    return createTunnelInterruptedError({
+      reason: 'transport_disposed',
+      phase,
+      admitted: 'unknown',
+      retryable: true
+    });
+  }
+  return null;
+}

--- a/packages/sandbox/src/tunnels/restart.ts
+++ b/packages/sandbox/src/tunnels/restart.ts
@@ -1,0 +1,31 @@
+import {
+  META_STORAGE_KEY,
+  readMap,
+  readMetaMap,
+  STORAGE_KEY,
+  type TunnelMap,
+  type TunnelMetaMap,
+  type TunnelsStorage
+} from './storage';
+
+export async function pruneTunnelsForRestart(
+  storage: TunnelsStorage
+): Promise<void> {
+  await storage.transaction(async (txn) => {
+    const map = await readMap(txn);
+    const meta = await readMetaMap(txn);
+    const nextMap: TunnelMap = {};
+    const nextMeta: TunnelMetaMap = {};
+    for (const [portKey, info] of Object.entries(map)) {
+      if (info.name) {
+        nextMap[portKey] = info;
+        nextMeta[portKey] = {
+          ...(meta[portKey] ?? { optionsHash: `v1:named:${info.name}` }),
+          needsRespawn: true
+        };
+      }
+    }
+    await txn.put(STORAGE_KEY, nextMap);
+    await txn.put(META_STORAGE_KEY, nextMeta);
+  });
+}

--- a/packages/sandbox/src/tunnels/sandbox-control-callback.ts
+++ b/packages/sandbox/src/tunnels/sandbox-control-callback.ts
@@ -32,17 +32,19 @@ export class SandboxControlCallbackImpl
   async onTunnelExit(
     id: string,
     port: number,
-    exitCode: number | null
+    exitCode: number | null,
+    runId?: string
   ): Promise<void> {
     const handler = this.getHandler();
     if (!handler) {
       this.logger.debug('onTunnelExit: no handler bound; ignoring', {
         id,
         port,
-        exitCode
+        exitCode,
+        runId
       });
       return;
     }
-    await handler(id, port, exitCode);
+    await handler(id, port, exitCode, runId);
   }
 }

--- a/packages/sandbox/src/tunnels/storage.ts
+++ b/packages/sandbox/src/tunnels/storage.ts
@@ -1,0 +1,54 @@
+import type { TunnelInfo, TunnelOptions } from '@repo/shared';
+import type { RuntimeIdentityID } from '../current-runtime-identity';
+import type { SandboxLifetimeID } from '../sandbox-lifetime';
+
+export const STORAGE_KEY = 'tunnels';
+export const META_STORAGE_KEY = 'tunnels:meta';
+
+export interface TunnelsStorageTxn {
+  get<T>(key: string): Promise<T | undefined>;
+  put<T>(key: string, value: T): Promise<void>;
+  delete(key: string): Promise<boolean>;
+}
+
+export interface TunnelsStorage extends TunnelsStorageTxn {
+  transaction<T>(closure: (txn: TunnelsStorageTxn) => Promise<T>): Promise<T>;
+}
+
+export type TunnelMap = Record<string, TunnelInfo>;
+
+export interface TunnelMetaEntry {
+  optionsHash: string;
+  dnsRecordId?: string;
+  runtimeIdentityID?: RuntimeIdentityID;
+  sandboxLifetimeID?: SandboxLifetimeID;
+  tunnelRunId?: string;
+  accountId?: string;
+  zoneId?: string;
+  needsRespawn?: boolean;
+}
+
+export type TunnelMetaMap = Record<string, TunnelMetaEntry>;
+
+export async function readMap(storage: TunnelsStorageTxn): Promise<TunnelMap> {
+  return (await storage.get<TunnelMap>(STORAGE_KEY)) ?? {};
+}
+
+export async function readMetaMap(
+  storage: TunnelsStorageTxn
+): Promise<TunnelMetaMap> {
+  return (await storage.get<TunnelMetaMap>(META_STORAGE_KEY)) ?? {};
+}
+
+export function computeOptionsHash(options?: TunnelOptions): string {
+  if (!options || !options.name) return 'v1:quick';
+  return `v1:named:${options.name}`;
+}
+
+function normaliseHash(hash: string): string {
+  return hash.startsWith('v1:') ? hash.slice(3) : hash;
+}
+
+export function optionsHashesEqual(a: string, b: string): boolean {
+  return normaliseHash(a) === normaliseHash(b);
+}

--- a/packages/sandbox/src/tunnels/tunnels-handler.ts
+++ b/packages/sandbox/src/tunnels/tunnels-handler.ts
@@ -11,6 +11,7 @@
 
 import { RpcTarget } from 'cloudflare:workers';
 import type {
+  EnsureTunnelRunResult,
   Logger,
   NamedTunnelInfo,
   QuickTunnelInfo,
@@ -19,6 +20,21 @@ import type {
   TunnelOptions
 } from '@repo/shared';
 import { logCanonicalEvent } from '@repo/shared';
+import {
+  type CurrentRuntimeIdentity,
+  type RuntimeIdentityID,
+  RuntimeIdentityInactiveError
+} from '../current-runtime-identity';
+import {
+  ErrorCode,
+  OperationInterruptedError,
+  RPCTransportError
+} from '../errors';
+import {
+  type CurrentSandboxLifetime,
+  SandboxLifetimeChangedError,
+  type SandboxLifetimeID
+} from '../sandbox-lifetime';
 import {
   SandboxSecurityError,
   validatePort,
@@ -93,6 +109,10 @@ export interface TunnelsHandlerHost {
    * to the global `fetch`. Tests inject a mock here.
    */
   fetcher?: typeof fetch;
+  /** Current container runtime fence for runtime-local quick tunnel records. */
+  currentRuntime?: CurrentRuntimeIdentity;
+  /** Logical sandbox lifetime fence for recovery across destroy(). */
+  currentLifetime?: CurrentSandboxLifetime;
 }
 
 export interface TunnelsHandler {
@@ -111,7 +131,8 @@ export interface TunnelsHandler {
 export type TunnelExitHandler = (
   id: string,
   port: number,
-  exitCode: number | null
+  exitCode: number | null,
+  runId?: string
 ) => Promise<void>;
 
 export interface TunnelsHandle {
@@ -148,6 +169,12 @@ interface TunnelMetaEntry {
   optionsHash: string;
   /** Cloudflare DNS record id for named tunnels; absent for quick. */
   dnsRecordId?: string;
+  /** Runtime identity that owns a runtime-local quick tunnel record. */
+  runtimeIdentityID?: RuntimeIdentityID;
+  /** Sandbox lifetime that owns this tunnel record. */
+  sandboxLifetimeID?: SandboxLifetimeID;
+  /** Runtime-local cloudflared process run id. */
+  tunnelRunId?: string;
   /**
    * Resolved `(accountId, zoneId)` the named tunnel was provisioned
    * against. Compared on cache hit to detect env-var changes that
@@ -190,6 +217,86 @@ function shortId(): string {
   return Array.from(buf)
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('');
+}
+
+function runtimeRunId(): string {
+  return `run-${crypto.randomUUID()}`;
+}
+
+const TUNNEL_GET_MAX_RECOVERY_ATTEMPTS = 2;
+
+function createTunnelInterruptedError(params: {
+  reason:
+    | 'runtime_replaced'
+    | 'transport_disposed'
+    | 'sandbox_lifetime_changed'
+    | 'recovery_exhausted';
+  phase: string;
+  admitted: boolean | 'unknown';
+  retryable: boolean;
+  recoveryAttempts?: number;
+  maxRecoveryAttempts?: number;
+}): OperationInterruptedError {
+  return new OperationInterruptedError({
+    message:
+      params.reason === 'recovery_exhausted'
+        ? 'Tunnel recovery attempts were exhausted'
+        : 'Tunnel operation was interrupted by a sandbox runtime change',
+    code: ErrorCode.OPERATION_INTERRUPTED,
+    httpStatus: 409,
+    context: {
+      reason: params.reason,
+      operation: 'tunnel.get',
+      phase: params.phase,
+      admitted: params.admitted,
+      retryable: params.retryable,
+      ...(params.recoveryAttempts !== undefined && {
+        recoveryAttempts: params.recoveryAttempts
+      }),
+      ...(params.maxRecoveryAttempts !== undefined && {
+        maxRecoveryAttempts: params.maxRecoveryAttempts
+      })
+    },
+    timestamp: new Date().toISOString(),
+    suggestion: params.retryable
+      ? 'Retry tunnels.get() for the same port so the SDK can establish a fresh tunnel run.'
+      : 'Start a new tunnels.get() call only if this tunnel is still desired for the current sandbox.'
+  });
+}
+
+function translateTunnelInterruption(
+  error: unknown,
+  phase: string,
+  admitted: boolean | 'unknown'
+): OperationInterruptedError | null {
+  if (error instanceof OperationInterruptedError) {
+    return error;
+  }
+  if (error instanceof RuntimeIdentityInactiveError) {
+    return createTunnelInterruptedError({
+      reason: 'runtime_replaced',
+      phase,
+      admitted,
+      retryable: true
+    });
+  }
+  if (error instanceof SandboxLifetimeChangedError) {
+    return createTunnelInterruptedError({
+      reason: 'sandbox_lifetime_changed',
+      phase,
+      admitted,
+      retryable: false
+    });
+  }
+  if (error instanceof RPCTransportError) {
+    return createTunnelInterruptedError({
+      reason: 'transport_disposed',
+      phase,
+      admitted: 'unknown',
+      retryable: true
+    });
+  }
+  return null;
 }
 
 /**
@@ -334,66 +441,74 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
       if (options?.name !== undefined) validateTunnelName(options.name);
       const requestedHash = computeOptionsHash(options);
 
-      const info = await this.#withPortLock(port, async () => {
-        const map = await readMap(this.#host.storage);
-        const existing = map[port.toString()];
-        if (existing) {
-          const meta = await readMetaMap(this.#host.storage);
-          const metaEntry = meta[port.toString()];
-          const cachedHash = metaEntry?.optionsHash;
-          // Quick tunnels created before the meta sidecar shipped, or
-          // any port whose meta entry was lost, fall back to comparing
-          // by discriminator alone so cache hits keep working.
-          const effectiveHash =
-            cachedHash ??
-            (existing.name ? `v1:named:${existing.name}` : 'v1:quick');
-          if (!optionsHashesEqual(effectiveHash, requestedHash)) {
-            throw new Error(
-              `Tunnel on port ${port} was created with different options. ` +
-                `Call destroy(${port}) before changing tunnel options.`
-            );
-          }
-          // Container restart marker: the CF-side tunnel + DNS still
-          // exist, but `cloudflared` died with the container. Fall
-          // through to the named-tunnel provision path, which reuses
-          // the tagged tunnel via `findTunnelByName` and respawns the
-          // process. Only named tunnels get this branch; quick tunnels
-          // were dropped from storage by `pruneTunnelsForRestart`.
-          if (metaEntry?.needsRespawn && existing.name) {
-            return await this.#provisionNamedTunnel(port, existing.name);
-          }
-          // Config-drift check for named tunnels: if CLOUDFLARE_ZONE_ID
-          // (or the resolved account id) changed since the tunnel was
-          // provisioned, the cached `hostname` is stale and would no
-          // longer resolve. Re-provision against the current config;
-          // `#provisionNamedTunnel` handles tunnel + DNS reuse via the
-          // `findTunnelByName` and `upsertCNAME` paths.
-          if (existing.name && this.#host.getNamedTunnelConfig) {
-            const currentConfig = await this.#host.getNamedTunnelConfig();
-            const storedAccountId = metaEntry?.accountId;
-            const storedZoneId = metaEntry?.zoneId;
+      const info = await this.#getWithRecovery(port, options, () => {
+        return this.#withPortLock(port, async () => {
+          const map = await readMap(this.#host.storage);
+          const existing = map[port.toString()];
+          if (existing) {
+            const meta = await readMetaMap(this.#host.storage);
+            const metaEntry = meta[port.toString()];
+            const cachedHash = metaEntry?.optionsHash;
+            // Quick tunnels created before the meta sidecar shipped, or
+            // any port whose meta entry was lost, fall back to comparing
+            // by discriminator alone so cache hits keep working.
+            const effectiveHash =
+              cachedHash ??
+              (existing.name ? `v1:named:${existing.name}` : 'v1:quick');
+            if (!optionsHashesEqual(effectiveHash, requestedHash)) {
+              throw new Error(
+                `Tunnel on port ${port} was created with different options. ` +
+                  `Call destroy(${port}) before changing tunnel options.`
+              );
+            }
             if (
-              (storedAccountId !== undefined &&
-                storedAccountId !== currentConfig.accountId) ||
-              (storedZoneId !== undefined &&
-                storedZoneId !== currentConfig.zoneId)
+              !existing.name &&
+              (await this.#quickTunnelRecordIsStale(metaEntry))
             ) {
-              // The cached zone name is for the old zone id; clear it
-              // so `#provisionNamedTunnel` re-resolves against the new
-              // one. Without this, `hostname` would be `<name>.<old
-              // zone name>` even after re-provision.
-              this.#zoneNamePromise = null;
+              return await this.#provisionQuickTunnel(port);
+            }
+            // Container restart marker: the CF-side tunnel + DNS still
+            // exist, but `cloudflared` died with the container. Fall
+            // through to the named-tunnel provision path, which reuses
+            // the tagged tunnel via `findTunnelByName` and respawns the
+            // process. Only named tunnels get this branch; quick tunnels
+            // were dropped from storage by `pruneTunnelsForRestart`.
+            if (metaEntry?.needsRespawn && existing.name) {
               return await this.#provisionNamedTunnel(port, existing.name);
             }
+            // Config-drift check for named tunnels: if CLOUDFLARE_ZONE_ID
+            // (or the resolved account id) changed since the tunnel was
+            // provisioned, the cached `hostname` is stale and would no
+            // longer resolve. Re-provision against the current config;
+            // `#provisionNamedTunnel` handles tunnel + DNS reuse via the
+            // `findTunnelByName` and `upsertCNAME` paths.
+            if (existing.name && this.#host.getNamedTunnelConfig) {
+              const currentConfig = await this.#host.getNamedTunnelConfig();
+              const storedAccountId = metaEntry?.accountId;
+              const storedZoneId = metaEntry?.zoneId;
+              if (
+                (storedAccountId !== undefined &&
+                  storedAccountId !== currentConfig.accountId) ||
+                (storedZoneId !== undefined &&
+                  storedZoneId !== currentConfig.zoneId)
+              ) {
+                // The cached zone name is for the old zone id; clear it
+                // so `#provisionNamedTunnel` re-resolves against the new
+                // one. Without this, `hostname` would be `<name>.<old
+                // zone name>` even after re-provision.
+                this.#zoneNamePromise = null;
+                return await this.#provisionNamedTunnel(port, existing.name);
+              }
+            }
+            cacheState = 'hit';
+            return existing;
           }
-          cacheState = 'hit';
-          return existing;
-        }
 
-        if (options?.name) {
-          return await this.#provisionNamedTunnel(port, options.name);
-        }
-        return await this.#provisionQuickTunnel(port);
+          if (options?.name) {
+            return await this.#provisionNamedTunnel(port, options.name);
+          }
+          return await this.#provisionQuickTunnel(port);
+        });
       });
       outcome = 'success';
       return info;
@@ -412,6 +527,68 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
     }
   }
 
+  async #getWithRecovery(
+    port: number,
+    options: TunnelOptions | undefined,
+    run: () => Promise<TunnelInfo>
+  ): Promise<TunnelInfo> {
+    let recoveryAttempts = 0;
+    while (true) {
+      try {
+        return await run();
+      } catch (error) {
+        const interrupted = translateTunnelInterruption(
+          error,
+          'provisioning',
+          'unknown'
+        );
+        if (!interrupted || options?.name || !interrupted.context.retryable) {
+          throw error;
+        }
+        if (recoveryAttempts >= TUNNEL_GET_MAX_RECOVERY_ATTEMPTS) {
+          throw createTunnelInterruptedError({
+            reason: 'recovery_exhausted',
+            phase: 'interrupted',
+            admitted: interrupted.context.admitted,
+            retryable: false,
+            recoveryAttempts,
+            maxRecoveryAttempts: TUNNEL_GET_MAX_RECOVERY_ATTEMPTS
+          });
+        }
+        recoveryAttempts++;
+        await this.#clearQuickTunnelStorage(port);
+      }
+    }
+  }
+
+  async #clearQuickTunnelStorage(port: number): Promise<void> {
+    await this.#host.storage.transaction(async (txn) => {
+      const map = await readMap(txn);
+      delete map[port.toString()];
+      await txn.put(STORAGE_KEY, map);
+      const meta = await readMetaMap(txn);
+      delete meta[port.toString()];
+      await txn.put(META_STORAGE_KEY, meta);
+    });
+  }
+
+  async #quickTunnelRecordIsStale(
+    metaEntry?: TunnelMetaEntry
+  ): Promise<boolean> {
+    if (!this.#host.currentRuntime || !this.#host.currentLifetime) {
+      return false;
+    }
+    if (!metaEntry?.runtimeIdentityID || !metaEntry.sandboxLifetimeID) {
+      return true;
+    }
+    const runtime = await this.#host.currentRuntime.get();
+    const lifetime = await this.#host.currentLifetime.getOrCreate();
+    return (
+      runtime?.id !== metaEntry.runtimeIdentityID ||
+      lifetime.id !== metaEntry.sandboxLifetimeID
+    );
+  }
+
   /**
    * Provision a fresh quick tunnel and persist it. Caller holds the
    * per-port lock.
@@ -424,6 +601,10 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
    * persistent failure still surfaces.
    */
   async #provisionQuickTunnel(port: number): Promise<QuickTunnelInfo> {
+    if (this.#host.currentRuntime && this.#host.currentLifetime) {
+      return await this.#provisionQuickTunnelRun(port);
+    }
+
     const MAX_ID_RETRIES = 3;
     let lastError: unknown;
     for (let attempt = 0; attempt < MAX_ID_RETRIES; attempt += 1) {
@@ -452,6 +633,89 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
     // caller sees something diagnosable; in practice this branch is
     // unreachable given the 32-bit id space and per-sandbox tunnel count.
     throw lastError ?? new Error('Failed to mint a unique quick-tunnel id');
+  }
+
+  async #provisionQuickTunnelRun(port: number): Promise<QuickTunnelInfo> {
+    if (!this.#host.currentRuntime || !this.#host.currentLifetime) {
+      throw new Error('Quick tunnel runtime fences are not configured');
+    }
+
+    const lifetime = await this.#host.currentLifetime.getOrCreate();
+    const tunnelId = `quick-${crypto.randomUUID()}`;
+    const runId = runtimeRunId();
+
+    let ensureResult: EnsureTunnelRunResult;
+    try {
+      ensureResult = await this.#host.client.tunnels.ensureTunnelRun({
+        tunnelId,
+        runId,
+        mode: 'quick',
+        port
+      });
+    } catch (error) {
+      const interrupted = translateTunnelInterruption(
+        error,
+        'runtime_ready',
+        'unknown'
+      );
+      throw interrupted ?? error;
+    }
+
+    const runtime =
+      (await this.#host.currentRuntime.get()) ??
+      (await this.#host.currentRuntime.markStarted());
+    try {
+      await this.#host.currentRuntime.assertActive(runtime);
+      await this.#host.currentLifetime.assertCurrent(lifetime);
+    } catch (error) {
+      const interrupted = translateTunnelInterruption(
+        error,
+        'runtime_ready',
+        'unknown'
+      );
+      throw interrupted ?? error;
+    }
+
+    const { run } = ensureResult;
+    if (!run.url || !run.hostname) {
+      throw new Error('Quick tunnel run did not produce a public URL');
+    }
+
+    const spawned: QuickTunnelInfo = {
+      id: run.tunnelId,
+      port: run.port,
+      url: run.url,
+      hostname: run.hostname,
+      createdAt: run.startedAt
+    };
+
+    await this.#host.storage.transaction(async (txn) => {
+      const nextMap = await readMap(txn);
+      nextMap[port.toString()] = spawned;
+      await txn.put(STORAGE_KEY, nextMap);
+      const nextMeta = await readMetaMap(txn);
+      nextMeta[port.toString()] = {
+        optionsHash: 'v1:quick',
+        runtimeIdentityID: runtime.id,
+        sandboxLifetimeID: lifetime.id,
+        tunnelRunId: run.runId
+      };
+      await txn.put(META_STORAGE_KEY, nextMeta);
+    });
+
+    try {
+      await this.#host.currentRuntime.assertActive(runtime);
+      await this.#host.currentLifetime.assertCurrent(lifetime);
+    } catch (error) {
+      const interrupted = translateTunnelInterruption(
+        error,
+        'storage_committed',
+        true
+      );
+      throw interrupted ?? error;
+    }
+
+    return spawned;
   }
 
   /**
@@ -614,7 +878,14 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
         // named tunnels: destroy() is also responsible for Cloudflare-side
         // cleanup, which must still run if the container already stopped.
         try {
-          await this.#host.client.tunnels.destroyTunnel(existing.id);
+          if (metaBefore?.tunnelRunId) {
+            await this.#host.client.tunnels.stopTunnelRun({
+              tunnelId: existing.id,
+              runId: metaBefore.tunnelRunId
+            });
+          } else {
+            await this.#host.client.tunnels.destroyTunnel(existing.id);
+          }
         } catch (error) {
           if (isTunnelNotFoundError(error)) {
             // Container already forgot — fall through to CF cleanup.
@@ -763,7 +1034,12 @@ export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandle {
 
   const tunnels = new TunnelsRpcTarget(host, withPortLock);
 
-  const handleTunnelExit: TunnelExitHandler = async (id, port, exitCode) => {
+  const handleTunnelExit: TunnelExitHandler = async (
+    id,
+    port,
+    exitCode,
+    runId
+  ) => {
     const startTime = Date.now();
     let outcome: 'success' | 'error' = 'error';
     let caughtError: Error | undefined;
@@ -777,6 +1053,15 @@ export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandle {
           // cloudflared dies → new get() spawns fresh → old callback
           // fires" would clobber the new record.
           if (existing?.id !== id) return;
+          const meta = await readMetaMap(txn);
+          const metaEntry = meta[port.toString()];
+          if (
+            runId &&
+            metaEntry?.tunnelRunId &&
+            metaEntry.tunnelRunId !== runId
+          ) {
+            return;
+          }
 
           if (existing.name) {
             // Named tunnel. The Cloudflare-side tunnel and DNS record
@@ -791,12 +1076,10 @@ export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandle {
             // band) that would crash-loop without a backoff/circuit
             // breaker, and the symmetric "wait for next get()" is the
             // same contract container restart already offers.
-            const meta = await readMetaMap(txn);
             meta[port.toString()] = {
-              ...meta[port.toString()],
+              ...metaEntry,
               optionsHash:
-                meta[port.toString()]?.optionsHash ??
-                `v1:named:${existing.name}`,
+                metaEntry?.optionsHash ?? `v1:named:${existing.name}`,
               needsRespawn: true
             };
             await txn.put(META_STORAGE_KEY, meta);
@@ -807,7 +1090,6 @@ export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandle {
           // process and cannot be recovered. Drop both entries.
           delete map[port.toString()];
           await txn.put(STORAGE_KEY, map);
-          const meta = await readMetaMap(txn);
           delete meta[port.toString()];
           await txn.put(META_STORAGE_KEY, meta);
         });

--- a/packages/sandbox/src/tunnels/tunnels-handler.ts
+++ b/packages/sandbox/src/tunnels/tunnels-handler.ts
@@ -3,10 +3,10 @@
  * `createTunnelsHandler(host)` and exposed as `sandbox.tunnels`.
  *
  * Storage is the source of truth. The DO holds a `Record<portString, TunnelInfo>`
- * under the `tunnels` storage key. `Sandbox.onStart()` clears the key on every
- * container restart so any record in storage is by construction backed by a
- * running `cloudflared` process; the handler never needs to verify that
- * separately against the container.
+ * under the `tunnels` storage key, with internal lifecycle metadata under
+ * `tunnels:meta`. Container restarts drop quick tunnel records and mark named
+ * tunnels for respawn, so public list/get calls only return records that are
+ * usable for the current runtime.
  */
 
 import { RpcTarget } from 'cloudflare:workers';
@@ -20,21 +20,8 @@ import type {
   TunnelOptions
 } from '@repo/shared';
 import { logCanonicalEvent } from '@repo/shared';
-import {
-  type CurrentRuntimeIdentity,
-  type RuntimeIdentityID,
-  RuntimeIdentityInactiveError
-} from '../current-runtime-identity';
-import {
-  ErrorCode,
-  OperationInterruptedError,
-  RPCTransportError
-} from '../errors';
-import {
-  type CurrentSandboxLifetime,
-  SandboxLifetimeChangedError,
-  type SandboxLifetimeID
-} from '../sandbox-lifetime';
+import type { CurrentRuntimeIdentity } from '../current-runtime-identity';
+import type { CurrentSandboxLifetime } from '../sandbox-lifetime';
 import {
   SandboxSecurityError,
   validatePort,
@@ -49,33 +36,29 @@ import {
   getZoneName,
   upsertCNAME
 } from './cloudflare-api';
+import {
+  createTunnelInterruptedError,
+  runtimeRunId,
+  TUNNEL_GET_MAX_RECOVERY_ATTEMPTS,
+  translateTunnelInterruption
+} from './lifecycle';
+import {
+  computeOptionsHash,
+  META_STORAGE_KEY,
+  optionsHashesEqual,
+  readMap,
+  readMetaMap,
+  STORAGE_KEY,
+  type TunnelMetaEntry,
+  type TunnelsStorage
+} from './storage';
+
+export { pruneTunnelsForRestart } from './restart';
+export type { TunnelsStorage, TunnelsStorageTxn } from './storage';
 
 /** Subset of the RPC client this handler depends on. */
 interface TunnelsRPCClient {
   tunnels: SandboxTunnelsAPI;
-}
-
-/**
- * Subset of `DurableObjectTransaction` (and `DurableObjectStorage`) used
- * inside a transaction closure — no nested `transaction()`.
- */
-export interface TunnelsStorageTxn {
-  get<T>(key: string): Promise<T | undefined>;
-  put<T>(key: string, value: T): Promise<void>;
-  delete(key: string): Promise<boolean>;
-}
-
-/**
- * Subset of `DurableObjectStorage` the handler uses.
- *
- * `transaction` gives optimistic concurrency for the read-modify-write
- * paths in `get()` and `destroy()`: while we await the container RPC,
- * another request to the same DO can land and rewrite the `tunnels`
- * key. Wrapping the write in `transaction()` makes the runtime retry
- * on conflict instead of clobbering the concurrent write.
- */
-export interface TunnelsStorage extends TunnelsStorageTxn {
-  transaction<T>(closure: (txn: TunnelsStorageTxn) => Promise<T>): Promise<T>;
 }
 
 /** Subset of the Sandbox DO the handler reads from. */
@@ -150,57 +133,17 @@ export interface TunnelsHandle {
   destroyAll: () => Promise<void>;
 }
 
-/** DO storage key for the `port → TunnelInfo` map. */
-const STORAGE_KEY = 'tunnels';
-
-/**
- * Sidecar storage key for per-port metadata the handler needs but the
- * public `TunnelInfo` shape does not carry: the options hash used to
- * detect divergent retries, and (for named tunnels) the DNS record id
- * needed for cleanup. Kept under a separate key so the existing
- * `tunnels` shape remains a clean `Record<port, TunnelInfo>`.
- */
-const META_STORAGE_KEY = 'tunnels:meta';
-
-type TunnelMap = Record<string, TunnelInfo>;
-
-interface TunnelMetaEntry {
-  /** Stable hash of the `options` object the tunnel was created with. */
-  optionsHash: string;
-  /** Cloudflare DNS record id for named tunnels; absent for quick. */
-  dnsRecordId?: string;
-  /** Runtime identity that owns a runtime-local quick tunnel record. */
-  runtimeIdentityID?: RuntimeIdentityID;
-  /** Sandbox lifetime that owns this tunnel record. */
-  sandboxLifetimeID?: SandboxLifetimeID;
-  /** Runtime-local cloudflared process run id. */
-  tunnelRunId?: string;
-  /**
-   * Resolved `(accountId, zoneId)` the named tunnel was provisioned
-   * against. Compared on cache hit to detect env-var changes that
-   * would otherwise silently serve a stale URL (the cached
-   * `TunnelInfo.hostname` is `<name>.<old-zone-name>` and would no
-   * longer resolve to a live tunnel). Absent on quick tunnels.
-   */
-  accountId?: string;
-  zoneId?: string;
-  /**
-   * Set by `pruneTunnelsForRestart` on container restart for named
-   * tunnels. The Cloudflare-side resources (tunnel + DNS) survive the
-   * restart, but the `cloudflared` process inside the container died
-   * with it. The next `get(port, { name })` call sees this flag on a
-   * cache hit and falls through to `#provisionNamedTunnel`, which
-   * reuses the existing tunnel via `findTunnelByName` and respawns
-   * `cloudflared`. Absent on quick tunnels (which are dropped from
-   * storage outright on restart).
-   */
-  needsRespawn?: boolean;
-}
-
-type TunnelMetaMap = Record<string, TunnelMetaEntry>;
-
 /** Per-port serializer shared between `TunnelsRpcTarget` and the exit hook. */
 type WithPortLock = <T>(port: number, fn: () => Promise<T>) => Promise<T>;
+
+type QuickTunnelRunIdentity = {
+  tunnelId: string;
+  runId: string;
+};
+
+type TunnelGetRecoveryState = {
+  quickRun?: QuickTunnelRunIdentity;
+};
 
 function validateTunnelPort(port: number): void {
   if (!validatePort(port)) {
@@ -219,95 +162,15 @@ function shortId(): string {
     .join('');
 }
 
-function runtimeRunId(): string {
-  return `run-${crypto.randomUUID()}`;
-}
-
-const TUNNEL_GET_MAX_RECOVERY_ATTEMPTS = 2;
-
-function createTunnelInterruptedError(params: {
-  reason:
-    | 'runtime_replaced'
-    | 'transport_disposed'
-    | 'sandbox_lifetime_changed'
-    | 'recovery_exhausted';
-  phase: string;
-  admitted: boolean | 'unknown';
-  retryable: boolean;
-  recoveryAttempts?: number;
-  maxRecoveryAttempts?: number;
-}): OperationInterruptedError {
-  return new OperationInterruptedError({
-    message:
-      params.reason === 'recovery_exhausted'
-        ? 'Tunnel recovery attempts were exhausted'
-        : 'Tunnel operation was interrupted by a sandbox runtime change',
-    code: ErrorCode.OPERATION_INTERRUPTED,
-    httpStatus: 409,
-    context: {
-      reason: params.reason,
-      operation: 'tunnel.get',
-      phase: params.phase,
-      admitted: params.admitted,
-      retryable: params.retryable,
-      ...(params.recoveryAttempts !== undefined && {
-        recoveryAttempts: params.recoveryAttempts
-      }),
-      ...(params.maxRecoveryAttempts !== undefined && {
-        maxRecoveryAttempts: params.maxRecoveryAttempts
-      })
-    },
-    timestamp: new Date().toISOString(),
-    suggestion: params.retryable
-      ? 'Retry tunnels.get() for the same port so the SDK can establish a fresh tunnel run.'
-      : 'Start a new tunnels.get() call only if this tunnel is still desired for the current sandbox.'
-  });
-}
-
-function translateTunnelInterruption(
-  error: unknown,
-  phase: string,
-  admitted: boolean | 'unknown'
-): OperationInterruptedError | null {
-  if (error instanceof OperationInterruptedError) {
-    return error;
-  }
-  if (error instanceof RuntimeIdentityInactiveError) {
-    return createTunnelInterruptedError({
-      reason: 'runtime_replaced',
-      phase,
-      admitted,
-      retryable: true
-    });
-  }
-  if (error instanceof SandboxLifetimeChangedError) {
-    return createTunnelInterruptedError({
-      reason: 'sandbox_lifetime_changed',
-      phase,
-      admitted,
-      retryable: false
-    });
-  }
-  if (error instanceof RPCTransportError) {
-    return createTunnelInterruptedError({
-      reason: 'transport_disposed',
-      phase,
-      admitted: 'unknown',
-      retryable: true
-    });
-  }
-  return null;
-}
-
 /**
  * Match a structured SandboxError code anywhere on the error — translated
  * SandboxErrors expose the code both as a top-level `code` field and on
  * the nested `errorResponse.code`. Used for the few error codes the SDK
  * recognises and recovers from (TUNNEL_NOT_FOUND, TUNNEL_ALREADY_RUNNING).
  *
- * Previous versions matched by substring on `error.message`, which
- * false-positived on any error whose message merely quoted the literal
- * code token.
+ * Message strings may quote error-code tokens for diagnostics, so matching
+ * only structured fields keeps recovery branches tied to explicit error
+ * contracts.
  */
 function hasErrorCode(error: unknown, code: string): boolean {
   if (!error || typeof error !== 'object') return false;
@@ -326,40 +189,6 @@ function isTunnelNotFoundError(error: unknown): boolean {
 
 function isTunnelAlreadyRunningError(error: unknown): boolean {
   return hasErrorCode(error, 'TUNNEL_ALREADY_RUNNING');
-}
-
-async function readMap(storage: TunnelsStorageTxn): Promise<TunnelMap> {
-  return (await storage.get<TunnelMap>(STORAGE_KEY)) ?? {};
-}
-
-async function readMetaMap(storage: TunnelsStorageTxn): Promise<TunnelMetaMap> {
-  return (await storage.get<TunnelMetaMap>(META_STORAGE_KEY)) ?? {};
-}
-
-/**
- * Stable hash of `options`. Empty/undefined options collapse to the same
- * hash so `get(port)`, `get(port, {})`, and `get(port, { name: undefined })`
- * all hit the same cache entry. Named tunnels hash on `name` alone (the
- * only option today).
- *
- * The `v1:` prefix exists so a future addition of a second option (e.g.
- * `subdomain`) can change the canonical form without colliding with an
- * older record's hash. Comparison goes through `optionsHashesEqual`, which
- * normalises legacy unversioned hashes (`quick`, `named:foo`) to their v1
- * form before equality, so upgrading does not invalidate cached records.
- */
-function computeOptionsHash(options?: TunnelOptions): string {
-  if (!options || !options.name) return 'v1:quick';
-  return `v1:named:${options.name}`;
-}
-
-/** Strip the optional `v1:` prefix so legacy hashes compare equal. */
-function normaliseHash(hash: string): string {
-  return hash.startsWith('v1:') ? hash.slice(3) : hash;
-}
-
-function optionsHashesEqual(a: string, b: string): boolean {
-  return normaliseHash(a) === normaliseHash(b);
 }
 
 /**
@@ -441,8 +270,8 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
       if (options?.name !== undefined) validateTunnelName(options.name);
       const requestedHash = computeOptionsHash(options);
 
-      const info = await this.#getWithRecovery(port, options, () => {
-        return this.#withPortLock(port, async () => {
+      const info = await this.#withPortLock(port, () =>
+        this.#getWithRecovery(port, options, async (recovery) => {
           const map = await readMap(this.#host.storage);
           const existing = map[port.toString()];
           if (existing) {
@@ -465,7 +294,7 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
               !existing.name &&
               (await this.#quickTunnelRecordIsStale(metaEntry))
             ) {
-              return await this.#provisionQuickTunnel(port);
+              return await this.#provisionQuickTunnel(port, recovery);
             }
             // Container restart marker: the CF-side tunnel + DNS still
             // exist, but `cloudflared` died with the container. Fall
@@ -494,8 +323,7 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
               ) {
                 // The cached zone name is for the old zone id; clear it
                 // so `#provisionNamedTunnel` re-resolves against the new
-                // one. Without this, `hostname` would be `<name>.<old
-                // zone name>` even after re-provision.
+                // one and returns a hostname in the current zone.
                 this.#zoneNamePromise = null;
                 return await this.#provisionNamedTunnel(port, existing.name);
               }
@@ -507,9 +335,9 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
           if (options?.name) {
             return await this.#provisionNamedTunnel(port, options.name);
           }
-          return await this.#provisionQuickTunnel(port);
-        });
-      });
+          return await this.#provisionQuickTunnel(port, recovery);
+        })
+      );
       outcome = 'success';
       return info;
     } catch (error) {
@@ -530,12 +358,13 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
   async #getWithRecovery(
     port: number,
     options: TunnelOptions | undefined,
-    run: () => Promise<TunnelInfo>
+    run: (recovery: TunnelGetRecoveryState) => Promise<TunnelInfo>
   ): Promise<TunnelInfo> {
     let recoveryAttempts = 0;
+    const recovery: TunnelGetRecoveryState = {};
     while (true) {
       try {
-        return await run();
+        return await run(recovery);
       } catch (error) {
         const interrupted = translateTunnelInterruption(
           error,
@@ -546,6 +375,7 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
           throw error;
         }
         if (recoveryAttempts >= TUNNEL_GET_MAX_RECOVERY_ATTEMPTS) {
+          await this.#clearQuickTunnelStorage(port);
           throw createTunnelInterruptedError({
             reason: 'recovery_exhausted',
             phase: 'interrupted',
@@ -556,6 +386,9 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
           });
         }
         recoveryAttempts++;
+        if (interrupted.context.reason === 'runtime_replaced') {
+          recovery.quickRun = undefined;
+        }
         await this.#clearQuickTunnelStorage(port);
       }
     }
@@ -600,9 +433,12 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
    * surfacing the confusing error — the retry budget caps the loop so a
    * persistent failure still surfaces.
    */
-  async #provisionQuickTunnel(port: number): Promise<QuickTunnelInfo> {
+  async #provisionQuickTunnel(
+    port: number,
+    recovery: TunnelGetRecoveryState
+  ): Promise<QuickTunnelInfo> {
     if (this.#host.currentRuntime && this.#host.currentLifetime) {
-      return await this.#provisionQuickTunnelRun(port);
+      return await this.#provisionQuickTunnelRun(port, recovery);
     }
 
     const MAX_ID_RETRIES = 3;
@@ -635,20 +471,17 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
     throw lastError ?? new Error('Failed to mint a unique quick-tunnel id');
   }
 
-  async #provisionQuickTunnelRun(port: number): Promise<QuickTunnelInfo> {
+  async #provisionQuickTunnelRun(
+    port: number,
+    recovery: TunnelGetRecoveryState
+  ): Promise<QuickTunnelInfo> {
     if (!this.#host.currentRuntime || !this.#host.currentLifetime) {
       throw new Error('Quick tunnel runtime fences are not configured');
     }
 
     const lifetime = await this.#host.currentLifetime.getOrCreate();
-    const tunnelId = `quick-${crypto.randomUUID()}`;
-    const runId = runtimeRunId();
-
-    const runtime =
-      (await this.#host.currentRuntime.get()) ??
-      (await this.#host.currentRuntime.markStarted());
+    const runtimeBeforeAdmission = await this.#host.currentRuntime.get();
     try {
-      await this.#host.currentRuntime.assertActive(runtime);
       await this.#host.currentLifetime.assertCurrent(lifetime);
     } catch (error) {
       const interrupted = translateTunnelInterruption(
@@ -659,7 +492,14 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
       throw interrupted ?? error;
     }
 
+    recovery.quickRun ??= {
+      tunnelId: `quick-${crypto.randomUUID()}`,
+      runId: runtimeRunId()
+    };
+    const { tunnelId, runId } = recovery.quickRun;
+
     let ensureResult: EnsureTunnelRunResult;
+    let runtime = runtimeBeforeAdmission;
     try {
       ensureResult = await this.#host.client.tunnels.ensureTunnelRun({
         tunnelId,
@@ -667,6 +507,9 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
         mode: 'quick',
         port
       });
+      runtime ??=
+        (await this.#host.currentRuntime.get()) ??
+        (await this.#host.currentRuntime.markStarted());
       await this.#host.currentRuntime.assertActive(runtime);
       await this.#host.currentLifetime.assertCurrent(lifetime);
     } catch (error) {
@@ -935,13 +778,10 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
 
         const fetcher = this.#host.fetcher;
         // Prefer the account/zone the tunnel was provisioned in over the
-        // currently-resolved config. Without this, a user who rotated
-        // CLOUDFLARE_ZONE_ID (or CLOUDFLARE_TUNNEL_ACCOUNT_ID) between
-        // get() and destroy() would issue DELETE against the new zone/
-        // account and orphan the original resources. Stored values are
-        // absent on records created before the meta gained these fields;
-        // fall back to the resolved config so legacy records still get
-        // cleaned up (no drift was tracked for them anyway).
+        // currently-resolved config. The stored values target the original
+        // Cloudflare resources even when bindings change between get() and
+        // destroy(). Records created before these fields existed fall back
+        // to the resolved config.
         const accountId = metaBefore.accountId ?? config.accountId;
         const zoneId = metaBefore.zoneId ?? config.zoneId;
         await Promise.allSettled([
@@ -1051,9 +891,8 @@ export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandle {
           const map = await readMap(txn);
           const existing = map[port.toString()];
           // Defensive: only act if storage still references this exact
-          // tunnel id. Without this check, a sequence like "old
-          // cloudflared dies → new get() spawns fresh → old callback
-          // fires" would clobber the new record.
+          // tunnel id. Stale callbacks from older cloudflared processes
+          // leave the current record intact.
           if (existing?.id !== id) return;
           const meta = await readMetaMap(txn);
           const metaEntry = meta[port.toString()];
@@ -1148,58 +987,4 @@ export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandle {
     handleTunnelExit,
     destroyAll
   };
-}
-
-/**
- * Reconcile storage with a fresh container.
- *
- * Called from `Sandbox.onStart()` after every container restart. The
- * `cloudflared` processes the container was running all died with it, so
- * any stored record is *not* currently backed by a running tunnel.
- *
- * Two tunnel flavours, two recovery stories:
- *
- *   - Quick tunnels: the `*.trycloudflare.com` URL is bound to the dead
- *     `cloudflared` process. Nothing on Cloudflare's side outlives the
- *     container, and the URL is unrecoverable. Drop the record from both
- *     maps so the next `get(port)` takes the miss branch and mints a new
- *     URL.
- *   - Named tunnels: the Cloudflare-side tunnel + DNS record survive.
- *     The hostname is stable, the DNS still resolves to
- *     `<tunnelId>.cfargotunnel.com`, and the next caller can reuse both
- *     by walking the same `findTunnelByName` / `upsertCNAME` path the
- *     SDK uses for retries. Keep the record in storage and mark the
- *     meta entry `needsRespawn: true`; the next `get(port, { name })`
- *     cache hit falls through to `#provisionNamedTunnel` to respawn
- *     `cloudflared`.
- *
- * Crucially, named-tunnel metadata (including `dnsRecordId`) is
- * preserved so `destroy(port)` and `sandbox.destroy()` can still clean
- * up the Cloudflare-side resources after a restart. Wiping meta
- * unconditionally — the previous behaviour — silently leaked the tunnel
- * and DNS record on every restart.
- */
-export async function pruneTunnelsForRestart(
-  storage: TunnelsStorage
-): Promise<void> {
-  await storage.transaction(async (txn) => {
-    const map = await readMap(txn);
-    const meta = await readMetaMap(txn);
-    const nextMap: TunnelMap = {};
-    const nextMeta: TunnelMetaMap = {};
-    for (const [portKey, info] of Object.entries(map)) {
-      // Discriminate by the public `name` field on `TunnelInfo`: named
-      // tunnels carry the user-provided label, quick tunnels omit it.
-      if (info.name) {
-        nextMap[portKey] = info;
-        nextMeta[portKey] = {
-          ...(meta[portKey] ?? { optionsHash: `v1:named:${info.name}` }),
-          needsRespawn: true
-        };
-      }
-      // Quick tunnels are dropped from both maps by omission.
-    }
-    await txn.put(STORAGE_KEY, nextMap);
-    await txn.put(META_STORAGE_KEY, nextMeta);
-  });
 }

--- a/packages/sandbox/src/tunnels/tunnels-handler.ts
+++ b/packages/sandbox/src/tunnels/tunnels-handler.ts
@@ -644,14 +644,12 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
     const tunnelId = `quick-${crypto.randomUUID()}`;
     const runId = runtimeRunId();
 
-    let ensureResult: EnsureTunnelRunResult;
+    const runtime =
+      (await this.#host.currentRuntime.get()) ??
+      (await this.#host.currentRuntime.markStarted());
     try {
-      ensureResult = await this.#host.client.tunnels.ensureTunnelRun({
-        tunnelId,
-        runId,
-        mode: 'quick',
-        port
-      });
+      await this.#host.currentRuntime.assertActive(runtime);
+      await this.#host.currentLifetime.assertCurrent(lifetime);
     } catch (error) {
       const interrupted = translateTunnelInterruption(
         error,
@@ -661,10 +659,14 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
       throw interrupted ?? error;
     }
 
-    const runtime =
-      (await this.#host.currentRuntime.get()) ??
-      (await this.#host.currentRuntime.markStarted());
+    let ensureResult: EnsureTunnelRunResult;
     try {
+      ensureResult = await this.#host.client.tunnels.ensureTunnelRun({
+        tunnelId,
+        runId,
+        mode: 'quick',
+        port
+      });
       await this.#host.currentRuntime.assertActive(runtime);
       await this.#host.currentLifetime.assertCurrent(lifetime);
     } catch (error) {

--- a/packages/sandbox/tests/backup-restore-lifecycle.test.ts
+++ b/packages/sandbox/tests/backup-restore-lifecycle.test.ts
@@ -98,10 +98,13 @@ async function createBackupSandbox(
   params: {
     storageHooks?: { onPut?: (key: string, value: StoredValue) => void };
     bucket?: TestBucket;
+    initialRuntime?: 'active' | 'cold';
   } = {}
 ) {
   const storageMap = new Map<string, StoredValue>();
-  storageMap.set('currentRuntimeIdentity', { id: 'runtime-1' });
+  if (params.initialRuntime !== 'cold') {
+    storageMap.set('currentRuntimeIdentity', { id: 'runtime-1' });
+  }
   storageMap.set('sandbox:lifetime', {
     id: 'lifetime-1',
     generation: 1,
@@ -110,6 +113,7 @@ async function createBackupSandbox(
   });
 
   const storage = createStorage(storageMap, params.storageHooks);
+  const containerState = { running: params.initialRuntime !== 'cold' };
   const ctx = {
     storage,
     blockConcurrencyWhile: vi.fn(<T>(callback: () => Promise<T>) => callback()),
@@ -119,7 +123,7 @@ async function createBackupSandbox(
       equals: vi.fn(),
       name: 'test-sandbox'
     },
-    container: { running: true }
+    container: containerState
   } as unknown as DurableObjectState<{}>;
 
   const bucket = params.bucket ?? createBackupBucket();
@@ -135,12 +139,17 @@ async function createBackupSandbox(
     expect(ctx.blockConcurrencyWhile).toHaveBeenCalled();
   });
 
-  vi.spyOn(sandbox.client.utils, 'createSession').mockResolvedValue({
-    success: true,
-    id: 'backup-session',
-    message: 'Created',
-    timestamp: '2026-06-23T12:00:00.000Z'
-  });
+  vi.spyOn(sandbox.client.utils, 'createSession').mockImplementation(
+    async () => {
+      containerState.running = true;
+      return {
+        success: true,
+        id: 'backup-session',
+        message: 'Created',
+        timestamp: '2026-06-23T12:00:00.000Z'
+      };
+    }
+  );
   vi.spyOn(sandbox.client.utils, 'deleteSession').mockResolvedValue({
     success: true,
     sessionId: 'backup-session',
@@ -256,6 +265,29 @@ describe('backup restore lifecycle', () => {
     ) as BackupRestoreOperationRecord;
     expect(record.status).toBe('interrupted');
     expect(record.phase).toBe('interrupted');
+  });
+
+  it('starts the backup session before fencing a cold runtime', async () => {
+    const { sandbox, storageMap } = await createBackupSandbox({
+      initialRuntime: 'cold'
+    });
+    const backupId = crypto.randomUUID();
+
+    await expect(
+      sandbox.restoreBackup({ id: backupId, dir: '/workspace/project' })
+    ).resolves.toEqual({
+      success: true,
+      id: backupId,
+      dir: '/workspace/project'
+    });
+
+    expect(sandbox.client.utils.createSession).toHaveBeenCalled();
+    const record = storageMap.get(
+      `operations:restore:${backupId}:/workspace/project`
+    ) as BackupRestoreOperationRecord;
+    expect(record.status).toBe('committed');
+    expect(record.phase).toBe('verified');
+    expect(record.runtimeIdentityID).toBeDefined();
   });
 
   it('does not retry when the sandbox lifetime changes before runtime work starts', async () => {

--- a/packages/sandbox/tests/backup-restore-lifecycle.test.ts
+++ b/packages/sandbox/tests/backup-restore-lifecycle.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BackupRestoreOperationRecord } from '../src/backup/restore-operation-store';
+import { ErrorCode, RPCTransportError } from '../src/errors';
+import { Sandbox } from '../src/sandbox';
+
+vi.mock('./interpreter', () => ({
+  CodeInterpreter: vi.fn().mockImplementation(() => ({}))
+}));
+
+vi.mock('@cloudflare/containers', () => {
+  class MockContainer {
+    ctx: unknown;
+    env: unknown;
+    sleepAfter: string | number = '10m';
+
+    constructor(ctx: unknown, env: unknown) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+
+    async getState(): Promise<{ status: string }> {
+      return { status: 'healthy' };
+    }
+
+    renewActivityTimeout(): void {}
+  }
+
+  return {
+    Container: MockContainer,
+    ContainerProxy: MockContainer,
+    getContainer: vi.fn(),
+    switchPort: vi.fn((request: Request) => request)
+  };
+});
+
+type StoredValue = unknown;
+
+type TestStorage = DurableObjectStorage & {
+  backing: Map<string, StoredValue>;
+};
+
+type TestBucket = ReturnType<typeof createBackupBucket>;
+
+function createStorage(
+  initial = new Map<string, StoredValue>(),
+  hooks?: { onPut?: (key: string, value: StoredValue) => void }
+): TestStorage {
+  const storage = {
+    backing: initial,
+    get: vi.fn(async (key: string) => initial.get(key) ?? null),
+    put: vi.fn(async (key: string, value: StoredValue) => {
+      initial.set(key, value);
+      hooks?.onPut?.(key, value);
+    }),
+    delete: vi.fn(async (key: string) => {
+      initial.delete(key);
+    }),
+    list: vi.fn(async () => new Map<string, StoredValue>()),
+    transaction: vi.fn(
+      async (callback: (txn: DurableObjectTransaction) => unknown) =>
+        callback(storage as unknown as DurableObjectTransaction)
+    )
+  };
+  return storage as unknown as TestStorage;
+}
+
+function createBackupBucket(createdAt = '2026-06-23T12:00:00.000Z') {
+  return {
+    put: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({
+        ttl: 259_200,
+        createdAt,
+        dir: '/workspace/project'
+      })
+    }),
+    head: vi.fn().mockResolvedValue({ size: 42 }),
+    delete: vi.fn().mockResolvedValue(undefined),
+    list: vi.fn().mockResolvedValue({ objects: [], truncated: false })
+  };
+}
+
+function createDisposedRPCError(): RPCTransportError {
+  return new RPCTransportError({
+    code: ErrorCode.RPC_TRANSPORT_ERROR,
+    message: 'RPC session was shut down by disposing the main stub',
+    httpStatus: 503,
+    context: {
+      kind: 'session_disposed',
+      originalMessage: 'RPC session was shut down by disposing the main stub',
+      errorName: 'Error'
+    },
+    timestamp: '2026-06-23T12:00:00.000Z'
+  });
+}
+
+async function createBackupSandbox(
+  params: {
+    storageHooks?: { onPut?: (key: string, value: StoredValue) => void };
+    bucket?: TestBucket;
+  } = {}
+) {
+  const storageMap = new Map<string, StoredValue>();
+  storageMap.set('currentRuntimeIdentity', { id: 'runtime-1' });
+  storageMap.set('sandbox:lifetime', {
+    id: 'lifetime-1',
+    generation: 1,
+    createdAt: '2026-06-23T12:00:00.000Z',
+    updatedAt: '2026-06-23T12:00:00.000Z'
+  });
+
+  const storage = createStorage(storageMap, params.storageHooks);
+  const ctx = {
+    storage,
+    blockConcurrencyWhile: vi.fn(<T>(callback: () => Promise<T>) => callback()),
+    waitUntil: vi.fn(),
+    id: {
+      toString: () => 'test-sandbox-id',
+      equals: vi.fn(),
+      name: 'test-sandbox'
+    },
+    container: { running: true }
+  } as unknown as DurableObjectState<{}>;
+
+  const bucket = params.bucket ?? createBackupBucket();
+  const sandbox = new Sandbox(ctx, {
+    BACKUP_BUCKET: bucket,
+    CLOUDFLARE_ACCOUNT_ID: 'test-account',
+    R2_ACCESS_KEY_ID: 'test-key',
+    R2_SECRET_ACCESS_KEY: 'test-secret',
+    BACKUP_BUCKET_NAME: 'test-backups'
+  });
+
+  await vi.waitFor(() => {
+    expect(ctx.blockConcurrencyWhile).toHaveBeenCalled();
+  });
+
+  vi.spyOn(sandbox.client.utils, 'createSession').mockResolvedValue({
+    success: true,
+    id: 'backup-session',
+    message: 'Created',
+    timestamp: '2026-06-23T12:00:00.000Z'
+  });
+  vi.spyOn(sandbox.client.utils, 'deleteSession').mockResolvedValue({
+    success: true,
+    sessionId: 'backup-session',
+    timestamp: '2026-06-23T12:00:00.000Z'
+  });
+  vi.spyOn(sandbox.client.backup, 'restoreArchive').mockResolvedValue({
+    success: true,
+    dir: '/workspace/project'
+  });
+
+  const sandboxInternals = sandbox as unknown as {
+    downloadBackupParallel: (
+      archivePath: string,
+      r2Key: string,
+      sizeBytes: number,
+      backupId: string,
+      dir: string,
+      sessionId: string
+    ) => Promise<void>;
+    execWithSession: () => Promise<{
+      stdout: string;
+      stderr: string;
+      exitCode: number;
+    }>;
+  };
+  vi.spyOn(sandboxInternals, 'downloadBackupParallel').mockResolvedValue(
+    undefined
+  );
+  vi.spyOn(sandboxInternals, 'execWithSession').mockResolvedValue({
+    stdout: '0',
+    stderr: '',
+    exitCode: 0
+  });
+
+  return { sandbox, storageMap, bucket };
+}
+
+describe('backup restore lifecycle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-23T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('retries and succeeds when runtime replacement is detected after archive readiness', async () => {
+    const backupId = crypto.randomUUID();
+    let replaced = false;
+    const { sandbox, storageMap } = await createBackupSandbox({
+      storageHooks: {
+        onPut(key, value) {
+          const record = value as Partial<BackupRestoreOperationRecord>;
+          if (
+            !replaced &&
+            key === `operations:restore:${backupId}:/workspace/project` &&
+            record.phase === 'archive_ready'
+          ) {
+            replaced = true;
+            storageMap.set('currentRuntimeIdentity', { id: 'runtime-2' });
+          }
+        }
+      }
+    });
+
+    const result = await sandbox.restoreBackup({
+      id: backupId,
+      dir: '/workspace/project'
+    });
+
+    expect(result).toEqual({
+      success: true,
+      id: backupId,
+      dir: '/workspace/project'
+    });
+    expect(sandbox.client.backup.restoreArchive).toHaveBeenCalledTimes(2);
+    const record = storageMap.get(
+      `operations:restore:${backupId}:/workspace/project`
+    ) as BackupRestoreOperationRecord;
+    expect(record.status).toBe('committed');
+    expect(record.phase).toBe('verified');
+    expect(record.runtimeIdentityID).toBe('runtime-2');
+  });
+
+  it('surfaces OPERATION_INTERRUPTED after exhausting runtime recovery attempts', async () => {
+    const { sandbox, storageMap } = await createBackupSandbox();
+    const backupId = crypto.randomUUID();
+    vi.spyOn(sandbox.client.backup, 'restoreArchive').mockRejectedValue(
+      createDisposedRPCError()
+    );
+
+    await expect(
+      sandbox.restoreBackup({ id: backupId, dir: '/workspace/project' })
+    ).rejects.toMatchObject({
+      name: 'OperationInterruptedError',
+      code: ErrorCode.OPERATION_INTERRUPTED,
+      context: {
+        reason: 'recovery_exhausted',
+        operation: 'backup.restore',
+        phase: 'interrupted',
+        admitted: 'unknown',
+        retryable: false,
+        recoveryAttempts: 2,
+        maxRecoveryAttempts: 2
+      }
+    });
+
+    expect(sandbox.client.backup.restoreArchive).toHaveBeenCalledTimes(3);
+    const record = storageMap.get(
+      `operations:restore:${backupId}:/workspace/project`
+    ) as BackupRestoreOperationRecord;
+    expect(record.status).toBe('interrupted');
+    expect(record.phase).toBe('interrupted');
+  });
+
+  it('does not retry when the sandbox lifetime changes before runtime work starts', async () => {
+    const backupId = crypto.randomUUID();
+    let lifetimeChanged = false;
+    const { sandbox, storageMap } = await createBackupSandbox({
+      storageHooks: {
+        onPut(key, value) {
+          const record = value as Partial<BackupRestoreOperationRecord>;
+          if (
+            !lifetimeChanged &&
+            key === `operations:restore:${backupId}:/workspace/project` &&
+            record.phase === 'validating'
+          ) {
+            lifetimeChanged = true;
+            storageMap.set('sandbox:lifetime', {
+              id: 'lifetime-2',
+              generation: 2,
+              createdAt: '2026-06-23T12:00:00.000Z',
+              updatedAt: '2026-06-23T12:00:00.000Z'
+            });
+          }
+        }
+      }
+    });
+
+    await expect(
+      sandbox.restoreBackup({ id: backupId, dir: '/workspace/project' })
+    ).rejects.toMatchObject({
+      name: 'OperationInterruptedError',
+      context: {
+        reason: 'sandbox_lifetime_changed',
+        operation: 'backup.restore',
+        phase: 'validating',
+        admitted: 'unknown',
+        retryable: false
+      }
+    });
+
+    expect(sandbox.client.backup.restoreArchive).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sandbox/tests/container-connection.test.ts
+++ b/packages/sandbox/tests/container-connection.test.ts
@@ -369,9 +369,11 @@ describe('ContainerControlConnection', () => {
         });
 
         const connectPromise = conn.connect();
-        const assertion = expect(connectPromise).rejects.toThrow(
-          'WebSocket upgrade failed: 500'
-        );
+        // Exhausted retryable responses now surface as ContainerUnavailableError.
+        const assertion = expect(connectPromise).rejects.toMatchObject({
+          code: 'CONTAINER_UNAVAILABLE',
+          context: { reason: 'rpc_upgrade_failed', retryable: true }
+        });
 
         // Run all timers — connect() must settle even with fake timers.
         await vi.advanceTimersByTimeAsync(60_000);
@@ -411,9 +413,12 @@ describe('ContainerControlConnection', () => {
         retryTimeoutMs: 0
       });
 
-      await expect(conn.connect()).rejects.toThrow(
-        'WebSocket upgrade failed: 500'
-      );
+      // Even when retries are disabled, a retryable status surfaces as
+      // ContainerUnavailableError (not a generic upgrade_failed message).
+      await expect(conn.connect()).rejects.toMatchObject({
+        code: 'CONTAINER_UNAVAILABLE',
+        context: { reason: 'rpc_upgrade_failed', retryable: true }
+      });
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
@@ -458,9 +463,11 @@ describe('ContainerControlConnection', () => {
         conn.setRetryTimeoutMs(1_000);
 
         const connectPromise = conn.connect();
-        const assertion = expect(connectPromise).rejects.toThrow(
-          'WebSocket upgrade failed: 503'
-        );
+        // Budget too small for retry: ContainerUnavailableError surfaces immediately.
+        const assertion = expect(connectPromise).rejects.toMatchObject({
+          code: 'CONTAINER_UNAVAILABLE',
+          context: { reason: 'rpc_upgrade_failed', retryable: true }
+        });
 
         await vi.advanceTimersByTimeAsync(60_000);
         await assertion;
@@ -506,6 +513,54 @@ describe('ContainerControlConnection', () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+  });
+
+  describe('structured error classification', () => {
+    it('throws ContainerUnavailableError when upgrade response contains structured CONTAINER_UNAVAILABLE body', async () => {
+      const body = JSON.stringify({
+        code: 'CONTAINER_UNAVAILABLE',
+        message: 'Container is starting',
+        context: { reason: 'container_starting', retryable: true }
+      });
+      const conn = new ContainerControlConnection({
+        stub: {
+          fetch: vi.fn().mockResolvedValue(
+            new Response(body, {
+              status: 503,
+              headers: { 'content-type': 'application/json' }
+            })
+          )
+        },
+        retryTimeoutMs: 0
+      });
+
+      const error = await conn.connect().catch((e: unknown) => e);
+      expect((error as { code?: string }).code).toBe('CONTAINER_UNAVAILABLE');
+      expect((error as Error).constructor.name).toBe(
+        'ContainerUnavailableError'
+      );
+      expect((error as { context?: { reason?: string } }).context?.reason).toBe(
+        'container_starting'
+      );
+    });
+
+    it('fires onClose after a failed connect so the client can discard the poisoned connection', async () => {
+      const onClose = vi.fn();
+      const conn = new ContainerControlConnection({
+        stub: {
+          fetch: vi
+            .fn()
+            .mockResolvedValue(
+              new Response('Container unavailable', { status: 503 })
+            )
+        },
+        retryTimeoutMs: 0,
+        onClose
+      });
+
+      await expect(conn.connect()).rejects.toThrow();
+      expect(onClose).toHaveBeenCalledOnce();
     });
   });
 

--- a/packages/sandbox/tests/container-connection.test.ts
+++ b/packages/sandbox/tests/container-connection.test.ts
@@ -545,6 +545,34 @@ describe('ContainerControlConnection', () => {
       );
     });
 
+    it('fills required container-unavailable context fields when the response context is partial', async () => {
+      const body = JSON.stringify({
+        code: 'CONTAINER_UNAVAILABLE',
+        message: 'Container was replaced',
+        context: {}
+      });
+      const conn = new ContainerControlConnection({
+        stub: {
+          fetch: vi.fn().mockResolvedValue(
+            new Response(body, {
+              status: 503,
+              headers: { 'content-type': 'application/json' }
+            })
+          )
+        },
+        retryTimeoutMs: 0
+      });
+
+      const error = await conn.connect().catch((e: unknown) => e);
+      expect((error as { code?: string }).code).toBe('CONTAINER_UNAVAILABLE');
+      expect(error).toMatchObject({
+        context: {
+          reason: 'container_replaced',
+          retryable: true
+        }
+      });
+    });
+
     it('fires onClose after a failed connect so the client can discard the poisoned connection', async () => {
       const onClose = vi.fn();
       const conn = new ContainerControlConnection({

--- a/packages/sandbox/tests/local-backup-restore-lifecycle.test.ts
+++ b/packages/sandbox/tests/local-backup-restore-lifecycle.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BackupRestoreOperationRecord } from '../src/backup/restore-operation-store';
+import { ErrorCode, RPCTransportError } from '../src/errors';
+import { Sandbox } from '../src/sandbox';
+
+vi.mock('./interpreter', () => ({
+  CodeInterpreter: vi.fn().mockImplementation(() => ({}))
+}));
+
+vi.mock('@cloudflare/containers', () => {
+  class MockContainer {
+    ctx: unknown;
+    env: unknown;
+    sleepAfter: string | number = '10m';
+
+    constructor(ctx: unknown, env: unknown) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+
+    async getState(): Promise<{ status: string }> {
+      return { status: 'healthy' };
+    }
+
+    renewActivityTimeout(): void {}
+  }
+
+  return {
+    Container: MockContainer,
+    ContainerProxy: MockContainer,
+    getContainer: vi.fn(),
+    switchPort: vi.fn((request: Request) => request)
+  };
+});
+
+type StoredValue = unknown;
+
+type LocalBucket = ReturnType<typeof createMockR2Bucket>;
+
+function createStorage(initial = new Map<string, StoredValue>()) {
+  const storage = {
+    get: vi.fn(async (key: string) => initial.get(key) ?? null),
+    put: vi.fn(async (key: string, value: StoredValue) => {
+      initial.set(key, value);
+    }),
+    delete: vi.fn(async (key: string) => {
+      initial.delete(key);
+    }),
+    list: vi.fn(async () => new Map<string, StoredValue>()),
+    transaction: vi.fn(
+      async (callback: (txn: DurableObjectTransaction) => unknown) =>
+        callback(storage as unknown as DurableObjectTransaction)
+    )
+  };
+  return storage as unknown as DurableObjectStorage;
+}
+
+function createDisposedRPCError(): RPCTransportError {
+  return new RPCTransportError({
+    code: ErrorCode.RPC_TRANSPORT_ERROR,
+    message: 'RPC session was shut down by disposing the main stub',
+    httpStatus: 503,
+    context: {
+      kind: 'session_disposed',
+      originalMessage: 'RPC session was shut down by disposing the main stub',
+      errorName: 'Error'
+    },
+    timestamp: '2026-06-23T12:00:00.000Z'
+  });
+}
+
+function createMockR2Bucket() {
+  const store = new Map<string, { data: ArrayBuffer; size: number }>();
+  return {
+    put: vi.fn(async (key: string, data: string | Uint8Array) => {
+      const bytes =
+        typeof data === 'string' ? new TextEncoder().encode(data) : data;
+      store.set(key, {
+        data: new Uint8Array(bytes).buffer as ArrayBuffer,
+        size: bytes.byteLength
+      });
+    }),
+    get: vi.fn(async (key: string) => {
+      const entry = store.get(key);
+      if (!entry) return null;
+      return {
+        arrayBuffer: async () => entry.data,
+        json: async <T>() =>
+          JSON.parse(new TextDecoder().decode(entry.data)) as T,
+        body: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new Uint8Array(entry.data));
+            controller.close();
+          }
+        })
+      };
+    }),
+    head: vi.fn(async (key: string) => {
+      const entry = store.get(key);
+      if (!entry) return null;
+      return { size: entry.size };
+    }),
+    delete: vi.fn(async (key: string) => {
+      store.delete(key);
+    }),
+    list: vi.fn(async () => ({ objects: [], truncated: false }))
+  };
+}
+
+async function createLocalRestoreSandbox(
+  params: { bucket?: LocalBucket } = {}
+) {
+  const storageMap = new Map<string, StoredValue>();
+  storageMap.set('currentRuntimeIdentity', { id: 'runtime-1' });
+  storageMap.set('sandbox:lifetime', {
+    id: 'lifetime-1',
+    generation: 1,
+    createdAt: '2026-06-23T12:00:00.000Z',
+    updatedAt: '2026-06-23T12:00:00.000Z'
+  });
+
+  const bucket = params.bucket ?? createMockR2Bucket();
+  const backupId = '12345678-1234-1234-1234-123456789012';
+  await bucket.put(
+    `backups/${backupId}/meta.json`,
+    JSON.stringify({
+      id: backupId,
+      dir: '/workspace/project',
+      sizeBytes: 4,
+      ttl: 3600,
+      createdAt: '2026-06-23T12:00:00.000Z'
+    })
+  );
+  await bucket.put(
+    `backups/${backupId}/data.sqsh`,
+    new Uint8Array([0x68, 0x73, 0x71, 0x73])
+  );
+
+  const ctx = {
+    storage: createStorage(storageMap),
+    blockConcurrencyWhile: vi.fn(<T>(callback: () => Promise<T>) => callback()),
+    waitUntil: vi.fn(),
+    id: {
+      toString: () => 'test-sandbox-id',
+      equals: vi.fn(),
+      name: 'test-sandbox'
+    },
+    container: { running: true }
+  } as unknown as DurableObjectState<{}>;
+
+  const sandbox = new Sandbox(ctx, { BACKUP_BUCKET: bucket });
+  await vi.waitFor(() => {
+    expect(ctx.blockConcurrencyWhile).toHaveBeenCalled();
+  });
+
+  vi.spyOn(sandbox.client.utils, 'createSession').mockResolvedValue({
+    success: true,
+    id: 'backup-session',
+    message: 'Created',
+    timestamp: '2026-06-23T12:00:00.000Z'
+  });
+  vi.spyOn(sandbox.client.utils, 'deleteSession').mockResolvedValue({
+    success: true,
+    sessionId: 'backup-session',
+    timestamp: '2026-06-23T12:00:00.000Z'
+  });
+  vi.spyOn(sandbox.client.files, 'writeFile').mockResolvedValue({
+    success: true,
+    path: `/var/backups/${backupId}.sqsh`,
+    timestamp: '2026-06-23T12:00:00.000Z'
+  });
+  vi.spyOn(sandbox.client.commands, 'execute').mockResolvedValue({
+    success: true,
+    stdout: '',
+    stderr: '',
+    exitCode: 0,
+    command: '',
+    timestamp: '2026-06-23T12:00:00.000Z'
+  });
+
+  return { sandbox, storageMap, backupId };
+}
+
+describe('local backup restore lifecycle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-23T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('uses lifecycle records and verifies local restore completion', async () => {
+    const { sandbox, storageMap, backupId } = await createLocalRestoreSandbox();
+
+    const result = await sandbox.restoreBackup({
+      id: backupId,
+      dir: '/workspace/project',
+      localBucket: true
+    });
+
+    const record = storageMap.get(
+      `operations:restore:${backupId}:/workspace/project`
+    ) as BackupRestoreOperationRecord;
+    expect(record).toMatchObject({
+      operationKey: `restore:${backupId}:/workspace/project`,
+      kind: 'backup.restore',
+      status: 'committed',
+      phase: 'verified',
+      runtimeIdentityID: 'runtime-1',
+      payload: {
+        backupId,
+        dir: '/workspace/project',
+        archiveSize: 4
+      },
+      result
+    });
+  });
+
+  it('does not mark local archive_ready before writeFile completes', async () => {
+    const { sandbox, storageMap, backupId } = await createLocalRestoreSandbox();
+    vi.spyOn(sandbox.client.files, 'writeFile').mockImplementationOnce(
+      async () => {
+        const record = storageMap.get(
+          `operations:restore:${backupId}:/workspace/project`
+        ) as BackupRestoreOperationRecord;
+        expect(record.phase).toBe('runtime_ready');
+        return {
+          success: true,
+          path: `/var/backups/${backupId}.sqsh`,
+          timestamp: '2026-06-23T12:00:00.000Z'
+        };
+      }
+    );
+
+    await sandbox.restoreBackup({
+      id: backupId,
+      dir: '/workspace/project',
+      localBucket: true
+    });
+  });
+
+  it('recovers internally when local archive write loses the RPC transport once', async () => {
+    const { sandbox, storageMap, backupId } = await createLocalRestoreSandbox();
+    const writeFileSpy = vi
+      .spyOn(sandbox.client.files, 'writeFile')
+      .mockRejectedValueOnce(createDisposedRPCError())
+      .mockResolvedValueOnce({
+        success: true,
+        path: `/var/backups/${backupId}.sqsh`,
+        timestamp: '2026-06-23T12:00:00.000Z'
+      });
+
+    const result = await sandbox.restoreBackup({
+      id: backupId,
+      dir: '/workspace/project',
+      localBucket: true
+    });
+
+    expect(result).toEqual({
+      success: true,
+      id: backupId,
+      dir: '/workspace/project'
+    });
+    expect(writeFileSpy).toHaveBeenCalledTimes(2);
+    const record = storageMap.get(
+      `operations:restore:${backupId}:/workspace/project`
+    ) as BackupRestoreOperationRecord;
+    expect(record.status).toBe('committed');
+    expect(record.phase).toBe('verified');
+  });
+});

--- a/packages/sandbox/tests/local-backup.test.ts
+++ b/packages/sandbox/tests/local-backup.test.ts
@@ -124,6 +124,7 @@ interface MockCtx {
     equals: ReturnType<typeof vi.fn>;
     name: string;
   };
+  container: { running: boolean };
 }
 
 describe('Local Backup & Restore', () => {
@@ -136,12 +137,17 @@ describe('Local Backup & Restore', () => {
     vi.clearAllMocks();
 
     mockBucket = createMockR2Bucket();
+    const storageState = new Map<string, unknown>();
 
     mockCtx = {
       storage: {
-        get: vi.fn().mockResolvedValue(null),
-        put: vi.fn().mockResolvedValue(undefined),
-        delete: vi.fn().mockResolvedValue(undefined),
+        get: vi.fn(async (key: string) => storageState.get(key) ?? null),
+        put: vi.fn(async (key: string, value: unknown) => {
+          storageState.set(key, value);
+        }),
+        delete: vi.fn(async (key: string) => {
+          storageState.delete(key);
+        }),
         list: vi.fn().mockResolvedValue(new Map())
       },
       blockConcurrencyWhile: vi
@@ -154,7 +160,8 @@ describe('Local Backup & Restore', () => {
         toString: () => 'test-sandbox-id',
         equals: vi.fn(),
         name: 'test-sandbox'
-      } as any
+      } as any,
+      container: { running: true }
     };
 
     mockEnv = {

--- a/packages/sandbox/tests/operation-interrupted-error.test.ts
+++ b/packages/sandbox/tests/operation-interrupted-error.test.ts
@@ -1,0 +1,86 @@
+import type { OperationInterruptedContext } from '@repo/shared/errors';
+import { ErrorCode } from '@repo/shared/errors';
+import { describe, expect, it } from 'vitest';
+import { OperationInterruptedError } from '../src/errors';
+
+function makeOperationInterruptedResponse(
+  overrides: Partial<OperationInterruptedContext> = {}
+) {
+  const context: OperationInterruptedContext = {
+    reason: 'runtime_replaced',
+    operation: 'backup.restore',
+    phase: 'archive_ready',
+    admitted: true,
+    retryable: true,
+    ...overrides
+  };
+  return {
+    code: ErrorCode.OPERATION_INTERRUPTED,
+    message: 'Operation was interrupted',
+    context,
+    httpStatus: 409,
+    timestamp: new Date().toISOString()
+  };
+}
+
+describe('OperationInterruptedError', () => {
+  it('has the correct name', () => {
+    const err = new OperationInterruptedError(
+      makeOperationInterruptedResponse()
+    );
+    expect(err.name).toBe('OperationInterruptedError');
+  });
+
+  it('is an instance of SandboxError', async () => {
+    const { SandboxError } = await import('../src/errors/classes');
+    const err = new OperationInterruptedError(
+      makeOperationInterruptedResponse()
+    );
+    expect(err).toBeInstanceOf(SandboxError);
+  });
+
+  it('exposes reason, operation, phase, admitted, retryable from context', () => {
+    const err = new OperationInterruptedError(
+      makeOperationInterruptedResponse({
+        reason: 'sandbox_lifetime_changed',
+        operation: 'backup.restore',
+        phase: 'validating',
+        admitted: 'unknown',
+        retryable: false
+      })
+    );
+    expect(err.context.reason).toBe('sandbox_lifetime_changed');
+    expect(err.context.operation).toBe('backup.restore');
+    expect(err.context.phase).toBe('validating');
+    expect(err.context.admitted).toBe('unknown');
+    expect(err.context.retryable).toBe(false);
+  });
+
+  it('exposes recoveryAttempts and maxRecoveryAttempts when present', () => {
+    const err = new OperationInterruptedError(
+      makeOperationInterruptedResponse({
+        reason: 'recovery_exhausted',
+        retryable: false,
+        recoveryAttempts: 2,
+        maxRecoveryAttempts: 2
+      })
+    );
+    expect(err.context.recoveryAttempts).toBe(2);
+    expect(err.context.maxRecoveryAttempts).toBe(2);
+  });
+
+  it('ErrorCode.OPERATION_INTERRUPTED exists', () => {
+    expect(ErrorCode.OPERATION_INTERRUPTED).toBe('OPERATION_INTERRUPTED');
+  });
+
+  it('OperationInterruptedError is exported from @cloudflare/sandbox public barrel', async () => {
+    const sdkExports = await import('../src/index');
+    expect(sdkExports.OperationInterruptedError).toBeDefined();
+    // Context type export is type-only; verify the error class is constructable
+    expect(
+      new sdkExports.OperationInterruptedError(
+        makeOperationInterruptedResponse()
+      )
+    ).toBeInstanceOf(sdkExports.OperationInterruptedError);
+  });
+});

--- a/packages/sandbox/tests/rpc-client-retry.test.ts
+++ b/packages/sandbox/tests/rpc-client-retry.test.ts
@@ -1,3 +1,5 @@
+import type { ErrorResponse } from '@repo/shared/errors';
+import { ErrorCode } from '@repo/shared/errors';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
@@ -41,7 +43,11 @@ vi.mock('../src/container-control/connection', () => ({
   }
 }));
 
-import { ContainerControlClient } from '../src/container-control/client';
+import {
+  ContainerControlClient,
+  translateRPCError
+} from '../src/container-control/client';
+import { SandboxError } from '../src/errors/classes';
 
 describe('ContainerControlClient retry timeout wiring', () => {
   beforeEach(() => {
@@ -105,5 +111,31 @@ describe('ContainerControlClient retry timeout wiring', () => {
 
     expect(captured.options).toHaveLength(1);
     expect(captured.options[0].retryTimeoutMs).toBe(15_000);
+  });
+});
+
+describe('translateRPCError', () => {
+  it('re-throws SandboxError subclasses without wrapping as RPCTransportError', () => {
+    const originalError = new SandboxError({
+      code: ErrorCode.BACKUP_RESTORE_FAILED,
+      message: 'Restore interrupted',
+      context: { dir: '/workspace', backupId: 'bk-1' },
+      httpStatus: 500,
+      timestamp: new Date().toISOString()
+    } as ErrorResponse<{ dir: string; backupId: string }>);
+
+    let caughtError: unknown;
+    try {
+      translateRPCError(originalError);
+    } catch (e) {
+      caughtError = e;
+    }
+
+    // The same instance must be re-thrown unchanged, not a freshly
+    // constructed error that loses context or changes identity.
+    expect(caughtError).toBe(originalError);
+    expect((caughtError as Error).constructor.name).not.toBe(
+      'RPCTransportError'
+    );
   });
 });

--- a/packages/sandbox/tests/sandbox-control-callback.test.ts
+++ b/packages/sandbox/tests/sandbox-control-callback.test.ts
@@ -31,7 +31,7 @@ describe('SandboxControlCallbackImpl', () => {
     await cb.onTunnelExit('quick-a', 8080, 0);
 
     expect(handler).toHaveBeenCalledTimes(1);
-    expect(handler).toHaveBeenCalledWith('quick-a', 8080, 0);
+    expect(handler).toHaveBeenCalledWith('quick-a', 8080, 0, undefined);
   });
 
   it('passes through a null exitCode (signalled process)', async () => {
@@ -40,7 +40,16 @@ describe('SandboxControlCallbackImpl', () => {
 
     await cb.onTunnelExit('quick-b', 8081, null);
 
-    expect(handler).toHaveBeenCalledWith('quick-b', 8081, null);
+    expect(handler).toHaveBeenCalledWith('quick-b', 8081, null, undefined);
+  });
+
+  it('passes through a runtime run id when present', async () => {
+    const handler = vi.fn<TunnelExitHandler>().mockResolvedValue(undefined);
+    const cb = new SandboxControlCallbackImpl(() => handler, makeLogger());
+
+    await cb.onTunnelExit('quick-b', 8081, 0, 'run-current');
+
+    expect(handler).toHaveBeenCalledWith('quick-b', 8081, 0, 'run-current');
   });
 
   it('is a no-op when the accessor returns null', async () => {

--- a/packages/sandbox/tests/sandbox-destroy-lifetime.test.ts
+++ b/packages/sandbox/tests/sandbox-destroy-lifetime.test.ts
@@ -1,0 +1,164 @@
+import { Container } from '@cloudflare/containers';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { connect, Sandbox } from '../src/sandbox';
+
+vi.mock('./interpreter', () => ({
+  CodeInterpreter: vi.fn().mockImplementation(() => ({}))
+}));
+
+vi.mock('@cloudflare/containers', () => {
+  const MockContainer = class Container {
+    ctx: unknown;
+    env: unknown;
+    sleepAfter: string | number = '10m';
+    constructor(ctx: unknown, env: unknown) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+    async fetch(_request: Request): Promise<Response> {
+      return new Response('Mock');
+    }
+    async containerFetch(_request: Request, _port: number): Promise<Response> {
+      return new Response('Mock');
+    }
+    async startAndWaitForPorts(): Promise<void> {}
+    async destroy(): Promise<void> {}
+    async stop(): Promise<void> {}
+    async getState() {
+      return { status: 'healthy' };
+    }
+    renewActivityTimeout() {}
+  };
+
+  const MockContainerProxy = class ContainerProxy {
+    ctx: unknown;
+    env: unknown;
+    constructor(ctx: unknown, env: unknown) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+    async fetch(_request: Request): Promise<Response> {
+      return new Response('Mock');
+    }
+  };
+
+  return {
+    Container: MockContainer,
+    ContainerProxy: MockContainerProxy,
+    getContainer: vi.fn(),
+    switchPort: vi.fn((request: Request) => request)
+  };
+});
+
+describe('Sandbox destroy() sandbox lifetime', () => {
+  let sandbox: Sandbox;
+  let putCalls: Array<{ key: string; seq: number }>;
+  let deleteCalls: Array<{ key: string; seq: number }>;
+  let callSeq: number;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    putCalls = [];
+    deleteCalls = [];
+    callSeq = 0;
+
+    const storageState = new Map<string, unknown>();
+
+    const storage = {
+      get: vi.fn(async (key: string) => storageState.get(key) ?? null),
+      put: vi.fn(async (key: string, value: unknown) => {
+        putCalls.push({ key, seq: callSeq++ });
+        storageState.set(key, value);
+      }),
+      delete: vi.fn(async (key: string) => {
+        deleteCalls.push({ key, seq: callSeq++ });
+        storageState.delete(key);
+      }),
+      list: vi.fn().mockResolvedValue(new Map()),
+      transaction: vi.fn(async (callback: (s: typeof storage) => unknown) =>
+        callback(storage)
+      )
+    };
+
+    const mockCtx = {
+      storage,
+      blockConcurrencyWhile: vi
+        .fn()
+        .mockImplementation(<T>(cb: () => Promise<T>): Promise<T> => cb()),
+      waitUntil: vi.fn(),
+      container: { running: true, start: vi.fn() },
+      id: {
+        toString: () => 'test-sandbox-id',
+        equals: vi.fn(),
+        name: 'test-sandbox'
+      }
+    };
+
+    const stub = new Sandbox(
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+      {}
+    );
+
+    await vi.waitFor(() => {
+      expect(mockCtx.blockConcurrencyWhile).toHaveBeenCalled();
+    });
+    await Promise.all(
+      (
+        mockCtx.blockConcurrencyWhile as {
+          mock: { results: Array<{ value: unknown }> };
+        }
+      ).mock.results.map((r) => r.value)
+    );
+
+    sandbox = Object.assign(stub, { wsConnect: connect(stub) });
+
+    vi.spyOn(Container.prototype, 'destroy').mockImplementation(async () => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rotates sandbox lifetime before clearing currentRuntimeIdentity', async () => {
+    await sandbox.destroy();
+
+    // The sandbox:lifetime rotation put must exist
+    const lifetimePut = putCalls.find((c) => c.key === 'sandbox:lifetime');
+    expect(lifetimePut, 'expected a put to sandbox:lifetime').toBeDefined();
+
+    // The currentRuntimeIdentity delete must exist
+    const runtimeDelete = deleteCalls.find(
+      (c) => c.key === 'currentRuntimeIdentity'
+    );
+    expect(
+      runtimeDelete,
+      'expected a delete of currentRuntimeIdentity'
+    ).toBeDefined();
+
+    if (!lifetimePut || !runtimeDelete) {
+      throw new Error('Expected lifetime rotation and runtime clear calls');
+    }
+    expect(lifetimePut.seq).toBeLessThan(runtimeDelete.seq);
+  });
+
+  it('does not rotate lifetime during onStart()', async () => {
+    putCalls = [];
+
+    // Simulate onStart (called internally by the container lifecycle)
+    await (sandbox as unknown as { onStart: () => Promise<void> }).onStart();
+
+    const lifetimePut = putCalls.find((c) => c.key === 'sandbox:lifetime');
+    expect(lifetimePut).toBeUndefined();
+  });
+
+  it('does not rotate lifetime during onStop()', async () => {
+    putCalls = [];
+
+    // Simulate onStop
+    await (sandbox as unknown as { onStop: () => Promise<void> }).onStop();
+
+    const lifetimePut = putCalls.find((c) => c.key === 'sandbox:lifetime');
+    expect(lifetimePut).toBeUndefined();
+  });
+});

--- a/packages/sandbox/tests/sandbox-lifetime.test.ts
+++ b/packages/sandbox/tests/sandbox-lifetime.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CurrentSandboxLifetime,
+  SandboxLifetime,
+  SandboxLifetimeChangedError
+} from '../src/sandbox-lifetime';
+
+function createStorage(initial = new Map<string, unknown>()) {
+  return {
+    get: vi.fn(async (key: string) => initial.get(key) ?? null),
+    put: vi.fn(async (key: string, value: unknown) => {
+      initial.set(key, value);
+    })
+  };
+}
+
+describe('CurrentSandboxLifetime', () => {
+  it('getOrCreate() returns a stable id on repeated calls', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const first = await currentLifetime.getOrCreate();
+    const second = await currentLifetime.getOrCreate();
+
+    expect(first.id).toBe(second.id);
+    expect(typeof first.id).toBe('string');
+    expect(first.id.length).toBeGreaterThan(0);
+  });
+
+  it('getOrCreate() persists the record to storage', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    await currentLifetime.getOrCreate();
+
+    // Storage must have been written
+    expect(storage.put).toHaveBeenCalledOnce();
+    expect(map.has('sandbox:lifetime')).toBe(true);
+  });
+
+  it('getOrCreate() does not overwrite an existing lifetime', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const first = await currentLifetime.getOrCreate();
+    // put should have been called exactly once — the second call reads from storage
+    const putCallsBefore = storage.put.mock.calls.length;
+    const second = await currentLifetime.getOrCreate();
+
+    expect(storage.put.mock.calls.length).toBe(putCallsBefore);
+    expect(second.id).toBe(first.id);
+  });
+
+  it('rotate() changes the lifetime id', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const original = await currentLifetime.getOrCreate();
+    const rotated = await currentLifetime.rotate();
+
+    expect(rotated.id).not.toBe(original.id);
+  });
+
+  it('rotate() increments the generation', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const original = await currentLifetime.getOrCreate();
+    const rotated = await currentLifetime.rotate();
+
+    expect(rotated.generation).toBeGreaterThan(original.generation);
+  });
+
+  it('assertCurrent() resolves when lifetime matches current storage', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const lifetime = await currentLifetime.getOrCreate();
+    await expect(
+      currentLifetime.assertCurrent(lifetime)
+    ).resolves.toBeUndefined();
+  });
+
+  it('assertCurrent() throws SandboxLifetimeChangedError for a stale lifetime', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const stale = await currentLifetime.getOrCreate();
+    // Rotate so the stored id is different from stale
+    await currentLifetime.rotate();
+
+    await expect(currentLifetime.assertCurrent(stale)).rejects.toThrow(
+      SandboxLifetimeChangedError
+    );
+  });
+
+  it('isCurrent() returns true for current lifetime', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const lifetime = await currentLifetime.getOrCreate();
+    expect(await currentLifetime.isCurrent(lifetime)).toBe(true);
+  });
+
+  it('isCurrent() returns false for stale lifetime after rotate', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const stale = await currentLifetime.getOrCreate();
+    await currentLifetime.rotate();
+
+    expect(await currentLifetime.isCurrent(stale)).toBe(false);
+  });
+
+  it('SandboxLifetimeChangedError has the expected name and message', () => {
+    const err = new SandboxLifetimeChangedError();
+    expect(err.name).toBe('SandboxLifetimeChangedError');
+    expect(err.message).toBe('Sandbox lifetime is no longer current');
+  });
+
+  it('SandboxLifetime.owns() returns true for a scoped record', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const lifetime = await currentLifetime.getOrCreate();
+    const scoped = lifetime.scope({ data: 'test' });
+    expect(lifetime.owns(scoped)).toBe(true);
+  });
+
+  it('SandboxLifetime.owns() returns false for a record from a different lifetime', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const first = await currentLifetime.getOrCreate();
+    const second = await currentLifetime.rotate();
+    const scoped = second.scope({ data: 'test' });
+
+    expect(first.owns(scoped)).toBe(false);
+  });
+});

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -8,6 +8,7 @@ import {
   ProcessNotFoundError
 } from '../src/errors';
 import { connect, Sandbox } from '../src/sandbox';
+import { SessionInitInvalidatedError } from '../src/session-init';
 
 // Mock dependencies before imports
 vi.mock('./interpreter', () => ({
@@ -931,9 +932,7 @@ describe('Sandbox - Automatic Session Management', () => {
       )
         .mockImplementationOnce(async (_id: string) => {
           callCount++;
-          throw new Error(
-            'Default session initialization was invalidated by a container stop'
-          );
+          throw new SessionInitInvalidatedError();
         })
         .mockImplementationOnce(async (sessionId: string) => {
           callCount++;

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -857,7 +857,11 @@ describe('Sandbox - Automatic Session Management', () => {
       expect(calls[2][1]).toBe('sandbox-renamed');
     });
 
-    it('invalidates an in-flight init when onStop runs mid-flight', async () => {
+    it('retries default session init after onStop invalidates an in-flight init', async () => {
+      // An exec whose session-create RPC completes after a container stop now
+      // retries the session init once with the new generation. The retry
+      // succeeds, writing the session to storage, and the original exec call
+      // also resolves.
       let resolveCreate!: (value: unknown) => void;
       vi.mocked(sandbox.client.utils.createSession).mockReturnValueOnce(
         new Promise((resolve) => {
@@ -869,15 +873,23 @@ describe('Sandbox - Automatic Session Management', () => {
       await (sandbox as any).onStop();
 
       resolveCreate({ success: true, id: 'sandbox-default', message: 'ok' });
-      await expect(inflight).rejects.toThrow();
+      // Retry absorbs the invalidation — the exec recovers transparently.
+      await inflight;
 
+      // The retry's successful init writes the session to storage.
       const defaultSessionPuts = vi
         .mocked(mockCtx.storage.put)
         .mock.calls.filter((call) => call[0] === 'defaultSession');
-      expect(defaultSessionPuts).toHaveLength(0);
+      expect(defaultSessionPuts).toHaveLength(1);
+      // createSession: once for the invalidated attempt + once for the retry.
+      expect(sandbox.client.utils.createSession).toHaveBeenCalledTimes(2);
     });
 
-    it('does not join a stale init promise after onStop clears it', async () => {
+    it('uses the session already established by a concurrent caller when retrying', async () => {
+      // When onStop fires while a session-create RPC is in flight, and a
+      // concurrent exec starts a fresh init, the retrying exec picks up the
+      // session that the concurrent exec wrote rather than issuing a third
+      // createSession call.
       let resolveFirst!: (value: unknown) => void;
       vi.mocked(sandbox.client.utils.createSession)
         .mockReturnValueOnce(
@@ -896,10 +908,55 @@ describe('Sandbox - Automatic Session Management', () => {
       const second = sandbox.exec('echo two');
 
       resolveFirst({ success: true, id: 'sandbox-default', message: 'ok' });
-      await expect(first).rejects.toThrow();
+      // Both execs resolve: the retry in `first` sees the session that
+      // `second` already established via the fast path in ensureDefaultSession.
+      await first;
       await second;
 
+      // Only two createSession calls: one for the invalidated `first` attempt,
+      // one for `second`. The `first` retry uses the fast path.
       expect(sandbox.client.utils.createSession).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries default session initialization once after container generation invalidation', async () => {
+      let callCount = 0;
+      vi.spyOn(
+        sandbox as unknown as {
+          initializeDefaultSession: (
+            id: string,
+            gen: number
+          ) => Promise<string>;
+        },
+        'initializeDefaultSession'
+      )
+        .mockImplementationOnce(async (_id: string) => {
+          callCount++;
+          throw new Error(
+            'Default session initialization was invalidated by a container stop'
+          );
+        })
+        .mockImplementationOnce(async (sessionId: string) => {
+          callCount++;
+          // Mirror the real impl: write to in-memory cache so ensureDefaultSession
+          // sees the session as initialized on success.
+          (sandbox as unknown as { defaultSession: string }).defaultSession =
+            sessionId;
+          return sessionId;
+        });
+
+      vi.mocked(sandbox.client.commands.execute).mockResolvedValueOnce({
+        success: true,
+        stdout: 'ok',
+        stderr: '',
+        exitCode: 0,
+        command: 'echo ok',
+        timestamp: new Date().toISOString()
+      } as never);
+
+      // Should succeed: retry absorbs the generation-invalidation error.
+      await sandbox.exec('echo ok');
+
+      expect(callCount).toBe(2);
     });
 
     it('keeps default shell state independent of sessionless proxy configuration', async () => {

--- a/packages/sandbox/tests/tunnels-handler-lifecycle.test.ts
+++ b/packages/sandbox/tests/tunnels-handler-lifecycle.test.ts
@@ -1,0 +1,505 @@
+import type {
+  EnsureTunnelRunRequest,
+  EnsureTunnelRunResult,
+  Logger,
+  StopTunnelRunRequest,
+  StopTunnelRunResult,
+  TunnelInfo
+} from '@repo/shared';
+import type { Mock } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { RuntimeIdentityInactiveError } from '../src/current-runtime-identity';
+import { ErrorCode, RPCTransportError } from '../src/errors';
+import {
+  createTunnelsHandler,
+  pruneTunnelsForRestart,
+  type TunnelsStorage
+} from '../src/tunnels/tunnels-handler';
+
+type RunQuickTunnelMock = Mock<
+  (id: string, port: number) => Promise<TunnelInfo>
+>;
+type DestroyTunnelMock = Mock<(id: string) => Promise<unknown>>;
+type ListTunnelsMock = Mock<() => Promise<TunnelInfo[]>>;
+type EnsureTunnelRunMock = Mock<
+  (request: EnsureTunnelRunRequest) => Promise<EnsureTunnelRunResult>
+>;
+type StopTunnelRunMock = Mock<
+  (request: StopTunnelRunRequest) => Promise<StopTunnelRunResult>
+>;
+
+interface MockTunnelsClient {
+  runQuickTunnel: RunQuickTunnelMock;
+  destroyTunnel: DestroyTunnelMock;
+  listTunnels: ListTunnelsMock;
+  ensureTunnelRun: EnsureTunnelRunMock;
+  stopTunnelRun: StopTunnelRunMock;
+}
+
+function makeLogger(): Logger {
+  const log: Logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(() => log)
+  } as unknown as Logger;
+  return log;
+}
+
+function makeClient(): { client: { tunnels: MockTunnelsClient } } {
+  return {
+    client: {
+      tunnels: {
+        runQuickTunnel:
+          vi.fn<(id: string, port: number) => Promise<TunnelInfo>>(),
+        destroyTunnel: vi.fn<(id: string) => Promise<unknown>>(),
+        listTunnels: vi.fn<() => Promise<TunnelInfo[]>>(),
+        ensureTunnelRun:
+          vi.fn<
+            (request: EnsureTunnelRunRequest) => Promise<EnsureTunnelRunResult>
+          >(),
+        stopTunnelRun:
+          vi.fn<
+            (request: StopTunnelRunRequest) => Promise<StopTunnelRunResult>
+          >()
+      }
+    }
+  };
+}
+
+function makeStorage(initial?: Record<string, TunnelInfo>): TunnelsStorage {
+  const data = new Map<string, unknown>();
+  if (initial) data.set('tunnels', { ...initial });
+  let txQueue: Promise<unknown> = Promise.resolve();
+  const storage = {
+    get: vi.fn(async (key: string) => data.get(key)),
+    put: vi.fn(async (key: string, next: unknown) => {
+      data.set(key, JSON.parse(JSON.stringify(next)));
+    }),
+    delete: vi.fn(async (key: string) => data.delete(key)),
+    transaction: vi.fn((closure: (txn: unknown) => Promise<unknown>) => {
+      const next = txQueue.then(() => closure(storage));
+      txQueue = next.catch(() => undefined);
+      return next;
+    })
+  } as unknown as TunnelsStorage;
+  return storage;
+}
+
+function makeRuntimeFences(runtimeId = 'runtime-1') {
+  const runtime = {
+    id: runtimeId,
+    owns: (record: { readonly runtimeIdentityID: string }) =>
+      record.runtimeIdentityID === runtimeId,
+    scope: <T extends object>(value: T) => ({
+      ...value,
+      runtimeIdentityID: runtimeId
+    })
+  };
+  const lifetime = {
+    id: 'lifetime-1',
+    generation: 1,
+    createdAt: '2026-05-13T00:00:00.000Z',
+    updatedAt: '2026-05-13T00:00:00.000Z',
+    owns: (record: { readonly sandboxLifetimeID: string }) =>
+      record.sandboxLifetimeID === 'lifetime-1',
+    scope: <T extends object>(value: T) => ({
+      ...value,
+      sandboxLifetimeID: 'lifetime-1'
+    })
+  };
+
+  return {
+    runtime,
+    lifetime,
+    currentRuntime: {
+      get: vi.fn<() => Promise<typeof runtime | null>>(async () => runtime),
+      markStarted: vi.fn(async () => runtime),
+      assertActive: vi.fn(async (_runtime: typeof runtime) => {})
+    },
+    currentLifetime: {
+      getOrCreate: vi.fn(async () => lifetime),
+      assertCurrent: vi.fn(async () => {})
+    }
+  };
+}
+
+function makeRecord(overrides: Partial<TunnelInfo> = {}): TunnelInfo {
+  return {
+    id: 'quick-0123456789abcdef',
+    port: 8080,
+    url: 'https://stub.trycloudflare.com',
+    hostname: 'stub.trycloudflare.com',
+    createdAt: '2026-05-13T00:00:00.000Z',
+    ...overrides
+  };
+}
+
+function createDisposedRPCError(): RPCTransportError {
+  return new RPCTransportError({
+    code: ErrorCode.RPC_TRANSPORT_ERROR,
+    message: 'RPC session was shut down by disposing the main stub',
+    httpStatus: 503,
+    context: {
+      kind: 'session_disposed',
+      originalMessage: 'RPC session was shut down by disposing the main stub',
+      errorName: 'Error'
+    },
+    timestamp: '2026-05-13T00:00:00.000Z'
+  });
+}
+
+function makeHandler() {
+  const { client } = makeClient();
+  const storage = makeStorage();
+  const fences = makeRuntimeFences();
+  const { tunnels } = createTunnelsHandler({
+    client: client as unknown as Parameters<
+      typeof createTunnelsHandler
+    >[0]['client'],
+    storage,
+    logger: makeLogger(),
+    currentRuntime: fences.currentRuntime,
+    currentLifetime: fences.currentLifetime
+  } as unknown as Parameters<typeof createTunnelsHandler>[0]);
+  return { client, storage, handler: tunnels, fences };
+}
+
+describe('tunnels handler > quick lifecycle recovery', () => {
+  it('uses ensureTunnelRun and stores runtime metadata for quick tunnels', async () => {
+    const { client, storage, handler } = makeHandler();
+    client.tunnels.ensureTunnelRun.mockImplementation(async (request) => ({
+      started: true,
+      run: {
+        tunnelId: request.tunnelId,
+        runId: request.runId,
+        mode: 'quick',
+        port: request.port,
+        url: 'https://fresh.trycloudflare.com',
+        hostname: 'fresh.trycloudflare.com',
+        startedAt: '2026-05-13T00:00:00.000Z'
+      }
+    }));
+
+    const info = await handler.get(8080);
+
+    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(1);
+    expect(client.tunnels.runQuickTunnel).not.toHaveBeenCalled();
+    const request = client.tunnels.ensureTunnelRun.mock.calls[0][0];
+    expect(info).toMatchObject({
+      id: request.tunnelId,
+      port: 8080,
+      url: 'https://fresh.trycloudflare.com',
+      hostname: 'fresh.trycloudflare.com'
+    });
+    const meta = await storage.get<Record<string, unknown>>('tunnels:meta');
+    expect(meta?.['8080']).toMatchObject({
+      optionsHash: 'v1:quick',
+      runtimeIdentityID: 'runtime-1',
+      sandboxLifetimeID: 'lifetime-1',
+      tunnelRunId: request.runId
+    });
+  });
+
+  it('retries quick tunnel provisioning when runtime replacement is detected before commit', async () => {
+    const { client, storage, handler, fences } = makeHandler();
+    client.tunnels.ensureTunnelRun.mockImplementation(async (request) => ({
+      started: true,
+      run: {
+        tunnelId: request.tunnelId,
+        runId: request.runId,
+        mode: 'quick',
+        port: request.port,
+        url: `https://${request.runId}.trycloudflare.com`,
+        hostname: `${request.runId}.trycloudflare.com`,
+        startedAt: '2026-05-13T00:00:00.000Z'
+      }
+    }));
+    fences.currentRuntime.assertActive
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new RuntimeIdentityInactiveError())
+      .mockResolvedValue(undefined);
+
+    const info = await handler.get(8080);
+
+    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(2);
+    const secondRunId = client.tunnels.ensureTunnelRun.mock.calls[1][0].runId;
+    expect(info.hostname).toBe(`${secondRunId}.trycloudflare.com`);
+    const stored = await storage.get<Record<string, TunnelInfo>>('tunnels');
+    expect(stored?.['8080']).toEqual(info);
+  });
+
+  it('captures runtime before quick tunnel admission so a replacement during spawn retries', async () => {
+    const { client, storage, handler, fences } = makeHandler();
+    let activeRuntimeId = 'runtime-1';
+    const makeRuntime = (id: string) => ({
+      id,
+      owns: (record: { readonly runtimeIdentityID: string }) =>
+        record.runtimeIdentityID === id,
+      scope: <T extends object>(value: T) => ({
+        ...value,
+        runtimeIdentityID: id
+      })
+    });
+    fences.currentRuntime.get.mockImplementation(async () =>
+      makeRuntime(activeRuntimeId)
+    );
+    fences.currentRuntime.assertActive.mockImplementation(async (runtime) => {
+      if (runtime.id !== activeRuntimeId) {
+        throw new RuntimeIdentityInactiveError();
+      }
+    });
+    client.tunnels.ensureTunnelRun.mockImplementation(async (request) => {
+      if (client.tunnels.ensureTunnelRun.mock.calls.length === 1) {
+        activeRuntimeId = 'runtime-2';
+      }
+      return {
+        started: true,
+        run: {
+          tunnelId: request.tunnelId,
+          runId: request.runId,
+          mode: 'quick',
+          port: request.port,
+          url: `https://${request.runId}.trycloudflare.com`,
+          hostname: `${request.runId}.trycloudflare.com`,
+          startedAt: '2026-05-13T00:00:00.000Z'
+        }
+      };
+    });
+
+    const info = await handler.get(8080);
+
+    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(2);
+    const staleRunId = client.tunnels.ensureTunnelRun.mock.calls[0][0].runId;
+    const currentRunId = client.tunnels.ensureTunnelRun.mock.calls[1][0].runId;
+    expect(info.hostname).toBe(`${currentRunId}.trycloudflare.com`);
+    expect(info.hostname).not.toBe(`${staleRunId}.trycloudflare.com`);
+    const meta =
+      await storage.get<Record<string, { runtimeIdentityID: string }>>(
+        'tunnels:meta'
+      );
+    expect(meta?.['8080'].runtimeIdentityID).toBe('runtime-2');
+  });
+
+  it('replays the same quick tunnel run identity after response-loss interruption', async () => {
+    const { client, handler } = makeHandler();
+    client.tunnels.ensureTunnelRun
+      .mockRejectedValueOnce(createDisposedRPCError())
+      .mockImplementationOnce(async (request) => ({
+        started: false,
+        run: {
+          tunnelId: request.tunnelId,
+          runId: request.runId,
+          mode: 'quick',
+          port: request.port,
+          url: `https://${request.runId}.trycloudflare.com`,
+          hostname: `${request.runId}.trycloudflare.com`,
+          startedAt: '2026-05-13T00:00:00.000Z'
+        }
+      }));
+
+    const info = await handler.get(8080);
+
+    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(2);
+    const first = client.tunnels.ensureTunnelRun.mock.calls[0][0];
+    const second = client.tunnels.ensureTunnelRun.mock.calls[1][0];
+    expect(second).toMatchObject({
+      tunnelId: first.tunnelId,
+      runId: first.runId,
+      mode: 'quick',
+      port: 8080
+    });
+    expect(info.hostname).toBe(`${first.runId}.trycloudflare.com`);
+  });
+
+  it('serializes concurrent quick tunnel gets across response-loss recovery', async () => {
+    const { client, handler } = makeHandler();
+    const firstAdmission = Promise.withResolvers<EnsureTunnelRunResult>();
+    client.tunnels.ensureTunnelRun
+      .mockReturnValueOnce(firstAdmission.promise)
+      .mockImplementation(async (request) => ({
+        started: false,
+        run: {
+          tunnelId: request.tunnelId,
+          runId: request.runId,
+          mode: 'quick',
+          port: request.port,
+          url: `https://${request.runId}.trycloudflare.com`,
+          hostname: `${request.runId}.trycloudflare.com`,
+          startedAt: '2026-05-13T00:00:00.000Z'
+        }
+      }));
+
+    const firstGet = handler.get(8080);
+    await vi.waitFor(() => {
+      expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(1);
+    });
+
+    const secondGet = handler.get(8080);
+    await Promise.resolve();
+    firstAdmission.reject(createDisposedRPCError());
+
+    const [first, second] = await Promise.all([firstGet, secondGet]);
+
+    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(2);
+    const firstCall = client.tunnels.ensureTunnelRun.mock.calls[0][0];
+    const replayCall = client.tunnels.ensureTunnelRun.mock.calls[1][0];
+    expect(replayCall).toMatchObject({
+      tunnelId: firstCall.tunnelId,
+      runId: firstCall.runId
+    });
+    expect(second).toEqual(first);
+  });
+
+  it('admits a quick tunnel run before asserting that a cold runtime is active', async () => {
+    const { client, handler, fences } = makeHandler();
+    const runtime = fences.runtime;
+    fences.currentRuntime.get.mockImplementationOnce(async () => null);
+    fences.currentRuntime.markStarted.mockResolvedValueOnce(runtime);
+    let admitted = false;
+    fences.currentRuntime.assertActive.mockImplementation(async () => {
+      if (!admitted) {
+        throw new RuntimeIdentityInactiveError();
+      }
+    });
+    client.tunnels.ensureTunnelRun.mockImplementation(async (request) => {
+      admitted = true;
+      return {
+        started: true,
+        run: {
+          tunnelId: request.tunnelId,
+          runId: request.runId,
+          mode: 'quick',
+          port: request.port,
+          url: 'https://cold.trycloudflare.com',
+          hostname: 'cold.trycloudflare.com',
+          startedAt: '2026-05-13T00:00:00.000Z'
+        }
+      };
+    });
+
+    await expect(handler.get(8080)).resolves.toMatchObject({
+      hostname: 'cold.trycloudflare.com'
+    });
+    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces OPERATION_INTERRUPTED and leaves storage empty after quick tunnel recovery exhaustion', async () => {
+    const { client, storage, handler, fences } = makeHandler();
+    client.tunnels.ensureTunnelRun.mockImplementation(async (request) => ({
+      started: true,
+      run: {
+        tunnelId: request.tunnelId,
+        runId: request.runId,
+        mode: 'quick',
+        port: request.port,
+        url: `https://${request.runId}.trycloudflare.com`,
+        hostname: `${request.runId}.trycloudflare.com`,
+        startedAt: '2026-05-13T00:00:00.000Z'
+      }
+    }));
+    let assertActiveCalls = 0;
+    fences.currentRuntime.assertActive.mockImplementation(async () => {
+      assertActiveCalls += 1;
+      if (assertActiveCalls % 2 === 0) {
+        throw new RuntimeIdentityInactiveError();
+      }
+    });
+
+    await expect(handler.get(8080)).rejects.toMatchObject({
+      name: 'OperationInterruptedError',
+      code: ErrorCode.OPERATION_INTERRUPTED,
+      context: {
+        reason: 'recovery_exhausted',
+        operation: 'tunnel.get',
+        phase: 'interrupted',
+        admitted: true,
+        retryable: false,
+        recoveryAttempts: 2,
+        maxRecoveryAttempts: 2
+      }
+    });
+
+    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(3);
+    expect(await storage.get<Record<string, TunnelInfo>>('tunnels')).toEqual(
+      {}
+    );
+  });
+});
+
+describe('TunnelsHandler public surface', () => {
+  it('does not expose any exit hook on the public interface', () => {
+    const { client } = makeClient();
+    const { tunnels, handleTunnelExit } = createTunnelsHandler({
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage: makeStorage(),
+      logger: makeLogger()
+    } as unknown as Parameters<typeof createTunnelsHandler>[0]);
+    expect(handleTunnelExit).toBeTypeOf('function');
+    expect('handleTunnelExit' in (tunnels as unknown as object)).toBe(false);
+  });
+});
+
+describe('route-based SandboxClient.tunnels placeholder', () => {
+  it('throws "RPC transport required" from any method on the proxy', async () => {
+    const { SandboxClient } = await import('../src/clients/sandbox-client');
+    const client = new SandboxClient({ baseUrl: 'http://test.invalid' });
+    expect(() =>
+      (client.tunnels as unknown as { get: () => void }).get()
+    ).toThrow(/RPC transport/);
+    expect(() =>
+      (client.tunnels as unknown as { list: () => void }).list()
+    ).toThrow(/RPC transport/);
+    expect(() =>
+      (client.tunnels as unknown as { destroy: () => void }).destroy()
+    ).toThrow(/RPC transport/);
+  });
+});
+
+describe('pruneTunnelsForRestart', () => {
+  it('drops quick-tunnel entries and marks named ones for respawn', async () => {
+    const quick = makeRecord({ id: 'quick-1', port: 8080 });
+    const named = makeRecord({
+      id: 'named-1',
+      port: 9090,
+      name: 'app',
+      hostname: 'app.example.com',
+      url: 'https://app.example.com'
+    });
+    const storage = makeStorage({ '8080': quick, '9090': named });
+    await storage.put('tunnels:meta', {
+      '8080': { optionsHash: 'v1:quick' },
+      '9090': {
+        optionsHash: 'v1:named:app',
+        dnsRecordId: 'dns-1',
+        accountId: 'acct',
+        zoneId: 'zone'
+      }
+    });
+
+    await pruneTunnelsForRestart(storage);
+
+    expect(await storage.get('tunnels')).toEqual({ '9090': named });
+    expect(await storage.get('tunnels:meta')).toEqual({
+      '9090': {
+        optionsHash: 'v1:named:app',
+        dnsRecordId: 'dns-1',
+        accountId: 'acct',
+        zoneId: 'zone',
+        needsRespawn: true
+      }
+    });
+  });
+
+  it('is a no-op on empty storage', async () => {
+    const storage = makeStorage();
+
+    await pruneTunnelsForRestart(storage);
+
+    expect(await storage.get('tunnels')).toEqual({});
+    expect(await storage.get('tunnels:meta')).toEqual({});
+  });
+});

--- a/packages/sandbox/tests/tunnels-handler.test.ts
+++ b/packages/sandbox/tests/tunnels-handler.test.ts
@@ -6,9 +6,18 @@
  * lightweight in-memory `ctx.storage` shim.
  */
 
-import type { Logger, TunnelInfo } from '@repo/shared';
+import type {
+  EnsureTunnelRunRequest,
+  EnsureTunnelRunResult,
+  Logger,
+  StopTunnelRunRequest,
+  StopTunnelRunResult,
+  TunnelInfo
+} from '@repo/shared';
 import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RuntimeIdentityInactiveError } from '../src/current-runtime-identity';
+import { ErrorCode } from '../src/errors';
 import { SandboxSecurityError } from '../src/security';
 import {
   createTunnelsHandler,
@@ -33,6 +42,12 @@ type RunQuickTunnelMock = Mock<
 >;
 type DestroyTunnelMock = Mock<(id: string) => Promise<unknown>>;
 type ListTunnelsMock = Mock<() => Promise<TunnelInfo[]>>;
+type EnsureTunnelRunMock = Mock<
+  (request: EnsureTunnelRunRequest) => Promise<EnsureTunnelRunResult>
+>;
+type StopTunnelRunMock = Mock<
+  (request: StopTunnelRunRequest) => Promise<StopTunnelRunResult>
+>;
 type StorageGetMock = Mock<(key: string) => Promise<unknown>>;
 type StoragePutMock = Mock<(key: string, next: unknown) => Promise<unknown>>;
 type StorageTransactionMock = Mock<
@@ -44,6 +59,8 @@ interface MockTunnelsClient {
   runQuickTunnel: RunQuickTunnelMock;
   destroyTunnel: DestroyTunnelMock;
   listTunnels: ListTunnelsMock;
+  ensureTunnelRun: EnsureTunnelRunMock;
+  stopTunnelRun: StopTunnelRunMock;
 }
 
 function makeClient(): { client: { tunnels: MockTunnelsClient } } {
@@ -53,7 +70,15 @@ function makeClient(): { client: { tunnels: MockTunnelsClient } } {
         runQuickTunnel:
           vi.fn<(id: string, port: number) => Promise<TunnelInfo>>(),
         destroyTunnel: vi.fn<(id: string) => Promise<unknown>>(),
-        listTunnels: vi.fn<() => Promise<TunnelInfo[]>>()
+        listTunnels: vi.fn<() => Promise<TunnelInfo[]>>(),
+        ensureTunnelRun:
+          vi.fn<
+            (request: EnsureTunnelRunRequest) => Promise<EnsureTunnelRunResult>
+          >(),
+        stopTunnelRun:
+          vi.fn<
+            (request: StopTunnelRunRequest) => Promise<StopTunnelRunResult>
+          >()
       }
     }
   };
@@ -94,6 +119,44 @@ function makeStorage(initial?: Record<string, TunnelInfo>): TunnelsStorage {
   return storage;
 }
 
+function makeRuntimeFences(runtimeId = 'runtime-1') {
+  const runtime = {
+    id: runtimeId,
+    owns: (record: { readonly runtimeIdentityID: string }) =>
+      record.runtimeIdentityID === runtimeId,
+    scope: <T extends object>(value: T) => ({
+      ...value,
+      runtimeIdentityID: runtimeId
+    })
+  };
+  const lifetime = {
+    id: 'lifetime-1',
+    generation: 1,
+    createdAt: '2026-05-13T00:00:00.000Z',
+    updatedAt: '2026-05-13T00:00:00.000Z',
+    owns: (record: { readonly sandboxLifetimeID: string }) =>
+      record.sandboxLifetimeID === 'lifetime-1',
+    scope: <T extends object>(value: T) => ({
+      ...value,
+      sandboxLifetimeID: 'lifetime-1'
+    })
+  };
+
+  return {
+    runtime,
+    lifetime,
+    currentRuntime: {
+      get: vi.fn(async () => runtime),
+      markStarted: vi.fn(async () => runtime),
+      assertActive: vi.fn(async () => {})
+    },
+    currentLifetime: {
+      getOrCreate: vi.fn(async () => lifetime),
+      assertCurrent: vi.fn(async () => {})
+    }
+  };
+}
+
 function makeRecord(overrides: Partial<TunnelInfo> = {}): TunnelInfo {
   return {
     id: 'quick-0123456789abcdef',
@@ -105,16 +168,21 @@ function makeRecord(overrides: Partial<TunnelInfo> = {}): TunnelInfo {
   };
 }
 
-function makeHandler() {
+function makeHandler(options: { withFences?: boolean } = {}) {
   const { client } = makeClient();
   const storage = makeStorage();
+  const fences = options.withFences ? makeRuntimeFences() : undefined;
   const { tunnels, handleTunnelExit } = createTunnelsHandler({
     client: client as unknown as Parameters<
       typeof createTunnelsHandler
     >[0]['client'],
     storage,
-    logger: makeLogger()
-  });
+    logger: makeLogger(),
+    ...(fences && {
+      currentRuntime: fences.currentRuntime,
+      currentLifetime: fences.currentLifetime
+    })
+  } as unknown as Parameters<typeof createTunnelsHandler>[0]);
   // `handler` alias kept for legacy test bodies; new tests should
   // reach for `tunnels` and `handleTunnelExit` directly.
   return {
@@ -122,7 +190,8 @@ function makeHandler() {
     storage,
     handler: tunnels,
     tunnels,
-    handleTunnelExit
+    handleTunnelExit,
+    fences
   };
 }
 
@@ -133,6 +202,140 @@ describe('tunnels handler > get', () => {
   });
   afterEach(() => {
     warn.mockRestore();
+  });
+
+  it('uses ensureTunnelRun and stores runtime metadata for quick tunnels', async () => {
+    const { client, storage, handler } = makeHandler({ withFences: true });
+    client.tunnels.ensureTunnelRun.mockImplementation(async (request) => ({
+      started: true,
+      run: {
+        tunnelId: request.tunnelId,
+        runId: request.runId,
+        mode: 'quick',
+        port: request.port,
+        url: 'https://fresh.trycloudflare.com',
+        hostname: 'fresh.trycloudflare.com',
+        startedAt: '2026-05-13T00:00:00.000Z'
+      }
+    }));
+
+    const info = await handler.get(8080);
+
+    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(1);
+    expect(client.tunnels.runQuickTunnel).not.toHaveBeenCalled();
+    const request = client.tunnels.ensureTunnelRun.mock.calls[0][0];
+    expect(request).toMatchObject({ mode: 'quick', port: 8080 });
+    expect(request.tunnelId).toMatch(/^quick-/);
+    expect(request.runId).toMatch(/^run-/);
+    expect(info).toMatchObject({
+      id: request.tunnelId,
+      port: 8080,
+      url: 'https://fresh.trycloudflare.com',
+      hostname: 'fresh.trycloudflare.com'
+    });
+    const meta = await storage.get<Record<string, unknown>>('tunnels:meta');
+    expect(meta?.['8080']).toMatchObject({
+      optionsHash: 'v1:quick',
+      runtimeIdentityID: 'runtime-1',
+      sandboxLifetimeID: 'lifetime-1',
+      tunnelRunId: request.runId
+    });
+  });
+
+  it('retries quick tunnel provisioning when runtime replacement is detected before commit', async () => {
+    const { client, storage, handler, fences } = makeHandler({
+      withFences: true
+    });
+    client.tunnels.ensureTunnelRun.mockImplementation(async (request) => ({
+      started: true,
+      run: {
+        tunnelId: request.tunnelId,
+        runId: request.runId,
+        mode: 'quick',
+        port: request.port,
+        url: `https://${request.runId}.trycloudflare.com`,
+        hostname: `${request.runId}.trycloudflare.com`,
+        startedAt: '2026-05-13T00:00:00.000Z'
+      }
+    }));
+    fences?.currentRuntime.assertActive
+      .mockRejectedValueOnce(new RuntimeIdentityInactiveError())
+      .mockResolvedValue(undefined);
+
+    const info = await handler.get(8080);
+
+    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(2);
+    const secondRunId = client.tunnels.ensureTunnelRun.mock.calls[1][0].runId;
+    expect(info.hostname).toBe(`${secondRunId}.trycloudflare.com`);
+    const stored = await storage.get<Record<string, TunnelInfo>>('tunnels');
+    expect(stored?.['8080']).toEqual(info);
+  });
+
+  it('surfaces OPERATION_INTERRUPTED and leaves storage empty after quick tunnel recovery exhaustion', async () => {
+    const { client, storage, handler, fences } = makeHandler({
+      withFences: true
+    });
+    client.tunnels.ensureTunnelRun.mockImplementation(async (request) => ({
+      started: true,
+      run: {
+        tunnelId: request.tunnelId,
+        runId: request.runId,
+        mode: 'quick',
+        port: request.port,
+        url: `https://${request.runId}.trycloudflare.com`,
+        hostname: `${request.runId}.trycloudflare.com`,
+        startedAt: '2026-05-13T00:00:00.000Z'
+      }
+    }));
+    fences?.currentRuntime.assertActive.mockRejectedValue(
+      new RuntimeIdentityInactiveError()
+    );
+
+    await expect(handler.get(8080)).rejects.toMatchObject({
+      name: 'OperationInterruptedError',
+      code: ErrorCode.OPERATION_INTERRUPTED,
+      context: {
+        reason: 'recovery_exhausted',
+        operation: 'tunnel.get',
+        phase: 'interrupted',
+        admitted: 'unknown',
+        retryable: false,
+        recoveryAttempts: 2,
+        maxRecoveryAttempts: 2
+      }
+    });
+
+    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(3);
+    expect(await storage.get<Record<string, TunnelInfo>>('tunnels')).toEqual(
+      {}
+    );
+  });
+
+  it('ignores stale tunnel exit callbacks whose run id does not match storage metadata', async () => {
+    const record = makeRecord({ id: 'quick-current', port: 8080 });
+    const storage = makeStorage({ '8080': record });
+    await storage.put('tunnels:meta', {
+      '8080': {
+        optionsHash: 'v1:quick',
+        runtimeIdentityID: 'runtime-1',
+        sandboxLifetimeID: 'lifetime-1',
+        tunnelRunId: 'run-current'
+      }
+    });
+    const { client } = makeClient();
+    const { handleTunnelExit } = createTunnelsHandler({
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage,
+      logger: makeLogger()
+    });
+
+    await handleTunnelExit('quick-current', 8080, 0, 'run-old');
+
+    expect(await storage.get<Record<string, TunnelInfo>>('tunnels')).toEqual({
+      '8080': record
+    });
   });
 
   it('mints a `quick-<8 hex>` id and forwards it to the RPC client on cache miss', async () => {
@@ -369,6 +572,36 @@ describe('tunnels handler > destroy', () => {
     const metaPut = putCalls.find(([key]) => key === 'tunnels:meta');
     expect(tunnelsPut?.[1]).toEqual({});
     expect(metaPut?.[1]).toEqual({});
+  });
+
+  it('calls stopTunnelRun with the exact run ref when runtime metadata exists', async () => {
+    const record = makeRecord({ id: 'quick-runref', port: 8080 });
+    const { client } = makeClient();
+    const storage = makeStorage({ '8080': record });
+    await storage.put('tunnels:meta', {
+      '8080': {
+        optionsHash: 'v1:quick',
+        runtimeIdentityID: 'runtime-1',
+        sandboxLifetimeID: 'lifetime-1',
+        tunnelRunId: 'run-1'
+      }
+    });
+    const { tunnels: handler } = createTunnelsHandler({
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage,
+      logger: makeLogger()
+    });
+    client.tunnels.stopTunnelRun.mockResolvedValue({ stopped: true });
+
+    await handler.destroy(8080);
+
+    expect(client.tunnels.stopTunnelRun).toHaveBeenCalledWith({
+      tunnelId: record.id,
+      runId: 'run-1'
+    });
+    expect(client.tunnels.destroyTunnel).not.toHaveBeenCalled();
   });
 
   it('wraps the read-modify-write in storage.transaction()', async () => {

--- a/packages/sandbox/tests/tunnels-handler.test.ts
+++ b/packages/sandbox/tests/tunnels-handler.test.ts
@@ -17,7 +17,7 @@ import type {
 import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { RuntimeIdentityInactiveError } from '../src/current-runtime-identity';
-import { ErrorCode } from '../src/errors';
+import { ErrorCode, RPCTransportError } from '../src/errors';
 import { SandboxSecurityError } from '../src/security';
 import {
   createTunnelsHandler,
@@ -146,7 +146,7 @@ function makeRuntimeFences(runtimeId = 'runtime-1') {
     runtime,
     lifetime,
     currentRuntime: {
-      get: vi.fn(async () => runtime),
+      get: vi.fn<() => Promise<typeof runtime | null>>(async () => runtime),
       markStarted: vi.fn(async () => runtime),
       assertActive: vi.fn(async (_runtime: typeof runtime) => {})
     },
@@ -166,6 +166,20 @@ function makeRecord(overrides: Partial<TunnelInfo> = {}): TunnelInfo {
     createdAt: '2026-05-13T00:00:00.000Z',
     ...overrides
   };
+}
+
+function createDisposedRPCError(): RPCTransportError {
+  return new RPCTransportError({
+    code: ErrorCode.RPC_TRANSPORT_ERROR,
+    message: 'RPC session was shut down by disposing the main stub',
+    httpStatus: 503,
+    context: {
+      kind: 'session_disposed',
+      originalMessage: 'RPC session was shut down by disposing the main stub',
+      errorName: 'Error'
+    },
+    timestamp: '2026-05-13T00:00:00.000Z'
+  });
 }
 
 function makeHandler(options: { withFences?: boolean } = {}) {
@@ -202,172 +216,6 @@ describe('tunnels handler > get', () => {
   });
   afterEach(() => {
     warn.mockRestore();
-  });
-
-  it('uses ensureTunnelRun and stores runtime metadata for quick tunnels', async () => {
-    const { client, storage, handler } = makeHandler({ withFences: true });
-    client.tunnels.ensureTunnelRun.mockImplementation(async (request) => ({
-      started: true,
-      run: {
-        tunnelId: request.tunnelId,
-        runId: request.runId,
-        mode: 'quick',
-        port: request.port,
-        url: 'https://fresh.trycloudflare.com',
-        hostname: 'fresh.trycloudflare.com',
-        startedAt: '2026-05-13T00:00:00.000Z'
-      }
-    }));
-
-    const info = await handler.get(8080);
-
-    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(1);
-    expect(client.tunnels.runQuickTunnel).not.toHaveBeenCalled();
-    const request = client.tunnels.ensureTunnelRun.mock.calls[0][0];
-    expect(request).toMatchObject({ mode: 'quick', port: 8080 });
-    expect(request.tunnelId).toMatch(/^quick-/);
-    expect(request.runId).toMatch(/^run-/);
-    expect(info).toMatchObject({
-      id: request.tunnelId,
-      port: 8080,
-      url: 'https://fresh.trycloudflare.com',
-      hostname: 'fresh.trycloudflare.com'
-    });
-    const meta = await storage.get<Record<string, unknown>>('tunnels:meta');
-    expect(meta?.['8080']).toMatchObject({
-      optionsHash: 'v1:quick',
-      runtimeIdentityID: 'runtime-1',
-      sandboxLifetimeID: 'lifetime-1',
-      tunnelRunId: request.runId
-    });
-  });
-
-  it('retries quick tunnel provisioning when runtime replacement is detected before commit', async () => {
-    const { client, storage, handler, fences } = makeHandler({
-      withFences: true
-    });
-    client.tunnels.ensureTunnelRun.mockImplementation(async (request) => ({
-      started: true,
-      run: {
-        tunnelId: request.tunnelId,
-        runId: request.runId,
-        mode: 'quick',
-        port: request.port,
-        url: `https://${request.runId}.trycloudflare.com`,
-        hostname: `${request.runId}.trycloudflare.com`,
-        startedAt: '2026-05-13T00:00:00.000Z'
-      }
-    }));
-    fences?.currentRuntime.assertActive
-      .mockResolvedValueOnce(undefined)
-      .mockRejectedValueOnce(new RuntimeIdentityInactiveError())
-      .mockResolvedValue(undefined);
-
-    const info = await handler.get(8080);
-
-    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(2);
-    const secondRunId = client.tunnels.ensureTunnelRun.mock.calls[1][0].runId;
-    expect(info.hostname).toBe(`${secondRunId}.trycloudflare.com`);
-    const stored = await storage.get<Record<string, TunnelInfo>>('tunnels');
-    expect(stored?.['8080']).toEqual(info);
-  });
-
-  it('captures runtime before quick tunnel admission so a replacement during spawn retries', async () => {
-    const { client, storage, handler, fences } = makeHandler({
-      withFences: true
-    });
-    let activeRuntimeId = 'runtime-1';
-    const makeRuntime = (id: string) => ({
-      id,
-      owns: (record: { readonly runtimeIdentityID: string }) =>
-        record.runtimeIdentityID === id,
-      scope: <T extends object>(value: T) => ({
-        ...value,
-        runtimeIdentityID: id
-      })
-    });
-    fences?.currentRuntime.get.mockImplementation(async () =>
-      makeRuntime(activeRuntimeId)
-    );
-    fences?.currentRuntime.assertActive.mockImplementation(async (runtime) => {
-      if (runtime.id !== activeRuntimeId) {
-        throw new RuntimeIdentityInactiveError();
-      }
-    });
-    client.tunnels.ensureTunnelRun.mockImplementation(async (request) => {
-      if (client.tunnels.ensureTunnelRun.mock.calls.length === 1) {
-        activeRuntimeId = 'runtime-2';
-      }
-      return {
-        started: true,
-        run: {
-          tunnelId: request.tunnelId,
-          runId: request.runId,
-          mode: 'quick',
-          port: request.port,
-          url: `https://${request.runId}.trycloudflare.com`,
-          hostname: `${request.runId}.trycloudflare.com`,
-          startedAt: '2026-05-13T00:00:00.000Z'
-        }
-      };
-    });
-
-    const info = await handler.get(8080);
-
-    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(2);
-    const staleRunId = client.tunnels.ensureTunnelRun.mock.calls[0][0].runId;
-    const currentRunId = client.tunnels.ensureTunnelRun.mock.calls[1][0].runId;
-    expect(info.hostname).toBe(`${currentRunId}.trycloudflare.com`);
-    expect(info.hostname).not.toBe(`${staleRunId}.trycloudflare.com`);
-    const meta =
-      await storage.get<Record<string, { runtimeIdentityID: string }>>(
-        'tunnels:meta'
-      );
-    expect(meta?.['8080'].runtimeIdentityID).toBe('runtime-2');
-  });
-
-  it('surfaces OPERATION_INTERRUPTED and leaves storage empty after quick tunnel recovery exhaustion', async () => {
-    const { client, storage, handler, fences } = makeHandler({
-      withFences: true
-    });
-    client.tunnels.ensureTunnelRun.mockImplementation(async (request) => ({
-      started: true,
-      run: {
-        tunnelId: request.tunnelId,
-        runId: request.runId,
-        mode: 'quick',
-        port: request.port,
-        url: `https://${request.runId}.trycloudflare.com`,
-        hostname: `${request.runId}.trycloudflare.com`,
-        startedAt: '2026-05-13T00:00:00.000Z'
-      }
-    }));
-    let assertActiveCalls = 0;
-    fences?.currentRuntime.assertActive.mockImplementation(async () => {
-      assertActiveCalls += 1;
-      if (assertActiveCalls % 2 === 0) {
-        throw new RuntimeIdentityInactiveError();
-      }
-    });
-
-    await expect(handler.get(8080)).rejects.toMatchObject({
-      name: 'OperationInterruptedError',
-      code: ErrorCode.OPERATION_INTERRUPTED,
-      context: {
-        reason: 'recovery_exhausted',
-        operation: 'tunnel.get',
-        phase: 'interrupted',
-        admitted: 'unknown',
-        retryable: false,
-        recoveryAttempts: 2,
-        maxRecoveryAttempts: 2
-      }
-    });
-
-    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(3);
-    expect(await storage.get<Record<string, TunnelInfo>>('tunnels')).toEqual(
-      {}
-    );
   });
 
   it('ignores stale tunnel exit callbacks whose run id does not match storage metadata', async () => {
@@ -1132,83 +980,5 @@ describe('tunnels handler > handleTunnelExit', () => {
       String(msg).includes('tunnel.exit')
     );
     expect(eventCall).toBeDefined();
-  });
-});
-
-describe('TunnelsHandler public surface', () => {
-  it('does not expose any exit hook on the public interface', () => {
-    // Compile-time guard: if a future change adds a method to
-    // TunnelsHandler beyond get/list/destroy, this assertion fails
-    // and the developer has to consciously update the allowlist.
-    type AllowedKeys = 'get' | 'list' | 'destroy';
-    type _Check = keyof TunnelsHandler extends AllowedKeys ? true : false;
-    const ok: _Check = true;
-    expect(ok).toBe(true);
-  });
-});
-
-describe('route-based SandboxClient.tunnels placeholder', () => {
-  it('throws "RPC transport required" from any method on the proxy', async () => {
-    const { SandboxClient } = await import('../src/clients/sandbox-client');
-    const client = new SandboxClient({ baseUrl: 'http://test.invalid' });
-    expect(() =>
-      (client.tunnels as unknown as { get: () => void }).get()
-    ).toThrow(/RPC transport/);
-    expect(() =>
-      (client.tunnels as unknown as { list: () => void }).list()
-    ).toThrow(/RPC transport/);
-    expect(() =>
-      (client.tunnels as unknown as { destroy: () => void }).destroy()
-    ).toThrow(/RPC transport/);
-  });
-});
-
-describe('pruneTunnelsForRestart', () => {
-  it('drops quick-tunnel entries and marks named ones for respawn', async () => {
-    const storage = makeStorage();
-    await (storage.put as StoragePutMock)('tunnels', {
-      '8080': {
-        id: 'quick-abc',
-        port: 8080,
-        url: 'https://x.trycloudflare.com',
-        hostname: 'x.trycloudflare.com',
-        createdAt: '2024-01-01T00:00:00.000Z'
-      },
-      '8081': {
-        id: 'uuid-1',
-        port: 8081,
-        name: 'app',
-        hostname: 'app.example.com',
-        url: 'https://app.example.com',
-        createdAt: '2024-01-01T00:00:00.000Z'
-      }
-    });
-    await (storage.put as StoragePutMock)('tunnels:meta', {
-      '8080': { optionsHash: 'quick' },
-      '8081': { optionsHash: 'named:app', dnsRecordId: 'rec-1' }
-    });
-
-    await pruneTunnelsForRestart(storage);
-
-    const nextTunnels = (await (storage.get as StorageGetMock)(
-      'tunnels'
-    )) as Record<string, { name?: string }>;
-    const nextMeta = (await (storage.get as StorageGetMock)(
-      'tunnels:meta'
-    )) as Record<string, { needsRespawn?: boolean; dnsRecordId?: string }>;
-    expect(Object.keys(nextTunnels)).toEqual(['8081']);
-    expect(nextMeta['8081']?.needsRespawn).toBe(true);
-    // dnsRecordId is preserved so destroy() can still clean up.
-    expect(nextMeta['8081']?.dnsRecordId).toBe('rec-1');
-    expect(nextMeta['8080']).toBeUndefined();
-  });
-
-  it('is a no-op on empty storage', async () => {
-    const storage = makeStorage();
-    await pruneTunnelsForRestart(storage);
-    const nextTunnels = (await (storage.get as StorageGetMock)(
-      'tunnels'
-    )) as Record<string, unknown>;
-    expect(nextTunnels).toEqual({});
   });
 });

--- a/packages/sandbox/tests/tunnels-handler.test.ts
+++ b/packages/sandbox/tests/tunnels-handler.test.ts
@@ -148,7 +148,7 @@ function makeRuntimeFences(runtimeId = 'runtime-1') {
     currentRuntime: {
       get: vi.fn(async () => runtime),
       markStarted: vi.fn(async () => runtime),
-      assertActive: vi.fn(async () => {})
+      assertActive: vi.fn(async (_runtime: typeof runtime) => {})
     },
     currentLifetime: {
       getOrCreate: vi.fn(async () => lifetime),
@@ -259,6 +259,7 @@ describe('tunnels handler > get', () => {
       }
     }));
     fences?.currentRuntime.assertActive
+      .mockResolvedValueOnce(undefined)
       .mockRejectedValueOnce(new RuntimeIdentityInactiveError())
       .mockResolvedValue(undefined);
 
@@ -269,6 +270,60 @@ describe('tunnels handler > get', () => {
     expect(info.hostname).toBe(`${secondRunId}.trycloudflare.com`);
     const stored = await storage.get<Record<string, TunnelInfo>>('tunnels');
     expect(stored?.['8080']).toEqual(info);
+  });
+
+  it('captures runtime before quick tunnel admission so a replacement during spawn retries', async () => {
+    const { client, storage, handler, fences } = makeHandler({
+      withFences: true
+    });
+    let activeRuntimeId = 'runtime-1';
+    const makeRuntime = (id: string) => ({
+      id,
+      owns: (record: { readonly runtimeIdentityID: string }) =>
+        record.runtimeIdentityID === id,
+      scope: <T extends object>(value: T) => ({
+        ...value,
+        runtimeIdentityID: id
+      })
+    });
+    fences?.currentRuntime.get.mockImplementation(async () =>
+      makeRuntime(activeRuntimeId)
+    );
+    fences?.currentRuntime.assertActive.mockImplementation(async (runtime) => {
+      if (runtime.id !== activeRuntimeId) {
+        throw new RuntimeIdentityInactiveError();
+      }
+    });
+    client.tunnels.ensureTunnelRun.mockImplementation(async (request) => {
+      if (client.tunnels.ensureTunnelRun.mock.calls.length === 1) {
+        activeRuntimeId = 'runtime-2';
+      }
+      return {
+        started: true,
+        run: {
+          tunnelId: request.tunnelId,
+          runId: request.runId,
+          mode: 'quick',
+          port: request.port,
+          url: `https://${request.runId}.trycloudflare.com`,
+          hostname: `${request.runId}.trycloudflare.com`,
+          startedAt: '2026-05-13T00:00:00.000Z'
+        }
+      };
+    });
+
+    const info = await handler.get(8080);
+
+    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(2);
+    const staleRunId = client.tunnels.ensureTunnelRun.mock.calls[0][0].runId;
+    const currentRunId = client.tunnels.ensureTunnelRun.mock.calls[1][0].runId;
+    expect(info.hostname).toBe(`${currentRunId}.trycloudflare.com`);
+    expect(info.hostname).not.toBe(`${staleRunId}.trycloudflare.com`);
+    const meta =
+      await storage.get<Record<string, { runtimeIdentityID: string }>>(
+        'tunnels:meta'
+      );
+    expect(meta?.['8080'].runtimeIdentityID).toBe('runtime-2');
   });
 
   it('surfaces OPERATION_INTERRUPTED and leaves storage empty after quick tunnel recovery exhaustion', async () => {
@@ -287,9 +342,13 @@ describe('tunnels handler > get', () => {
         startedAt: '2026-05-13T00:00:00.000Z'
       }
     }));
-    fences?.currentRuntime.assertActive.mockRejectedValue(
-      new RuntimeIdentityInactiveError()
-    );
+    let assertActiveCalls = 0;
+    fences?.currentRuntime.assertActive.mockImplementation(async () => {
+      assertActiveCalls += 1;
+      if (assertActiveCalls % 2 === 0) {
+        throw new RuntimeIdentityInactiveError();
+      }
+    });
 
     await expect(handler.get(8080)).rejects.toMatchObject({
       name: 'OperationInterruptedError',

--- a/packages/shared/src/errors/codes.ts
+++ b/packages/shared/src/errors/codes.ts
@@ -147,7 +147,12 @@ export const ErrorCode = {
   // mid-call (peer close), the WebSocket failed before/after upgrade, the
   // peer sent a frame the transport cannot handle, or the session was
   // disposed while a call was in flight.
-  RPC_TRANSPORT_ERROR: 'RPC_TRANSPORT_ERROR'
+  RPC_TRANSPORT_ERROR: 'RPC_TRANSPORT_ERROR',
+
+  // Container Availability Errors (503) — raised when the sandbox container
+  // is not yet ready to accept requests or was replaced while a connection
+  // attempt was in progress. Always retryable from the caller's perspective.
+  CONTAINER_UNAVAILABLE: 'CONTAINER_UNAVAILABLE'
 } as const;
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/packages/shared/src/errors/codes.ts
+++ b/packages/shared/src/errors/codes.ts
@@ -152,7 +152,13 @@ export const ErrorCode = {
   // Container Availability Errors (503) — raised when the sandbox container
   // is not yet ready to accept requests or was replaced while a connection
   // attempt was in progress. Always retryable from the caller's perspective.
-  CONTAINER_UNAVAILABLE: 'CONTAINER_UNAVAILABLE'
+  CONTAINER_UNAVAILABLE: 'CONTAINER_UNAVAILABLE',
+
+  // Operation Lifecycle Errors (409) — raised when a sandbox-owned operation
+  // (e.g. backup restore) was interrupted by a runtime replacement or sandbox
+  // lifetime change after the operation had already been admitted. The caller
+  // should retry the full operation from the beginning.
+  OPERATION_INTERRUPTED: 'OPERATION_INTERRUPTED'
 } as const;
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/packages/shared/src/errors/contexts.ts
+++ b/packages/shared/src/errors/contexts.ts
@@ -241,6 +241,31 @@ export interface InternalErrorContext {
 }
 
 /**
+ * Container availability error context. Surfaced when the sandbox container
+ * cannot accept the incoming RPC connection. The container may be starting
+ * up, undergoing a runtime replacement, or temporarily unhealthy. The
+ * caller should retry the same operation.
+ */
+export interface ContainerUnavailableContext {
+  /**
+   * Categorical reason distinguishing startup unavailability from runtime
+   * replacement and exhausted upgrade retries.
+   */
+  reason:
+    | 'container_starting'
+    | 'container_unhealthy'
+    | 'container_replaced'
+    | 'rpc_upgrade_failed';
+  /**
+   * Always true — this error represents a transient unavailability, not a
+   * permanent failure. Callers should retry the same operation.
+   */
+  retryable: true;
+  /** Suggested delay in milliseconds before the next retry attempt. */
+  retryAfterMs?: number;
+}
+
+/**
  * RPC transport error contexts. Surfaced when the capnweb WebSocket session
  * fails on the SDK side rather than the container reporting a structured
  * error. Always retryable — the next call will open a fresh connection.

--- a/packages/shared/src/errors/contexts.ts
+++ b/packages/shared/src/errors/contexts.ts
@@ -302,3 +302,50 @@ export interface RPCTransportContext {
   /** WebSocket close reason, when available (kind === 'peer_closed'). */
   closeReason?: string;
 }
+
+/**
+ * Reason a sandbox-owned operation was interrupted. Callers may branch on
+ * this to decide whether to retry the full operation.
+ */
+export type OperationInterruptedReason =
+  /** The container runtime was replaced while the operation was in progress. */
+  | 'runtime_replaced'
+  /** The RPC session was disposed mid-operation. */
+  | 'transport_disposed'
+  /** The sandbox lifetime changed (destroy() was called). Not retryable. */
+  | 'sandbox_lifetime_changed'
+  /** Internal recovery attempts were exhausted. Not retryable. */
+  | 'recovery_exhausted';
+
+/**
+ * Operation interruption context. Surfaced when a sandbox-owned operation
+ * (such as backup restore) was interrupted by a runtime replacement or
+ * sandbox lifetime change. Public-safe: does not include internal ids.
+ */
+export interface OperationInterruptedContext {
+  /**
+   * Categorical reason. Use `retryable` to decide whether to retry rather
+   * than branching on the reason string.
+   */
+  reason: OperationInterruptedReason;
+  /** Name of the operation that was interrupted (e.g. 'backup.restore'). */
+  operation: string;
+  /** Lifecycle phase at which the interruption was detected. */
+  phase: string;
+  /**
+   * Whether the operation's container-local side effects reached the runtime.
+   * `false` means the operation was interrupted before admission; `true`
+   * means effects were committed; `'unknown'` means the operation may or may
+   * not have committed.
+   */
+  admitted: boolean | 'unknown';
+  /**
+   * Whether the caller can safely retry the full operation from the beginning.
+   * `sandbox_lifetime_changed` and `recovery_exhausted` set this to false.
+   */
+  retryable: boolean;
+  /** Number of internal recovery attempts made before surfacing this error. */
+  recoveryAttempts?: number;
+  /** Maximum number of internal recovery attempts allowed. */
+  maxRecoveryAttempts?: number;
+}

--- a/packages/shared/src/errors/index.ts
+++ b/packages/shared/src/errors/index.ts
@@ -41,6 +41,7 @@ export type {
   CodeExecutionContext,
   CommandErrorContext,
   CommandNotFoundContext,
+  ContainerUnavailableContext,
   ContextNotFoundContext,
   FileExistsContext,
   FileNotFoundContext,

--- a/packages/shared/src/errors/index.ts
+++ b/packages/shared/src/errors/index.ts
@@ -58,6 +58,8 @@ export type {
   InvalidPortContext,
   MissingCredentialsContext,
   OpencodeStartupContext,
+  OperationInterruptedContext,
+  OperationInterruptedReason,
   PortAlreadyExposedContext,
   PortErrorContext,
   PortNotExposedContext,

--- a/packages/shared/src/errors/status-map.ts
+++ b/packages/shared/src/errors/status-map.ts
@@ -44,6 +44,7 @@ export const ERROR_STATUS_MAP: Record<ErrorCode, number> = {
   [ErrorCode.PORT_IN_USE]: 409,
   [ErrorCode.RESOURCE_BUSY]: 409,
   [ErrorCode.SESSION_ALREADY_EXISTS]: 409,
+  [ErrorCode.OPERATION_INTERRUPTED]: 409,
 
   // 410 Gone
   [ErrorCode.SESSION_DESTROYED]: 410,

--- a/packages/shared/src/errors/status-map.ts
+++ b/packages/shared/src/errors/status-map.ts
@@ -71,6 +71,7 @@ export const ERROR_STATUS_MAP: Record<ErrorCode, number> = {
   [ErrorCode.INTERPRETER_NOT_READY]: 503,
   [ErrorCode.OPENCODE_STARTUP_FAILED]: 503,
   [ErrorCode.RPC_TRANSPORT_ERROR]: 503,
+  [ErrorCode.CONTAINER_UNAVAILABLE]: 503,
 
   // 408 Request Timeout
   [ErrorCode.PROCESS_READY_TIMEOUT]: 408,

--- a/packages/shared/src/errors/suggestions.ts
+++ b/packages/shared/src/errors/suggestions.ts
@@ -98,6 +98,9 @@ export function getSuggestion(
     case ErrorCode.BACKUP_RESTORE_FAILED:
       return 'Backup restoration failed. The archive may be corrupted or the target directory may be in use';
 
+    case ErrorCode.CONTAINER_UNAVAILABLE:
+      return 'The sandbox container is temporarily unavailable. Retry the same operation — it will succeed once the container is ready.';
+
     case ErrorCode.RPC_TRANSPORT_ERROR: {
       const kind = context.kind as string | undefined;
       switch (kind) {

--- a/packages/shared/src/errors/suggestions.ts
+++ b/packages/shared/src/errors/suggestions.ts
@@ -101,6 +101,9 @@ export function getSuggestion(
     case ErrorCode.CONTAINER_UNAVAILABLE:
       return 'The sandbox container is temporarily unavailable. Retry the same operation — it will succeed once the container is ready.';
 
+    case ErrorCode.OPERATION_INTERRUPTED:
+      return 'The operation was interrupted by a sandbox runtime change. Retry the full operation from the beginning.';
+
     case ErrorCode.RPC_TRANSPORT_ERROR: {
       const kind = context.kind as string | undefined;
       switch (kind) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -80,6 +80,10 @@ export type {
 } from './request-types.js';
 // RPC interface types (shared between SDK and container)
 export type {
+  EnsureNamedTunnelRunRequest,
+  EnsureQuickTunnelRunRequest,
+  EnsureTunnelRunRequest,
+  EnsureTunnelRunResult,
   NamedTunnelInfo,
   QuickTunnelInfo,
   SandboxAPI,
@@ -94,8 +98,13 @@ export type {
   SandboxTunnelsAPI,
   SandboxUtilsAPI,
   SandboxWatchAPI,
+  StopTunnelRunRequest,
+  StopTunnelRunResult,
   TunnelInfo,
-  TunnelOptions
+  TunnelOptions,
+  TunnelRunIdentity,
+  TunnelRunMode,
+  TunnelRunSnapshot
 } from './rpc-types.js';
 // Export shell utilities
 export { shellEscape } from './shell-escape.js';

--- a/packages/shared/src/rpc-types.ts
+++ b/packages/shared/src/rpc-types.ts
@@ -297,6 +297,78 @@ export interface TunnelOptions {
   name?: string;
 }
 
+// ---------------------------------------------------------------------------
+// Runtime-run tunnel control types
+// ---------------------------------------------------------------------------
+
+/**
+ * Stable logical identity for a single cloudflared process run.
+ * `tunnelId` is SDK-issued; `runId` is a per-run nonce minted by the SDK
+ * to support idempotent admission and stale-callback fencing.
+ */
+export interface TunnelRunIdentity {
+  tunnelId: string;
+  runId: string;
+}
+
+/** Discriminator for quick vs. named cloudflared modes. */
+export type TunnelRunMode = 'quick' | 'named';
+
+/** Request to start or replay a quick tunnel run. */
+export interface EnsureQuickTunnelRunRequest {
+  tunnelId: string;
+  runId: string;
+  mode: 'quick';
+  port: number;
+}
+
+/**
+ * Request to start or replay a named tunnel run.
+ * `token` is named-mode only and must never be persisted or logged.
+ */
+export interface EnsureNamedTunnelRunRequest {
+  tunnelId: string;
+  runId: string;
+  mode: 'named';
+  port: number;
+  /** Opaque Cloudflare tunnel token. Never logged or stored. */
+  token: string;
+}
+
+export type EnsureTunnelRunRequest =
+  | EnsureQuickTunnelRunRequest
+  | EnsureNamedTunnelRunRequest;
+
+/**
+ * Runtime-local snapshot of a running cloudflared process.
+ * Quick tunnels carry `url` and `hostname`; named tunnels leave them absent
+ * because the SDK owns the hostname via the Cloudflare API.
+ */
+export interface TunnelRunSnapshot {
+  tunnelId: string;
+  runId: string;
+  mode: TunnelRunMode;
+  port: number;
+  /** Public URL for quick tunnels (absent on named). */
+  url?: string;
+  /** Hostname portion of `url` for quick tunnels (absent on named). */
+  hostname?: string;
+  startedAt: string;
+}
+
+export interface EnsureTunnelRunResult {
+  run: TunnelRunSnapshot;
+  /** `true` when this call spawned the process; `false` on idempotent replay. */
+  started: boolean;
+}
+
+export type StopTunnelRunRequest = TunnelRunIdentity;
+
+export interface StopTunnelRunResult {
+  /** `true` when the exact run was found and stopped; `false` otherwise. */
+  stopped: boolean;
+}
+
 export interface SandboxTunnelsAPI {
   /** Spawn `cloudflared tunnel --url`. No credentials required. */
   runQuickTunnel(id: string, port: number): Promise<TunnelInfo>;
@@ -316,6 +388,21 @@ export interface SandboxTunnelsAPI {
   destroyTunnel(id: string): Promise<{ success: true; id: string }>;
   /** List tunnels currently running inside the container. */
   listTunnels(): Promise<TunnelInfo[]>;
+  /**
+   * Start or replay a cloudflared process run identified by `(tunnelId, runId)`.
+   * Same `runId` with same params is idempotent (`started: false`).
+   * Same `runId` with different params, or a different active run on the
+   * same port or tunnelId, returns a `TUNNEL_RUN_CONFLICT` error.
+   */
+  ensureTunnelRun(
+    request: EnsureTunnelRunRequest
+  ): Promise<EnsureTunnelRunResult>;
+  /**
+   * Stop the cloudflared process identified by the exact `(tunnelId, runId)` pair.
+   * Returns `{ stopped: true }` when the run was found and stopped;
+   * `{ stopped: false }` when no matching run is active (service success).
+   */
+  stopTunnelRun(request: StopTunnelRunRequest): Promise<StopTunnelRunResult>;
 }
 
 /**
@@ -337,6 +424,7 @@ export interface SandboxControlCallback {
   onTunnelExit(
     id: string,
     port: number,
-    exitCode: number | null
+    exitCode: number | null,
+    runId?: string
   ): Promise<void>;
 }


### PR DESCRIPTION
The Cloudflare runtime can replace a sandbox's container while SDK-owned work is in flight — most often during a deployment rollout (see #158). When that happens on the stable line today, in-flight operations surface raw transport failures: `createDir(...)` and other setup calls fail with `RPCTransportError: RPC session was shut down by disposing the main stub`, `restoreBackup()` returns a generic 500, and `tunnels.get()` can hand back a URL that no longer routes. These are the same failures we see intermittently in CI, and they affect users on the latest release now.

The proper fixes for this live on `next` (#763 backup, #776 tunnels), but they build on the beta transport removal and large backup/tunnel decompositions and won't reach `main` for several weeks. This PR ports the *behavior* of those fixes to the stable line as a surgical hotfix, reusing the same public names and durable concepts (`CONTAINER_UNAVAILABLE`, `OPERATION_INTERRUPTED`, runtime-identity fencing, tunnel `runId`) so the eventual `next` → `main` merge reconciles concepts rather than fighting stable-only terminology.

## Behavior changes

- **Container not yet ready vs. interrupted mid-operation are now distinct.** A failed `/rpc` upgrade discards the poisoned connection, preserves locally-raised SDK errors, and surfaces a retryable `CONTAINER_UNAVAILABLE` (503) once bounded upgrade retries are exhausted. This covers the file-watch / `createDir` setup failures seen during rollout.
- **`restoreBackup()` recovers from runtime replacement.** Restore is fenced by sandbox lifetime and runtime identity and retried boundedly when the runtime is replaced mid-restore. Recovery exhaustion surfaces as `OPERATION_INTERRUPTED` (409) instead of a generic 500.
- **`tunnels.get(port)` returns a usable quick tunnel after replacement.** Quick-tunnel provisioning is now idempotent across retries, and `tunnels.list()` no longer returns quick URLs known to be stale after restart reconciliation.

No public method signatures change. The new errors and a few tunnel run types are additive exports.

## Scope and what this deliberately does not do

This is a hotfix, not the `next` architecture. To stay stable-safe it keeps the existing files in place: recovery lands in `sandbox.ts` and `tunnels-handler.ts` rather than extracting a `BackupService` or splitting the tunnel subsystem into service/provisioner/rpc-target modules. Recovery is bounded (at most two retry attempts) and scoped to SDK-owned operations — there are no blanket retries around `exec()`, writes, renames, or other user operations that may have side effects. Operations are not retried across `destroy()` or a sandbox lifetime change.

One known limitation: named-tunnel durable cleanup intent (Track B on `next`) is out of scope here; this hotfix does not regress current stable named-tunnel behavior but also does not add the stronger cleanup guarantees landing on `next`.
