### PR TITLE
Recover stable quick tunnels

### DIFF
--- a/.changeset/stable-quick-tunnel-recovery.md
+++ b/.changeset/stable-quick-tunnel-recovery.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Recover quick tunnels when the sandbox runtime is replaced. `tunnels.get(port)` now provisions through an idempotent runtime-run boundary so a retry after a replacement returns a currently usable URL instead of a dead one, and `tunnels.list()` no longer returns quick tunnel URLs known to be stale after a container restart.

--- a/packages/sandbox-container/src/control-plane/api.ts
+++ b/packages/sandbox-container/src/control-plane/api.ts
@@ -1,6 +1,8 @@
 import type {
   CheckChangesRequest,
   CheckChangesResult,
+  EnsureTunnelRunRequest,
+  EnsureTunnelRunResult,
   ExecutionError,
   FileEncoding,
   FileInfo,
@@ -9,6 +11,8 @@ import type {
   OutputMessage,
   Result,
   SandboxAPI,
+  StopTunnelRunRequest,
+  StopTunnelRunResult,
   TunnelInfo,
   WatchRequest
 } from '@repo/shared';
@@ -1127,5 +1131,19 @@ class TunnelsRPCAPI extends RpcTarget {
 
   async listTunnels(): Promise<TunnelInfo[]> {
     return this.#svc.list();
+  }
+
+  async ensureTunnelRun(
+    request: EnsureTunnelRunRequest
+  ): Promise<EnsureTunnelRunResult> {
+    const result = await this.#svc.ensureTunnelRun(request);
+    return extractData<EnsureTunnelRunResult>(result);
+  }
+
+  async stopTunnelRun(
+    request: StopTunnelRunRequest
+  ): Promise<StopTunnelRunResult> {
+    const result = await this.#svc.stopTunnelRun(request);
+    return extractData<StopTunnelRunResult>(result);
   }
 }

--- a/packages/sandbox-container/src/services/tunnel-service.ts
+++ b/packages/sandbox-container/src/services/tunnel-service.ts
@@ -251,6 +251,23 @@ export class TunnelService {
       return serviceSuccess({ run: result.data.run, started: false });
     }
 
+    for (const rec of this.tunnels.values()) {
+      if (rec.info.port === port) {
+        return serviceError({
+          message: `Port ${port} already active under legacy tunnel ${rec.info.id}`,
+          code: 'TUNNEL_RUN_CONFLICT',
+          details: { runId, port, activeTunnelId: rec.info.id }
+        });
+      }
+      if (rec.info.id === tunnelId) {
+        return serviceError({
+          message: `Tunnel ${tunnelId} already active under legacy tunnel`,
+          code: 'TUNNEL_RUN_CONFLICT',
+          details: { tunnelId, runId }
+        });
+      }
+    }
+
     for (const rec of this.tunnelRuns.values()) {
       if (rec.request.port === port) {
         return serviceError({

--- a/packages/sandbox-container/src/services/tunnel-service.ts
+++ b/packages/sandbox-container/src/services/tunnel-service.ts
@@ -9,7 +9,16 @@
  * id without waiting for the create round-trip to resolve.
  */
 
-import type { Logger, SandboxControlCallback, TunnelInfo } from '@repo/shared';
+import type {
+  EnsureTunnelRunRequest,
+  EnsureTunnelRunResult,
+  Logger,
+  SandboxControlCallback,
+  StopTunnelRunRequest,
+  StopTunnelRunResult,
+  TunnelInfo,
+  TunnelRunSnapshot
+} from '@repo/shared';
 import type { ServiceResult } from '../core/types';
 import { serviceError, serviceSuccess } from '../core/types';
 import {
@@ -29,8 +38,32 @@ interface TunnelRecord {
   manager: TunnelManager;
 }
 
+/** Runtime-run registry entry for ensureTunnelRun/stopTunnelRun paths. */
+interface TunnelRunRecord {
+  request: EnsureTunnelRunRequest;
+  manager: TunnelManager;
+  result: Promise<ServiceResult<EnsureTunnelRunResult>>;
+}
+
+function tunnelRunRequestsMatch(
+  left: EnsureTunnelRunRequest,
+  right: EnsureTunnelRunRequest
+): boolean {
+  return (
+    left.tunnelId === right.tunnelId &&
+    left.runId === right.runId &&
+    left.mode === right.mode &&
+    left.port === right.port &&
+    (left.mode !== 'named' ||
+      right.mode !== 'named' ||
+      left.token === right.token)
+  );
+}
+
 export class TunnelService {
   private readonly tunnels = new Map<string, TunnelRecord>();
+  /** Keyed by `runId`. Separate from legacy `tunnels` so list() behavior is unchanged. */
+  private readonly tunnelRuns = new Map<string, TunnelRunRecord>();
 
   /**
    * @param logger Child logger for tunnel-service log lines.
@@ -193,6 +226,136 @@ export class TunnelService {
     }
   }
 
+  /**
+   * Start or replay a cloudflared run identified by `(tunnelId, runId)`.
+   * Idempotent: same request replays with `started: false`. Conflict:
+   * different params for same runId, or different active run on same
+   * port/tunnelId, returns `TUNNEL_RUN_CONFLICT`.
+   */
+  async ensureTunnelRun(
+    request: EnsureTunnelRunRequest
+  ): Promise<ServiceResult<EnsureTunnelRunResult>> {
+    const { tunnelId, runId, mode, port } = request;
+
+    const existing = this.tunnelRuns.get(runId);
+    if (existing) {
+      if (!tunnelRunRequestsMatch(existing.request, request)) {
+        return serviceError({
+          message: `Run ${runId} already active with different params`,
+          code: 'TUNNEL_RUN_CONFLICT',
+          details: { runId, tunnelId, port }
+        });
+      }
+      const result = await existing.result;
+      if (!result.success) return result;
+      return serviceSuccess({ run: result.data.run, started: false });
+    }
+
+    for (const rec of this.tunnelRuns.values()) {
+      if (rec.request.port === port) {
+        return serviceError({
+          message: `Port ${port} already active under run ${rec.request.runId}`,
+          code: 'TUNNEL_RUN_CONFLICT',
+          details: { runId, port, activeRunId: rec.request.runId }
+        });
+      }
+      if (rec.request.tunnelId === tunnelId) {
+        return serviceError({
+          message: `Tunnel ${tunnelId} already active under run ${rec.request.runId}`,
+          code: 'TUNNEL_RUN_CONFLICT',
+          details: { tunnelId, runId, activeRunId: rec.request.runId }
+        });
+      }
+    }
+
+    const token = mode === 'named' ? request.token : undefined;
+    const manager = new TunnelManager({
+      port,
+      token,
+      logger: this.logger,
+      onExit: (code) => {
+        this.tunnelRuns.delete(runId);
+        const cb = this.getControlCallback();
+        if (!cb) return;
+        cb.onTunnelExit(tunnelId, port, code, runId).catch((err) => {
+          this.logger.warn('onTunnelExit RPC failed (runtime-run)', {
+            tunnelId,
+            runId,
+            error: err instanceof Error ? err.message : String(err)
+          });
+        });
+      }
+    });
+
+    const result = this.startTunnelRun(request, manager);
+    this.tunnelRuns.set(runId, { request, manager, result });
+    return await result;
+  }
+
+  private async startTunnelRun(
+    request: EnsureTunnelRunRequest,
+    manager: TunnelManager
+  ): Promise<ServiceResult<EnsureTunnelRunResult>> {
+    const { tunnelId, runId, mode, port } = request;
+    try {
+      const startResult = await manager.start();
+      const snapshot: TunnelRunSnapshot = {
+        tunnelId,
+        runId,
+        mode,
+        port,
+        startedAt: new Date().toISOString(),
+        ...(mode === 'quick' && startResult.url
+          ? {
+              url: startResult.url,
+              hostname: new URL(startResult.url).hostname
+            }
+          : {})
+      };
+      this.logger.info('Tunnel run started', { tunnelId, runId, mode, port });
+      return serviceSuccess({ run: snapshot, started: true });
+    } catch (err) {
+      this.tunnelRuns.delete(runId);
+      await manager.stop().catch(() => {});
+      if (err instanceof CloudflaredNotFoundError) {
+        return serviceError({
+          message: err.message,
+          code: 'CLOUDFLARED_NOT_FOUND',
+          details: { tunnelId, runId, port, binary: err.binary }
+        });
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      return serviceError({
+        message: `Failed to start tunnel run: ${message}`,
+        code: 'TUNNEL_START_ERROR',
+        details: { tunnelId, runId, port }
+      });
+    }
+  }
+
+  /**
+   * Stop the cloudflared process identified by the exact `(tunnelId, runId)` pair.
+   * Returns `{ stopped: true }` when found and stopped; `{ stopped: false }` when
+   * no matching run is active. A non-matching runId for a known tunnelId also
+   * returns `{ stopped: false }`; exact run identity is required for stop.
+   */
+  async stopTunnelRun(
+    request: StopTunnelRunRequest
+  ): Promise<ServiceResult<StopTunnelRunResult>> {
+    const { tunnelId, runId } = request;
+    const rec = this.tunnelRuns.get(runId);
+    if (!rec || rec.request.tunnelId !== tunnelId) {
+      return serviceSuccess({ stopped: false });
+    }
+    try {
+      await rec.manager.stop();
+    } finally {
+      this.tunnelRuns.delete(runId);
+    }
+    this.logger.info('Tunnel run stopped', { tunnelId, runId });
+    return serviceSuccess({ stopped: true });
+  }
+
   async destroyTunnel(id: string): Promise<ServiceResult<void>> {
     const record = this.tunnels.get(id);
     if (!record) {
@@ -217,7 +380,14 @@ export class TunnelService {
 
   /** Stop every tunnel. Called on container shutdown. */
   async destroyAll(): Promise<void> {
-    const ids = Array.from(this.tunnels.keys());
-    await Promise.all(ids.map((id) => this.destroyTunnel(id)));
+    const legacyIds = Array.from(this.tunnels.keys());
+    const runRefs = Array.from(this.tunnelRuns.values()).map(({ request }) => ({
+      tunnelId: request.tunnelId,
+      runId: request.runId
+    }));
+    await Promise.all([
+      ...legacyIds.map((id) => this.destroyTunnel(id)),
+      ...runRefs.map((ref) => this.stopTunnelRun(ref))
+    ]);
   }
 }

--- a/packages/sandbox-container/tests/rpc/sandbox-api-utils.test.ts
+++ b/packages/sandbox-container/tests/rpc/sandbox-api-utils.test.ts
@@ -138,3 +138,15 @@ describe('SandboxControlAPI utils.createSession', () => {
     expect(err.details?.containerPlacementId).toBeUndefined();
   });
 });
+
+describe('SandboxControlAPI tunnels.ensureTunnelRun and stopTunnelRun', () => {
+  it('exposes ensureTunnelRun on the tunnels sub-stub', () => {
+    const api = buildApi({} as unknown as SessionManager);
+    expect(typeof api.tunnels.ensureTunnelRun).toBe('function');
+  });
+
+  it('exposes stopTunnelRun on the tunnels sub-stub', () => {
+    const api = buildApi({} as unknown as SessionManager);
+    expect(typeof api.tunnels.stopTunnelRun).toBe('function');
+  });
+});

--- a/packages/sandbox-container/tests/services/tunnel-service.test.ts
+++ b/packages/sandbox-container/tests/services/tunnel-service.test.ts
@@ -884,6 +884,46 @@ describe('TunnelService > ensureTunnelRun', () => {
     expect(result.error.code).toBe('TUNNEL_RUN_CONFLICT');
   });
 
+  it('returns TUNNEL_RUN_CONFLICT when a legacy tunnel already uses the port', async () => {
+    const service = new TunnelService(mockLogger);
+
+    await withFakeCloudflared(QUICK_BANNER, async () => {
+      await service.runQuickTunnel('quick-legacy', 8080);
+    });
+
+    const result = await service.ensureTunnelRun({
+      tunnelId: 'tid-runtime',
+      runId: 'rid-runtime',
+      mode: 'quick',
+      port: 8080
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('TUNNEL_RUN_CONFLICT');
+    expect(fakeProcs).toHaveLength(1);
+  });
+
+  it('returns TUNNEL_RUN_CONFLICT when a legacy tunnel already uses the tunnel id', async () => {
+    const service = new TunnelService(mockLogger);
+
+    await withFakeCloudflared(QUICK_BANNER, async () => {
+      await service.runQuickTunnel('tid-legacy', 8080);
+    });
+
+    const result = await service.ensureTunnelRun({
+      tunnelId: 'tid-legacy',
+      runId: 'rid-runtime',
+      mode: 'quick',
+      port: 9090
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('TUNNEL_RUN_CONFLICT');
+    expect(fakeProcs).toHaveLength(1);
+  });
+
   it('returns TUNNEL_RUN_CONFLICT for different runId on same tunnelId', async () => {
     const service = new TunnelService(mockLogger);
 

--- a/packages/sandbox-container/tests/services/tunnel-service.test.ts
+++ b/packages/sandbox-container/tests/services/tunnel-service.test.ts
@@ -643,7 +643,6 @@ describe('TunnelService > runNamedTunnel', () => {
   });
 });
 
-
 // ---------------------------------------------------------------------------
 // Missing cloudflared binary
 // ---------------------------------------------------------------------------
@@ -712,5 +711,281 @@ describe('TunnelService > cloudflared binary missing', () => {
     expect(result.success).toBe(false);
     if (result.success) return;
     expect(result.error.code).toBe('TUNNEL_START_ERROR');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runtime-run API (ensureTunnelRun / stopTunnelRun)
+// ---------------------------------------------------------------------------
+
+describe('TunnelService > ensureTunnelRun', () => {
+  it('starts a quick run and returns the snapshot with started: true', async () => {
+    const service = new TunnelService(mockLogger);
+
+    let result!: Awaited<ReturnType<typeof service.ensureTunnelRun>>;
+    await withFakeCloudflared(QUICK_BANNER, async () => {
+      result = await service.ensureTunnelRun({
+        tunnelId: 'tid-1',
+        runId: 'rid-1',
+        mode: 'quick',
+        port: 8080
+      });
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.started).toBe(true);
+    expect(result.data.run.tunnelId).toBe('tid-1');
+    expect(result.data.run.runId).toBe('rid-1');
+    expect(result.data.run.mode).toBe('quick');
+    expect(result.data.run.port).toBe(8080);
+    expect(typeof result.data.run.url).toBe('string');
+    expect(result.data.run.url).toBeTruthy();
+    expect(typeof result.data.run.hostname).toBe('string');
+    expect(result.data.run.hostname).toBeTruthy();
+  });
+
+  it('replays the same runId + same params with started: false', async () => {
+    const service = new TunnelService(mockLogger);
+
+    await withFakeCloudflared(QUICK_BANNER, async () => {
+      await service.ensureTunnelRun({
+        tunnelId: 'tid-2',
+        runId: 'rid-2',
+        mode: 'quick',
+        port: 8080
+      });
+    });
+
+    // Replay — no new cloudflared should spawn
+    const result = await service.ensureTunnelRun({
+      tunnelId: 'tid-2',
+      runId: 'rid-2',
+      mode: 'quick',
+      port: 8080
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.started).toBe(false);
+    expect(result.data.run.runId).toBe('rid-2');
+    // Only one cloudflared was spawned across both calls
+    expect(fakeProcs).toHaveLength(1);
+  });
+
+  it('replays the same inflight runId without spawning another process', async () => {
+    const service = new TunnelService(mockLogger);
+
+    const first = service.ensureTunnelRun({
+      tunnelId: 'tid-inflight',
+      runId: 'rid-inflight',
+      mode: 'quick',
+      port: 8080
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fakeProcs).toHaveLength(1);
+
+    const replay = service.ensureTunnelRun({
+      tunnelId: 'tid-inflight',
+      runId: 'rid-inflight',
+      mode: 'quick',
+      port: 8080
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fakeProcs).toHaveLength(1);
+
+    fakeProcs[0].stderr.write(QUICK_BANNER);
+    await new Promise((r) => setTimeout(r, 30));
+    fetchHandler.ready = true;
+
+    const [firstResult, replayResult] = await Promise.all([first, replay]);
+    expect(firstResult.success).toBe(true);
+    expect(replayResult.success).toBe(true);
+    if (!replayResult.success) return;
+    expect(replayResult.data.started).toBe(false);
+    expect(replayResult.data.run.runId).toBe('rid-inflight');
+  });
+
+  it('rejects a different run on the same port while the first run is starting', async () => {
+    const service = new TunnelService(mockLogger);
+
+    const first = service.ensureTunnelRun({
+      tunnelId: 'tid-starting-a',
+      runId: 'rid-starting-a',
+      mode: 'quick',
+      port: 8080
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fakeProcs).toHaveLength(1);
+
+    const second = await service.ensureTunnelRun({
+      tunnelId: 'tid-starting-b',
+      runId: 'rid-starting-b',
+      mode: 'quick',
+      port: 8080
+    });
+
+    expect(second.success).toBe(false);
+    if (second.success) return;
+    expect(second.error.code).toBe('TUNNEL_RUN_CONFLICT');
+    expect(fakeProcs).toHaveLength(1);
+
+    fakeProcs[0].stderr.write(QUICK_BANNER);
+    await new Promise((r) => setTimeout(r, 30));
+    fetchHandler.ready = true;
+    expect((await first).success).toBe(true);
+  });
+
+  it('returns TUNNEL_RUN_CONFLICT for same runId with different params', async () => {
+    const service = new TunnelService(mockLogger);
+
+    await withFakeCloudflared(QUICK_BANNER, async () => {
+      await service.ensureTunnelRun({
+        tunnelId: 'tid-3',
+        runId: 'rid-3',
+        mode: 'quick',
+        port: 8080
+      });
+    });
+
+    const result = await service.ensureTunnelRun({
+      tunnelId: 'tid-3',
+      runId: 'rid-3',
+      mode: 'quick',
+      port: 9090 // different port
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('TUNNEL_RUN_CONFLICT');
+  });
+
+  it('returns TUNNEL_RUN_CONFLICT for different runId on same port', async () => {
+    const service = new TunnelService(mockLogger);
+
+    await withFakeCloudflared(QUICK_BANNER, async () => {
+      await service.ensureTunnelRun({
+        tunnelId: 'tid-4',
+        runId: 'rid-4a',
+        mode: 'quick',
+        port: 8080
+      });
+    });
+
+    const result = await service.ensureTunnelRun({
+      tunnelId: 'tid-5', // different tunnelId
+      runId: 'rid-4b', // different runId
+      mode: 'quick',
+      port: 8080 // same port
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('TUNNEL_RUN_CONFLICT');
+  });
+
+  it('returns TUNNEL_RUN_CONFLICT for different runId on same tunnelId', async () => {
+    const service = new TunnelService(mockLogger);
+
+    await withFakeCloudflared(QUICK_BANNER, async () => {
+      await service.ensureTunnelRun({
+        tunnelId: 'tid-6',
+        runId: 'rid-6a',
+        mode: 'quick',
+        port: 8080
+      });
+    });
+
+    const result = await service.ensureTunnelRun({
+      tunnelId: 'tid-6', // same tunnelId
+      runId: 'rid-6b', // different runId
+      mode: 'quick',
+      port: 9090
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.code).toBe('TUNNEL_RUN_CONFLICT');
+  });
+});
+
+describe('TunnelService > stopTunnelRun', () => {
+  it('stops the exact matching run and returns stopped: true', async () => {
+    const service = new TunnelService(mockLogger);
+
+    await withFakeCloudflared(QUICK_BANNER, async () => {
+      await service.ensureTunnelRun({
+        tunnelId: 'tid-s1',
+        runId: 'rid-s1',
+        mode: 'quick',
+        port: 8080
+      });
+    });
+
+    const stopPromise = service.stopTunnelRun({
+      tunnelId: 'tid-s1',
+      runId: 'rid-s1'
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    fakeProcs[0].resolveExit(0);
+    const result = await stopPromise;
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.stopped).toBe(true);
+    expect(fakeProcs[0].kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('returns stopped: false for a non-existent runId without error', async () => {
+    const service = new TunnelService(mockLogger);
+
+    const result = await service.stopTunnelRun({
+      tunnelId: 'tid-ghost',
+      runId: 'rid-ghost'
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.stopped).toBe(false);
+  });
+
+  it('returns stopped: false when tunnelId matches but runId differs', async () => {
+    const service = new TunnelService(mockLogger);
+
+    await withFakeCloudflared(QUICK_BANNER, async () => {
+      await service.ensureTunnelRun({
+        tunnelId: 'tid-s2',
+        runId: 'rid-s2',
+        mode: 'quick',
+        port: 8080
+      });
+    });
+
+    const result = await service.stopTunnelRun({
+      tunnelId: 'tid-s2',
+      runId: 'rid-s2-different'
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.stopped).toBe(false);
+    // Original process still running — no kill called for this attempt
+    expect(fakeProcs[0].kill).not.toHaveBeenCalled();
+  });
+
+  it('runtime-run records do not appear in legacy list()', async () => {
+    const service = new TunnelService(mockLogger);
+
+    await withFakeCloudflared(QUICK_BANNER, async () => {
+      await service.ensureTunnelRun({
+        tunnelId: 'tid-list',
+        runId: 'rid-list',
+        mode: 'quick',
+        port: 8080
+      });
+    });
+
+    // Legacy list() should be empty — runtime-run records are separate
+    expect(service.list()).toHaveLength(0);
   });
 });

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -5199,6 +5199,8 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       storage: this.ctx.storage,
       logger: this.logger,
       sandboxId: this.ctx.id.toString(),
+      currentRuntime: this.currentRuntime,
+      currentLifetime: this.currentLifetime,
       getNamedTunnelConfig: async () => {
         const envObj = this.env as Record<string, unknown>;
         const token = getEnvString(envObj, 'CLOUDFLARE_API_TOKEN');

--- a/packages/sandbox/src/tunnels/lifecycle.ts
+++ b/packages/sandbox/src/tunnels/lifecycle.ts
@@ -1,0 +1,84 @@
+import type { OperationInterruptedReason } from '@repo/shared/errors';
+import { RuntimeIdentityInactiveError } from '../current-runtime-identity';
+import {
+  ErrorCode,
+  OperationInterruptedError,
+  RPCTransportError
+} from '../errors';
+import { SandboxLifetimeChangedError } from '../sandbox-lifetime';
+
+export const TUNNEL_GET_MAX_RECOVERY_ATTEMPTS = 2;
+
+export function runtimeRunId(): string {
+  return `run-${crypto.randomUUID()}`;
+}
+
+export function createTunnelInterruptedError(params: {
+  reason: OperationInterruptedReason;
+  phase: string;
+  admitted: boolean | 'unknown';
+  retryable: boolean;
+  recoveryAttempts?: number;
+  maxRecoveryAttempts?: number;
+}): OperationInterruptedError {
+  return new OperationInterruptedError({
+    message:
+      params.reason === 'recovery_exhausted'
+        ? 'Tunnel recovery attempts were exhausted'
+        : 'Tunnel operation was interrupted by a sandbox runtime change',
+    code: ErrorCode.OPERATION_INTERRUPTED,
+    httpStatus: 409,
+    context: {
+      reason: params.reason,
+      operation: 'tunnel.get',
+      phase: params.phase,
+      admitted: params.admitted,
+      retryable: params.retryable,
+      ...(params.recoveryAttempts !== undefined && {
+        recoveryAttempts: params.recoveryAttempts
+      }),
+      ...(params.maxRecoveryAttempts !== undefined && {
+        maxRecoveryAttempts: params.maxRecoveryAttempts
+      })
+    },
+    timestamp: new Date().toISOString(),
+    suggestion: params.retryable
+      ? 'Retry tunnels.get() for the same port so the SDK can establish a fresh tunnel run.'
+      : 'Start a new tunnels.get() call only if this tunnel is still desired for the current sandbox.'
+  });
+}
+
+export function translateTunnelInterruption(
+  error: unknown,
+  phase: string,
+  admitted: boolean | 'unknown'
+): OperationInterruptedError | null {
+  if (error instanceof OperationInterruptedError) {
+    return error;
+  }
+  if (error instanceof RuntimeIdentityInactiveError) {
+    return createTunnelInterruptedError({
+      reason: 'runtime_replaced',
+      phase,
+      admitted,
+      retryable: true
+    });
+  }
+  if (error instanceof SandboxLifetimeChangedError) {
+    return createTunnelInterruptedError({
+      reason: 'sandbox_lifetime_changed',
+      phase,
+      admitted,
+      retryable: false
+    });
+  }
+  if (error instanceof RPCTransportError) {
+    return createTunnelInterruptedError({
+      reason: 'transport_disposed',
+      phase,
+      admitted: 'unknown',
+      retryable: true
+    });
+  }
+  return null;
+}

--- a/packages/sandbox/src/tunnels/lifecycle.ts
+++ b/packages/sandbox/src/tunnels/lifecycle.ts
@@ -6,11 +6,12 @@ import {
   RPCTransportError
 } from '../errors';
 import { SandboxLifetimeChangedError } from '../sandbox-lifetime';
+import { randomId } from './random-id';
 
 export const TUNNEL_GET_MAX_RECOVERY_ATTEMPTS = 2;
 
 export function runtimeRunId(): string {
-  return `run-${crypto.randomUUID()}`;
+  return `run-${randomId()}`;
 }
 
 export function createTunnelInterruptedError(params: {

--- a/packages/sandbox/src/tunnels/random-id.ts
+++ b/packages/sandbox/src/tunnels/random-id.ts
@@ -1,0 +1,21 @@
+// Crockford base32 alphabet (lowercase), excluding i, l, o, u to avoid
+// visual ambiguity. 32 symbols means each character carries exactly 5 bits
+// of entropy drawn uniformly from crypto.getRandomValues, and the alphabet
+// is safe to use as a DNS label or URL path segment.
+const ID_ALPHABET = '0123456789abcdefghjkmnpqrstvwxyz';
+
+/**
+ * Generate a URL- and DNS-safe random id. The default 20 characters give
+ * ~100 bits of entropy, which keeps collisions negligible at any realistic
+ * volume without a uniqueness retry loop. 32 divides 256 evenly, so masking
+ * the low 5 bits of each random byte stays uniform.
+ */
+export function randomId(size = 20): string {
+  const bytes = new Uint8Array(size);
+  crypto.getRandomValues(bytes);
+  let id = '';
+  for (let i = 0; i < size; i += 1) {
+    id += ID_ALPHABET[bytes[i] & 31];
+  }
+  return id;
+}

--- a/packages/sandbox/src/tunnels/restart.ts
+++ b/packages/sandbox/src/tunnels/restart.ts
@@ -1,0 +1,31 @@
+import {
+  META_STORAGE_KEY,
+  readMap,
+  readMetaMap,
+  STORAGE_KEY,
+  type TunnelMap,
+  type TunnelMetaMap,
+  type TunnelsStorage
+} from './storage';
+
+export async function pruneTunnelsForRestart(
+  storage: TunnelsStorage
+): Promise<void> {
+  await storage.transaction(async (txn) => {
+    const map = await readMap(txn);
+    const meta = await readMetaMap(txn);
+    const nextMap: TunnelMap = {};
+    const nextMeta: TunnelMetaMap = {};
+    for (const [portKey, info] of Object.entries(map)) {
+      if (info.name) {
+        nextMap[portKey] = info;
+        nextMeta[portKey] = {
+          ...(meta[portKey] ?? { optionsHash: `v1:named:${info.name}` }),
+          needsRespawn: true
+        };
+      }
+    }
+    await txn.put(STORAGE_KEY, nextMap);
+    await txn.put(META_STORAGE_KEY, nextMeta);
+  });
+}

--- a/packages/sandbox/src/tunnels/sandbox-control-callback.ts
+++ b/packages/sandbox/src/tunnels/sandbox-control-callback.ts
@@ -32,17 +32,19 @@ export class SandboxControlCallbackImpl
   async onTunnelExit(
     id: string,
     port: number,
-    exitCode: number | null
+    exitCode: number | null,
+    runId?: string
   ): Promise<void> {
     const handler = this.getHandler();
     if (!handler) {
       this.logger.debug('onTunnelExit: no handler bound; ignoring', {
         id,
         port,
-        exitCode
+        exitCode,
+        runId
       });
       return;
     }
-    await handler(id, port, exitCode);
+    await handler(id, port, exitCode, runId);
   }
 }

--- a/packages/sandbox/src/tunnels/storage.ts
+++ b/packages/sandbox/src/tunnels/storage.ts
@@ -1,0 +1,54 @@
+import type { TunnelInfo, TunnelOptions } from '@repo/shared';
+import type { RuntimeIdentityID } from '../current-runtime-identity';
+import type { SandboxLifetimeID } from '../sandbox-lifetime';
+
+export const STORAGE_KEY = 'tunnels';
+export const META_STORAGE_KEY = 'tunnels:meta';
+
+export interface TunnelsStorageTxn {
+  get<T>(key: string): Promise<T | undefined>;
+  put<T>(key: string, value: T): Promise<void>;
+  delete(key: string): Promise<boolean>;
+}
+
+export interface TunnelsStorage extends TunnelsStorageTxn {
+  transaction<T>(closure: (txn: TunnelsStorageTxn) => Promise<T>): Promise<T>;
+}
+
+export type TunnelMap = Record<string, TunnelInfo>;
+
+export interface TunnelMetaEntry {
+  optionsHash: string;
+  dnsRecordId?: string;
+  runtimeIdentityID?: RuntimeIdentityID;
+  sandboxLifetimeID?: SandboxLifetimeID;
+  tunnelRunId?: string;
+  accountId?: string;
+  zoneId?: string;
+  needsRespawn?: boolean;
+}
+
+export type TunnelMetaMap = Record<string, TunnelMetaEntry>;
+
+export async function readMap(storage: TunnelsStorageTxn): Promise<TunnelMap> {
+  return (await storage.get<TunnelMap>(STORAGE_KEY)) ?? {};
+}
+
+export async function readMetaMap(
+  storage: TunnelsStorageTxn
+): Promise<TunnelMetaMap> {
+  return (await storage.get<TunnelMetaMap>(META_STORAGE_KEY)) ?? {};
+}
+
+export function computeOptionsHash(options?: TunnelOptions): string {
+  if (!options || !options.name) return 'v1:quick';
+  return `v1:named:${options.name}`;
+}
+
+function normaliseHash(hash: string): string {
+  return hash.startsWith('v1:') ? hash.slice(3) : hash;
+}
+
+export function optionsHashesEqual(a: string, b: string): boolean {
+  return normaliseHash(a) === normaliseHash(b);
+}

--- a/packages/sandbox/src/tunnels/tunnels-handler.ts
+++ b/packages/sandbox/src/tunnels/tunnels-handler.ts
@@ -295,6 +295,7 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
               !existing.name &&
               (await this.#quickTunnelRecordIsStale(metaEntry))
             ) {
+              await this.#stopStaleQuickTunnel(existing, metaEntry);
               return await this.#provisionQuickTunnel(port, recovery);
             }
             // Container restart marker: the CF-side tunnel + DNS still
@@ -421,6 +422,24 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
       runtime?.id !== metaEntry.runtimeIdentityID ||
       lifetime.id !== metaEntry.sandboxLifetimeID
     );
+  }
+
+  async #stopStaleQuickTunnel(
+    existing: TunnelInfo,
+    metaEntry?: TunnelMetaEntry
+  ): Promise<void> {
+    try {
+      if (metaEntry?.tunnelRunId) {
+        await this.#host.client.tunnels.stopTunnelRun({
+          tunnelId: existing.id,
+          runId: metaEntry.tunnelRunId
+        });
+      } else {
+        await this.#host.client.tunnels.destroyTunnel(existing.id);
+      }
+    } catch (error) {
+      if (!isTunnelNotFoundError(error)) throw error;
+    }
   }
 
   /**

--- a/packages/sandbox/src/tunnels/tunnels-handler.ts
+++ b/packages/sandbox/src/tunnels/tunnels-handler.ts
@@ -42,6 +42,7 @@ import {
   TUNNEL_GET_MAX_RECOVERY_ATTEMPTS,
   translateTunnelInterruption
 } from './lifecycle';
+import { randomId } from './random-id';
 import {
   computeOptionsHash,
   META_STORAGE_KEY,
@@ -493,7 +494,7 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
     }
 
     recovery.quickRun ??= {
-      tunnelId: `quick-${crypto.randomUUID()}`,
+      tunnelId: `quick-${randomId()}`,
       runId: runtimeRunId()
     };
     const { tunnelId, runId } = recovery.quickRun;

--- a/packages/sandbox/src/tunnels/tunnels-handler.ts
+++ b/packages/sandbox/src/tunnels/tunnels-handler.ts
@@ -3,14 +3,15 @@
  * `createTunnelsHandler(host)` and exposed as `sandbox.tunnels`.
  *
  * Storage is the source of truth. The DO holds a `Record<portString, TunnelInfo>`
- * under the `tunnels` storage key. `Sandbox.onStart()` clears the key on every
- * container restart so any record in storage is by construction backed by a
- * running `cloudflared` process; the handler never needs to verify that
- * separately against the container.
+ * under the `tunnels` storage key, with internal lifecycle metadata under
+ * `tunnels:meta`. Container restarts drop quick tunnel records and mark named
+ * tunnels for respawn, so public list/get calls only return records that are
+ * usable for the current runtime.
  */
 
 import { RpcTarget } from 'cloudflare:workers';
 import type {
+  EnsureTunnelRunResult,
   Logger,
   NamedTunnelInfo,
   QuickTunnelInfo,
@@ -19,6 +20,8 @@ import type {
   TunnelOptions
 } from '@repo/shared';
 import { logCanonicalEvent } from '@repo/shared';
+import type { CurrentRuntimeIdentity } from '../current-runtime-identity';
+import type { CurrentSandboxLifetime } from '../sandbox-lifetime';
 import {
   SandboxSecurityError,
   validatePort,
@@ -33,33 +36,29 @@ import {
   getZoneName,
   upsertCNAME
 } from './cloudflare-api';
+import {
+  createTunnelInterruptedError,
+  runtimeRunId,
+  TUNNEL_GET_MAX_RECOVERY_ATTEMPTS,
+  translateTunnelInterruption
+} from './lifecycle';
+import {
+  computeOptionsHash,
+  META_STORAGE_KEY,
+  optionsHashesEqual,
+  readMap,
+  readMetaMap,
+  STORAGE_KEY,
+  type TunnelMetaEntry,
+  type TunnelsStorage
+} from './storage';
+
+export { pruneTunnelsForRestart } from './restart';
+export type { TunnelsStorage, TunnelsStorageTxn } from './storage';
 
 /** Subset of the RPC client this handler depends on. */
 interface TunnelsRPCClient {
   tunnels: SandboxTunnelsAPI;
-}
-
-/**
- * Subset of `DurableObjectTransaction` (and `DurableObjectStorage`) used
- * inside a transaction closure — no nested `transaction()`.
- */
-export interface TunnelsStorageTxn {
-  get<T>(key: string): Promise<T | undefined>;
-  put<T>(key: string, value: T): Promise<void>;
-  delete(key: string): Promise<boolean>;
-}
-
-/**
- * Subset of `DurableObjectStorage` the handler uses.
- *
- * `transaction` gives optimistic concurrency for the read-modify-write
- * paths in `get()` and `destroy()`: while we await the container RPC,
- * another request to the same DO can land and rewrite the `tunnels`
- * key. Wrapping the write in `transaction()` makes the runtime retry
- * on conflict instead of clobbering the concurrent write.
- */
-export interface TunnelsStorage extends TunnelsStorageTxn {
-  transaction<T>(closure: (txn: TunnelsStorageTxn) => Promise<T>): Promise<T>;
 }
 
 /** Subset of the Sandbox DO the handler reads from. */
@@ -93,6 +92,10 @@ export interface TunnelsHandlerHost {
    * to the global `fetch`. Tests inject a mock here.
    */
   fetcher?: typeof fetch;
+  /** Current container runtime fence for runtime-local quick tunnel records. */
+  currentRuntime?: CurrentRuntimeIdentity;
+  /** Logical sandbox lifetime fence for recovery across destroy(). */
+  currentLifetime?: CurrentSandboxLifetime;
 }
 
 export interface TunnelsHandler {
@@ -111,7 +114,8 @@ export interface TunnelsHandler {
 export type TunnelExitHandler = (
   id: string,
   port: number,
-  exitCode: number | null
+  exitCode: number | null,
+  runId?: string
 ) => Promise<void>;
 
 export interface TunnelsHandle {
@@ -129,51 +133,17 @@ export interface TunnelsHandle {
   destroyAll: () => Promise<void>;
 }
 
-/** DO storage key for the `port → TunnelInfo` map. */
-const STORAGE_KEY = 'tunnels';
-
-/**
- * Sidecar storage key for per-port metadata the handler needs but the
- * public `TunnelInfo` shape does not carry: the options hash used to
- * detect divergent retries, and (for named tunnels) the DNS record id
- * needed for cleanup. Kept under a separate key so the existing
- * `tunnels` shape remains a clean `Record<port, TunnelInfo>`.
- */
-const META_STORAGE_KEY = 'tunnels:meta';
-
-type TunnelMap = Record<string, TunnelInfo>;
-
-interface TunnelMetaEntry {
-  /** Stable hash of the `options` object the tunnel was created with. */
-  optionsHash: string;
-  /** Cloudflare DNS record id for named tunnels; absent for quick. */
-  dnsRecordId?: string;
-  /**
-   * Resolved `(accountId, zoneId)` the named tunnel was provisioned
-   * against. Compared on cache hit to detect env-var changes that
-   * would otherwise silently serve a stale URL (the cached
-   * `TunnelInfo.hostname` is `<name>.<old-zone-name>` and would no
-   * longer resolve to a live tunnel). Absent on quick tunnels.
-   */
-  accountId?: string;
-  zoneId?: string;
-  /**
-   * Set by `pruneTunnelsForRestart` on container restart for named
-   * tunnels. The Cloudflare-side resources (tunnel + DNS) survive the
-   * restart, but the `cloudflared` process inside the container died
-   * with it. The next `get(port, { name })` call sees this flag on a
-   * cache hit and falls through to `#provisionNamedTunnel`, which
-   * reuses the existing tunnel via `findTunnelByName` and respawns
-   * `cloudflared`. Absent on quick tunnels (which are dropped from
-   * storage outright on restart).
-   */
-  needsRespawn?: boolean;
-}
-
-type TunnelMetaMap = Record<string, TunnelMetaEntry>;
-
 /** Per-port serializer shared between `TunnelsRpcTarget` and the exit hook. */
 type WithPortLock = <T>(port: number, fn: () => Promise<T>) => Promise<T>;
+
+type QuickTunnelRunIdentity = {
+  tunnelId: string;
+  runId: string;
+};
+
+type TunnelGetRecoveryState = {
+  quickRun?: QuickTunnelRunIdentity;
+};
 
 function validateTunnelPort(port: number): void {
   if (!validatePort(port)) {
@@ -198,9 +168,9 @@ function shortId(): string {
  * the nested `errorResponse.code`. Used for the few error codes the SDK
  * recognises and recovers from (TUNNEL_NOT_FOUND, TUNNEL_ALREADY_RUNNING).
  *
- * Previous versions matched by substring on `error.message`, which
- * false-positived on any error whose message merely quoted the literal
- * code token.
+ * Message strings may quote error-code tokens for diagnostics, so matching
+ * only structured fields keeps recovery branches tied to explicit error
+ * contracts.
  */
 function hasErrorCode(error: unknown, code: string): boolean {
   if (!error || typeof error !== 'object') return false;
@@ -219,40 +189,6 @@ function isTunnelNotFoundError(error: unknown): boolean {
 
 function isTunnelAlreadyRunningError(error: unknown): boolean {
   return hasErrorCode(error, 'TUNNEL_ALREADY_RUNNING');
-}
-
-async function readMap(storage: TunnelsStorageTxn): Promise<TunnelMap> {
-  return (await storage.get<TunnelMap>(STORAGE_KEY)) ?? {};
-}
-
-async function readMetaMap(storage: TunnelsStorageTxn): Promise<TunnelMetaMap> {
-  return (await storage.get<TunnelMetaMap>(META_STORAGE_KEY)) ?? {};
-}
-
-/**
- * Stable hash of `options`. Empty/undefined options collapse to the same
- * hash so `get(port)`, `get(port, {})`, and `get(port, { name: undefined })`
- * all hit the same cache entry. Named tunnels hash on `name` alone (the
- * only option today).
- *
- * The `v1:` prefix exists so a future addition of a second option (e.g.
- * `subdomain`) can change the canonical form without colliding with an
- * older record's hash. Comparison goes through `optionsHashesEqual`, which
- * normalises legacy unversioned hashes (`quick`, `named:foo`) to their v1
- * form before equality, so upgrading does not invalidate cached records.
- */
-function computeOptionsHash(options?: TunnelOptions): string {
-  if (!options || !options.name) return 'v1:quick';
-  return `v1:named:${options.name}`;
-}
-
-/** Strip the optional `v1:` prefix so legacy hashes compare equal. */
-function normaliseHash(hash: string): string {
-  return hash.startsWith('v1:') ? hash.slice(3) : hash;
-}
-
-function optionsHashesEqual(a: string, b: string): boolean {
-  return normaliseHash(a) === normaliseHash(b);
 }
 
 /**
@@ -334,67 +270,74 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
       if (options?.name !== undefined) validateTunnelName(options.name);
       const requestedHash = computeOptionsHash(options);
 
-      const info = await this.#withPortLock(port, async () => {
-        const map = await readMap(this.#host.storage);
-        const existing = map[port.toString()];
-        if (existing) {
-          const meta = await readMetaMap(this.#host.storage);
-          const metaEntry = meta[port.toString()];
-          const cachedHash = metaEntry?.optionsHash;
-          // Quick tunnels created before the meta sidecar shipped, or
-          // any port whose meta entry was lost, fall back to comparing
-          // by discriminator alone so cache hits keep working.
-          const effectiveHash =
-            cachedHash ??
-            (existing.name ? `v1:named:${existing.name}` : 'v1:quick');
-          if (!optionsHashesEqual(effectiveHash, requestedHash)) {
-            throw new Error(
-              `Tunnel on port ${port} was created with different options. ` +
-                `Call destroy(${port}) before changing tunnel options.`
-            );
-          }
-          // Container restart marker: the CF-side tunnel + DNS still
-          // exist, but `cloudflared` died with the container. Fall
-          // through to the named-tunnel provision path, which reuses
-          // the tagged tunnel via `findTunnelByName` and respawns the
-          // process. Only named tunnels get this branch; quick tunnels
-          // were dropped from storage by `pruneTunnelsForRestart`.
-          if (metaEntry?.needsRespawn && existing.name) {
-            return await this.#provisionNamedTunnel(port, existing.name);
-          }
-          // Config-drift check for named tunnels: if CLOUDFLARE_ZONE_ID
-          // (or the resolved account id) changed since the tunnel was
-          // provisioned, the cached `hostname` is stale and would no
-          // longer resolve. Re-provision against the current config;
-          // `#provisionNamedTunnel` handles tunnel + DNS reuse via the
-          // `findTunnelByName` and `upsertCNAME` paths.
-          if (existing.name && this.#host.getNamedTunnelConfig) {
-            const currentConfig = await this.#host.getNamedTunnelConfig();
-            const storedAccountId = metaEntry?.accountId;
-            const storedZoneId = metaEntry?.zoneId;
+      const info = await this.#withPortLock(port, () =>
+        this.#getWithRecovery(port, options, async (recovery) => {
+          const map = await readMap(this.#host.storage);
+          const existing = map[port.toString()];
+          if (existing) {
+            const meta = await readMetaMap(this.#host.storage);
+            const metaEntry = meta[port.toString()];
+            const cachedHash = metaEntry?.optionsHash;
+            // Quick tunnels created before the meta sidecar shipped, or
+            // any port whose meta entry was lost, fall back to comparing
+            // by discriminator alone so cache hits keep working.
+            const effectiveHash =
+              cachedHash ??
+              (existing.name ? `v1:named:${existing.name}` : 'v1:quick');
+            if (!optionsHashesEqual(effectiveHash, requestedHash)) {
+              throw new Error(
+                `Tunnel on port ${port} was created with different options. ` +
+                  `Call destroy(${port}) before changing tunnel options.`
+              );
+            }
             if (
-              (storedAccountId !== undefined &&
-                storedAccountId !== currentConfig.accountId) ||
-              (storedZoneId !== undefined &&
-                storedZoneId !== currentConfig.zoneId)
+              !existing.name &&
+              (await this.#quickTunnelRecordIsStale(metaEntry))
             ) {
-              // The cached zone name is for the old zone id; clear it
-              // so `#provisionNamedTunnel` re-resolves against the new
-              // one. Without this, `hostname` would be `<name>.<old
-              // zone name>` even after re-provision.
-              this.#zoneNamePromise = null;
+              return await this.#provisionQuickTunnel(port, recovery);
+            }
+            // Container restart marker: the CF-side tunnel + DNS still
+            // exist, but `cloudflared` died with the container. Fall
+            // through to the named-tunnel provision path, which reuses
+            // the tagged tunnel via `findTunnelByName` and respawns the
+            // process. Only named tunnels get this branch; quick tunnels
+            // were dropped from storage by `pruneTunnelsForRestart`.
+            if (metaEntry?.needsRespawn && existing.name) {
               return await this.#provisionNamedTunnel(port, existing.name);
             }
+            // Config-drift check for named tunnels: if CLOUDFLARE_ZONE_ID
+            // (or the resolved account id) changed since the tunnel was
+            // provisioned, the cached `hostname` is stale and would no
+            // longer resolve. Re-provision against the current config;
+            // `#provisionNamedTunnel` handles tunnel + DNS reuse via the
+            // `findTunnelByName` and `upsertCNAME` paths.
+            if (existing.name && this.#host.getNamedTunnelConfig) {
+              const currentConfig = await this.#host.getNamedTunnelConfig();
+              const storedAccountId = metaEntry?.accountId;
+              const storedZoneId = metaEntry?.zoneId;
+              if (
+                (storedAccountId !== undefined &&
+                  storedAccountId !== currentConfig.accountId) ||
+                (storedZoneId !== undefined &&
+                  storedZoneId !== currentConfig.zoneId)
+              ) {
+                // The cached zone name is for the old zone id; clear it
+                // so `#provisionNamedTunnel` re-resolves against the new
+                // one and returns a hostname in the current zone.
+                this.#zoneNamePromise = null;
+                return await this.#provisionNamedTunnel(port, existing.name);
+              }
+            }
+            cacheState = 'hit';
+            return existing;
           }
-          cacheState = 'hit';
-          return existing;
-        }
 
-        if (options?.name) {
-          return await this.#provisionNamedTunnel(port, options.name);
-        }
-        return await this.#provisionQuickTunnel(port);
-      });
+          if (options?.name) {
+            return await this.#provisionNamedTunnel(port, options.name);
+          }
+          return await this.#provisionQuickTunnel(port, recovery);
+        })
+      );
       outcome = 'success';
       return info;
     } catch (error) {
@@ -412,6 +355,73 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
     }
   }
 
+  async #getWithRecovery(
+    port: number,
+    options: TunnelOptions | undefined,
+    run: (recovery: TunnelGetRecoveryState) => Promise<TunnelInfo>
+  ): Promise<TunnelInfo> {
+    let recoveryAttempts = 0;
+    const recovery: TunnelGetRecoveryState = {};
+    while (true) {
+      try {
+        return await run(recovery);
+      } catch (error) {
+        const interrupted = translateTunnelInterruption(
+          error,
+          'provisioning',
+          'unknown'
+        );
+        if (!interrupted || options?.name || !interrupted.context.retryable) {
+          throw error;
+        }
+        if (recoveryAttempts >= TUNNEL_GET_MAX_RECOVERY_ATTEMPTS) {
+          await this.#clearQuickTunnelStorage(port);
+          throw createTunnelInterruptedError({
+            reason: 'recovery_exhausted',
+            phase: 'interrupted',
+            admitted: interrupted.context.admitted,
+            retryable: false,
+            recoveryAttempts,
+            maxRecoveryAttempts: TUNNEL_GET_MAX_RECOVERY_ATTEMPTS
+          });
+        }
+        recoveryAttempts++;
+        if (interrupted.context.reason === 'runtime_replaced') {
+          recovery.quickRun = undefined;
+        }
+        await this.#clearQuickTunnelStorage(port);
+      }
+    }
+  }
+
+  async #clearQuickTunnelStorage(port: number): Promise<void> {
+    await this.#host.storage.transaction(async (txn) => {
+      const map = await readMap(txn);
+      delete map[port.toString()];
+      await txn.put(STORAGE_KEY, map);
+      const meta = await readMetaMap(txn);
+      delete meta[port.toString()];
+      await txn.put(META_STORAGE_KEY, meta);
+    });
+  }
+
+  async #quickTunnelRecordIsStale(
+    metaEntry?: TunnelMetaEntry
+  ): Promise<boolean> {
+    if (!this.#host.currentRuntime || !this.#host.currentLifetime) {
+      return false;
+    }
+    if (!metaEntry?.runtimeIdentityID || !metaEntry.sandboxLifetimeID) {
+      return true;
+    }
+    const runtime = await this.#host.currentRuntime.get();
+    const lifetime = await this.#host.currentLifetime.getOrCreate();
+    return (
+      runtime?.id !== metaEntry.runtimeIdentityID ||
+      lifetime.id !== metaEntry.sandboxLifetimeID
+    );
+  }
+
   /**
    * Provision a fresh quick tunnel and persist it. Caller holds the
    * per-port lock.
@@ -423,7 +433,14 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
    * surfacing the confusing error — the retry budget caps the loop so a
    * persistent failure still surfaces.
    */
-  async #provisionQuickTunnel(port: number): Promise<QuickTunnelInfo> {
+  async #provisionQuickTunnel(
+    port: number,
+    recovery: TunnelGetRecoveryState
+  ): Promise<QuickTunnelInfo> {
+    if (this.#host.currentRuntime && this.#host.currentLifetime) {
+      return await this.#provisionQuickTunnelRun(port, recovery);
+    }
+
     const MAX_ID_RETRIES = 3;
     let lastError: unknown;
     for (let attempt = 0; attempt < MAX_ID_RETRIES; attempt += 1) {
@@ -452,6 +469,98 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
     // caller sees something diagnosable; in practice this branch is
     // unreachable given the 32-bit id space and per-sandbox tunnel count.
     throw lastError ?? new Error('Failed to mint a unique quick-tunnel id');
+  }
+
+  async #provisionQuickTunnelRun(
+    port: number,
+    recovery: TunnelGetRecoveryState
+  ): Promise<QuickTunnelInfo> {
+    if (!this.#host.currentRuntime || !this.#host.currentLifetime) {
+      throw new Error('Quick tunnel runtime fences are not configured');
+    }
+
+    const lifetime = await this.#host.currentLifetime.getOrCreate();
+    const runtimeBeforeAdmission = await this.#host.currentRuntime.get();
+    try {
+      await this.#host.currentLifetime.assertCurrent(lifetime);
+    } catch (error) {
+      const interrupted = translateTunnelInterruption(
+        error,
+        'runtime_ready',
+        'unknown'
+      );
+      throw interrupted ?? error;
+    }
+
+    recovery.quickRun ??= {
+      tunnelId: `quick-${crypto.randomUUID()}`,
+      runId: runtimeRunId()
+    };
+    const { tunnelId, runId } = recovery.quickRun;
+
+    let ensureResult: EnsureTunnelRunResult;
+    let runtime = runtimeBeforeAdmission;
+    try {
+      ensureResult = await this.#host.client.tunnels.ensureTunnelRun({
+        tunnelId,
+        runId,
+        mode: 'quick',
+        port
+      });
+      runtime ??=
+        (await this.#host.currentRuntime.get()) ??
+        (await this.#host.currentRuntime.markStarted());
+      await this.#host.currentRuntime.assertActive(runtime);
+      await this.#host.currentLifetime.assertCurrent(lifetime);
+    } catch (error) {
+      const interrupted = translateTunnelInterruption(
+        error,
+        'runtime_ready',
+        'unknown'
+      );
+      throw interrupted ?? error;
+    }
+
+    const { run } = ensureResult;
+    if (!run.url || !run.hostname) {
+      throw new Error('Quick tunnel run did not produce a public URL');
+    }
+
+    const spawned: QuickTunnelInfo = {
+      id: run.tunnelId,
+      port: run.port,
+      url: run.url,
+      hostname: run.hostname,
+      createdAt: run.startedAt
+    };
+
+    await this.#host.storage.transaction(async (txn) => {
+      const nextMap = await readMap(txn);
+      nextMap[port.toString()] = spawned;
+      await txn.put(STORAGE_KEY, nextMap);
+      const nextMeta = await readMetaMap(txn);
+      nextMeta[port.toString()] = {
+        optionsHash: 'v1:quick',
+        runtimeIdentityID: runtime.id,
+        sandboxLifetimeID: lifetime.id,
+        tunnelRunId: run.runId
+      };
+      await txn.put(META_STORAGE_KEY, nextMeta);
+    });
+
+    try {
+      await this.#host.currentRuntime.assertActive(runtime);
+      await this.#host.currentLifetime.assertCurrent(lifetime);
+    } catch (error) {
+      const interrupted = translateTunnelInterruption(
+        error,
+        'storage_committed',
+        true
+      );
+      throw interrupted ?? error;
+    }
+
+    return spawned;
   }
 
   /**
@@ -614,7 +723,14 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
         // named tunnels: destroy() is also responsible for Cloudflare-side
         // cleanup, which must still run if the container already stopped.
         try {
-          await this.#host.client.tunnels.destroyTunnel(existing.id);
+          if (metaBefore?.tunnelRunId) {
+            await this.#host.client.tunnels.stopTunnelRun({
+              tunnelId: existing.id,
+              runId: metaBefore.tunnelRunId
+            });
+          } else {
+            await this.#host.client.tunnels.destroyTunnel(existing.id);
+          }
         } catch (error) {
           if (isTunnelNotFoundError(error)) {
             // Container already forgot — fall through to CF cleanup.
@@ -662,13 +778,10 @@ class TunnelsRpcTarget extends RpcTarget implements TunnelsHandler {
 
         const fetcher = this.#host.fetcher;
         // Prefer the account/zone the tunnel was provisioned in over the
-        // currently-resolved config. Without this, a user who rotated
-        // CLOUDFLARE_ZONE_ID (or CLOUDFLARE_TUNNEL_ACCOUNT_ID) between
-        // get() and destroy() would issue DELETE against the new zone/
-        // account and orphan the original resources. Stored values are
-        // absent on records created before the meta gained these fields;
-        // fall back to the resolved config so legacy records still get
-        // cleaned up (no drift was tracked for them anyway).
+        // currently-resolved config. The stored values target the original
+        // Cloudflare resources even when bindings change between get() and
+        // destroy(). Records created before these fields existed fall back
+        // to the resolved config.
         const accountId = metaBefore.accountId ?? config.accountId;
         const zoneId = metaBefore.zoneId ?? config.zoneId;
         await Promise.allSettled([
@@ -763,7 +876,12 @@ export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandle {
 
   const tunnels = new TunnelsRpcTarget(host, withPortLock);
 
-  const handleTunnelExit: TunnelExitHandler = async (id, port, exitCode) => {
+  const handleTunnelExit: TunnelExitHandler = async (
+    id,
+    port,
+    exitCode,
+    runId
+  ) => {
     const startTime = Date.now();
     let outcome: 'success' | 'error' = 'error';
     let caughtError: Error | undefined;
@@ -773,10 +891,18 @@ export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandle {
           const map = await readMap(txn);
           const existing = map[port.toString()];
           // Defensive: only act if storage still references this exact
-          // tunnel id. Without this check, a sequence like "old
-          // cloudflared dies → new get() spawns fresh → old callback
-          // fires" would clobber the new record.
+          // tunnel id. Stale callbacks from older cloudflared processes
+          // leave the current record intact.
           if (existing?.id !== id) return;
+          const meta = await readMetaMap(txn);
+          const metaEntry = meta[port.toString()];
+          if (
+            runId &&
+            metaEntry?.tunnelRunId &&
+            metaEntry.tunnelRunId !== runId
+          ) {
+            return;
+          }
 
           if (existing.name) {
             // Named tunnel. The Cloudflare-side tunnel and DNS record
@@ -791,12 +917,10 @@ export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandle {
             // band) that would crash-loop without a backoff/circuit
             // breaker, and the symmetric "wait for next get()" is the
             // same contract container restart already offers.
-            const meta = await readMetaMap(txn);
             meta[port.toString()] = {
-              ...meta[port.toString()],
+              ...metaEntry,
               optionsHash:
-                meta[port.toString()]?.optionsHash ??
-                `v1:named:${existing.name}`,
+                metaEntry?.optionsHash ?? `v1:named:${existing.name}`,
               needsRespawn: true
             };
             await txn.put(META_STORAGE_KEY, meta);
@@ -807,7 +931,6 @@ export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandle {
           // process and cannot be recovered. Drop both entries.
           delete map[port.toString()];
           await txn.put(STORAGE_KEY, map);
-          const meta = await readMetaMap(txn);
           delete meta[port.toString()];
           await txn.put(META_STORAGE_KEY, meta);
         });
@@ -864,58 +987,4 @@ export function createTunnelsHandler(host: TunnelsHandlerHost): TunnelsHandle {
     handleTunnelExit,
     destroyAll
   };
-}
-
-/**
- * Reconcile storage with a fresh container.
- *
- * Called from `Sandbox.onStart()` after every container restart. The
- * `cloudflared` processes the container was running all died with it, so
- * any stored record is *not* currently backed by a running tunnel.
- *
- * Two tunnel flavours, two recovery stories:
- *
- *   - Quick tunnels: the `*.trycloudflare.com` URL is bound to the dead
- *     `cloudflared` process. Nothing on Cloudflare's side outlives the
- *     container, and the URL is unrecoverable. Drop the record from both
- *     maps so the next `get(port)` takes the miss branch and mints a new
- *     URL.
- *   - Named tunnels: the Cloudflare-side tunnel + DNS record survive.
- *     The hostname is stable, the DNS still resolves to
- *     `<tunnelId>.cfargotunnel.com`, and the next caller can reuse both
- *     by walking the same `findTunnelByName` / `upsertCNAME` path the
- *     SDK uses for retries. Keep the record in storage and mark the
- *     meta entry `needsRespawn: true`; the next `get(port, { name })`
- *     cache hit falls through to `#provisionNamedTunnel` to respawn
- *     `cloudflared`.
- *
- * Crucially, named-tunnel metadata (including `dnsRecordId`) is
- * preserved so `destroy(port)` and `sandbox.destroy()` can still clean
- * up the Cloudflare-side resources after a restart. Wiping meta
- * unconditionally — the previous behaviour — silently leaked the tunnel
- * and DNS record on every restart.
- */
-export async function pruneTunnelsForRestart(
-  storage: TunnelsStorage
-): Promise<void> {
-  await storage.transaction(async (txn) => {
-    const map = await readMap(txn);
-    const meta = await readMetaMap(txn);
-    const nextMap: TunnelMap = {};
-    const nextMeta: TunnelMetaMap = {};
-    for (const [portKey, info] of Object.entries(map)) {
-      // Discriminate by the public `name` field on `TunnelInfo`: named
-      // tunnels carry the user-provided label, quick tunnels omit it.
-      if (info.name) {
-        nextMap[portKey] = info;
-        nextMeta[portKey] = {
-          ...(meta[portKey] ?? { optionsHash: `v1:named:${info.name}` }),
-          needsRespawn: true
-        };
-      }
-      // Quick tunnels are dropped from both maps by omission.
-    }
-    await txn.put(STORAGE_KEY, nextMap);
-    await txn.put(META_STORAGE_KEY, nextMeta);
-  });
 }

--- a/packages/sandbox/tests/sandbox-control-callback.test.ts
+++ b/packages/sandbox/tests/sandbox-control-callback.test.ts
@@ -31,7 +31,7 @@ describe('SandboxControlCallbackImpl', () => {
     await cb.onTunnelExit('quick-a', 8080, 0);
 
     expect(handler).toHaveBeenCalledTimes(1);
-    expect(handler).toHaveBeenCalledWith('quick-a', 8080, 0);
+    expect(handler).toHaveBeenCalledWith('quick-a', 8080, 0, undefined);
   });
 
   it('passes through a null exitCode (signalled process)', async () => {
@@ -40,7 +40,16 @@ describe('SandboxControlCallbackImpl', () => {
 
     await cb.onTunnelExit('quick-b', 8081, null);
 
-    expect(handler).toHaveBeenCalledWith('quick-b', 8081, null);
+    expect(handler).toHaveBeenCalledWith('quick-b', 8081, null, undefined);
+  });
+
+  it('passes through a runtime run id when present', async () => {
+    const handler = vi.fn<TunnelExitHandler>().mockResolvedValue(undefined);
+    const cb = new SandboxControlCallbackImpl(() => handler, makeLogger());
+
+    await cb.onTunnelExit('quick-b', 8081, 0, 'run-current');
+
+    expect(handler).toHaveBeenCalledWith('quick-b', 8081, 0, 'run-current');
   });
 
   it('is a no-op when the accessor returns null', async () => {

--- a/packages/sandbox/tests/tunnels-handler-lifecycle.test.ts
+++ b/packages/sandbox/tests/tunnels-handler-lifecycle.test.ts
@@ -202,6 +202,44 @@ describe('tunnels handler > quick lifecycle recovery', () => {
     });
   });
 
+  it('stops stale legacy quick tunnel records before refreshing them', async () => {
+    const legacy = makeRecord({ id: 'quick-legacy', port: 8080 });
+    const { client } = makeClient();
+    const storage = makeStorage({ '8080': legacy });
+    const fences = makeRuntimeFences();
+    const { tunnels: handler } = createTunnelsHandler({
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage,
+      logger: makeLogger(),
+      currentRuntime: fences.currentRuntime,
+      currentLifetime: fences.currentLifetime
+    } as unknown as Parameters<typeof createTunnelsHandler>[0]);
+    client.tunnels.destroyTunnel.mockResolvedValue({ success: true });
+    client.tunnels.ensureTunnelRun.mockImplementation(async (request) => ({
+      started: true,
+      run: {
+        tunnelId: request.tunnelId,
+        runId: request.runId,
+        mode: 'quick',
+        port: request.port,
+        url: 'https://fresh.trycloudflare.com',
+        hostname: 'fresh.trycloudflare.com',
+        startedAt: '2026-05-13T00:00:00.000Z'
+      }
+    }));
+
+    const info = await handler.get(8080);
+
+    expect(client.tunnels.destroyTunnel).toHaveBeenCalledWith('quick-legacy');
+    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(1);
+    expect(
+      client.tunnels.destroyTunnel.mock.invocationCallOrder[0]
+    ).toBeLessThan(client.tunnels.ensureTunnelRun.mock.invocationCallOrder[0]);
+    expect(info.hostname).toBe('fresh.trycloudflare.com');
+  });
+
   it('retries quick tunnel provisioning when runtime replacement is detected before commit', async () => {
     const { client, storage, handler, fences } = makeHandler();
     client.tunnels.ensureTunnelRun.mockImplementation(async (request) => ({

--- a/packages/sandbox/tests/tunnels-handler-lifecycle.test.ts
+++ b/packages/sandbox/tests/tunnels-handler-lifecycle.test.ts
@@ -1,0 +1,505 @@
+import type {
+  EnsureTunnelRunRequest,
+  EnsureTunnelRunResult,
+  Logger,
+  StopTunnelRunRequest,
+  StopTunnelRunResult,
+  TunnelInfo
+} from '@repo/shared';
+import type { Mock } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { RuntimeIdentityInactiveError } from '../src/current-runtime-identity';
+import { ErrorCode, RPCTransportError } from '../src/errors';
+import {
+  createTunnelsHandler,
+  pruneTunnelsForRestart,
+  type TunnelsStorage
+} from '../src/tunnels/tunnels-handler';
+
+type RunQuickTunnelMock = Mock<
+  (id: string, port: number) => Promise<TunnelInfo>
+>;
+type DestroyTunnelMock = Mock<(id: string) => Promise<unknown>>;
+type ListTunnelsMock = Mock<() => Promise<TunnelInfo[]>>;
+type EnsureTunnelRunMock = Mock<
+  (request: EnsureTunnelRunRequest) => Promise<EnsureTunnelRunResult>
+>;
+type StopTunnelRunMock = Mock<
+  (request: StopTunnelRunRequest) => Promise<StopTunnelRunResult>
+>;
+
+interface MockTunnelsClient {
+  runQuickTunnel: RunQuickTunnelMock;
+  destroyTunnel: DestroyTunnelMock;
+  listTunnels: ListTunnelsMock;
+  ensureTunnelRun: EnsureTunnelRunMock;
+  stopTunnelRun: StopTunnelRunMock;
+}
+
+function makeLogger(): Logger {
+  const log: Logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(() => log)
+  } as unknown as Logger;
+  return log;
+}
+
+function makeClient(): { client: { tunnels: MockTunnelsClient } } {
+  return {
+    client: {
+      tunnels: {
+        runQuickTunnel:
+          vi.fn<(id: string, port: number) => Promise<TunnelInfo>>(),
+        destroyTunnel: vi.fn<(id: string) => Promise<unknown>>(),
+        listTunnels: vi.fn<() => Promise<TunnelInfo[]>>(),
+        ensureTunnelRun:
+          vi.fn<
+            (request: EnsureTunnelRunRequest) => Promise<EnsureTunnelRunResult>
+          >(),
+        stopTunnelRun:
+          vi.fn<
+            (request: StopTunnelRunRequest) => Promise<StopTunnelRunResult>
+          >()
+      }
+    }
+  };
+}
+
+function makeStorage(initial?: Record<string, TunnelInfo>): TunnelsStorage {
+  const data = new Map<string, unknown>();
+  if (initial) data.set('tunnels', { ...initial });
+  let txQueue: Promise<unknown> = Promise.resolve();
+  const storage = {
+    get: vi.fn(async (key: string) => data.get(key)),
+    put: vi.fn(async (key: string, next: unknown) => {
+      data.set(key, JSON.parse(JSON.stringify(next)));
+    }),
+    delete: vi.fn(async (key: string) => data.delete(key)),
+    transaction: vi.fn((closure: (txn: unknown) => Promise<unknown>) => {
+      const next = txQueue.then(() => closure(storage));
+      txQueue = next.catch(() => undefined);
+      return next;
+    })
+  } as unknown as TunnelsStorage;
+  return storage;
+}
+
+function makeRuntimeFences(runtimeId = 'runtime-1') {
+  const runtime = {
+    id: runtimeId,
+    owns: (record: { readonly runtimeIdentityID: string }) =>
+      record.runtimeIdentityID === runtimeId,
+    scope: <T extends object>(value: T) => ({
+      ...value,
+      runtimeIdentityID: runtimeId
+    })
+  };
+  const lifetime = {
+    id: 'lifetime-1',
+    generation: 1,
+    createdAt: '2026-05-13T00:00:00.000Z',
+    updatedAt: '2026-05-13T00:00:00.000Z',
+    owns: (record: { readonly sandboxLifetimeID: string }) =>
+      record.sandboxLifetimeID === 'lifetime-1',
+    scope: <T extends object>(value: T) => ({
+      ...value,
+      sandboxLifetimeID: 'lifetime-1'
+    })
+  };
+
+  return {
+    runtime,
+    lifetime,
+    currentRuntime: {
+      get: vi.fn<() => Promise<typeof runtime | null>>(async () => runtime),
+      markStarted: vi.fn(async () => runtime),
+      assertActive: vi.fn(async (_runtime: typeof runtime) => {})
+    },
+    currentLifetime: {
+      getOrCreate: vi.fn(async () => lifetime),
+      assertCurrent: vi.fn(async () => {})
+    }
+  };
+}
+
+function makeRecord(overrides: Partial<TunnelInfo> = {}): TunnelInfo {
+  return {
+    id: 'quick-0123456789abcdef',
+    port: 8080,
+    url: 'https://stub.trycloudflare.com',
+    hostname: 'stub.trycloudflare.com',
+    createdAt: '2026-05-13T00:00:00.000Z',
+    ...overrides
+  };
+}
+
+function createDisposedRPCError(): RPCTransportError {
+  return new RPCTransportError({
+    code: ErrorCode.RPC_TRANSPORT_ERROR,
+    message: 'RPC session was shut down by disposing the main stub',
+    httpStatus: 503,
+    context: {
+      kind: 'session_disposed',
+      originalMessage: 'RPC session was shut down by disposing the main stub',
+      errorName: 'Error'
+    },
+    timestamp: '2026-05-13T00:00:00.000Z'
+  });
+}
+
+function makeHandler() {
+  const { client } = makeClient();
+  const storage = makeStorage();
+  const fences = makeRuntimeFences();
+  const { tunnels } = createTunnelsHandler({
+    client: client as unknown as Parameters<
+      typeof createTunnelsHandler
+    >[0]['client'],
+    storage,
+    logger: makeLogger(),
+    currentRuntime: fences.currentRuntime,
+    currentLifetime: fences.currentLifetime
+  } as unknown as Parameters<typeof createTunnelsHandler>[0]);
+  return { client, storage, handler: tunnels, fences };
+}
+
+describe('tunnels handler > quick lifecycle recovery', () => {
+  it('uses ensureTunnelRun and stores runtime metadata for quick tunnels', async () => {
+    const { client, storage, handler } = makeHandler();
+    client.tunnels.ensureTunnelRun.mockImplementation(async (request) => ({
+      started: true,
+      run: {
+        tunnelId: request.tunnelId,
+        runId: request.runId,
+        mode: 'quick',
+        port: request.port,
+        url: 'https://fresh.trycloudflare.com',
+        hostname: 'fresh.trycloudflare.com',
+        startedAt: '2026-05-13T00:00:00.000Z'
+      }
+    }));
+
+    const info = await handler.get(8080);
+
+    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(1);
+    expect(client.tunnels.runQuickTunnel).not.toHaveBeenCalled();
+    const request = client.tunnels.ensureTunnelRun.mock.calls[0][0];
+    expect(info).toMatchObject({
+      id: request.tunnelId,
+      port: 8080,
+      url: 'https://fresh.trycloudflare.com',
+      hostname: 'fresh.trycloudflare.com'
+    });
+    const meta = await storage.get<Record<string, unknown>>('tunnels:meta');
+    expect(meta?.['8080']).toMatchObject({
+      optionsHash: 'v1:quick',
+      runtimeIdentityID: 'runtime-1',
+      sandboxLifetimeID: 'lifetime-1',
+      tunnelRunId: request.runId
+    });
+  });
+
+  it('retries quick tunnel provisioning when runtime replacement is detected before commit', async () => {
+    const { client, storage, handler, fences } = makeHandler();
+    client.tunnels.ensureTunnelRun.mockImplementation(async (request) => ({
+      started: true,
+      run: {
+        tunnelId: request.tunnelId,
+        runId: request.runId,
+        mode: 'quick',
+        port: request.port,
+        url: `https://${request.runId}.trycloudflare.com`,
+        hostname: `${request.runId}.trycloudflare.com`,
+        startedAt: '2026-05-13T00:00:00.000Z'
+      }
+    }));
+    fences.currentRuntime.assertActive
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new RuntimeIdentityInactiveError())
+      .mockResolvedValue(undefined);
+
+    const info = await handler.get(8080);
+
+    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(2);
+    const secondRunId = client.tunnels.ensureTunnelRun.mock.calls[1][0].runId;
+    expect(info.hostname).toBe(`${secondRunId}.trycloudflare.com`);
+    const stored = await storage.get<Record<string, TunnelInfo>>('tunnels');
+    expect(stored?.['8080']).toEqual(info);
+  });
+
+  it('captures runtime before quick tunnel admission so a replacement during spawn retries', async () => {
+    const { client, storage, handler, fences } = makeHandler();
+    let activeRuntimeId = 'runtime-1';
+    const makeRuntime = (id: string) => ({
+      id,
+      owns: (record: { readonly runtimeIdentityID: string }) =>
+        record.runtimeIdentityID === id,
+      scope: <T extends object>(value: T) => ({
+        ...value,
+        runtimeIdentityID: id
+      })
+    });
+    fences.currentRuntime.get.mockImplementation(async () =>
+      makeRuntime(activeRuntimeId)
+    );
+    fences.currentRuntime.assertActive.mockImplementation(async (runtime) => {
+      if (runtime.id !== activeRuntimeId) {
+        throw new RuntimeIdentityInactiveError();
+      }
+    });
+    client.tunnels.ensureTunnelRun.mockImplementation(async (request) => {
+      if (client.tunnels.ensureTunnelRun.mock.calls.length === 1) {
+        activeRuntimeId = 'runtime-2';
+      }
+      return {
+        started: true,
+        run: {
+          tunnelId: request.tunnelId,
+          runId: request.runId,
+          mode: 'quick',
+          port: request.port,
+          url: `https://${request.runId}.trycloudflare.com`,
+          hostname: `${request.runId}.trycloudflare.com`,
+          startedAt: '2026-05-13T00:00:00.000Z'
+        }
+      };
+    });
+
+    const info = await handler.get(8080);
+
+    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(2);
+    const staleRunId = client.tunnels.ensureTunnelRun.mock.calls[0][0].runId;
+    const currentRunId = client.tunnels.ensureTunnelRun.mock.calls[1][0].runId;
+    expect(info.hostname).toBe(`${currentRunId}.trycloudflare.com`);
+    expect(info.hostname).not.toBe(`${staleRunId}.trycloudflare.com`);
+    const meta =
+      await storage.get<Record<string, { runtimeIdentityID: string }>>(
+        'tunnels:meta'
+      );
+    expect(meta?.['8080'].runtimeIdentityID).toBe('runtime-2');
+  });
+
+  it('replays the same quick tunnel run identity after response-loss interruption', async () => {
+    const { client, handler } = makeHandler();
+    client.tunnels.ensureTunnelRun
+      .mockRejectedValueOnce(createDisposedRPCError())
+      .mockImplementationOnce(async (request) => ({
+        started: false,
+        run: {
+          tunnelId: request.tunnelId,
+          runId: request.runId,
+          mode: 'quick',
+          port: request.port,
+          url: `https://${request.runId}.trycloudflare.com`,
+          hostname: `${request.runId}.trycloudflare.com`,
+          startedAt: '2026-05-13T00:00:00.000Z'
+        }
+      }));
+
+    const info = await handler.get(8080);
+
+    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(2);
+    const first = client.tunnels.ensureTunnelRun.mock.calls[0][0];
+    const second = client.tunnels.ensureTunnelRun.mock.calls[1][0];
+    expect(second).toMatchObject({
+      tunnelId: first.tunnelId,
+      runId: first.runId,
+      mode: 'quick',
+      port: 8080
+    });
+    expect(info.hostname).toBe(`${first.runId}.trycloudflare.com`);
+  });
+
+  it('serializes concurrent quick tunnel gets across response-loss recovery', async () => {
+    const { client, handler } = makeHandler();
+    const firstAdmission = Promise.withResolvers<EnsureTunnelRunResult>();
+    client.tunnels.ensureTunnelRun
+      .mockReturnValueOnce(firstAdmission.promise)
+      .mockImplementation(async (request) => ({
+        started: false,
+        run: {
+          tunnelId: request.tunnelId,
+          runId: request.runId,
+          mode: 'quick',
+          port: request.port,
+          url: `https://${request.runId}.trycloudflare.com`,
+          hostname: `${request.runId}.trycloudflare.com`,
+          startedAt: '2026-05-13T00:00:00.000Z'
+        }
+      }));
+
+    const firstGet = handler.get(8080);
+    await vi.waitFor(() => {
+      expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(1);
+    });
+
+    const secondGet = handler.get(8080);
+    await Promise.resolve();
+    firstAdmission.reject(createDisposedRPCError());
+
+    const [first, second] = await Promise.all([firstGet, secondGet]);
+
+    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(2);
+    const firstCall = client.tunnels.ensureTunnelRun.mock.calls[0][0];
+    const replayCall = client.tunnels.ensureTunnelRun.mock.calls[1][0];
+    expect(replayCall).toMatchObject({
+      tunnelId: firstCall.tunnelId,
+      runId: firstCall.runId
+    });
+    expect(second).toEqual(first);
+  });
+
+  it('admits a quick tunnel run before asserting that a cold runtime is active', async () => {
+    const { client, handler, fences } = makeHandler();
+    const runtime = fences.runtime;
+    fences.currentRuntime.get.mockImplementationOnce(async () => null);
+    fences.currentRuntime.markStarted.mockResolvedValueOnce(runtime);
+    let admitted = false;
+    fences.currentRuntime.assertActive.mockImplementation(async () => {
+      if (!admitted) {
+        throw new RuntimeIdentityInactiveError();
+      }
+    });
+    client.tunnels.ensureTunnelRun.mockImplementation(async (request) => {
+      admitted = true;
+      return {
+        started: true,
+        run: {
+          tunnelId: request.tunnelId,
+          runId: request.runId,
+          mode: 'quick',
+          port: request.port,
+          url: 'https://cold.trycloudflare.com',
+          hostname: 'cold.trycloudflare.com',
+          startedAt: '2026-05-13T00:00:00.000Z'
+        }
+      };
+    });
+
+    await expect(handler.get(8080)).resolves.toMatchObject({
+      hostname: 'cold.trycloudflare.com'
+    });
+    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces OPERATION_INTERRUPTED and leaves storage empty after quick tunnel recovery exhaustion', async () => {
+    const { client, storage, handler, fences } = makeHandler();
+    client.tunnels.ensureTunnelRun.mockImplementation(async (request) => ({
+      started: true,
+      run: {
+        tunnelId: request.tunnelId,
+        runId: request.runId,
+        mode: 'quick',
+        port: request.port,
+        url: `https://${request.runId}.trycloudflare.com`,
+        hostname: `${request.runId}.trycloudflare.com`,
+        startedAt: '2026-05-13T00:00:00.000Z'
+      }
+    }));
+    let assertActiveCalls = 0;
+    fences.currentRuntime.assertActive.mockImplementation(async () => {
+      assertActiveCalls += 1;
+      if (assertActiveCalls % 2 === 0) {
+        throw new RuntimeIdentityInactiveError();
+      }
+    });
+
+    await expect(handler.get(8080)).rejects.toMatchObject({
+      name: 'OperationInterruptedError',
+      code: ErrorCode.OPERATION_INTERRUPTED,
+      context: {
+        reason: 'recovery_exhausted',
+        operation: 'tunnel.get',
+        phase: 'interrupted',
+        admitted: true,
+        retryable: false,
+        recoveryAttempts: 2,
+        maxRecoveryAttempts: 2
+      }
+    });
+
+    expect(client.tunnels.ensureTunnelRun).toHaveBeenCalledTimes(3);
+    expect(await storage.get<Record<string, TunnelInfo>>('tunnels')).toEqual(
+      {}
+    );
+  });
+});
+
+describe('TunnelsHandler public surface', () => {
+  it('does not expose any exit hook on the public interface', () => {
+    const { client } = makeClient();
+    const { tunnels, handleTunnelExit } = createTunnelsHandler({
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage: makeStorage(),
+      logger: makeLogger()
+    } as unknown as Parameters<typeof createTunnelsHandler>[0]);
+    expect(handleTunnelExit).toBeTypeOf('function');
+    expect('handleTunnelExit' in (tunnels as unknown as object)).toBe(false);
+  });
+});
+
+describe('route-based SandboxClient.tunnels placeholder', () => {
+  it('throws "RPC transport required" from any method on the proxy', async () => {
+    const { SandboxClient } = await import('../src/clients/sandbox-client');
+    const client = new SandboxClient({ baseUrl: 'http://test.invalid' });
+    expect(() =>
+      (client.tunnels as unknown as { get: () => void }).get()
+    ).toThrow(/RPC transport/);
+    expect(() =>
+      (client.tunnels as unknown as { list: () => void }).list()
+    ).toThrow(/RPC transport/);
+    expect(() =>
+      (client.tunnels as unknown as { destroy: () => void }).destroy()
+    ).toThrow(/RPC transport/);
+  });
+});
+
+describe('pruneTunnelsForRestart', () => {
+  it('drops quick-tunnel entries and marks named ones for respawn', async () => {
+    const quick = makeRecord({ id: 'quick-1', port: 8080 });
+    const named = makeRecord({
+      id: 'named-1',
+      port: 9090,
+      name: 'app',
+      hostname: 'app.example.com',
+      url: 'https://app.example.com'
+    });
+    const storage = makeStorage({ '8080': quick, '9090': named });
+    await storage.put('tunnels:meta', {
+      '8080': { optionsHash: 'v1:quick' },
+      '9090': {
+        optionsHash: 'v1:named:app',
+        dnsRecordId: 'dns-1',
+        accountId: 'acct',
+        zoneId: 'zone'
+      }
+    });
+
+    await pruneTunnelsForRestart(storage);
+
+    expect(await storage.get('tunnels')).toEqual({ '9090': named });
+    expect(await storage.get('tunnels:meta')).toEqual({
+      '9090': {
+        optionsHash: 'v1:named:app',
+        dnsRecordId: 'dns-1',
+        accountId: 'acct',
+        zoneId: 'zone',
+        needsRespawn: true
+      }
+    });
+  });
+
+  it('is a no-op on empty storage', async () => {
+    const storage = makeStorage();
+
+    await pruneTunnelsForRestart(storage);
+
+    expect(await storage.get('tunnels')).toEqual({});
+    expect(await storage.get('tunnels:meta')).toEqual({});
+  });
+});

--- a/packages/sandbox/tests/tunnels-handler.test.ts
+++ b/packages/sandbox/tests/tunnels-handler.test.ts
@@ -6,9 +6,18 @@
  * lightweight in-memory `ctx.storage` shim.
  */
 
-import type { Logger, TunnelInfo } from '@repo/shared';
+import type {
+  EnsureTunnelRunRequest,
+  EnsureTunnelRunResult,
+  Logger,
+  StopTunnelRunRequest,
+  StopTunnelRunResult,
+  TunnelInfo
+} from '@repo/shared';
 import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RuntimeIdentityInactiveError } from '../src/current-runtime-identity';
+import { ErrorCode, RPCTransportError } from '../src/errors';
 import { SandboxSecurityError } from '../src/security';
 import {
   createTunnelsHandler,
@@ -33,6 +42,12 @@ type RunQuickTunnelMock = Mock<
 >;
 type DestroyTunnelMock = Mock<(id: string) => Promise<unknown>>;
 type ListTunnelsMock = Mock<() => Promise<TunnelInfo[]>>;
+type EnsureTunnelRunMock = Mock<
+  (request: EnsureTunnelRunRequest) => Promise<EnsureTunnelRunResult>
+>;
+type StopTunnelRunMock = Mock<
+  (request: StopTunnelRunRequest) => Promise<StopTunnelRunResult>
+>;
 type StorageGetMock = Mock<(key: string) => Promise<unknown>>;
 type StoragePutMock = Mock<(key: string, next: unknown) => Promise<unknown>>;
 type StorageTransactionMock = Mock<
@@ -44,6 +59,8 @@ interface MockTunnelsClient {
   runQuickTunnel: RunQuickTunnelMock;
   destroyTunnel: DestroyTunnelMock;
   listTunnels: ListTunnelsMock;
+  ensureTunnelRun: EnsureTunnelRunMock;
+  stopTunnelRun: StopTunnelRunMock;
 }
 
 function makeClient(): { client: { tunnels: MockTunnelsClient } } {
@@ -53,7 +70,15 @@ function makeClient(): { client: { tunnels: MockTunnelsClient } } {
         runQuickTunnel:
           vi.fn<(id: string, port: number) => Promise<TunnelInfo>>(),
         destroyTunnel: vi.fn<(id: string) => Promise<unknown>>(),
-        listTunnels: vi.fn<() => Promise<TunnelInfo[]>>()
+        listTunnels: vi.fn<() => Promise<TunnelInfo[]>>(),
+        ensureTunnelRun:
+          vi.fn<
+            (request: EnsureTunnelRunRequest) => Promise<EnsureTunnelRunResult>
+          >(),
+        stopTunnelRun:
+          vi.fn<
+            (request: StopTunnelRunRequest) => Promise<StopTunnelRunResult>
+          >()
       }
     }
   };
@@ -94,6 +119,44 @@ function makeStorage(initial?: Record<string, TunnelInfo>): TunnelsStorage {
   return storage;
 }
 
+function makeRuntimeFences(runtimeId = 'runtime-1') {
+  const runtime = {
+    id: runtimeId,
+    owns: (record: { readonly runtimeIdentityID: string }) =>
+      record.runtimeIdentityID === runtimeId,
+    scope: <T extends object>(value: T) => ({
+      ...value,
+      runtimeIdentityID: runtimeId
+    })
+  };
+  const lifetime = {
+    id: 'lifetime-1',
+    generation: 1,
+    createdAt: '2026-05-13T00:00:00.000Z',
+    updatedAt: '2026-05-13T00:00:00.000Z',
+    owns: (record: { readonly sandboxLifetimeID: string }) =>
+      record.sandboxLifetimeID === 'lifetime-1',
+    scope: <T extends object>(value: T) => ({
+      ...value,
+      sandboxLifetimeID: 'lifetime-1'
+    })
+  };
+
+  return {
+    runtime,
+    lifetime,
+    currentRuntime: {
+      get: vi.fn<() => Promise<typeof runtime | null>>(async () => runtime),
+      markStarted: vi.fn(async () => runtime),
+      assertActive: vi.fn(async (_runtime: typeof runtime) => {})
+    },
+    currentLifetime: {
+      getOrCreate: vi.fn(async () => lifetime),
+      assertCurrent: vi.fn(async () => {})
+    }
+  };
+}
+
 function makeRecord(overrides: Partial<TunnelInfo> = {}): TunnelInfo {
   return {
     id: 'quick-0123456789abcdef',
@@ -105,16 +168,35 @@ function makeRecord(overrides: Partial<TunnelInfo> = {}): TunnelInfo {
   };
 }
 
-function makeHandler() {
+function createDisposedRPCError(): RPCTransportError {
+  return new RPCTransportError({
+    code: ErrorCode.RPC_TRANSPORT_ERROR,
+    message: 'RPC session was shut down by disposing the main stub',
+    httpStatus: 503,
+    context: {
+      kind: 'session_disposed',
+      originalMessage: 'RPC session was shut down by disposing the main stub',
+      errorName: 'Error'
+    },
+    timestamp: '2026-05-13T00:00:00.000Z'
+  });
+}
+
+function makeHandler(options: { withFences?: boolean } = {}) {
   const { client } = makeClient();
   const storage = makeStorage();
+  const fences = options.withFences ? makeRuntimeFences() : undefined;
   const { tunnels, handleTunnelExit } = createTunnelsHandler({
     client: client as unknown as Parameters<
       typeof createTunnelsHandler
     >[0]['client'],
     storage,
-    logger: makeLogger()
-  });
+    logger: makeLogger(),
+    ...(fences && {
+      currentRuntime: fences.currentRuntime,
+      currentLifetime: fences.currentLifetime
+    })
+  } as unknown as Parameters<typeof createTunnelsHandler>[0]);
   // `handler` alias kept for legacy test bodies; new tests should
   // reach for `tunnels` and `handleTunnelExit` directly.
   return {
@@ -122,7 +204,8 @@ function makeHandler() {
     storage,
     handler: tunnels,
     tunnels,
-    handleTunnelExit
+    handleTunnelExit,
+    fences
   };
 }
 
@@ -133,6 +216,33 @@ describe('tunnels handler > get', () => {
   });
   afterEach(() => {
     warn.mockRestore();
+  });
+
+  it('ignores stale tunnel exit callbacks whose run id does not match storage metadata', async () => {
+    const record = makeRecord({ id: 'quick-current', port: 8080 });
+    const storage = makeStorage({ '8080': record });
+    await storage.put('tunnels:meta', {
+      '8080': {
+        optionsHash: 'v1:quick',
+        runtimeIdentityID: 'runtime-1',
+        sandboxLifetimeID: 'lifetime-1',
+        tunnelRunId: 'run-current'
+      }
+    });
+    const { client } = makeClient();
+    const { handleTunnelExit } = createTunnelsHandler({
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage,
+      logger: makeLogger()
+    });
+
+    await handleTunnelExit('quick-current', 8080, 0, 'run-old');
+
+    expect(await storage.get<Record<string, TunnelInfo>>('tunnels')).toEqual({
+      '8080': record
+    });
   });
 
   it('mints a `quick-<8 hex>` id and forwards it to the RPC client on cache miss', async () => {
@@ -369,6 +479,36 @@ describe('tunnels handler > destroy', () => {
     const metaPut = putCalls.find(([key]) => key === 'tunnels:meta');
     expect(tunnelsPut?.[1]).toEqual({});
     expect(metaPut?.[1]).toEqual({});
+  });
+
+  it('calls stopTunnelRun with the exact run ref when runtime metadata exists', async () => {
+    const record = makeRecord({ id: 'quick-runref', port: 8080 });
+    const { client } = makeClient();
+    const storage = makeStorage({ '8080': record });
+    await storage.put('tunnels:meta', {
+      '8080': {
+        optionsHash: 'v1:quick',
+        runtimeIdentityID: 'runtime-1',
+        sandboxLifetimeID: 'lifetime-1',
+        tunnelRunId: 'run-1'
+      }
+    });
+    const { tunnels: handler } = createTunnelsHandler({
+      client: client as unknown as Parameters<
+        typeof createTunnelsHandler
+      >[0]['client'],
+      storage,
+      logger: makeLogger()
+    });
+    client.tunnels.stopTunnelRun.mockResolvedValue({ stopped: true });
+
+    await handler.destroy(8080);
+
+    expect(client.tunnels.stopTunnelRun).toHaveBeenCalledWith({
+      tunnelId: record.id,
+      runId: 'run-1'
+    });
+    expect(client.tunnels.destroyTunnel).not.toHaveBeenCalled();
   });
 
   it('wraps the read-modify-write in storage.transaction()', async () => {
@@ -840,83 +980,5 @@ describe('tunnels handler > handleTunnelExit', () => {
       String(msg).includes('tunnel.exit')
     );
     expect(eventCall).toBeDefined();
-  });
-});
-
-describe('TunnelsHandler public surface', () => {
-  it('does not expose any exit hook on the public interface', () => {
-    // Compile-time guard: if a future change adds a method to
-    // TunnelsHandler beyond get/list/destroy, this assertion fails
-    // and the developer has to consciously update the allowlist.
-    type AllowedKeys = 'get' | 'list' | 'destroy';
-    type _Check = keyof TunnelsHandler extends AllowedKeys ? true : false;
-    const ok: _Check = true;
-    expect(ok).toBe(true);
-  });
-});
-
-describe('route-based SandboxClient.tunnels placeholder', () => {
-  it('throws "RPC transport required" from any method on the proxy', async () => {
-    const { SandboxClient } = await import('../src/clients/sandbox-client');
-    const client = new SandboxClient({ baseUrl: 'http://test.invalid' });
-    expect(() =>
-      (client.tunnels as unknown as { get: () => void }).get()
-    ).toThrow(/RPC transport/);
-    expect(() =>
-      (client.tunnels as unknown as { list: () => void }).list()
-    ).toThrow(/RPC transport/);
-    expect(() =>
-      (client.tunnels as unknown as { destroy: () => void }).destroy()
-    ).toThrow(/RPC transport/);
-  });
-});
-
-describe('pruneTunnelsForRestart', () => {
-  it('drops quick-tunnel entries and marks named ones for respawn', async () => {
-    const storage = makeStorage();
-    await (storage.put as StoragePutMock)('tunnels', {
-      '8080': {
-        id: 'quick-abc',
-        port: 8080,
-        url: 'https://x.trycloudflare.com',
-        hostname: 'x.trycloudflare.com',
-        createdAt: '2024-01-01T00:00:00.000Z'
-      },
-      '8081': {
-        id: 'uuid-1',
-        port: 8081,
-        name: 'app',
-        hostname: 'app.example.com',
-        url: 'https://app.example.com',
-        createdAt: '2024-01-01T00:00:00.000Z'
-      }
-    });
-    await (storage.put as StoragePutMock)('tunnels:meta', {
-      '8080': { optionsHash: 'quick' },
-      '8081': { optionsHash: 'named:app', dnsRecordId: 'rec-1' }
-    });
-
-    await pruneTunnelsForRestart(storage);
-
-    const nextTunnels = (await (storage.get as StorageGetMock)(
-      'tunnels'
-    )) as Record<string, { name?: string }>;
-    const nextMeta = (await (storage.get as StorageGetMock)(
-      'tunnels:meta'
-    )) as Record<string, { needsRespawn?: boolean; dnsRecordId?: string }>;
-    expect(Object.keys(nextTunnels)).toEqual(['8081']);
-    expect(nextMeta['8081']?.needsRespawn).toBe(true);
-    // dnsRecordId is preserved so destroy() can still clean up.
-    expect(nextMeta['8081']?.dnsRecordId).toBe('rec-1');
-    expect(nextMeta['8080']).toBeUndefined();
-  });
-
-  it('is a no-op on empty storage', async () => {
-    const storage = makeStorage();
-    await pruneTunnelsForRestart(storage);
-    const nextTunnels = (await (storage.get as StorageGetMock)(
-      'tunnels'
-    )) as Record<string, unknown>;
-    expect(nextTunnels).toEqual({});
   });
 });

--- a/packages/sandbox/tests/tunnels-random-id.test.ts
+++ b/packages/sandbox/tests/tunnels-random-id.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { randomId } from '../src/tunnels/random-id';
+
+describe('randomId', () => {
+  it('returns 20 lowercase base32 characters by default', () => {
+    for (let i = 0; i < 100; i += 1) {
+      expect(randomId()).toMatch(/^[0-9a-hjkmnp-tv-z]{20}$/);
+    }
+  });
+
+  it('honours a requested size', () => {
+    expect(randomId(8)).toHaveLength(8);
+    expect(randomId(32)).toHaveLength(32);
+  });
+
+  it('never emits the ambiguous characters i, l, o, or u', () => {
+    const sample = Array.from({ length: 500 }, () => randomId()).join('');
+    expect(sample).not.toMatch(/[ilou]/);
+  });
+
+  it('does not collide across a large batch', () => {
+    const ids = new Set(Array.from({ length: 10_000 }, () => randomId()));
+    expect(ids.size).toBe(10_000);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -80,6 +80,10 @@ export type {
 } from './request-types.js';
 // RPC interface types (shared between SDK and container)
 export type {
+  EnsureNamedTunnelRunRequest,
+  EnsureQuickTunnelRunRequest,
+  EnsureTunnelRunRequest,
+  EnsureTunnelRunResult,
   NamedTunnelInfo,
   QuickTunnelInfo,
   SandboxAPI,
@@ -94,8 +98,13 @@ export type {
   SandboxTunnelsAPI,
   SandboxUtilsAPI,
   SandboxWatchAPI,
+  StopTunnelRunRequest,
+  StopTunnelRunResult,
   TunnelInfo,
-  TunnelOptions
+  TunnelOptions,
+  TunnelRunIdentity,
+  TunnelRunMode,
+  TunnelRunSnapshot
 } from './rpc-types.js';
 // Export shell utilities
 export { shellEscape } from './shell-escape.js';

--- a/packages/shared/src/rpc-types.ts
+++ b/packages/shared/src/rpc-types.ts
@@ -297,6 +297,78 @@ export interface TunnelOptions {
   name?: string;
 }
 
+// ---------------------------------------------------------------------------
+// Runtime-run tunnel control types
+// ---------------------------------------------------------------------------
+
+/**
+ * Stable logical identity for a single cloudflared process run.
+ * `tunnelId` is SDK-issued; `runId` is a per-run nonce minted by the SDK
+ * to support idempotent admission and stale-callback fencing.
+ */
+export interface TunnelRunIdentity {
+  tunnelId: string;
+  runId: string;
+}
+
+/** Discriminator for quick vs. named cloudflared modes. */
+export type TunnelRunMode = 'quick' | 'named';
+
+/** Request to start or replay a quick tunnel run. */
+export interface EnsureQuickTunnelRunRequest {
+  tunnelId: string;
+  runId: string;
+  mode: 'quick';
+  port: number;
+}
+
+/**
+ * Request to start or replay a named tunnel run.
+ * `token` is named-mode only and must never be persisted or logged.
+ */
+export interface EnsureNamedTunnelRunRequest {
+  tunnelId: string;
+  runId: string;
+  mode: 'named';
+  port: number;
+  /** Opaque Cloudflare tunnel token. Never logged or stored. */
+  token: string;
+}
+
+export type EnsureTunnelRunRequest =
+  | EnsureQuickTunnelRunRequest
+  | EnsureNamedTunnelRunRequest;
+
+/**
+ * Runtime-local snapshot of a running cloudflared process.
+ * Quick tunnels carry `url` and `hostname`; named tunnels leave them absent
+ * because the SDK owns the hostname via the Cloudflare API.
+ */
+export interface TunnelRunSnapshot {
+  tunnelId: string;
+  runId: string;
+  mode: TunnelRunMode;
+  port: number;
+  /** Public URL for quick tunnels (absent on named). */
+  url?: string;
+  /** Hostname portion of `url` for quick tunnels (absent on named). */
+  hostname?: string;
+  startedAt: string;
+}
+
+export interface EnsureTunnelRunResult {
+  run: TunnelRunSnapshot;
+  /** `true` when this call spawned the process; `false` on idempotent replay. */
+  started: boolean;
+}
+
+export type StopTunnelRunRequest = TunnelRunIdentity;
+
+export interface StopTunnelRunResult {
+  /** `true` when the exact run was found and stopped; `false` otherwise. */
+  stopped: boolean;
+}
+
 export interface SandboxTunnelsAPI {
   /** Spawn `cloudflared tunnel --url`. No credentials required. */
   runQuickTunnel(id: string, port: number): Promise<TunnelInfo>;
@@ -316,6 +388,21 @@ export interface SandboxTunnelsAPI {
   destroyTunnel(id: string): Promise<{ success: true; id: string }>;
   /** List tunnels currently running inside the container. */
   listTunnels(): Promise<TunnelInfo[]>;
+  /**
+   * Start or replay a cloudflared process run identified by `(tunnelId, runId)`.
+   * Same `runId` with same params is idempotent (`started: false`).
+   * Same `runId` with different params, or a different active run on the
+   * same port or tunnelId, returns a `TUNNEL_RUN_CONFLICT` error.
+   */
+  ensureTunnelRun(
+    request: EnsureTunnelRunRequest
+  ): Promise<EnsureTunnelRunResult>;
+  /**
+   * Stop the cloudflared process identified by the exact `(tunnelId, runId)` pair.
+   * Returns `{ stopped: true }` when the run was found and stopped;
+   * `{ stopped: false }` when no matching run is active (service success).
+   */
+  stopTunnelRun(request: StopTunnelRunRequest): Promise<StopTunnelRunResult>;
 }
 
 /**
@@ -337,6 +424,7 @@ export interface SandboxControlCallback {
   onTunnelExit(
     id: string,
     port: number,
-    exitCode: number | null
+    exitCode: number | null,
+    runId?: string
   ): Promise<void>;
 }

--- a/tests/e2e/tunnel-quick-workflow.test.ts
+++ b/tests/e2e/tunnel-quick-workflow.test.ts
@@ -115,7 +115,7 @@ console.log("Server listening on port " + server.port);
       expect(tunnel.port).toBe(TUNNEL_TEST_PORT);
       expect(tunnel.url).toMatch(/^https:\/\/[a-z0-9-]+\.trycloudflare\.com$/);
       expect(tunnel.hostname).toMatch(/\.trycloudflare\.com$/);
-      expect(tunnel.id).toMatch(/^quick-[0-9a-f]{8}$/);
+      expect(tunnel.id).toMatch(/^quick-[0-9a-z]{20}$/);
 
       try {
         // 3. Idempotency: a second get() for the same port returns the


### PR DESCRIPTION
**Stack:** 3 of 3 — builds on the lifecycle error contract and recovery primitives from the two PRs below it. Open those first.

After the Cloudflare runtime replaces a sandbox's container, a quick tunnel created against the old runtime is dead — yet `tunnels.get(port)` could hand back its stale URL and `tunnels.list()` could keep advertising it. This is the tunnel-side runtime-replacement failure mode seen during deployment rollouts (see #158).

This PR makes quick tunnel provisioning recoverable through a runtime-run boundary:

- The Sandbox DO issues a short Crockford-base32 **logical tunnel id** and the container owns a runtime-local **`runId`**, so `ensureTunnelRun()` is **idempotent across retries** — a retry after a replacement (or a lost response) does not spawn a duplicate `cloudflared` process.
- A replacement during provisioning is **retried boundedly** so `tunnels.get(port)` returns a currently usable URL.
- Runtime-local process callbacks are **fenced by `runId`**, so a stale exit from an old run cannot disturb the current one.
- **`tunnels.list()`** no longer returns quick URLs known to be stale after restart reconciliation.

## Scope

This is a stable hotfix, not the `next` architecture (#776). The existing `tunnels-handler.ts` stays as the orchestration layer (with `lifecycle.ts` / `storage.ts` / `restart.ts` helpers extracted to keep it under the file-size ceiling); it does not backport the `next` tunnel service / provisioner / rpc-target split. Named-tunnel durable cleanup intent (Track B on `next`) is out of scope — this does not regress current stable named-tunnel behavior, but also does not add the stronger cleanup guarantees landing on `next`.

