### PR TITLE
Recover stable backup restores

### DIFF
--- a/.changeset/stable-backup-restore-recovery.md
+++ b/.changeset/stable-backup-restore-recovery.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Recover `restoreBackup()` when the sandbox runtime is replaced mid-restore. Restore is fenced by sandbox lifetime and runtime identity and retried boundedly when the runtime changes during the operation; if recovery is exhausted it surfaces as a structured `OPERATION_INTERRUPTED` error instead of a generic 500. Restores are not retried across `destroy()`.

--- a/.changeset/stable-backup-restore-recovery.md
+++ b/.changeset/stable-backup-restore-recovery.md
@@ -2,4 +2,4 @@
 '@cloudflare/sandbox': patch
 ---
 
-Recover `restoreBackup()` when the sandbox runtime is replaced mid-restore. Restore is fenced by sandbox lifetime and runtime identity and retried boundedly when the runtime changes during the operation; if recovery is exhausted it surfaces as a structured `OPERATION_INTERRUPTED` error instead of a generic 500. Restores are not retried across `destroy()`.
+Restoring a backup now survives a durable object restart.

--- a/packages/sandbox/src/backup/restore-lifecycle.ts
+++ b/packages/sandbox/src/backup/restore-lifecycle.ts
@@ -1,0 +1,445 @@
+import type {
+  CurrentRuntimeIdentity,
+  RuntimeIdentity
+} from '../current-runtime-identity';
+import { RuntimeIdentityInactiveError } from '../current-runtime-identity';
+import {
+  ErrorCode,
+  OperationInterruptedError,
+  RPCTransportError
+} from '../errors';
+import type {
+  CurrentSandboxLifetime,
+  SandboxLifetime
+} from '../sandbox-lifetime';
+import { SandboxLifetimeChangedError } from '../sandbox-lifetime';
+import {
+  type BackupRestoreOperationPhase,
+  type BackupRestoreOperationRecord,
+  type BackupRestoreOperationResult,
+  BackupRestoreOperationStore,
+  createBackupRestoreOperationRecord
+} from './restore-operation-store';
+
+const BACKUP_RESTORE_MAX_RECOVERY_ATTEMPTS = 2;
+
+type RestoreLifecycleDeps = {
+  storage: DurableObjectStorage;
+  currentRuntime: CurrentRuntimeIdentity;
+  currentLifetime: CurrentSandboxLifetime;
+};
+
+export type RestoreLifecycleContext = {
+  lifetime: SandboxLifetime;
+  runtimeReady: () => Promise<{
+    runtime: RuntimeIdentity;
+    operation: BackupRestoreOperationRecord;
+  }>;
+  archiveReady: (archiveSize?: number) => Promise<{
+    runtime: RuntimeIdentity;
+    operation: BackupRestoreOperationRecord;
+  }>;
+  verify: (
+    result: BackupRestoreOperationResult
+  ) => Promise<BackupRestoreOperationRecord>;
+};
+
+export class RestoreLifecycleRunner {
+  private readonly operationRecords: BackupRestoreOperationStore;
+
+  constructor(private readonly deps: RestoreLifecycleDeps) {
+    this.operationRecords = new BackupRestoreOperationStore(deps.storage);
+  }
+
+  async execute(params: {
+    backupId: string;
+    dir: string;
+    attempt: (
+      context: RestoreLifecycleContext
+    ) => Promise<BackupRestoreOperationResult>;
+  }): Promise<BackupRestoreOperationResult> {
+    return await this.runWithRecovery(async () => {
+      const { lifetime, operation } = await this.startOperation(
+        params.backupId,
+        params.dir
+      );
+      let currentOperation = operation;
+      let runtime: RuntimeIdentity | undefined;
+
+      const context: RestoreLifecycleContext = {
+        lifetime,
+        runtimeReady: async () => {
+          try {
+            runtime = await this.captureRuntime();
+            await this.deps.currentLifetime.assertCurrent(lifetime);
+          } catch (error) {
+            const interrupted = await this.translateFenceError(
+              error,
+              currentOperation,
+              'validating',
+              'unknown'
+            );
+            throw interrupted ?? error;
+          }
+
+          currentOperation = await this.markRuntimeReady(
+            currentOperation,
+            runtime
+          );
+          return { runtime, operation: currentOperation };
+        },
+        archiveReady: async (archiveSize) => {
+          if (!runtime) {
+            throw new Error(
+              'Backup restore archiveReady requires runtimeReady()'
+            );
+          }
+
+          try {
+            await this.assertFences(runtime, lifetime);
+          } catch (error) {
+            const interrupted = await this.translateFenceError(
+              error,
+              currentOperation,
+              currentOperation.phase,
+              true
+            );
+            throw interrupted ?? error;
+          }
+
+          currentOperation = await this.markArchiveReady(
+            currentOperation,
+            runtime,
+            archiveSize
+          );
+          return { runtime, operation: currentOperation };
+        },
+        verify: async (result) => {
+          if (!runtime) {
+            throw new Error(
+              'Backup restore verification requires runtimeReady()'
+            );
+          }
+
+          try {
+            await this.assertFences(runtime, lifetime);
+          } catch (error) {
+            const interrupted = await this.translateFenceError(
+              error,
+              currentOperation,
+              'archive_ready',
+              true
+            );
+            throw interrupted ?? error;
+          }
+
+          currentOperation = await this.markVerified(
+            currentOperation,
+            runtime,
+            result
+          );
+          return currentOperation;
+        }
+      };
+
+      try {
+        return await params.attempt(context);
+      } catch (error) {
+        const translatedRPC = await this.translateRPCError(
+          error,
+          currentOperation
+        );
+        if (translatedRPC) {
+          throw translatedRPC;
+        }
+
+        const translatedFence = await this.translateFenceError(
+          error,
+          currentOperation,
+          currentOperation.phase,
+          'unknown'
+        );
+        if (translatedFence) {
+          throw translatedFence;
+        }
+
+        if (!(error instanceof OperationInterruptedError)) {
+          await this.markFailed(currentOperation, error);
+        }
+        throw error;
+      }
+    });
+  }
+
+  private async runWithRecovery<T>(attempt: () => Promise<T>): Promise<T> {
+    let recoveryAttempts = 0;
+
+    while (true) {
+      try {
+        return await attempt();
+      } catch (error) {
+        if (!(error instanceof OperationInterruptedError)) {
+          throw error;
+        }
+
+        if (!error.context.retryable) {
+          throw error;
+        }
+
+        if (recoveryAttempts >= BACKUP_RESTORE_MAX_RECOVERY_ATTEMPTS) {
+          throw this.createRecoveryExhaustedError(error, recoveryAttempts);
+        }
+
+        recoveryAttempts++;
+      }
+    }
+  }
+
+  private async startOperation(
+    backupId: string,
+    dir: string
+  ): Promise<{
+    lifetime: SandboxLifetime;
+    operation: BackupRestoreOperationRecord;
+  }> {
+    const lifetime = await this.deps.currentLifetime.getOrCreate();
+    const operation = createBackupRestoreOperationRecord({
+      sandboxLifetimeID: lifetime.id,
+      backupId,
+      dir,
+      now: new Date().toISOString()
+    });
+    await this.operationRecords.put(operation);
+    return { lifetime, operation };
+  }
+
+  private async captureRuntime(): Promise<RuntimeIdentity> {
+    const runtime =
+      (await this.deps.currentRuntime.get()) ??
+      (await this.deps.currentRuntime.markStarted());
+    await this.deps.currentRuntime.assertActive(runtime);
+    return runtime;
+  }
+
+  private async assertFences(
+    runtime: RuntimeIdentity,
+    lifetime: SandboxLifetime
+  ): Promise<void> {
+    await this.deps.currentRuntime.assertActive(runtime);
+    await this.deps.currentLifetime.assertCurrent(lifetime);
+  }
+
+  private async markRuntimeReady(
+    operation: BackupRestoreOperationRecord,
+    runtime: RuntimeIdentity
+  ): Promise<BackupRestoreOperationRecord> {
+    const next: BackupRestoreOperationRecord = {
+      ...operation,
+      phase: 'runtime_ready',
+      runtimeIdentityID: runtime.id,
+      updatedAt: new Date().toISOString()
+    };
+    await this.operationRecords.put(next);
+    return next;
+  }
+
+  private async markArchiveReady(
+    operation: BackupRestoreOperationRecord,
+    runtime: RuntimeIdentity,
+    archiveSize?: number
+  ): Promise<BackupRestoreOperationRecord> {
+    const next: BackupRestoreOperationRecord = {
+      ...operation,
+      phase: 'archive_ready',
+      runtimeIdentityID: runtime.id,
+      payload: {
+        ...operation.payload,
+        ...(archiveSize !== undefined && { archiveSize })
+      },
+      updatedAt: new Date().toISOString()
+    };
+    await this.operationRecords.put(next);
+    return next;
+  }
+
+  private async markVerified(
+    operation: BackupRestoreOperationRecord,
+    runtime: RuntimeIdentity,
+    result: BackupRestoreOperationResult
+  ): Promise<BackupRestoreOperationRecord> {
+    const completedAt = new Date().toISOString();
+    const next: BackupRestoreOperationRecord = {
+      ...operation,
+      phase: 'verified',
+      status: 'committed',
+      runtimeIdentityID: runtime.id,
+      result,
+      completedAt,
+      updatedAt: completedAt
+    };
+    await this.operationRecords.put(next);
+    return next;
+  }
+
+  private async markFailed(
+    operation: BackupRestoreOperationRecord,
+    error: unknown
+  ): Promise<BackupRestoreOperationRecord> {
+    const completedAt = new Date().toISOString();
+    const message = error instanceof Error ? error.message : String(error);
+    const code =
+      error instanceof Error &&
+      'code' in error &&
+      typeof error.code === 'string'
+        ? error.code
+        : 'UNKNOWN';
+    const next: BackupRestoreOperationRecord = {
+      ...operation,
+      phase: 'failed',
+      status: 'failed',
+      error: {
+        code,
+        message,
+        retryable: false
+      },
+      completedAt,
+      updatedAt: completedAt
+    };
+    await this.operationRecords.put(next);
+    return next;
+  }
+
+  private async markInterrupted(
+    operation: BackupRestoreOperationRecord,
+    message: string,
+    retryable: boolean
+  ): Promise<BackupRestoreOperationRecord> {
+    const next: BackupRestoreOperationRecord = {
+      ...operation,
+      phase: 'interrupted',
+      status: 'interrupted',
+      error: {
+        code: ErrorCode.OPERATION_INTERRUPTED,
+        message,
+        retryable
+      },
+      updatedAt: new Date().toISOString()
+    };
+    await this.operationRecords.put(next);
+    return next;
+  }
+
+  private async translateFenceError(
+    error: unknown,
+    operation: BackupRestoreOperationRecord,
+    phase: BackupRestoreOperationPhase,
+    admitted: boolean | 'unknown'
+  ): Promise<OperationInterruptedError | null> {
+    if (
+      !(
+        error instanceof RuntimeIdentityInactiveError ||
+        error instanceof SandboxLifetimeChangedError
+      )
+    ) {
+      return null;
+    }
+
+    const reason =
+      error instanceof RuntimeIdentityInactiveError
+        ? 'runtime_replaced'
+        : 'sandbox_lifetime_changed';
+    const retryable = reason !== 'sandbox_lifetime_changed';
+    const message =
+      'Backup restore was interrupted before completion could be verified';
+    const interrupted = await this.markInterrupted(
+      operation,
+      message,
+      retryable
+    );
+    return this.createInterruptedError({
+      reason,
+      phase,
+      admitted,
+      retryable,
+      message,
+      operation: interrupted
+    });
+  }
+
+  private async translateRPCError(
+    error: unknown,
+    operation: BackupRestoreOperationRecord
+  ): Promise<OperationInterruptedError | null> {
+    if (!(error instanceof RPCTransportError)) {
+      return null;
+    }
+
+    const message =
+      'Backup restore was interrupted before completion could be verified';
+    const interruptedPhase = operation.phase;
+    const interrupted = await this.markInterrupted(operation, message, true);
+    return this.createInterruptedError({
+      reason: 'transport_disposed',
+      phase: interruptedPhase,
+      admitted: 'unknown',
+      retryable: true,
+      message,
+      operation: interrupted
+    });
+  }
+
+  private createInterruptedError(params: {
+    reason:
+      | 'runtime_replaced'
+      | 'transport_disposed'
+      | 'sandbox_lifetime_changed';
+    phase: BackupRestoreOperationPhase;
+    admitted: boolean | 'unknown';
+    retryable: boolean;
+    message: string;
+    operation: BackupRestoreOperationRecord;
+  }): OperationInterruptedError {
+    return new OperationInterruptedError({
+      message: params.message,
+      code: ErrorCode.OPERATION_INTERRUPTED,
+      httpStatus: 409,
+      context: {
+        reason: params.reason,
+        operation: 'backup.restore',
+        phase: params.phase,
+        admitted: params.admitted,
+        retryable: params.retryable
+      },
+      timestamp: new Date().toISOString(),
+      suggestion: this.suggestionFor(params.retryable)
+    });
+  }
+
+  private createRecoveryExhaustedError(
+    error: OperationInterruptedError,
+    recoveryAttempts: number
+  ): OperationInterruptedError {
+    return new OperationInterruptedError({
+      message: 'Backup restore recovery attempts were exhausted',
+      code: ErrorCode.OPERATION_INTERRUPTED,
+      httpStatus: 409,
+      context: {
+        reason: 'recovery_exhausted',
+        operation: error.context.operation,
+        phase: 'interrupted',
+        admitted: error.context.admitted,
+        retryable: false,
+        recoveryAttempts,
+        maxRecoveryAttempts: BACKUP_RESTORE_MAX_RECOVERY_ATTEMPTS
+      },
+      timestamp: new Date().toISOString(),
+      suggestion: this.suggestionFor(false)
+    });
+  }
+
+  private suggestionFor(retryable: boolean): string {
+    return retryable
+      ? 'Retry restoreBackup() with the same backup handle so the SDK can reconcile the restore operation.'
+      : 'Start a new restoreBackup() call only if restoring this backup is still desired for the current sandbox.';
+  }
+}

--- a/packages/sandbox/src/backup/restore-operation-store.ts
+++ b/packages/sandbox/src/backup/restore-operation-store.ts
@@ -1,0 +1,103 @@
+import type { RuntimeIdentityID } from '../current-runtime-identity';
+import type { SandboxLifetimeID } from '../sandbox-lifetime';
+
+export type BackupRestoreOperationStatus =
+  | 'running'
+  | 'committed'
+  | 'failed'
+  | 'interrupted';
+
+export type BackupRestoreOperationPhase =
+  | 'validating'
+  | 'runtime_ready'
+  | 'archive_ready'
+  | 'verified'
+  | 'failed'
+  | 'interrupted';
+
+export type BackupRestoreOperationError = {
+  code: string;
+  message: string;
+  retryable: boolean;
+};
+
+export type BackupRestoreOperationPayload = {
+  backupId: string;
+  dir: string;
+  archiveSize?: number;
+};
+
+export type BackupRestoreOperationResult = {
+  success: true;
+  id: string;
+  dir: string;
+};
+
+export type BackupRestoreOperationRecord = {
+  operationKey: string;
+  kind: 'backup.restore';
+  sandboxLifetimeID: SandboxLifetimeID;
+  phase: BackupRestoreOperationPhase;
+  status: BackupRestoreOperationStatus;
+  runtimeIdentityID?: RuntimeIdentityID;
+  payload: BackupRestoreOperationPayload;
+  result?: BackupRestoreOperationResult;
+  error?: BackupRestoreOperationError;
+  createdAt: string;
+  updatedAt: string;
+  completedAt?: string;
+};
+
+type OperationRecordStorage = Pick<DurableObjectStorage, 'get' | 'put'>;
+
+const OPERATION_STORAGE_PREFIX = 'operations:';
+
+export function backupRestoreOperationKey(
+  backupId: string,
+  dir: string
+): string {
+  return `restore:${backupId}:${dir}`;
+}
+
+export function createBackupRestoreOperationRecord(params: {
+  sandboxLifetimeID: SandboxLifetimeID;
+  backupId: string;
+  dir: string;
+  now: string;
+}): BackupRestoreOperationRecord {
+  return {
+    operationKey: backupRestoreOperationKey(params.backupId, params.dir),
+    kind: 'backup.restore',
+    sandboxLifetimeID: params.sandboxLifetimeID,
+    phase: 'validating',
+    status: 'running',
+    payload: {
+      backupId: params.backupId,
+      dir: params.dir
+    },
+    createdAt: params.now,
+    updatedAt: params.now
+  };
+}
+
+export class BackupRestoreOperationStore {
+  constructor(private readonly storage: OperationRecordStorage) {}
+
+  async get(
+    operationKey: string
+  ): Promise<BackupRestoreOperationRecord | null> {
+    return (
+      (await this.storage.get<BackupRestoreOperationRecord>(
+        this.storageKey(operationKey)
+      )) ?? null
+    );
+  }
+
+  async put(record: BackupRestoreOperationRecord): Promise<void> {
+    await this.storage.put(this.storageKey(record.operationKey), record);
+  }
+
+  storageKey(operationKey: string): string {
+    return `${OPERATION_STORAGE_PREFIX}${operationKey}`;
+  }
+}

--- a/packages/sandbox/src/sandbox-lifetime.ts
+++ b/packages/sandbox/src/sandbox-lifetime.ts
@@ -1,0 +1,129 @@
+/**
+ * Sandbox logical lifetime tracking.
+ *
+ * A sandbox lifetime represents the logical existence of a sandbox across
+ * container start/stop cycles. It changes only when the sandbox is explicitly
+ * destroyed via `sandbox.destroy()`. Restore and tunnel operations use the
+ * lifetime id as a fence so operations that started before `destroy()` do
+ * not recover into a new sandbox lifetime.
+ */
+
+type SandboxLifetimeStorage = Pick<
+  DurableObjectStorage | DurableObjectTransaction,
+  'get' | 'put'
+>;
+
+export type SandboxLifetimeID = string & {
+  readonly __sandboxLifetimeID: unique symbol;
+};
+
+export type SandboxLifetimeRecord = {
+  id: SandboxLifetimeID;
+  generation: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const SANDBOX_LIFETIME_STORAGE_KEY = 'sandbox:lifetime';
+
+export class SandboxLifetimeChangedError extends Error {
+  constructor() {
+    super('Sandbox lifetime is no longer current');
+    this.name = 'SandboxLifetimeChangedError';
+  }
+}
+
+export class SandboxLifetime {
+  readonly id: SandboxLifetimeID;
+  readonly generation: number;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+
+  constructor(readonly record: SandboxLifetimeRecord) {
+    this.id = record.id;
+    this.generation = record.generation;
+    this.createdAt = record.createdAt;
+    this.updatedAt = record.updatedAt;
+  }
+
+  owns(record: { readonly sandboxLifetimeID: SandboxLifetimeID }): boolean {
+    return record.sandboxLifetimeID === this.id;
+  }
+
+  scope<T extends object>(
+    value: T
+  ): T & { sandboxLifetimeID: SandboxLifetimeID } {
+    return {
+      ...value,
+      sandboxLifetimeID: this.id
+    };
+  }
+}
+
+export class CurrentSandboxLifetime {
+  constructor(private readonly storage: SandboxLifetimeStorage) {}
+
+  async get(): Promise<SandboxLifetime | null> {
+    const record =
+      (await this.storage.get<SandboxLifetimeRecord>(
+        SANDBOX_LIFETIME_STORAGE_KEY
+      )) ?? null;
+    return record ? new SandboxLifetime(record) : null;
+  }
+
+  /**
+   * Returns the current lifetime if one exists, or creates and persists a new
+   * one. The id is stable for the lifetime of the sandbox — it only changes
+   * when `rotate()` is called (on `destroy()`).
+   */
+  async getOrCreate(): Promise<SandboxLifetime> {
+    const existing = await this.get();
+    if (existing) {
+      return existing;
+    }
+
+    const now = new Date().toISOString();
+    const record: SandboxLifetimeRecord = {
+      id: crypto.randomUUID() as SandboxLifetimeID,
+      generation: 1,
+      createdAt: now,
+      updatedAt: now
+    };
+    await this.storage.put(SANDBOX_LIFETIME_STORAGE_KEY, record);
+    return new SandboxLifetime(record);
+  }
+
+  /**
+   * Creates and persists a new lifetime id, incrementing the generation
+   * counter. Called during `sandbox.destroy()` before runtime state is
+   * cleared so in-flight operations can detect the lifetime change.
+   */
+  async rotate(): Promise<SandboxLifetime> {
+    const existing = await this.get();
+    const now = new Date().toISOString();
+    const record: SandboxLifetimeRecord = {
+      id: crypto.randomUUID() as SandboxLifetimeID,
+      generation: (existing?.generation ?? 0) + 1,
+      createdAt: now,
+      updatedAt: now
+    };
+    await this.storage.put(SANDBOX_LIFETIME_STORAGE_KEY, record);
+    return new SandboxLifetime(record);
+  }
+
+  async isCurrent(lifetime: SandboxLifetime): Promise<boolean> {
+    const current = await this.get();
+    return current?.id === lifetime.id;
+  }
+
+  /**
+   * Throws `SandboxLifetimeChangedError` if the given lifetime is no longer
+   * the current one. Used by operation runners to abort operations that
+   * started before a `destroy()` call.
+   */
+  async assertCurrent(lifetime: SandboxLifetime): Promise<void> {
+    if (!(await this.isCurrent(lifetime))) {
+      throw new SandboxLifetimeChangedError();
+    }
+  }
+}

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -66,6 +66,9 @@ import {
 } from '@repo/shared/errors';
 import { DISABLE_SESSION_TOKEN } from '@repo/shared/internal';
 import { AwsClient } from 'aws4fetch';
+import type { RestoreLifecycleContext } from './backup/restore-lifecycle';
+import { RestoreLifecycleRunner } from './backup/restore-lifecycle';
+import type { BackupRestoreOperationResult } from './backup/restore-operation-store';
 import { type ExecuteResponse, SandboxClient } from './clients';
 import { ContainerControlClient } from './container-control';
 import {
@@ -106,6 +109,7 @@ import {
 } from './preview-proxy-protocol';
 import { isLocalhostPattern } from './preview-url';
 import { proxyTerminal } from './pty';
+import { CurrentSandboxLifetime } from './sandbox-lifetime';
 import {
   SandboxSecurityError,
   sanitizeSandboxId,
@@ -983,6 +987,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
   private activeMounts: Map<string, MountInfo> = new Map();
   private mountOperationQueue: Promise<void> = Promise.resolve();
   private currentRuntime: CurrentRuntimeIdentity;
+  private currentLifetime: CurrentSandboxLifetime;
   private transport: SandboxTransport = 'http';
 
   /**
@@ -1204,6 +1209,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       () => this.getState(),
       () => this.ctx.container?.running === true
     );
+
+    this.currentLifetime = new CurrentSandboxLifetime(this.ctx.storage);
 
     // Read transport setting from env var
     const transportEnv = envObj?.SANDBOX_TRANSPORT;
@@ -2713,6 +2720,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       // the container.
       await this.ctx.storage.delete(PORT_TOKENS_STORAGE_KEY);
       await this.clearActivePreviewPorts();
+      // Rotate sandbox lifetime before clearing runtime state so that
+      // in-flight operations can detect the lifetime change and abort.
+      await this.currentLifetime.rotate();
       await this.currentRuntime.clear();
 
       // Unmount all mounted buckets and cleanup (requires an active connection
@@ -6990,18 +7000,39 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    * Concurrent backup/restore calls on the same sandbox are serialized.
    */
   async restoreBackup(backup: DirectoryBackup): Promise<RestoreBackupResult> {
-    if (backup.localBucket) {
-      return await this.enqueueBackupOp(() =>
-        this.doRestoreBackupLocal(backup)
-      );
+    if (!backup.localBucket) {
+      this.requireBackupBucket();
     }
-    this.requireBackupBucket();
-    return await this.enqueueBackupOp(() => this.doRestoreBackup(backup));
+    return await this.enqueueBackupOp(() =>
+      this.doRestoreBackupWithRecovery(backup)
+    );
+  }
+
+  private async doRestoreBackupWithRecovery(
+    backup: DirectoryBackup
+  ): Promise<BackupRestoreOperationResult> {
+    const runner = new RestoreLifecycleRunner({
+      storage: this.ctx.storage,
+      currentRuntime: this.currentRuntime,
+      currentLifetime: this.currentLifetime
+    });
+
+    return await runner.execute({
+      backupId: backup.id,
+      dir: backup.dir,
+      attempt: async (lifecycle) => {
+        if (backup.localBucket) {
+          return await this.doRestoreBackupLocal(backup, lifecycle);
+        }
+        return await this.doRestoreBackup(backup, lifecycle);
+      }
+    });
   }
 
   private async doRestoreBackup(
-    backup: DirectoryBackup
-  ): Promise<RestoreBackupResult> {
+    backup: DirectoryBackup,
+    lifecycle: RestoreLifecycleContext
+  ): Promise<BackupRestoreOperationResult> {
     const restoreStartTime = Date.now();
     const bucket = this.requireBackupBucket();
     this.requirePresignedURLSupport();
@@ -7100,6 +7131,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       }
 
       backupSession = await this.ensureBackupSession();
+      await lifecycle.runtimeReady();
       const archivePath = `${BACKUP_CONTAINER_DIR}/${id}.sqsh`;
 
       // Step 3: Tear down existing FUSE mounts before overwriting the archive.
@@ -7144,6 +7176,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         );
       }
 
+      await lifecycle.archiveReady(archiveHead.size);
+
       const restoreResult = await this.client.backup.restoreArchive(
         dir,
         archivePath,
@@ -7160,13 +7194,16 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         });
       }
 
-      outcome = 'success';
-
-      return {
-        success: true,
+      const result = {
+        success: true as const,
         dir,
         id
       };
+      await lifecycle.verify(result);
+
+      outcome = 'success';
+
+      return result;
     } catch (error) {
       caughtError = error instanceof Error ? error : new Error(String(error));
       if (id && backupSession) {
@@ -7199,8 +7236,9 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
    * unsquashfs for extraction instead of squashfuse + fuse-overlayfs.
    */
   private async doRestoreBackupLocal(
-    backup: DirectoryBackup
-  ): Promise<RestoreBackupResult> {
+    backup: DirectoryBackup,
+    lifecycle: RestoreLifecycleContext
+  ): Promise<BackupRestoreOperationResult> {
     const restoreStartTime = Date.now();
     const { id, dir } = backup;
 
@@ -7265,6 +7303,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         ttl: number;
         createdAt: string;
         dir: string;
+        sizeBytes?: number;
       }>();
 
       // Check TTL with 60-second buffer
@@ -7310,8 +7349,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
           timestamp: new Date().toISOString()
         });
       }
+      const archiveSize = metadata.sizeBytes;
 
       backupSession = await this.ensureBackupSession();
+      await lifecycle.runtimeReady();
       const archivePath = `${BACKUP_CONTAINER_DIR}/${id}.sqsh`;
 
       // Ensure backup directory exists
@@ -7371,6 +7412,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         }
       }
 
+      await lifecycle.archiveReady(archiveSize);
+
       // Step 3: Extract archive using unsquashfs (no FUSE needed)
       const extractResult = await this.execWithSession(
         `/usr/bin/unsquashfs -f -d ${shellEscape(dir)} ${shellEscape(archivePath)}`,
@@ -7388,6 +7431,13 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         });
       }
 
+      const result = {
+        success: true as const,
+        dir,
+        id
+      };
+      await lifecycle.verify(result);
+
       // Clean up archive after extraction (no FUSE mount holds it open)
       await this.execWithSession(
         `rm -f ${shellEscape(archivePath)}`,
@@ -7397,11 +7447,7 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
 
       outcome = 'success';
 
-      return {
-        success: true,
-        dir,
-        id
-      };
+      return result;
     } catch (error) {
       caughtError = error instanceof Error ? error : new Error(String(error));
       if (id && backupSession) {

--- a/packages/sandbox/tests/backup-restore-lifecycle.test.ts
+++ b/packages/sandbox/tests/backup-restore-lifecycle.test.ts
@@ -1,0 +1,332 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BackupRestoreOperationRecord } from '../src/backup/restore-operation-store';
+import { ErrorCode, RPCTransportError } from '../src/errors';
+import { Sandbox } from '../src/sandbox';
+
+vi.mock('./interpreter', () => ({
+  CodeInterpreter: vi.fn().mockImplementation(() => ({}))
+}));
+
+vi.mock('@cloudflare/containers', () => {
+  class MockContainer {
+    ctx: unknown;
+    env: unknown;
+    sleepAfter: string | number = '10m';
+
+    constructor(ctx: unknown, env: unknown) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+
+    async getState(): Promise<{ status: string }> {
+      return { status: 'healthy' };
+    }
+
+    renewActivityTimeout(): void {}
+  }
+
+  return {
+    Container: MockContainer,
+    ContainerProxy: MockContainer,
+    getContainer: vi.fn(),
+    switchPort: vi.fn((request: Request) => request)
+  };
+});
+
+type StoredValue = unknown;
+
+type TestStorage = DurableObjectStorage & {
+  backing: Map<string, StoredValue>;
+};
+
+type TestBucket = ReturnType<typeof createBackupBucket>;
+
+function createStorage(
+  initial = new Map<string, StoredValue>(),
+  hooks?: { onPut?: (key: string, value: StoredValue) => void }
+): TestStorage {
+  const storage = {
+    backing: initial,
+    get: vi.fn(async (key: string) => initial.get(key) ?? null),
+    put: vi.fn(async (key: string, value: StoredValue) => {
+      initial.set(key, value);
+      hooks?.onPut?.(key, value);
+    }),
+    delete: vi.fn(async (key: string) => {
+      initial.delete(key);
+    }),
+    list: vi.fn(async () => new Map<string, StoredValue>()),
+    transaction: vi.fn(
+      async (callback: (txn: DurableObjectTransaction) => unknown) =>
+        callback(storage as unknown as DurableObjectTransaction)
+    )
+  };
+  return storage as unknown as TestStorage;
+}
+
+function createBackupBucket(createdAt = '2026-06-23T12:00:00.000Z') {
+  return {
+    put: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({
+        ttl: 259_200,
+        createdAt,
+        dir: '/workspace/project'
+      })
+    }),
+    head: vi.fn().mockResolvedValue({ size: 42 }),
+    delete: vi.fn().mockResolvedValue(undefined),
+    list: vi.fn().mockResolvedValue({ objects: [], truncated: false })
+  };
+}
+
+function createDisposedRPCError(): RPCTransportError {
+  return new RPCTransportError({
+    code: ErrorCode.RPC_TRANSPORT_ERROR,
+    message: 'RPC session was shut down by disposing the main stub',
+    httpStatus: 503,
+    context: {
+      kind: 'session_disposed',
+      originalMessage: 'RPC session was shut down by disposing the main stub',
+      errorName: 'Error'
+    },
+    timestamp: '2026-06-23T12:00:00.000Z'
+  });
+}
+
+async function createBackupSandbox(
+  params: {
+    storageHooks?: { onPut?: (key: string, value: StoredValue) => void };
+    bucket?: TestBucket;
+    initialRuntime?: 'active' | 'cold';
+  } = {}
+) {
+  const storageMap = new Map<string, StoredValue>();
+  if (params.initialRuntime !== 'cold') {
+    storageMap.set('currentRuntimeIdentity', { id: 'runtime-1' });
+  }
+  storageMap.set('sandbox:lifetime', {
+    id: 'lifetime-1',
+    generation: 1,
+    createdAt: '2026-06-23T12:00:00.000Z',
+    updatedAt: '2026-06-23T12:00:00.000Z'
+  });
+
+  const storage = createStorage(storageMap, params.storageHooks);
+  const containerState = { running: params.initialRuntime !== 'cold' };
+  const ctx = {
+    storage,
+    blockConcurrencyWhile: vi.fn(<T>(callback: () => Promise<T>) => callback()),
+    waitUntil: vi.fn(),
+    id: {
+      toString: () => 'test-sandbox-id',
+      equals: vi.fn(),
+      name: 'test-sandbox'
+    },
+    container: containerState
+  } as unknown as DurableObjectState<{}>;
+
+  const bucket = params.bucket ?? createBackupBucket();
+  const sandbox = new Sandbox(ctx, {
+    BACKUP_BUCKET: bucket,
+    CLOUDFLARE_ACCOUNT_ID: 'test-account',
+    R2_ACCESS_KEY_ID: 'test-key',
+    R2_SECRET_ACCESS_KEY: 'test-secret',
+    BACKUP_BUCKET_NAME: 'test-backups'
+  });
+
+  await vi.waitFor(() => {
+    expect(ctx.blockConcurrencyWhile).toHaveBeenCalled();
+  });
+
+  vi.spyOn(sandbox.client.utils, 'createSession').mockImplementation(
+    async () => {
+      containerState.running = true;
+      return {
+        success: true,
+        id: 'backup-session',
+        message: 'Created',
+        timestamp: '2026-06-23T12:00:00.000Z'
+      };
+    }
+  );
+  vi.spyOn(sandbox.client.utils, 'deleteSession').mockResolvedValue({
+    success: true,
+    sessionId: 'backup-session',
+    timestamp: '2026-06-23T12:00:00.000Z'
+  });
+  vi.spyOn(sandbox.client.backup, 'restoreArchive').mockResolvedValue({
+    success: true,
+    dir: '/workspace/project'
+  });
+
+  const sandboxInternals = sandbox as unknown as {
+    downloadBackupParallel: (
+      archivePath: string,
+      r2Key: string,
+      sizeBytes: number,
+      backupId: string,
+      dir: string,
+      sessionId: string
+    ) => Promise<void>;
+    execWithSession: () => Promise<{
+      stdout: string;
+      stderr: string;
+      exitCode: number;
+    }>;
+  };
+  vi.spyOn(sandboxInternals, 'downloadBackupParallel').mockResolvedValue(
+    undefined
+  );
+  vi.spyOn(sandboxInternals, 'execWithSession').mockResolvedValue({
+    stdout: '0',
+    stderr: '',
+    exitCode: 0
+  });
+
+  return { sandbox, storageMap, bucket };
+}
+
+describe('backup restore lifecycle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-23T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('retries and succeeds when runtime replacement is detected after archive readiness', async () => {
+    const backupId = crypto.randomUUID();
+    let replaced = false;
+    const { sandbox, storageMap } = await createBackupSandbox({
+      storageHooks: {
+        onPut(key, value) {
+          const record = value as Partial<BackupRestoreOperationRecord>;
+          if (
+            !replaced &&
+            key === `operations:restore:${backupId}:/workspace/project` &&
+            record.phase === 'archive_ready'
+          ) {
+            replaced = true;
+            storageMap.set('currentRuntimeIdentity', { id: 'runtime-2' });
+          }
+        }
+      }
+    });
+
+    const result = await sandbox.restoreBackup({
+      id: backupId,
+      dir: '/workspace/project'
+    });
+
+    expect(result).toEqual({
+      success: true,
+      id: backupId,
+      dir: '/workspace/project'
+    });
+    expect(sandbox.client.backup.restoreArchive).toHaveBeenCalledTimes(2);
+    const record = storageMap.get(
+      `operations:restore:${backupId}:/workspace/project`
+    ) as BackupRestoreOperationRecord;
+    expect(record.status).toBe('committed');
+    expect(record.phase).toBe('verified');
+    expect(record.runtimeIdentityID).toBe('runtime-2');
+  });
+
+  it('surfaces OPERATION_INTERRUPTED after exhausting runtime recovery attempts', async () => {
+    const { sandbox, storageMap } = await createBackupSandbox();
+    const backupId = crypto.randomUUID();
+    vi.spyOn(sandbox.client.backup, 'restoreArchive').mockRejectedValue(
+      createDisposedRPCError()
+    );
+
+    await expect(
+      sandbox.restoreBackup({ id: backupId, dir: '/workspace/project' })
+    ).rejects.toMatchObject({
+      name: 'OperationInterruptedError',
+      code: ErrorCode.OPERATION_INTERRUPTED,
+      context: {
+        reason: 'recovery_exhausted',
+        operation: 'backup.restore',
+        phase: 'interrupted',
+        admitted: 'unknown',
+        retryable: false,
+        recoveryAttempts: 2,
+        maxRecoveryAttempts: 2
+      }
+    });
+
+    expect(sandbox.client.backup.restoreArchive).toHaveBeenCalledTimes(3);
+    const record = storageMap.get(
+      `operations:restore:${backupId}:/workspace/project`
+    ) as BackupRestoreOperationRecord;
+    expect(record.status).toBe('interrupted');
+    expect(record.phase).toBe('interrupted');
+  });
+
+  it('starts the backup session before fencing a cold runtime', async () => {
+    const { sandbox, storageMap } = await createBackupSandbox({
+      initialRuntime: 'cold'
+    });
+    const backupId = crypto.randomUUID();
+
+    await expect(
+      sandbox.restoreBackup({ id: backupId, dir: '/workspace/project' })
+    ).resolves.toEqual({
+      success: true,
+      id: backupId,
+      dir: '/workspace/project'
+    });
+
+    expect(sandbox.client.utils.createSession).toHaveBeenCalled();
+    const record = storageMap.get(
+      `operations:restore:${backupId}:/workspace/project`
+    ) as BackupRestoreOperationRecord;
+    expect(record.status).toBe('committed');
+    expect(record.phase).toBe('verified');
+    expect(record.runtimeIdentityID).toBeDefined();
+  });
+
+  it('does not retry when the sandbox lifetime changes before runtime work starts', async () => {
+    const backupId = crypto.randomUUID();
+    let lifetimeChanged = false;
+    const { sandbox, storageMap } = await createBackupSandbox({
+      storageHooks: {
+        onPut(key, value) {
+          const record = value as Partial<BackupRestoreOperationRecord>;
+          if (
+            !lifetimeChanged &&
+            key === `operations:restore:${backupId}:/workspace/project` &&
+            record.phase === 'validating'
+          ) {
+            lifetimeChanged = true;
+            storageMap.set('sandbox:lifetime', {
+              id: 'lifetime-2',
+              generation: 2,
+              createdAt: '2026-06-23T12:00:00.000Z',
+              updatedAt: '2026-06-23T12:00:00.000Z'
+            });
+          }
+        }
+      }
+    });
+
+    await expect(
+      sandbox.restoreBackup({ id: backupId, dir: '/workspace/project' })
+    ).rejects.toMatchObject({
+      name: 'OperationInterruptedError',
+      context: {
+        reason: 'sandbox_lifetime_changed',
+        operation: 'backup.restore',
+        phase: 'validating',
+        admitted: 'unknown',
+        retryable: false
+      }
+    });
+
+    expect(sandbox.client.backup.restoreArchive).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sandbox/tests/local-backup-restore-lifecycle.test.ts
+++ b/packages/sandbox/tests/local-backup-restore-lifecycle.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BackupRestoreOperationRecord } from '../src/backup/restore-operation-store';
+import { ErrorCode, RPCTransportError } from '../src/errors';
+import { Sandbox } from '../src/sandbox';
+
+vi.mock('./interpreter', () => ({
+  CodeInterpreter: vi.fn().mockImplementation(() => ({}))
+}));
+
+vi.mock('@cloudflare/containers', () => {
+  class MockContainer {
+    ctx: unknown;
+    env: unknown;
+    sleepAfter: string | number = '10m';
+
+    constructor(ctx: unknown, env: unknown) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+
+    async getState(): Promise<{ status: string }> {
+      return { status: 'healthy' };
+    }
+
+    renewActivityTimeout(): void {}
+  }
+
+  return {
+    Container: MockContainer,
+    ContainerProxy: MockContainer,
+    getContainer: vi.fn(),
+    switchPort: vi.fn((request: Request) => request)
+  };
+});
+
+type StoredValue = unknown;
+
+type LocalBucket = ReturnType<typeof createMockR2Bucket>;
+
+function createStorage(initial = new Map<string, StoredValue>()) {
+  const storage = {
+    get: vi.fn(async (key: string) => initial.get(key) ?? null),
+    put: vi.fn(async (key: string, value: StoredValue) => {
+      initial.set(key, value);
+    }),
+    delete: vi.fn(async (key: string) => {
+      initial.delete(key);
+    }),
+    list: vi.fn(async () => new Map<string, StoredValue>()),
+    transaction: vi.fn(
+      async (callback: (txn: DurableObjectTransaction) => unknown) =>
+        callback(storage as unknown as DurableObjectTransaction)
+    )
+  };
+  return storage as unknown as DurableObjectStorage;
+}
+
+function createDisposedRPCError(): RPCTransportError {
+  return new RPCTransportError({
+    code: ErrorCode.RPC_TRANSPORT_ERROR,
+    message: 'RPC session was shut down by disposing the main stub',
+    httpStatus: 503,
+    context: {
+      kind: 'session_disposed',
+      originalMessage: 'RPC session was shut down by disposing the main stub',
+      errorName: 'Error'
+    },
+    timestamp: '2026-06-23T12:00:00.000Z'
+  });
+}
+
+function createMockR2Bucket() {
+  const store = new Map<string, { data: ArrayBuffer; size: number }>();
+  return {
+    put: vi.fn(async (key: string, data: string | Uint8Array) => {
+      const bytes =
+        typeof data === 'string' ? new TextEncoder().encode(data) : data;
+      store.set(key, {
+        data: new Uint8Array(bytes).buffer as ArrayBuffer,
+        size: bytes.byteLength
+      });
+    }),
+    get: vi.fn(async (key: string) => {
+      const entry = store.get(key);
+      if (!entry) return null;
+      return {
+        arrayBuffer: async () => entry.data,
+        json: async <T>() =>
+          JSON.parse(new TextDecoder().decode(entry.data)) as T,
+        body: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new Uint8Array(entry.data));
+            controller.close();
+          }
+        })
+      };
+    }),
+    head: vi.fn(async (key: string) => {
+      const entry = store.get(key);
+      if (!entry) return null;
+      return { size: entry.size };
+    }),
+    delete: vi.fn(async (key: string) => {
+      store.delete(key);
+    }),
+    list: vi.fn(async () => ({ objects: [], truncated: false }))
+  };
+}
+
+async function createLocalRestoreSandbox(
+  params: { bucket?: LocalBucket } = {}
+) {
+  const storageMap = new Map<string, StoredValue>();
+  storageMap.set('currentRuntimeIdentity', { id: 'runtime-1' });
+  storageMap.set('sandbox:lifetime', {
+    id: 'lifetime-1',
+    generation: 1,
+    createdAt: '2026-06-23T12:00:00.000Z',
+    updatedAt: '2026-06-23T12:00:00.000Z'
+  });
+
+  const bucket = params.bucket ?? createMockR2Bucket();
+  const backupId = '12345678-1234-1234-1234-123456789012';
+  await bucket.put(
+    `backups/${backupId}/meta.json`,
+    JSON.stringify({
+      id: backupId,
+      dir: '/workspace/project',
+      sizeBytes: 4,
+      ttl: 3600,
+      createdAt: '2026-06-23T12:00:00.000Z'
+    })
+  );
+  await bucket.put(
+    `backups/${backupId}/data.sqsh`,
+    new Uint8Array([0x68, 0x73, 0x71, 0x73])
+  );
+
+  const ctx = {
+    storage: createStorage(storageMap),
+    blockConcurrencyWhile: vi.fn(<T>(callback: () => Promise<T>) => callback()),
+    waitUntil: vi.fn(),
+    id: {
+      toString: () => 'test-sandbox-id',
+      equals: vi.fn(),
+      name: 'test-sandbox'
+    },
+    container: { running: true }
+  } as unknown as DurableObjectState<{}>;
+
+  const sandbox = new Sandbox(ctx, { BACKUP_BUCKET: bucket });
+  await vi.waitFor(() => {
+    expect(ctx.blockConcurrencyWhile).toHaveBeenCalled();
+  });
+
+  vi.spyOn(sandbox.client.utils, 'createSession').mockResolvedValue({
+    success: true,
+    id: 'backup-session',
+    message: 'Created',
+    timestamp: '2026-06-23T12:00:00.000Z'
+  });
+  vi.spyOn(sandbox.client.utils, 'deleteSession').mockResolvedValue({
+    success: true,
+    sessionId: 'backup-session',
+    timestamp: '2026-06-23T12:00:00.000Z'
+  });
+  vi.spyOn(sandbox.client.files, 'writeFile').mockResolvedValue({
+    success: true,
+    path: `/var/backups/${backupId}.sqsh`,
+    timestamp: '2026-06-23T12:00:00.000Z'
+  });
+  vi.spyOn(sandbox.client.commands, 'execute').mockResolvedValue({
+    success: true,
+    stdout: '',
+    stderr: '',
+    exitCode: 0,
+    command: '',
+    timestamp: '2026-06-23T12:00:00.000Z'
+  });
+
+  return { sandbox, storageMap, backupId };
+}
+
+describe('local backup restore lifecycle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-23T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('uses lifecycle records and verifies local restore completion', async () => {
+    const { sandbox, storageMap, backupId } = await createLocalRestoreSandbox();
+
+    const result = await sandbox.restoreBackup({
+      id: backupId,
+      dir: '/workspace/project',
+      localBucket: true
+    });
+
+    const record = storageMap.get(
+      `operations:restore:${backupId}:/workspace/project`
+    ) as BackupRestoreOperationRecord;
+    expect(record).toMatchObject({
+      operationKey: `restore:${backupId}:/workspace/project`,
+      kind: 'backup.restore',
+      status: 'committed',
+      phase: 'verified',
+      runtimeIdentityID: 'runtime-1',
+      payload: {
+        backupId,
+        dir: '/workspace/project',
+        archiveSize: 4
+      },
+      result
+    });
+  });
+
+  it('does not mark local archive_ready before writeFile completes', async () => {
+    const { sandbox, storageMap, backupId } = await createLocalRestoreSandbox();
+    vi.spyOn(sandbox.client.files, 'writeFile').mockImplementationOnce(
+      async () => {
+        const record = storageMap.get(
+          `operations:restore:${backupId}:/workspace/project`
+        ) as BackupRestoreOperationRecord;
+        expect(record.phase).toBe('runtime_ready');
+        return {
+          success: true,
+          path: `/var/backups/${backupId}.sqsh`,
+          timestamp: '2026-06-23T12:00:00.000Z'
+        };
+      }
+    );
+
+    await sandbox.restoreBackup({
+      id: backupId,
+      dir: '/workspace/project',
+      localBucket: true
+    });
+  });
+
+  it('recovers internally when local archive write loses the RPC transport once', async () => {
+    const { sandbox, storageMap, backupId } = await createLocalRestoreSandbox();
+    const writeFileSpy = vi
+      .spyOn(sandbox.client.files, 'writeFile')
+      .mockRejectedValueOnce(createDisposedRPCError())
+      .mockResolvedValueOnce({
+        success: true,
+        path: `/var/backups/${backupId}.sqsh`,
+        timestamp: '2026-06-23T12:00:00.000Z'
+      });
+
+    const result = await sandbox.restoreBackup({
+      id: backupId,
+      dir: '/workspace/project',
+      localBucket: true
+    });
+
+    expect(result).toEqual({
+      success: true,
+      id: backupId,
+      dir: '/workspace/project'
+    });
+    expect(writeFileSpy).toHaveBeenCalledTimes(2);
+    const record = storageMap.get(
+      `operations:restore:${backupId}:/workspace/project`
+    ) as BackupRestoreOperationRecord;
+    expect(record.status).toBe('committed');
+    expect(record.phase).toBe('verified');
+  });
+});

--- a/packages/sandbox/tests/local-backup.test.ts
+++ b/packages/sandbox/tests/local-backup.test.ts
@@ -124,6 +124,7 @@ interface MockCtx {
     equals: ReturnType<typeof vi.fn>;
     name: string;
   };
+  container: { running: boolean };
 }
 
 describe('Local Backup & Restore', () => {
@@ -136,12 +137,17 @@ describe('Local Backup & Restore', () => {
     vi.clearAllMocks();
 
     mockBucket = createMockR2Bucket();
+    const storageState = new Map<string, unknown>();
 
     mockCtx = {
       storage: {
-        get: vi.fn().mockResolvedValue(null),
-        put: vi.fn().mockResolvedValue(undefined),
-        delete: vi.fn().mockResolvedValue(undefined),
+        get: vi.fn(async (key: string) => storageState.get(key) ?? null),
+        put: vi.fn(async (key: string, value: unknown) => {
+          storageState.set(key, value);
+        }),
+        delete: vi.fn(async (key: string) => {
+          storageState.delete(key);
+        }),
         list: vi.fn().mockResolvedValue(new Map())
       },
       blockConcurrencyWhile: vi
@@ -154,7 +160,8 @@ describe('Local Backup & Restore', () => {
         toString: () => 'test-sandbox-id',
         equals: vi.fn(),
         name: 'test-sandbox'
-      } as any
+      } as any,
+      container: { running: true }
     };
 
     mockEnv = {

--- a/packages/sandbox/tests/operation-interrupted-error.test.ts
+++ b/packages/sandbox/tests/operation-interrupted-error.test.ts
@@ -1,0 +1,86 @@
+import type { OperationInterruptedContext } from '@repo/shared/errors';
+import { ErrorCode } from '@repo/shared/errors';
+import { describe, expect, it } from 'vitest';
+import { OperationInterruptedError } from '../src/errors';
+
+function makeOperationInterruptedResponse(
+  overrides: Partial<OperationInterruptedContext> = {}
+) {
+  const context: OperationInterruptedContext = {
+    reason: 'runtime_replaced',
+    operation: 'backup.restore',
+    phase: 'archive_ready',
+    admitted: true,
+    retryable: true,
+    ...overrides
+  };
+  return {
+    code: ErrorCode.OPERATION_INTERRUPTED,
+    message: 'Operation was interrupted',
+    context,
+    httpStatus: 409,
+    timestamp: new Date().toISOString()
+  };
+}
+
+describe('OperationInterruptedError', () => {
+  it('has the correct name', () => {
+    const err = new OperationInterruptedError(
+      makeOperationInterruptedResponse()
+    );
+    expect(err.name).toBe('OperationInterruptedError');
+  });
+
+  it('is an instance of SandboxError', async () => {
+    const { SandboxError } = await import('../src/errors/classes');
+    const err = new OperationInterruptedError(
+      makeOperationInterruptedResponse()
+    );
+    expect(err).toBeInstanceOf(SandboxError);
+  });
+
+  it('exposes reason, operation, phase, admitted, retryable from context', () => {
+    const err = new OperationInterruptedError(
+      makeOperationInterruptedResponse({
+        reason: 'sandbox_lifetime_changed',
+        operation: 'backup.restore',
+        phase: 'validating',
+        admitted: 'unknown',
+        retryable: false
+      })
+    );
+    expect(err.context.reason).toBe('sandbox_lifetime_changed');
+    expect(err.context.operation).toBe('backup.restore');
+    expect(err.context.phase).toBe('validating');
+    expect(err.context.admitted).toBe('unknown');
+    expect(err.context.retryable).toBe(false);
+  });
+
+  it('exposes recoveryAttempts and maxRecoveryAttempts when present', () => {
+    const err = new OperationInterruptedError(
+      makeOperationInterruptedResponse({
+        reason: 'recovery_exhausted',
+        retryable: false,
+        recoveryAttempts: 2,
+        maxRecoveryAttempts: 2
+      })
+    );
+    expect(err.context.recoveryAttempts).toBe(2);
+    expect(err.context.maxRecoveryAttempts).toBe(2);
+  });
+
+  it('ErrorCode.OPERATION_INTERRUPTED exists', () => {
+    expect(ErrorCode.OPERATION_INTERRUPTED).toBe('OPERATION_INTERRUPTED');
+  });
+
+  it('OperationInterruptedError is exported from @cloudflare/sandbox public barrel', async () => {
+    const sdkExports = await import('../src/index');
+    expect(sdkExports.OperationInterruptedError).toBeDefined();
+    // Context type export is type-only; verify the error class is constructable
+    expect(
+      new sdkExports.OperationInterruptedError(
+        makeOperationInterruptedResponse()
+      )
+    ).toBeInstanceOf(sdkExports.OperationInterruptedError);
+  });
+});

--- a/packages/sandbox/tests/sandbox-destroy-lifetime.test.ts
+++ b/packages/sandbox/tests/sandbox-destroy-lifetime.test.ts
@@ -1,0 +1,164 @@
+import { Container } from '@cloudflare/containers';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { connect, Sandbox } from '../src/sandbox';
+
+vi.mock('./interpreter', () => ({
+  CodeInterpreter: vi.fn().mockImplementation(() => ({}))
+}));
+
+vi.mock('@cloudflare/containers', () => {
+  const MockContainer = class Container {
+    ctx: unknown;
+    env: unknown;
+    sleepAfter: string | number = '10m';
+    constructor(ctx: unknown, env: unknown) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+    async fetch(_request: Request): Promise<Response> {
+      return new Response('Mock');
+    }
+    async containerFetch(_request: Request, _port: number): Promise<Response> {
+      return new Response('Mock');
+    }
+    async startAndWaitForPorts(): Promise<void> {}
+    async destroy(): Promise<void> {}
+    async stop(): Promise<void> {}
+    async getState() {
+      return { status: 'healthy' };
+    }
+    renewActivityTimeout() {}
+  };
+
+  const MockContainerProxy = class ContainerProxy {
+    ctx: unknown;
+    env: unknown;
+    constructor(ctx: unknown, env: unknown) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+    async fetch(_request: Request): Promise<Response> {
+      return new Response('Mock');
+    }
+  };
+
+  return {
+    Container: MockContainer,
+    ContainerProxy: MockContainerProxy,
+    getContainer: vi.fn(),
+    switchPort: vi.fn((request: Request) => request)
+  };
+});
+
+describe('Sandbox destroy() sandbox lifetime', () => {
+  let sandbox: Sandbox;
+  let putCalls: Array<{ key: string; seq: number }>;
+  let deleteCalls: Array<{ key: string; seq: number }>;
+  let callSeq: number;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    putCalls = [];
+    deleteCalls = [];
+    callSeq = 0;
+
+    const storageState = new Map<string, unknown>();
+
+    const storage = {
+      get: vi.fn(async (key: string) => storageState.get(key) ?? null),
+      put: vi.fn(async (key: string, value: unknown) => {
+        putCalls.push({ key, seq: callSeq++ });
+        storageState.set(key, value);
+      }),
+      delete: vi.fn(async (key: string) => {
+        deleteCalls.push({ key, seq: callSeq++ });
+        storageState.delete(key);
+      }),
+      list: vi.fn().mockResolvedValue(new Map()),
+      transaction: vi.fn(async (callback: (s: typeof storage) => unknown) =>
+        callback(storage)
+      )
+    };
+
+    const mockCtx = {
+      storage,
+      blockConcurrencyWhile: vi
+        .fn()
+        .mockImplementation(<T>(cb: () => Promise<T>): Promise<T> => cb()),
+      waitUntil: vi.fn(),
+      container: { running: true, start: vi.fn() },
+      id: {
+        toString: () => 'test-sandbox-id',
+        equals: vi.fn(),
+        name: 'test-sandbox'
+      }
+    };
+
+    const stub = new Sandbox(
+      mockCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+      {}
+    );
+
+    await vi.waitFor(() => {
+      expect(mockCtx.blockConcurrencyWhile).toHaveBeenCalled();
+    });
+    await Promise.all(
+      (
+        mockCtx.blockConcurrencyWhile as {
+          mock: { results: Array<{ value: unknown }> };
+        }
+      ).mock.results.map((r) => r.value)
+    );
+
+    sandbox = Object.assign(stub, { wsConnect: connect(stub) });
+
+    vi.spyOn(Container.prototype, 'destroy').mockImplementation(async () => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rotates sandbox lifetime before clearing currentRuntimeIdentity', async () => {
+    await sandbox.destroy();
+
+    // The sandbox:lifetime rotation put must exist
+    const lifetimePut = putCalls.find((c) => c.key === 'sandbox:lifetime');
+    expect(lifetimePut, 'expected a put to sandbox:lifetime').toBeDefined();
+
+    // The currentRuntimeIdentity delete must exist
+    const runtimeDelete = deleteCalls.find(
+      (c) => c.key === 'currentRuntimeIdentity'
+    );
+    expect(
+      runtimeDelete,
+      'expected a delete of currentRuntimeIdentity'
+    ).toBeDefined();
+
+    if (!lifetimePut || !runtimeDelete) {
+      throw new Error('Expected lifetime rotation and runtime clear calls');
+    }
+    expect(lifetimePut.seq).toBeLessThan(runtimeDelete.seq);
+  });
+
+  it('does not rotate lifetime during onStart()', async () => {
+    putCalls = [];
+
+    // Simulate onStart (called internally by the container lifecycle)
+    await (sandbox as unknown as { onStart: () => Promise<void> }).onStart();
+
+    const lifetimePut = putCalls.find((c) => c.key === 'sandbox:lifetime');
+    expect(lifetimePut).toBeUndefined();
+  });
+
+  it('does not rotate lifetime during onStop()', async () => {
+    putCalls = [];
+
+    // Simulate onStop
+    await (sandbox as unknown as { onStop: () => Promise<void> }).onStop();
+
+    const lifetimePut = putCalls.find((c) => c.key === 'sandbox:lifetime');
+    expect(lifetimePut).toBeUndefined();
+  });
+});

--- a/packages/sandbox/tests/sandbox-lifetime.test.ts
+++ b/packages/sandbox/tests/sandbox-lifetime.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CurrentSandboxLifetime,
+  SandboxLifetime,
+  SandboxLifetimeChangedError
+} from '../src/sandbox-lifetime';
+
+function createStorage(initial = new Map<string, unknown>()) {
+  return {
+    get: vi.fn(async (key: string) => initial.get(key) ?? null),
+    put: vi.fn(async (key: string, value: unknown) => {
+      initial.set(key, value);
+    })
+  };
+}
+
+describe('CurrentSandboxLifetime', () => {
+  it('getOrCreate() returns a stable id on repeated calls', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const first = await currentLifetime.getOrCreate();
+    const second = await currentLifetime.getOrCreate();
+
+    expect(first.id).toBe(second.id);
+    expect(typeof first.id).toBe('string');
+    expect(first.id.length).toBeGreaterThan(0);
+  });
+
+  it('getOrCreate() persists the record to storage', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    await currentLifetime.getOrCreate();
+
+    // Storage must have been written
+    expect(storage.put).toHaveBeenCalledOnce();
+    expect(map.has('sandbox:lifetime')).toBe(true);
+  });
+
+  it('getOrCreate() does not overwrite an existing lifetime', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const first = await currentLifetime.getOrCreate();
+    // put should have been called exactly once — the second call reads from storage
+    const putCallsBefore = storage.put.mock.calls.length;
+    const second = await currentLifetime.getOrCreate();
+
+    expect(storage.put.mock.calls.length).toBe(putCallsBefore);
+    expect(second.id).toBe(first.id);
+  });
+
+  it('rotate() changes the lifetime id', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const original = await currentLifetime.getOrCreate();
+    const rotated = await currentLifetime.rotate();
+
+    expect(rotated.id).not.toBe(original.id);
+  });
+
+  it('rotate() increments the generation', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const original = await currentLifetime.getOrCreate();
+    const rotated = await currentLifetime.rotate();
+
+    expect(rotated.generation).toBeGreaterThan(original.generation);
+  });
+
+  it('assertCurrent() resolves when lifetime matches current storage', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const lifetime = await currentLifetime.getOrCreate();
+    await expect(
+      currentLifetime.assertCurrent(lifetime)
+    ).resolves.toBeUndefined();
+  });
+
+  it('assertCurrent() throws SandboxLifetimeChangedError for a stale lifetime', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const stale = await currentLifetime.getOrCreate();
+    // Rotate so the stored id is different from stale
+    await currentLifetime.rotate();
+
+    await expect(currentLifetime.assertCurrent(stale)).rejects.toThrow(
+      SandboxLifetimeChangedError
+    );
+  });
+
+  it('isCurrent() returns true for current lifetime', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const lifetime = await currentLifetime.getOrCreate();
+    expect(await currentLifetime.isCurrent(lifetime)).toBe(true);
+  });
+
+  it('isCurrent() returns false for stale lifetime after rotate', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const stale = await currentLifetime.getOrCreate();
+    await currentLifetime.rotate();
+
+    expect(await currentLifetime.isCurrent(stale)).toBe(false);
+  });
+
+  it('SandboxLifetimeChangedError has the expected name and message', () => {
+    const err = new SandboxLifetimeChangedError();
+    expect(err.name).toBe('SandboxLifetimeChangedError');
+    expect(err.message).toBe('Sandbox lifetime is no longer current');
+  });
+
+  it('SandboxLifetime.owns() returns true for a scoped record', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const lifetime = await currentLifetime.getOrCreate();
+    const scoped = lifetime.scope({ data: 'test' });
+    expect(lifetime.owns(scoped)).toBe(true);
+  });
+
+  it('SandboxLifetime.owns() returns false for a record from a different lifetime', async () => {
+    const map = new Map<string, unknown>();
+    const storage = createStorage(map);
+    const currentLifetime = new CurrentSandboxLifetime(
+      storage as unknown as DurableObjectState['storage']
+    );
+
+    const first = await currentLifetime.getOrCreate();
+    const second = await currentLifetime.rotate();
+    const scoped = second.scope({ data: 'test' });
+
+    expect(first.owns(scoped)).toBe(false);
+  });
+});


### PR DESCRIPTION
**Stack:** 2 of 3 — builds on the lifecycle error contract from the container-unavailable PR. Open that one first.

When the Cloudflare runtime replaces a sandbox's container while a backup restore is in progress, `restoreBackup()` fails with a generic 500 and leaves the caller unsure whether the restore committed. This is one of the runtime-replacement failure modes seen during deployment rollouts (see #158).

This PR runs restore through a lifecycle that makes it recoverable:

- Each attempt is **fenced by sandbox lifetime and runtime identity**, so an attempt that started against a now-replaced runtime is detected rather than silently writing to the wrong container.
- Runtime replacement mid-restore is **retried boundedly** (at most two recovery attempts).
- Restore is **not retried across `destroy()`** or a sandbox lifetime change.
- When bounded recovery is exhausted, the caller gets a structured **`OPERATION_INTERRUPTED` (409)** with retry guidance instead of an opaque failure.

## Scope

This is a stable hotfix, not the `next` architecture (#763). Recovery lands in the existing `sandbox.ts` restore path plus a narrow lifecycle runner and operation-record store, rather than extracting a `BackupService`. Recovery is scoped to this SDK-owned operation — there are no blanket retries around `exec()`, writes, renames, or other user operations that may have side effects.
