### PR TITLE
Improve scaling of bridge warm pool under load

### DIFF
--- a/.changeset/bridge-custom-spans.md
+++ b/.changeset/bridge-custom-spans.md
@@ -1,0 +1,9 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Instrument the bridge API with Cloudflare custom spans. Each endpoint now emits
+a `bridge.<operation>` span annotated with the sandbox ID, container UUID, and
+operation-specific metadata (command, file path, port, session ID, and so on),
+so requests are traceable end to end. Enable tracing with
+`observability.traces.enabled` in your Worker configuration.

--- a/.changeset/warm-pool-batched-scale-up.md
+++ b/.changeset/warm-pool-batched-scale-up.md
@@ -1,0 +1,7 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Fill the warm pool in bounded-parallel batches instead of one container at a
+time, so it primes and recovers far faster after a burst. Tune the batch size
+with `WARM_POOL_SCALE_BATCH_SIZE` (default 5, clamped to 20).

--- a/.changeset/warm-pool-eager-refill.md
+++ b/.changeset/warm-pool-eager-refill.md
@@ -1,0 +1,8 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Refill the warm pool the moment it drains instead of waiting for the next
+background tick. After a burst consumes warm containers, replenishment now
+starts immediately, cutting the latency tail for sandboxes created during
+sustained or back-to-back bursts.

--- a/.changeset/warm-pool-max-instances.md
+++ b/.changeset/warm-pool-max-instances.md
@@ -1,0 +1,9 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Let the warm pool know its instance ceiling up front via the
+`WARM_POOL_MAX_INSTANCES` bridge variable. Set it to match your container's
+`max_instances` so the pool makes correct capacity decisions without first
+crashing into the limit. `0` (the default) preserves the existing auto-learn
+behaviour.

--- a/bridge/worker/README.md
+++ b/bridge/worker/README.md
@@ -151,7 +151,6 @@ curl -X POST http://localhost:8787/v1/sandbox/mfrggzdfmy2tqnrz/exec \
 
 Read a file from the sandbox filesystem. The file path is given in the URL after `/file/` as an absolute path without the leading slash (e.g. `workspace/main.py` for `/workspace/main.py`). Must resolve within `/workspace`. Returns raw bytes (`application/octet-stream`).
 
-
 ```sh
 curl -X GET http://localhost:8787/v1/sandbox/mfrggzdfmy2tqnrz/file/workspace/main.py \
   -H "Authorization: Bearer $SANDBOX_API_KEY"
@@ -428,10 +427,12 @@ The pool is primed (its alarm loop started) in two ways:
 
 Set these variables in `wrangler.jsonc` (under `vars`) or via `wrangler secret put`:
 
-| Variable                     | Default   | Description                                                                          |
-| ---------------------------- | --------- | ------------------------------------------------------------------------------------ |
-| `WARM_POOL_TARGET`           | `"0"`     | Number of idle containers to keep warm. **0 disables the pool** (no surprise bills). |
-| `WARM_POOL_REFRESH_INTERVAL` | `"10000"` | Milliseconds between pool health-check / replenishment cycles.                       |
+| Variable                     | Default   | Description                                                                                                                                         |
+| ---------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `WARM_POOL_TARGET`           | `"0"`     | Number of idle containers to keep warm. **0 disables the pool** (no surprise bills).                                                                |
+| `WARM_POOL_REFRESH_INTERVAL` | `"10000"` | Milliseconds between pool health-check / replenishment cycles.                                                                                      |
+| `WARM_POOL_MAX_INSTANCES`    | `"0"`     | Capacity ceiling the pool plans against. Set it to match `containers[].max_instances`. **0 leaves the ceiling to be learned from capacity errors.** |
+| `WARM_POOL_SCALE_BATCH_SIZE` | `"5"`     | Number of containers started in parallel per scale-up batch. Clamped to `[1, 20]`.                                                                  |
 
 The cron trigger frequency can be adjusted in `wrangler.jsonc` under `triggers.crons`. Remove the cron entirely if you only want manual priming via `POST /v1/pool/prime`.
 

--- a/bridge/worker/src/__tests__/tracing.test.ts
+++ b/bridge/worker/src/__tests__/tracing.test.ts
@@ -1,0 +1,99 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Capture every setAttribute call across all spans created during a test.
+const attributeCalls: Array<[string, unknown]> = [];
+let traced = false;
+
+vi.mock('cloudflare:workers', () => ({
+  tracing: {
+    enterSpan: async (_name: string, callback: (span: unknown) => unknown) => {
+      const span = {
+        isTraced: traced,
+        setAttribute: (key: string, value?: unknown) => {
+          attributeCalls.push([key, value]);
+        }
+      };
+      return callback(span);
+    }
+  }
+}));
+
+const { annotate, traced: tracedWrap } = await import('../../../../packages/sandbox/src/bridge/tracing');
+
+type TestEnv = {
+  Bindings: Record<string, unknown>;
+  Variables: { containerUUID: string; span?: unknown };
+};
+
+function attr(key: string): unknown {
+  return attributeCalls.find(([k]) => k === key)?.[1];
+}
+
+describe('bridge tracing helper', () => {
+  beforeEach(() => {
+    attributeCalls.length = 0;
+    traced = true;
+  });
+
+  it('wraps a handler in a span seeded with common attributes', async () => {
+    const app = new Hono<TestEnv>();
+    app.use('/v1/sandbox/:id/thing', async (c, next) => {
+      c.set('containerUUID', 'container-xyz');
+      return next();
+    });
+    app.get(
+      '/v1/sandbox/:id/thing',
+      tracedWrap('thing', async (c) => c.json({ ok: true }))
+    );
+
+    const res = await app.request('/v1/sandbox/abc/thing');
+    expect(res.status).toBe(200);
+
+    expect(attr('bridge.operation')).toBe('thing');
+    expect(attr('http.request.method')).toBe('GET');
+    expect(attr('http.route')).toBe('/v1/sandbox/:id/thing');
+    expect(attr('sandbox.id')).toBe('abc');
+    expect(attr('sandbox.container_uuid')).toBe('container-xyz');
+    expect(attr('http.response.status_code')).toBe(200);
+  });
+
+  it('exposes the active span to annotate()', async () => {
+    const app = new Hono<TestEnv>();
+    app.get(
+      '/v1/sandbox/:id/thing',
+      tracedWrap('thing', async (c) => {
+        annotate(c, 'custom.key', 42);
+        return c.json({ ok: true });
+      })
+    );
+
+    await app.request('/v1/sandbox/abc/thing');
+    expect(attr('custom.key')).toBe(42);
+  });
+
+  it('records the response status for error responses', async () => {
+    const app = new Hono<TestEnv>();
+    app.get(
+      '/v1/sandbox/:id/thing',
+      tracedWrap('thing', async (c) => c.json({ error: 'nope' }, 502))
+    );
+
+    const res = await app.request('/v1/sandbox/abc/thing');
+    expect(res.status).toBe(502);
+    expect(attr('http.response.status_code')).toBe(502);
+  });
+
+  it('annotate() is a no-op when no span is set', async () => {
+    const app = new Hono<TestEnv>();
+    app.get('/plain', async (c) => {
+      // No traced() wrapper, so no span on the context.
+      annotate(c, 'should.not.appear', 'x');
+      return c.json({ ok: true });
+    });
+
+    const res = await app.request('/plain');
+    expect(res.status).toBe(200);
+    expect(attr('should.not.appear')).toBeUndefined();
+  });
+});

--- a/bridge/worker/src/__tests__/warm-pool.test.ts
+++ b/bridge/worker/src/__tests__/warm-pool.test.ts
@@ -58,6 +58,8 @@ async function withPool(
     maxInstances?: number | null;
     /** Operator-declared ceiling passed through configure() (Proposal 1). */
     configuredMaxInstances?: number;
+    /** Bounded-parallel batch size passed through configure() (TICKET2). */
+    scaleBatchSize?: number;
     warmContainers?: string[];
     assignments?: [string, string][];
     containerBehavior?: {
@@ -97,7 +99,8 @@ async function withPool(
     await instance.configure({
       warmTarget: opts.warmTarget ?? 0,
       refreshInterval: 60_000,
-      ...(opts.configuredMaxInstances !== undefined ? { maxInstances: opts.configuredMaxInstances } : {})
+      ...(opts.configuredMaxInstances !== undefined ? { maxInstances: opts.configuredMaxInstances } : {}),
+      ...(opts.scaleBatchSize !== undefined ? { scaleBatchSize: opts.scaleBatchSize } : {})
     });
 
     await callback(instance, mock);
@@ -224,6 +227,145 @@ describe('WarmPool', () => {
         async (pool) => {
           await pool.alarm();
           expect(startCount).toBe(0);
+        }
+      );
+    });
+  });
+
+  // ── batched scale-up (TICKET2) ─────────────────────────────────────────
+
+  describe('batched scale-up', () => {
+    /**
+     * Behavior wrapper that records the peak number of concurrent
+     * startAndWaitForPorts calls in flight at once.
+     */
+    function concurrencyTracker() {
+      let inFlight = 0;
+      let maxInFlight = 0;
+      let startCount = 0;
+      return {
+        startCount: () => startCount,
+        maxInFlight: () => maxInFlight,
+        behavior: {
+          startAndWaitForPorts: vi.fn(async () => {
+            startCount++;
+            inFlight++;
+            maxInFlight = Math.max(maxInFlight, inFlight);
+            // Yield so siblings in the same batch can also enter.
+            await Promise.resolve();
+            await Promise.resolve();
+            inFlight--;
+          }),
+          getState: vi.fn(async () => ({ status: 'running' as const }))
+        }
+      };
+    }
+
+    it('starts containers in bounded-parallel batches', async () => {
+      const tracker = concurrencyTracker();
+      await withPool(
+        {
+          warmTarget: 10,
+          configuredMaxInstances: 100,
+          scaleBatchSize: 5,
+          containerBehavior: tracker.behavior
+        },
+        async (pool) => {
+          await pool.alarm();
+          const stats = await pool.getStats();
+          expect(stats.warm).toBe(10);
+          expect(tracker.startCount()).toBe(10);
+          // Bounded: never more than batch size in flight at once.
+          expect(tracker.maxInFlight()).toBe(5);
+        }
+      );
+    });
+
+    it('batch size of 1 reproduces serial behaviour', async () => {
+      const tracker = concurrencyTracker();
+      await withPool(
+        {
+          warmTarget: 4,
+          configuredMaxInstances: 100,
+          scaleBatchSize: 1,
+          containerBehavior: tracker.behavior
+        },
+        async (pool) => {
+          await pool.alarm();
+          expect((await pool.getStats()).warm).toBe(4);
+          expect(tracker.maxInFlight()).toBe(1);
+        }
+      );
+    });
+
+    it('clamps batch size to a safe maximum', async () => {
+      const tracker = concurrencyTracker();
+      await withPool(
+        {
+          warmTarget: 30,
+          configuredMaxInstances: 100,
+          scaleBatchSize: 1000,
+          containerBehavior: tracker.behavior
+        },
+        async (pool) => {
+          await pool.alarm();
+          // Clamped to the documented max of 20, not 1000.
+          expect(tracker.maxInFlight()).toBe(20);
+        }
+      );
+    });
+
+    it('stops launching batches once capacity is exhausted mid-fill', async () => {
+      let startCount = 0;
+      await withPool(
+        {
+          warmTarget: 20,
+          scaleBatchSize: 5,
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {
+              startCount++;
+              // First batch of 5 succeeds; the second batch hits the cap.
+              if (startCount > 5) {
+                throw new Error(MAX_INSTANCES_ERROR);
+              }
+            }),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          await pool.alarm();
+          // 5 succeed, the straddling batch of 5 all fail (bounded overshoot),
+          // then the loop stops — no third batch.
+          expect(startCount).toBe(10);
+          const stats = await pool.getStats();
+          expect(stats.warm).toBe(5);
+        }
+      );
+    });
+
+    it('adds only successful UUIDs from a partial-failure batch', async () => {
+      let startCount = 0;
+      await withPool(
+        {
+          warmTarget: 4,
+          configuredMaxInstances: 100,
+          scaleBatchSize: 5,
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {
+              startCount++;
+              // Odd-numbered starts fail with a non-capacity error.
+              if (startCount % 2 === 1) {
+                throw new Error('transient boot failure');
+              }
+            }),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          await pool.alarm();
+          const stats = await pool.getStats();
+          // 2 of the 4 attempted succeeded; pool not corrupted.
+          expect(stats.warm).toBe(2);
         }
       );
     });
@@ -583,6 +725,8 @@ describe('WarmPool', () => {
       await withPool(
         {
           warmTarget: 5,
+          // Serial batches isolate the mid-loop capacity stop.
+          scaleBatchSize: 1,
           containerBehavior: {
             startAndWaitForPorts: vi.fn(async () => {
               startCount++;
@@ -830,6 +974,9 @@ describe('WarmPool', () => {
       await withPool(
         {
           warmTarget: 3,
+          // Reactive discovery counts on serial starts; batch size 1 keeps the
+          // inferred ceiling accurate for the learn-by-crashing path.
+          scaleBatchSize: 1,
           containerBehavior: {
             startAndWaitForPorts: vi.fn(async () => {
               totalStarted++;

--- a/bridge/worker/src/__tests__/warm-pool.test.ts
+++ b/bridge/worker/src/__tests__/warm-pool.test.ts
@@ -343,6 +343,44 @@ describe('WarmPool', () => {
       );
     });
 
+    it('records the accurate ceiling after a partial-capacity batch', async () => {
+      // Regression: with parallel batches, recordCapacityLimit() runs while a
+      // batch's successful starts are not yet in warmContainers, so it would
+      // infer a ceiling lower than reality and reject available capacity.
+      let startCount = 0;
+      await withPool(
+        {
+          warmTarget: 10,
+          scaleBatchSize: 5,
+          // Two slots already taken by live assignments.
+          assignments: [
+            ['s1', 'a1'],
+            ['s2', 'a2']
+          ],
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {
+              startCount++;
+              // Only the first 3 starts succeed; the rest hit the cap.
+              if (startCount > 3) {
+                throw new Error(MAX_INSTANCES_ERROR);
+              }
+            }),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          await pool.alarm();
+          const stats = await pool.getStats();
+          // 3 warm + 2 assigned = 5 real containers running.
+          expect(stats.warm).toBe(3);
+          expect(stats.total).toBe(5);
+          // The inferred ceiling must reflect the true total, not the stale
+          // pre-batch count of 2.
+          expect(stats.maxInstances).toBe(5);
+        }
+      );
+    });
+
     it('adds only successful UUIDs from a partial-failure batch', async () => {
       let startCount = 0;
       await withPool(

--- a/bridge/worker/src/__tests__/warm-pool.test.ts
+++ b/bridge/worker/src/__tests__/warm-pool.test.ts
@@ -56,6 +56,8 @@ async function withPool(
   opts: {
     warmTarget?: number;
     maxInstances?: number | null;
+    /** Operator-declared ceiling passed through configure() (Proposal 1). */
+    configuredMaxInstances?: number;
     warmContainers?: string[];
     assignments?: [string, string][];
     containerBehavior?: {
@@ -94,7 +96,8 @@ async function withPool(
     // Configure
     await instance.configure({
       warmTarget: opts.warmTarget ?? 0,
-      refreshInterval: 60_000
+      refreshInterval: 60_000,
+      ...(opts.configuredMaxInstances !== undefined ? { maxInstances: opts.configuredMaxInstances } : {})
     });
 
     await callback(instance, mock);
@@ -562,6 +565,139 @@ describe('WarmPool', () => {
         async (pool) => {
           const stats = await pool.getStats();
           expect(stats.maxInstances).toBeNull();
+        }
+      );
+    });
+  });
+
+  // ── Configured max_instances (Proposal 1) ──────────────────────────────
+
+  describe('configured max_instances', () => {
+    it('seeds knownMaxInstances from config before any container start', async () => {
+      await withPool(
+        {
+          warmTarget: 0,
+          configuredMaxInstances: 100
+        },
+        async (pool) => {
+          const stats = await pool.getStats();
+          expect(stats.maxInstances).toBe(100);
+        }
+      );
+    });
+
+    it('does not require a discovery 502 to learn the ceiling', async () => {
+      let startCount = 0;
+      await withPool(
+        {
+          warmTarget: 5,
+          configuredMaxInstances: 2,
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {
+              startCount++;
+            }),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          await pool.alarm();
+          // Clamped to configured ceiling of 2 — no failed start needed.
+          expect(startCount).toBe(2);
+        }
+      );
+    });
+
+    it('keeps a learned-lower ceiling over a higher configured value', async () => {
+      await withPool(
+        {
+          warmTarget: 0,
+          maxInstances: 3,
+          configuredMaxInstances: 100
+        },
+        async (pool) => {
+          const stats = await pool.getStats();
+          expect(stats.maxInstances).toBe(3);
+        }
+      );
+    });
+
+    it('keeps a configured-lower ceiling over a higher learned value', async () => {
+      await withPool(
+        {
+          warmTarget: 0,
+          maxInstances: 50,
+          configuredMaxInstances: 10
+        },
+        async (pool) => {
+          const stats = await pool.getStats();
+          expect(stats.maxInstances).toBe(10);
+        }
+      );
+    });
+
+    it('treats 0 as auto-learn (preserves null ceiling)', async () => {
+      await withPool(
+        {
+          warmTarget: 0,
+          configuredMaxInstances: 0
+        },
+        async (pool) => {
+          const stats = await pool.getStats();
+          expect(stats.maxInstances).toBeNull();
+        }
+      );
+    });
+
+    it('never starts beyond the configured ceiling in getContainer', async () => {
+      await withPool(
+        {
+          warmTarget: 0,
+          configuredMaxInstances: 2,
+          assignments: [
+            ['user1', 'c1'],
+            ['user2', 'c2']
+          ],
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {}),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          await expect(pool.getContainer('user3')).rejects.toThrow('instance limit reached');
+        }
+      );
+    });
+
+    it('re-seeds the configured ceiling after a successful probe clears it', async () => {
+      let startCount = 0;
+      await withPool(
+        {
+          warmTarget: 3,
+          maxInstances: 2,
+          configuredMaxInstances: 5,
+          assignments: [
+            ['user1', 'c1'],
+            ['user2', 'c2']
+          ],
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {
+              startCount++;
+            }),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          // Probe succeeds, clears the learned limit of 2.
+          await pool.alarm();
+          expect((await pool.getStats()).maxInstances).toBeNull();
+          // Next configure() (every request) re-seeds the configured ceiling.
+          await pool.configure({
+            warmTarget: 3,
+            refreshInterval: 60_000,
+            maxInstances: 5
+          });
+          const stats = await pool.getStats();
+          expect(stats.maxInstances).toBe(5);
         }
       );
     });

--- a/bridge/worker/src/__tests__/warm-pool.test.ts
+++ b/bridge/worker/src/__tests__/warm-pool.test.ts
@@ -359,6 +359,123 @@ describe('WarmPool', () => {
 
   // ── startContainer error detection ─────────────────────────────────────
 
+  describe('eager refill', () => {
+    it('refills the warm pool after a pop without waiting for the alarm', async () => {
+      let startCount = 0;
+      await withPool(
+        {
+          warmTarget: 2,
+          configuredMaxInstances: 10,
+          warmContainers: ['w1', 'w2'],
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {
+              startCount++;
+            }),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          await pool.getContainer('user1');
+          // Wait for the fire-and-forget refill to settle.
+          await (pool as unknown as { refillPromise: Promise<void> | null }).refillPromise;
+          const stats = await pool.getStats();
+          expect(stats.warm).toBe(2);
+          expect(startCount).toBe(1);
+        }
+      );
+    });
+
+    it('debounces concurrent pops to a single in-flight refill', async () => {
+      let release: () => void = () => {};
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      await withPool(
+        {
+          warmTarget: 5,
+          configuredMaxInstances: 10,
+          warmContainers: ['w1', 'w2', 'w3'],
+          assignments: [
+            ['user1', 'c1'],
+            ['user2', 'c2']
+          ],
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {
+              await gate;
+            }),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          let adjustCount = 0;
+          const wrapped = pool as unknown as {
+            adjustPool: () => Promise<void>;
+            refillPromise: Promise<void> | null;
+          };
+          const orig = wrapped.adjustPool.bind(pool);
+          wrapped.adjustPool = async () => {
+            adjustCount++;
+            return orig();
+          };
+
+          await Promise.all([pool.getContainer('user3'), pool.getContainer('user4')]);
+
+          // Two pops, but only one refill should be in flight.
+          expect(adjustCount).toBe(1);
+
+          release();
+          await wrapped.refillPromise;
+        }
+      );
+    });
+
+    it('eager refill never exceeds remaining capacity', async () => {
+      let startCount = 0;
+      await withPool(
+        {
+          warmTarget: 5,
+          configuredMaxInstances: 3,
+          warmContainers: ['w1'],
+          assignments: [['user1', 'c1']],
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {
+              startCount++;
+            }),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          // Pop w1 → warm 0, assigned 2, total 2. Ceiling 3 leaves room for 1.
+          await pool.getContainer('user2');
+          await (pool as unknown as { refillPromise: Promise<void> | null }).refillPromise;
+          expect(startCount).toBe(1);
+          const stats = await pool.getStats();
+          expect(stats.warm).toBe(1);
+        }
+      );
+    });
+
+    it('refill failure does not reject getContainer', async () => {
+      await withPool(
+        {
+          warmTarget: 2,
+          configuredMaxInstances: 10,
+          warmContainers: ['w1', 'w2'],
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {
+              throw new Error('boom');
+            }),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          await expect(pool.getContainer('user1')).resolves.toBeDefined();
+          await (pool as unknown as { refillPromise: Promise<void> | null }).refillPromise;
+        }
+      );
+    });
+  });
+
   describe('startContainer / error detection', () => {
     it('records knownMaxInstances when max_instances error is thrown', async () => {
       await withPool(

--- a/bridge/worker/wrangler.jsonc
+++ b/bridge/worker/wrangler.jsonc
@@ -62,7 +62,14 @@
     // Target number of pre-warmed containers (0 = disabled, no surprise bills).
     "WARM_POOL_TARGET": "0",
     // How often the pool alarm checks health and replenishes containers (ms).
-    "WARM_POOL_REFRESH_INTERVAL": "10000"
+    "WARM_POOL_REFRESH_INTERVAL": "10000",
+    // Operator-declared instance ceiling. Set this to match
+    // containers[].max_instances above so the pool knows its capacity without
+    // crashing into the limit first. 0 = unknown (auto-learn from platform
+    // errors). Note the effective warm ceiling is max_instances minus any
+    // assigned containers, so warmTarget cannot equal max_instances while
+    // sandboxes are in use.
+    "WARM_POOL_MAX_INSTANCES": "0"
   },
   "preview_urls": false
 }

--- a/bridge/worker/wrangler.jsonc
+++ b/bridge/worker/wrangler.jsonc
@@ -69,7 +69,11 @@
     // errors). Note the effective warm ceiling is max_instances minus any
     // assigned containers, so warmTarget cannot equal max_instances while
     // sandboxes are in use.
-    "WARM_POOL_MAX_INSTANCES": "0"
+    "WARM_POOL_MAX_INSTANCES": "0",
+    // Number of containers the pool starts in parallel per scale-up batch.
+    // Higher fills the pool faster; too high risks the platform throttling a
+    // cold-start stampede. Clamped to [1, 20]. Default 5.
+    "WARM_POOL_SCALE_BATCH_SIZE": "5"
   },
   "preview_urls": false
 }

--- a/bridge/worker/wrangler.jsonc
+++ b/bridge/worker/wrangler.jsonc
@@ -8,8 +8,13 @@
     "enabled": true,
     // Enable distributed tracing so the bridge's custom spans
     // (bridge.<operation>) are recorded alongside automatic instrumentation.
+    // Each span is annotated with the sandbox ID, container UUID, and
+    // operation-specific metadata (command, file path, port, session, etc.).
     "traces": {
-      "enabled": true
+      "enabled": true,
+      // Fraction of requests to trace (0.0–1.0). 1.0 traces everything; lower
+      // it to reduce overhead and cost under high traffic.
+      "head_sampling_rate": 1
     }
   },
   // The Sandbox Durable Object + its container image.
@@ -20,9 +25,9 @@
       // Replace with a custom Dockerfile path if you need extra tooling
       // (e.g. git, Python, Node.js) in the sandbox container.
       "image": "./Dockerfile",
-      // "lite" is a good default for getting started; upgrade to "standard-1"
-      // (4 vCPU / 8 GiB RAM) for production workloads.
-      "instance_type": "lite",
+      // "standard-1" (4 vCPU / 8 GiB RAM) suits production workloads; drop to
+      // "lite" to minimise cost when getting started.
+      "instance_type": "standard-1",
       "max_instances": 3
     }
   ],

--- a/bridge/worker/wrangler.jsonc
+++ b/bridge/worker/wrangler.jsonc
@@ -5,7 +5,12 @@
   "compatibility_date": "2025-05-06",
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
-    "enabled": true
+    "enabled": true,
+    // Enable distributed tracing so the bridge's custom spans
+    // (bridge.<operation>) are recorded alongside automatic instrumentation.
+    "traces": {
+      "enabled": true
+    }
   },
   // The Sandbox Durable Object + its container image.
   // Bump the migration tag whenever new_sqlite_classes changes.

--- a/packages/sandbox/src/bridge/AGENTS.md
+++ b/packages/sandbox/src/bridge/AGENTS.md
@@ -11,6 +11,7 @@ Consumer-facing documentation (API reference, deployment, security) lives in [`b
 - `warm-pool.ts` — `WarmPool` Durable Object that maintains a pool of pre-started sandbox containers (adapted from [cf-container-warm-pool](https://github.com/mikenomitch/cf-container-warm-pool)).
 - `pool.ts` — Pool management helpers used by routes.
 - `helpers.ts` — Utility functions (path validation, shell quoting, SSE formatting).
+- `tracing.ts` — Custom span instrumentation: wraps each route handler in a `bridge.<operation>` Cloudflare custom span, seeding common attributes and exposing the active span for operation-specific metadata.
 - `types.ts` — `BridgeConfig`, `BridgeEnv`, `WorkerHandlers` type definitions.
 - `openapi.ts` — OpenAPI 3.1 schema definition.
 - `openapi-html.ts` — Self-contained HTML renderer for the OpenAPI spec.

--- a/packages/sandbox/src/bridge/pool.ts
+++ b/packages/sandbox/src/bridge/pool.ts
@@ -21,8 +21,10 @@ export function parsePoolConfig(env: BridgeEnv): Required<WarmPoolConfig> {
     ) || 10_000;
   const maxInstances =
     Number.parseInt((env.WARM_POOL_MAX_INSTANCES as string) || '0', 10) || 0;
+  const scaleBatchSize =
+    Number.parseInt((env.WARM_POOL_SCALE_BATCH_SIZE as string) || '5', 10) || 5;
 
-  return { warmTarget, refreshInterval, maxInstances };
+  return { warmTarget, refreshInterval, maxInstances, scaleBatchSize };
 }
 
 /**

--- a/packages/sandbox/src/bridge/pool.ts
+++ b/packages/sandbox/src/bridge/pool.ts
@@ -3,6 +3,27 @@
  */
 
 import type { BridgeEnv } from './types';
+import type { WarmPoolConfig } from './warm-pool';
+
+/**
+ * Parse warm-pool configuration from bridge env vars.
+ *
+ * `WARM_POOL_MAX_INSTANCES` should match `containers[].max_instances` in
+ * wrangler.jsonc. 0/unset means auto-learn the ceiling reactively.
+ */
+export function parsePoolConfig(env: BridgeEnv): Required<WarmPoolConfig> {
+  const warmTarget =
+    Number.parseInt((env.WARM_POOL_TARGET as string) || '0', 10) || 0;
+  const refreshInterval =
+    Number.parseInt(
+      (env.WARM_POOL_REFRESH_INTERVAL as string) || '10000',
+      10
+    ) || 10_000;
+  const maxInstances =
+    Number.parseInt((env.WARM_POOL_MAX_INSTANCES as string) || '0', 10) || 0;
+
+  return { warmTarget, refreshInterval, maxInstances };
+}
 
 /**
  * Prime the warm pool — pushes current configuration to the WarmPool
@@ -14,16 +35,10 @@ export async function primePool(
   env: BridgeEnv,
   warmPoolBinding: string
 ): Promise<void> {
-  const warmTarget =
-    Number.parseInt((env.WARM_POOL_TARGET as string) || '0', 10) || 0;
-  const refreshInterval =
-    Number.parseInt(
-      (env.WARM_POOL_REFRESH_INTERVAL as string) || '10000',
-      10
-    ) || 10_000;
+  const config = parsePoolConfig(env);
 
   const ns = env[warmPoolBinding] as DurableObjectNamespace;
   const poolId = ns.idFromName('global-pool');
   const poolStub = ns.get(poolId);
-  await (poolStub as any).configure({ warmTarget, refreshInterval });
+  await (poolStub as any).configure(config);
 }

--- a/packages/sandbox/src/bridge/routes.ts
+++ b/packages/sandbox/src/bridge/routes.ts
@@ -35,7 +35,7 @@ import {
 } from './helpers';
 import { OPENAPI_SCHEMA } from './openapi';
 import { renderOpenApiHtml } from './openapi-html';
-import { primePool } from './pool';
+import { parsePoolConfig, primePool } from './pool';
 import type {
   BridgeEnv,
   ExecRequest,
@@ -392,20 +392,12 @@ export function createBridgeApp(
   app.use(`${apiPrefix}/sandbox/:id/*`, async (c, next) => {
     const sandboxId = c.req.param('id');
 
-    const warmTarget =
-      Number.parseInt((c.env.WARM_POOL_TARGET as string) || '0', 10) || 0;
-    const refreshInterval =
-      Number.parseInt(
-        (c.env.WARM_POOL_REFRESH_INTERVAL as string) || '10000',
-        10
-      ) || 10_000;
-
     const poolNs = getWarmPoolNs(c.env);
     const poolId = poolNs.idFromName('global-pool');
     const poolStub = poolNs.get(poolId);
 
     try {
-      await (poolStub as any).configure({ warmTarget, refreshInterval });
+      await (poolStub as any).configure(parsePoolConfig(c.env));
       const containerUUID = await (poolStub as any).getContainer(sandboxId);
       c.set('containerUUID', containerUUID);
     } catch (err) {
@@ -1195,20 +1187,12 @@ export function createBridgeApp(
   });
 
   app.get(`${apiPrefix}/pool/stats`, async (c) => {
-    const warmTarget =
-      Number.parseInt((c.env.WARM_POOL_TARGET as string) || '0', 10) || 0;
-    const refreshInterval =
-      Number.parseInt(
-        (c.env.WARM_POOL_REFRESH_INTERVAL as string) || '10000',
-        10
-      ) || 10_000;
-
     const poolNs = getWarmPoolNs(c.env);
     const poolId = poolNs.idFromName('global-pool');
     const poolStub = poolNs.get(poolId);
 
     try {
-      await (poolStub as any).configure({ warmTarget, refreshInterval });
+      await (poolStub as any).configure(parsePoolConfig(c.env));
     } catch {
       // Continue — stats should still be readable even if config push fails.
     }
@@ -1218,20 +1202,12 @@ export function createBridgeApp(
   });
 
   app.post(`${apiPrefix}/pool/shutdown-prewarmed`, async (c) => {
-    const warmTarget =
-      Number.parseInt((c.env.WARM_POOL_TARGET as string) || '0', 10) || 0;
-    const refreshInterval =
-      Number.parseInt(
-        (c.env.WARM_POOL_REFRESH_INTERVAL as string) || '10000',
-        10
-      ) || 10_000;
-
     const poolNs = getWarmPoolNs(c.env);
     const poolId = poolNs.idFromName('global-pool');
     const poolStub = poolNs.get(poolId);
 
     try {
-      await (poolStub as any).configure({ warmTarget, refreshInterval });
+      await (poolStub as any).configure(parsePoolConfig(c.env));
     } catch {
       // Continue.
     }

--- a/packages/sandbox/src/bridge/routes.ts
+++ b/packages/sandbox/src/bridge/routes.ts
@@ -36,6 +36,7 @@ import {
 import { OPENAPI_SCHEMA } from './openapi';
 import { renderOpenApiHtml } from './openapi-html';
 import { parsePoolConfig, primePool } from './pool';
+import { annotate, type BridgeHonoEnv, traced } from './tracing';
 import type {
   BridgeEnv,
   ExecRequest,
@@ -314,13 +315,8 @@ export interface RouteConfig {
 // App factory
 // ---------------------------------------------------------------------------
 
-export function createBridgeApp(
-  config: RouteConfig
-): Hono<{ Bindings: BridgeEnv; Variables: { containerUUID: string } }> {
-  const app = new Hono<{
-    Bindings: BridgeEnv;
-    Variables: { containerUUID: string };
-  }>();
+export function createBridgeApp(config: RouteConfig): Hono<BridgeHonoEnv> {
+  const app = new Hono<BridgeHonoEnv>();
 
   const { sandboxBinding, warmPoolBinding, apiPrefix } = config;
 
@@ -365,25 +361,29 @@ export function createBridgeApp(
   // POST /sandbox
   // ------------------------------------------------------------------
 
-  app.post(`${apiPrefix}/sandbox`, async (c) => {
-    // Auth — same logic as the /sandbox/* middleware
-    const token = c.env.SANDBOX_API_KEY as string | undefined;
-    if (token) {
-      const authHeader = c.req.header('Authorization') ?? '';
-      const provided = authHeader.toLowerCase().startsWith('bearer ')
-        ? authHeader.slice(7)
-        : '';
-      if (provided !== token) {
-        return errorJson('Unauthorized', 'unauthorized', 401);
+  app.post(
+    `${apiPrefix}/sandbox`,
+    traced('create_sandbox', async (c) => {
+      // Auth — same logic as the /sandbox/* middleware
+      const token = c.env.SANDBOX_API_KEY as string | undefined;
+      if (token) {
+        const authHeader = c.req.header('Authorization') ?? '';
+        const provided = authHeader.toLowerCase().startsWith('bearer ')
+          ? authHeader.slice(7)
+          : '';
+        if (provided !== token) {
+          return errorJson('Unauthorized', 'unauthorized', 401);
+        }
       }
-    }
 
-    // Generate a sandbox ID: 16 random bytes → base32 (lowercase a-z, 2-7), 26 chars
-    const bytes = new Uint8Array(16);
-    crypto.getRandomValues(bytes);
-    const id = base32Encode(bytes);
-    return c.json({ id });
-  });
+      // Generate a sandbox ID: 16 random bytes → base32 (lowercase a-z, 2-7), 26 chars
+      const bytes = new Uint8Array(16);
+      crypto.getRandomValues(bytes);
+      const id = base32Encode(bytes);
+      annotate(c, 'sandbox.id', id);
+      return c.json({ id });
+    })
+  );
 
   // ------------------------------------------------------------------
   // Pool resolution middleware — maps sandbox ID to container UUID
@@ -443,705 +443,803 @@ export function createBridgeApp(
   // POST /sandbox/:id/exec
   // ------------------------------------------------------------------
 
-  app.post(`${apiPrefix}/sandbox/:id/exec`, async (c) => {
-    let body: ExecRequest;
-    try {
-      body = await c.req.json<ExecRequest>();
-    } catch {
-      return errorJson('Invalid JSON body', 'invalid_request', 400);
-    }
+  app.post(
+    `${apiPrefix}/sandbox/:id/exec`,
+    traced('exec', async (c) => {
+      let body: ExecRequest;
+      try {
+        body = await c.req.json<ExecRequest>();
+      } catch {
+        return errorJson('Invalid JSON body', 'invalid_request', 400);
+      }
 
-    if (!Array.isArray(body.argv) || body.argv.length === 0) {
-      return errorJson(
-        'argv must be a non-empty array',
-        'invalid_request',
-        400
-      );
-    }
-
-    const sandbox = getSandboxWithoutDefaultSession(
-      getSandboxNs(c.env),
-      c.get('containerUUID')
-    );
-    const rawSessionId = c.req.header('Session-Id');
-    let executor:
-      | BridgeSandbox
-      | Awaited<ReturnType<BridgeSandbox['getSession']>> = sandbox;
-    if (rawSessionId) {
-      const sessionId = validateSessionId(rawSessionId);
-      if (!sessionId)
-        return errorJson('Invalid session ID format', 'invalid_request', 400);
-      executor = await sandbox.getSession(sessionId);
-    }
-
-    const command = body.argv.map(shellQuote).join(' ');
-
-    const opts: { timeout?: number; cwd?: string } = {};
-    if (typeof body.timeout_ms === 'number') {
-      opts.timeout = body.timeout_ms;
-    }
-    if (typeof body.cwd === 'string') {
-      const resolvedCwd = resolveWorkspacePath(body.cwd);
-      if (!resolvedCwd) {
+      if (!Array.isArray(body.argv) || body.argv.length === 0) {
         return errorJson(
-          'cwd must resolve to a location within /workspace',
+          'argv must be a non-empty array',
           'invalid_request',
-          403
+          400
         );
       }
-      opts.cwd = resolvedCwd;
-    }
 
-    // --- SSE streaming response ---
-    const { readable, writable } = new TransformStream();
-    const writer = writable.getWriter();
-    const encoder = new TextEncoder();
+      annotate(c, 'exec.argv_count', body.argv.length);
+      if (body.argv[0]) annotate(c, 'exec.command', body.argv[0]);
 
-    let closed = false;
-    let lastWrite: Promise<void> = Promise.resolve();
-
-    /** Write a single SSE event. Chains on the previous write to respect backpressure. */
-    function writeSSE(event: string, data: string): void {
-      if (closed) return;
-      // SSE spec: each line of data needs its own "data:" prefix
-      const payload = data
-        .split('\n')
-        .map((line) => `data: ${line}`)
-        .join('\n');
-      lastWrite = lastWrite.then(() =>
-        writer.write(encoder.encode(`event: ${event}\n${payload}\n\n`))
+      const sandbox = getSandboxWithoutDefaultSession(
+        getSandboxNs(c.env),
+        c.get('containerUUID')
       );
-    }
+      const rawSessionId = c.req.header('Session-Id');
+      let executor:
+        | BridgeSandbox
+        | Awaited<ReturnType<BridgeSandbox['getSession']>> = sandbox;
+      if (rawSessionId) {
+        const sessionId = validateSessionId(rawSessionId);
+        if (!sessionId)
+          return errorJson('Invalid session ID format', 'invalid_request', 400);
+        annotate(c, 'session.id', sessionId);
+        executor = await sandbox.getSession(sessionId);
+      }
 
-    function closeStream(): void {
-      if (closed) return;
-      closed = true;
-      lastWrite.then(() => writer.close()).catch(() => {});
-    }
+      const command = body.argv.map(shellQuote).join(' ');
 
-    executor
-      .exec(command, {
-        ...opts,
-        stream: true,
-        onOutput(stream: 'stdout' | 'stderr', data: string) {
-          writeSSE(stream, toBase64(data));
-        },
-        onComplete(result: { exitCode: number }) {
-          writeSSE('exit', JSON.stringify({ exit_code: result.exitCode }));
-          closeStream();
-        },
-        onError(err: Error) {
+      const opts: { timeout?: number; cwd?: string } = {};
+      if (typeof body.timeout_ms === 'number') {
+        opts.timeout = body.timeout_ms;
+        annotate(c, 'exec.timeout_ms', body.timeout_ms);
+      }
+      if (typeof body.cwd === 'string') {
+        const resolvedCwd = resolveWorkspacePath(body.cwd);
+        if (!resolvedCwd) {
+          return errorJson(
+            'cwd must resolve to a location within /workspace',
+            'invalid_request',
+            403
+          );
+        }
+        opts.cwd = resolvedCwd;
+        annotate(c, 'exec.cwd', resolvedCwd);
+      }
+
+      // --- SSE streaming response ---
+      const { readable, writable } = new TransformStream();
+      const writer = writable.getWriter();
+      const encoder = new TextEncoder();
+
+      let closed = false;
+      let lastWrite: Promise<void> = Promise.resolve();
+
+      /** Write a single SSE event. Chains on the previous write to respect backpressure. */
+      function writeSSE(event: string, data: string): void {
+        if (closed) return;
+        // SSE spec: each line of data needs its own "data:" prefix
+        const payload = data
+          .split('\n')
+          .map((line) => `data: ${line}`)
+          .join('\n');
+        lastWrite = lastWrite.then(() =>
+          writer.write(encoder.encode(`event: ${event}\n${payload}\n\n`))
+        );
+      }
+
+      function closeStream(): void {
+        if (closed) return;
+        closed = true;
+        lastWrite.then(() => writer.close()).catch(() => {});
+      }
+
+      executor
+        .exec(command, {
+          ...opts,
+          stream: true,
+          onOutput(stream: 'stdout' | 'stderr', data: string) {
+            writeSSE(stream, toBase64(data));
+          },
+          onComplete(result: { exitCode: number }) {
+            writeSSE('exit', JSON.stringify({ exit_code: result.exitCode }));
+            closeStream();
+          },
+          onError(err: Error) {
+            writeSSE(
+              'error',
+              JSON.stringify({ error: err.message, code: 'exec_error' })
+            );
+            closeStream();
+          }
+        })
+        .catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
           writeSSE(
             'error',
-            JSON.stringify({ error: err.message, code: 'exec_error' })
+            JSON.stringify({
+              error: `exec failed: ${msg}`,
+              code: 'exec_transport_error'
+            })
           );
           closeStream();
-        }
-      })
-      .catch((err: unknown) => {
-        const msg = err instanceof Error ? err.message : String(err);
-        writeSSE(
-          'error',
-          JSON.stringify({
-            error: `exec failed: ${msg}`,
-            code: 'exec_transport_error'
-          })
-        );
-        closeStream();
-      });
+        });
 
-    return new Response(readable, {
-      status: 200,
-      headers: {
-        'Content-Type': 'text/event-stream',
-        'Cache-Control': 'no-cache'
-      }
-    });
-  });
+      return new Response(readable, {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache'
+        }
+      });
+    })
+  );
 
   // ------------------------------------------------------------------
   // GET /sandbox/:id/file/*
   // ------------------------------------------------------------------
 
-  app.get(`${apiPrefix}/sandbox/:id/file/*`, async (c) => {
-    const sandboxId = c.req.param('id');
+  app.get(
+    `${apiPrefix}/sandbox/:id/file/*`,
+    traced('read_file', async (c) => {
+      const sandboxId = c.req.param('id');
 
-    // Extract everything after /file/ in the URL path
-    const fullPath = c.req.path;
-    const marker = `${apiPrefix}/sandbox/${sandboxId}/file/`;
-    const relativePath = fullPath.slice(marker.length);
+      // Extract everything after /file/ in the URL path
+      const fullPath = c.req.path;
+      const marker = `${apiPrefix}/sandbox/${sandboxId}/file/`;
+      const relativePath = fullPath.slice(marker.length);
 
-    if (!relativePath) {
-      return errorJson('file path must not be empty', 'invalid_request', 400);
-    }
+      if (!relativePath) {
+        return errorJson('file path must not be empty', 'invalid_request', 400);
+      }
 
-    // Prepend / to make it absolute before validation
-    const resolvedPath = resolveWorkspacePath(`/${relativePath}`);
-    if (!resolvedPath) {
-      return errorJson(
-        'path must resolve to a location within /workspace',
-        'invalid_request',
-        403
-      );
-    }
-
-    const sandbox = getSandboxWithoutDefaultSession(
-      getSandboxNs(c.env),
-      c.get('containerUUID')
-    );
-    const rawSessionId = c.req.header('Session-Id');
-    let executor:
-      | BridgeSandbox
-      | Awaited<ReturnType<BridgeSandbox['getSession']>> = sandbox;
-    if (rawSessionId) {
-      const sessionId = validateSessionId(rawSessionId);
-      if (!sessionId)
-        return errorJson('Invalid session ID format', 'invalid_request', 400);
-      executor = await sandbox.getSession(sessionId);
-    }
-
-    try {
-      const stream = await executor.readFileStream(resolvedPath);
-      return new Response(sseToByteStream(stream), {
-        status: 200,
-        headers: { 'Content-Type': 'application/octet-stream' }
-      });
-    } catch (err) {
-      const code = (err as { code?: string }).code;
-      if (code === 'FILE_NOT_FOUND') {
+      // Prepend / to make it absolute before validation
+      const resolvedPath = resolveWorkspacePath(`/${relativePath}`);
+      if (!resolvedPath) {
         return errorJson(
-          `File not found: ${resolvedPath}`,
-          'workspace_read_not_found',
-          404
+          'path must resolve to a location within /workspace',
+          'invalid_request',
+          403
         );
       }
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(`read failed: ${msg}`, 'exec_transport_error', 502);
-    }
-  });
+
+      annotate(c, 'file.path', resolvedPath);
+
+      const sandbox = getSandboxWithoutDefaultSession(
+        getSandboxNs(c.env),
+        c.get('containerUUID')
+      );
+      const rawSessionId = c.req.header('Session-Id');
+      let executor:
+        | BridgeSandbox
+        | Awaited<ReturnType<BridgeSandbox['getSession']>> = sandbox;
+      if (rawSessionId) {
+        const sessionId = validateSessionId(rawSessionId);
+        if (!sessionId)
+          return errorJson('Invalid session ID format', 'invalid_request', 400);
+        annotate(c, 'session.id', sessionId);
+        executor = await sandbox.getSession(sessionId);
+      }
+
+      try {
+        const stream = await executor.readFileStream(resolvedPath);
+        return new Response(sseToByteStream(stream), {
+          status: 200,
+          headers: { 'Content-Type': 'application/octet-stream' }
+        });
+      } catch (err) {
+        const code = (err as { code?: string }).code;
+        if (code === 'FILE_NOT_FOUND') {
+          return errorJson(
+            `File not found: ${resolvedPath}`,
+            'workspace_read_not_found',
+            404
+          );
+        }
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(`read failed: ${msg}`, 'exec_transport_error', 502);
+      }
+    })
+  );
 
   // ------------------------------------------------------------------
   // PUT /sandbox/:id/file/*
   // ------------------------------------------------------------------
 
-  app.put(`${apiPrefix}/sandbox/:id/file/*`, async (c) => {
-    const sandboxId = c.req.param('id');
+  app.put(
+    `${apiPrefix}/sandbox/:id/file/*`,
+    traced('write_file', async (c) => {
+      const sandboxId = c.req.param('id');
 
-    // Extract everything after /file/ in the URL path
-    const fullPath = c.req.path;
-    const marker = `${apiPrefix}/sandbox/${sandboxId}/file/`;
-    const relativePath = fullPath.slice(marker.length);
+      // Extract everything after /file/ in the URL path
+      const fullPath = c.req.path;
+      const marker = `${apiPrefix}/sandbox/${sandboxId}/file/`;
+      const relativePath = fullPath.slice(marker.length);
 
-    if (!relativePath) {
-      return errorJson('file path must not be empty', 'invalid_request', 400);
-    }
+      if (!relativePath) {
+        return errorJson('file path must not be empty', 'invalid_request', 400);
+      }
 
-    // Prepend / to make it absolute before validation
-    const resolvedPath = resolveWorkspacePath(`/${relativePath}`);
-    if (!resolvedPath) {
-      return errorJson(
-        'path must resolve to a location within /workspace',
-        'invalid_request',
-        403
-      );
-    }
-
-    const sandbox = getSandboxWithoutDefaultSession(
-      getSandboxNs(c.env),
-      c.get('containerUUID')
-    );
-    const rawSessionId = c.req.header('Session-Id');
-    let executor:
-      | BridgeSandbox
-      | Awaited<ReturnType<BridgeSandbox['getSession']>> = sandbox;
-    if (rawSessionId) {
-      const sessionId = validateSessionId(rawSessionId);
-      if (!sessionId)
-        return errorJson('Invalid session ID format', 'invalid_request', 400);
-      executor = await sandbox.getSession(sessionId);
-    }
-
-    try {
-      const buffer = await c.req.arrayBuffer();
-      const MAX_WRITE_BYTES = 32 * 1024 * 1024; // 32 MiB — matches RPC payload limit
-      if (buffer.byteLength > MAX_WRITE_BYTES) {
+      // Prepend / to make it absolute before validation
+      const resolvedPath = resolveWorkspacePath(`/${relativePath}`);
+      if (!resolvedPath) {
         return errorJson(
-          `payload too large: ${buffer.byteLength} bytes exceeds the ${MAX_WRITE_BYTES}-byte limit`,
-          'payload_too_large',
-          413
+          'path must resolve to a location within /workspace',
+          'invalid_request',
+          403
         );
       }
 
-      const bytes = new Uint8Array(buffer);
-      let b64 = '';
-      const CHUNK = 6144; // 6144 = 3 * 2048 — no intermediate padding
-      for (let i = 0; i < bytes.length; i += CHUNK) {
-        b64 += btoa(String.fromCharCode(...bytes.subarray(i, i + CHUNK)));
-      }
-      await executor.writeFile(resolvedPath, b64, { encoding: 'base64' });
-      const response: WriteResponse = { ok: true };
-      return c.json(response);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(
-        `write failed: ${msg}`,
-        'workspace_archive_write_error',
-        502
+      annotate(c, 'file.path', resolvedPath);
+
+      const sandbox = getSandboxWithoutDefaultSession(
+        getSandboxNs(c.env),
+        c.get('containerUUID')
       );
-    }
-  });
+      const rawSessionId = c.req.header('Session-Id');
+      let executor:
+        | BridgeSandbox
+        | Awaited<ReturnType<BridgeSandbox['getSession']>> = sandbox;
+      if (rawSessionId) {
+        const sessionId = validateSessionId(rawSessionId);
+        if (!sessionId)
+          return errorJson('Invalid session ID format', 'invalid_request', 400);
+        annotate(c, 'session.id', sessionId);
+        executor = await sandbox.getSession(sessionId);
+      }
+
+      try {
+        const buffer = await c.req.arrayBuffer();
+        annotate(c, 'file.size_bytes', buffer.byteLength);
+        const MAX_WRITE_BYTES = 32 * 1024 * 1024; // 32 MiB — matches RPC payload limit
+        if (buffer.byteLength > MAX_WRITE_BYTES) {
+          return errorJson(
+            `payload too large: ${buffer.byteLength} bytes exceeds the ${MAX_WRITE_BYTES}-byte limit`,
+            'payload_too_large',
+            413
+          );
+        }
+
+        const bytes = new Uint8Array(buffer);
+        let b64 = '';
+        const CHUNK = 6144; // 6144 = 3 * 2048 — no intermediate padding
+        for (let i = 0; i < bytes.length; i += CHUNK) {
+          b64 += btoa(String.fromCharCode(...bytes.subarray(i, i + CHUNK)));
+        }
+        await executor.writeFile(resolvedPath, b64, { encoding: 'base64' });
+        const response: WriteResponse = { ok: true };
+        return c.json(response);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(
+          `write failed: ${msg}`,
+          'workspace_archive_write_error',
+          502
+        );
+      }
+    })
+  );
 
   // ------------------------------------------------------------------
   // POST /sandbox/:id/tunnel/:port
   // DELETE /sandbox/:id/tunnel/:port
   // ------------------------------------------------------------------
 
-  app.post(`${apiPrefix}/sandbox/:id/tunnel/:port`, async (c) => {
-    const port = Number(c.req.param('port'));
-    if (!validatePort(port)) {
-      return errorJson('Invalid port', 'invalid_request', 400);
-    }
+  app.post(
+    `${apiPrefix}/sandbox/:id/tunnel/:port`,
+    traced('tunnel_create', async (c) => {
+      const port = Number(c.req.param('port'));
+      if (!validatePort(port)) {
+        return errorJson('Invalid port', 'invalid_request', 400);
+      }
 
-    const options = parseTunnelOptions(await c.req.text());
-    if (options instanceof Response) return options;
+      annotate(c, 'tunnel.port', port);
 
-    const sandbox = getSandboxWithoutDefaultSession(
-      getSandboxNs(c.env),
-      c.get('containerUUID')
-    );
+      const options = parseTunnelOptions(await c.req.text());
+      if (options instanceof Response) return options;
+      if (options?.name) annotate(c, 'tunnel.name', options.name);
 
-    try {
-      const tunnel = await sandbox.tunnels.get(port, options);
-      return c.json(tunnel);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(`tunnel failed: ${msg}`, 'tunnel_error', 502);
-    }
-  });
+      const sandbox = getSandboxWithoutDefaultSession(
+        getSandboxNs(c.env),
+        c.get('containerUUID')
+      );
 
-  app.delete(`${apiPrefix}/sandbox/:id/tunnel/:port`, async (c) => {
-    const port = Number(c.req.param('port'));
-    if (!validatePort(port)) {
-      return errorJson('Invalid port', 'invalid_request', 400);
-    }
+      try {
+        const tunnel = await sandbox.tunnels.get(port, options);
+        return c.json(tunnel);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(`tunnel failed: ${msg}`, 'tunnel_error', 502);
+      }
+    })
+  );
 
-    const sandbox = getSandboxWithoutDefaultSession(
-      getSandboxNs(c.env),
-      c.get('containerUUID')
-    );
+  app.delete(
+    `${apiPrefix}/sandbox/:id/tunnel/:port`,
+    traced('tunnel_destroy', async (c) => {
+      const port = Number(c.req.param('port'));
+      if (!validatePort(port)) {
+        return errorJson('Invalid port', 'invalid_request', 400);
+      }
 
-    try {
-      await sandbox.tunnels.destroy(port);
-      return c.body(null, 204);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(`tunnel failed: ${msg}`, 'tunnel_error', 502);
-    }
-  });
+      annotate(c, 'tunnel.port', port);
+
+      const sandbox = getSandboxWithoutDefaultSession(
+        getSandboxNs(c.env),
+        c.get('containerUUID')
+      );
+
+      try {
+        await sandbox.tunnels.destroy(port);
+        return c.body(null, 204);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(`tunnel failed: ${msg}`, 'tunnel_error', 502);
+      }
+    })
+  );
 
   // ------------------------------------------------------------------
   // GET /sandbox/:id/running
   // ------------------------------------------------------------------
 
-  app.get(`${apiPrefix}/sandbox/:id/running`, async (c) => {
-    const sandbox = getSandboxWithoutDefaultSession(
-      getSandboxNs(c.env),
-      c.get('containerUUID')
-    );
+  app.get(
+    `${apiPrefix}/sandbox/:id/running`,
+    traced('running', async (c) => {
+      const sandbox = getSandboxWithoutDefaultSession(
+        getSandboxNs(c.env),
+        c.get('containerUUID')
+      );
 
-    try {
-      await sandbox.exec('true');
-      const response: RunningResponse = { running: true };
-      return c.json(response);
-    } catch {
-      const response: RunningResponse = { running: false };
-      return c.json(response);
-    }
-  });
+      try {
+        await sandbox.exec('true');
+        annotate(c, 'sandbox.running', true);
+        const response: RunningResponse = { running: true };
+        return c.json(response);
+      } catch {
+        annotate(c, 'sandbox.running', false);
+        const response: RunningResponse = { running: false };
+        return c.json(response);
+      }
+    })
+  );
 
   // ------------------------------------------------------------------
   // GET /sandbox/:id/pty (WebSocket upgrade)
   // ------------------------------------------------------------------
 
-  app.get(`${apiPrefix}/sandbox/:id/pty`, async (c) => {
-    // 1. Require WebSocket upgrade
-    const upgrade = c.req.header('Upgrade');
-    if (!upgrade || upgrade.toLowerCase() !== 'websocket') {
-      return errorJson('WebSocket upgrade required', 'invalid_request', 400);
-    }
-
-    const sandbox = getSandboxWithoutDefaultSession(
-      getSandboxNs(c.env),
-      c.get('containerUUID')
-    );
-
-    // 2. Parse PtyOptions from query params
-    const colsParam = c.req.query('cols');
-    const rowsParam = c.req.query('rows');
-    const shell = c.req.query('shell');
-    const sessionId = c.req.header('Session-Id') || c.req.query('session');
-
-    const cols = colsParam ? Number(colsParam) : 80;
-    const rows = rowsParam ? Number(rowsParam) : 24;
-
-    if (Number.isNaN(cols) || Number.isNaN(rows)) {
-      return errorJson(
-        'cols and rows must be valid numbers',
-        'invalid_request',
-        400
-      );
-    }
-
-    const opts: PtyOptions = { cols, rows };
-    if (shell) {
-      opts.shell = shell;
-    }
-
-    try {
-      if (sessionId) {
-        const validatedId = validateSessionId(sessionId);
-        if (!validatedId)
-          return errorJson('Invalid session ID format', 'invalid_request', 400);
-        const sess = await sandbox.getSession(validatedId);
-        return await sess.terminal(c.req.raw, opts);
+  app.get(
+    `${apiPrefix}/sandbox/:id/pty`,
+    traced('pty', async (c) => {
+      // 1. Require WebSocket upgrade
+      const upgrade = c.req.header('Upgrade');
+      if (!upgrade || upgrade.toLowerCase() !== 'websocket') {
+        return errorJson('WebSocket upgrade required', 'invalid_request', 400);
       }
-      return await sandbox.terminal(c.req.raw, opts);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(`terminal failed: ${msg}`, 'exec_transport_error', 502);
-    }
-  });
+
+      const sandbox = getSandboxWithoutDefaultSession(
+        getSandboxNs(c.env),
+        c.get('containerUUID')
+      );
+
+      // 2. Parse PtyOptions from query params
+      const colsParam = c.req.query('cols');
+      const rowsParam = c.req.query('rows');
+      const shell = c.req.query('shell');
+      const sessionId = c.req.header('Session-Id') || c.req.query('session');
+
+      const cols = colsParam ? Number(colsParam) : 80;
+      const rows = rowsParam ? Number(rowsParam) : 24;
+
+      if (Number.isNaN(cols) || Number.isNaN(rows)) {
+        return errorJson(
+          'cols and rows must be valid numbers',
+          'invalid_request',
+          400
+        );
+      }
+
+      annotate(c, 'pty.cols', cols);
+      annotate(c, 'pty.rows', rows);
+
+      const opts: PtyOptions = { cols, rows };
+      if (shell) {
+        opts.shell = shell;
+        annotate(c, 'pty.shell', shell);
+      }
+
+      try {
+        if (sessionId) {
+          const validatedId = validateSessionId(sessionId);
+          if (!validatedId)
+            return errorJson(
+              'Invalid session ID format',
+              'invalid_request',
+              400
+            );
+          annotate(c, 'session.id', validatedId);
+          const sess = await sandbox.getSession(validatedId);
+          return await sess.terminal(c.req.raw, opts);
+        }
+        return await sandbox.terminal(c.req.raw, opts);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(
+          `terminal failed: ${msg}`,
+          'exec_transport_error',
+          502
+        );
+      }
+    })
+  );
 
   // ------------------------------------------------------------------
   // POST /sandbox/:id/persist
   // ------------------------------------------------------------------
 
-  app.post(`${apiPrefix}/sandbox/:id/persist`, async (c) => {
-    const root = '/workspace';
+  app.post(
+    `${apiPrefix}/sandbox/:id/persist`,
+    traced('persist', async (c) => {
+      const root = '/workspace';
 
-    // Decode any exclude paths passed from the client layer.
-    const excludesParam = c.req.query('excludes') ?? '';
-    const excludes = excludesParam
-      ? excludesParam.split(',').filter((s) => s.length > 0)
-      : [];
+      // Decode any exclude paths passed from the client layer.
+      const excludesParam = c.req.query('excludes') ?? '';
+      const excludes = excludesParam
+        ? excludesParam.split(',').filter((s) => s.length > 0)
+        : [];
 
-    // Validate excludes don't contain path traversal
-    for (const ex of excludes) {
-      if (ex.includes('..')) {
-        return errorJson(
-          'exclude paths must not contain ".."',
-          'invalid_request',
-          400
-        );
+      annotate(c, 'persist.exclude_count', excludes.length);
+
+      // Validate excludes don't contain path traversal
+      for (const ex of excludes) {
+        if (ex.includes('..')) {
+          return errorJson(
+            'exclude paths must not contain ".."',
+            'invalid_request',
+            400
+          );
+        }
       }
-    }
 
-    const sandbox = getSandboxWithoutDefaultSession(
-      getSandboxNs(c.env),
-      c.get('containerUUID')
-    );
+      const sandbox = getSandboxWithoutDefaultSession(
+        getSandboxNs(c.env),
+        c.get('containerUUID')
+      );
 
-    const tmpPath = `/tmp/sandbox-persist-${Date.now()}.tar`;
-    const excludeArgs = excludes
-      .map((rel) => `--exclude ${shellQuote(`./${rel.replace(/^\.\//, '')}`)}`)
-      .join(' ');
-    const tarCmd = excludeArgs
-      ? `tar cf ${shellQuote(tmpPath)} ${excludeArgs} -C ${shellQuote(root)} .`
-      : `tar cf ${shellQuote(tmpPath)} -C ${shellQuote(root)} .`;
+      const tmpPath = `/tmp/sandbox-persist-${Date.now()}.tar`;
+      const excludeArgs = excludes
+        .map(
+          (rel) => `--exclude ${shellQuote(`./${rel.replace(/^\.\//, '')}`)}`
+        )
+        .join(' ');
+      const tarCmd = excludeArgs
+        ? `tar cf ${shellQuote(tmpPath)} ${excludeArgs} -C ${shellQuote(root)} .`
+        : `tar cf ${shellQuote(tmpPath)} -C ${shellQuote(root)} .`;
 
-    try {
-      const result = await sandbox.exec(tarCmd);
+      try {
+        const result = await sandbox.exec(tarCmd);
 
-      if (result.exitCode !== 0) {
+        if (result.exitCode !== 0) {
+          return errorJson(
+            `tar failed (exit ${result.exitCode}): ${result.stderr}`,
+            'workspace_archive_read_error',
+            502
+          );
+        }
+
+        const stream = await sandbox.readFileStream(tmpPath);
+
+        // Best-effort cleanup; don't await so we don't delay the response.
+        sandbox.exec(`rm -f ${shellQuote(tmpPath)}`).catch(() => {});
+
+        return new Response(sseToByteStream(stream), {
+          status: 200,
+          headers: { 'Content-Type': 'application/octet-stream' }
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
         return errorJson(
-          `tar failed (exit ${result.exitCode}): ${result.stderr}`,
+          `persist failed: ${msg}`,
           'workspace_archive_read_error',
           502
         );
       }
-
-      const stream = await sandbox.readFileStream(tmpPath);
-
-      // Best-effort cleanup; don't await so we don't delay the response.
-      sandbox.exec(`rm -f ${shellQuote(tmpPath)}`).catch(() => {});
-
-      return new Response(sseToByteStream(stream), {
-        status: 200,
-        headers: { 'Content-Type': 'application/octet-stream' }
-      });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(
-        `persist failed: ${msg}`,
-        'workspace_archive_read_error',
-        502
-      );
-    }
-  });
+    })
+  );
 
   // ------------------------------------------------------------------
   // POST /sandbox/:id/hydrate
   // ------------------------------------------------------------------
 
-  app.post(`${apiPrefix}/sandbox/:id/hydrate`, async (c) => {
-    const root = '/workspace';
+  app.post(
+    `${apiPrefix}/sandbox/:id/hydrate`,
+    traced('hydrate', async (c) => {
+      const root = '/workspace';
 
-    const sandbox = getSandboxWithoutDefaultSession(
-      getSandboxNs(c.env),
-      c.get('containerUUID')
-    );
-
-    // Read the raw tar bytes from the request body.
-    let tarBytes: Uint8Array;
-    try {
-      const buffer = await c.req.arrayBuffer();
-      tarBytes = new Uint8Array(buffer);
-    } catch {
-      return errorJson('Could not read request body', 'invalid_request', 400);
-    }
-
-    if (tarBytes.byteLength === 0) {
-      return errorJson('Empty tar payload', 'invalid_request', 400);
-    }
-
-    const MAX_HYDRATE_BYTES = 32 * 1024 * 1024; // 32 MiB
-    if (tarBytes.byteLength > MAX_HYDRATE_BYTES) {
-      return errorJson(
-        `tar payload too large: ${tarBytes.byteLength} bytes exceeds the ${MAX_HYDRATE_BYTES}-byte limit`,
-        'invalid_request',
-        400
+      const sandbox = getSandboxWithoutDefaultSession(
+        getSandboxNs(c.env),
+        c.get('containerUUID')
       );
-    }
 
-    try {
-      await sandbox.exec(`mkdir -p ${shellQuote(root)}`);
-
-      const tmpPath = `/tmp/sandbox-hydrate-${Date.now()}.tar`;
-
-      let b64 = '';
-      const CHUNK = 6144; // 6144 = 3 * 2048 — no intermediate padding
-      for (let i = 0; i < tarBytes.length; i += CHUNK) {
-        b64 += btoa(String.fromCharCode(...tarBytes.subarray(i, i + CHUNK)));
+      // Read the raw tar bytes from the request body.
+      let tarBytes: Uint8Array;
+      try {
+        const buffer = await c.req.arrayBuffer();
+        tarBytes = new Uint8Array(buffer);
+      } catch {
+        return errorJson('Could not read request body', 'invalid_request', 400);
       }
-      await sandbox.writeFile(tmpPath, b64, { encoding: 'base64' });
 
-      const extractResult = await sandbox.exec(
-        `tar xf ${shellQuote(tmpPath)} -C ${shellQuote(root)} && rm -f ${shellQuote(tmpPath)}`
-      );
-      if (extractResult.exitCode !== 0) {
+      annotate(c, 'hydrate.size_bytes', tarBytes.byteLength);
+
+      if (tarBytes.byteLength === 0) {
+        return errorJson('Empty tar payload', 'invalid_request', 400);
+      }
+
+      const MAX_HYDRATE_BYTES = 32 * 1024 * 1024; // 32 MiB
+      if (tarBytes.byteLength > MAX_HYDRATE_BYTES) {
         return errorJson(
-          `tar extract failed (exit ${extractResult.exitCode}): ${extractResult.stderr}`,
+          `tar payload too large: ${tarBytes.byteLength} bytes exceeds the ${MAX_HYDRATE_BYTES}-byte limit`,
+          'invalid_request',
+          400
+        );
+      }
+
+      try {
+        await sandbox.exec(`mkdir -p ${shellQuote(root)}`);
+
+        const tmpPath = `/tmp/sandbox-hydrate-${Date.now()}.tar`;
+
+        let b64 = '';
+        const CHUNK = 6144; // 6144 = 3 * 2048 — no intermediate padding
+        for (let i = 0; i < tarBytes.length; i += CHUNK) {
+          b64 += btoa(String.fromCharCode(...tarBytes.subarray(i, i + CHUNK)));
+        }
+        await sandbox.writeFile(tmpPath, b64, { encoding: 'base64' });
+
+        const extractResult = await sandbox.exec(
+          `tar xf ${shellQuote(tmpPath)} -C ${shellQuote(root)} && rm -f ${shellQuote(tmpPath)}`
+        );
+        if (extractResult.exitCode !== 0) {
+          return errorJson(
+            `tar extract failed (exit ${extractResult.exitCode}): ${extractResult.stderr}`,
+            'workspace_archive_write_error',
+            502
+          );
+        }
+
+        return c.json({ ok: true });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(
+          `hydrate failed: ${msg}`,
           'workspace_archive_write_error',
           502
         );
       }
-
-      return c.json({ ok: true });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(
-        `hydrate failed: ${msg}`,
-        'workspace_archive_write_error',
-        502
-      );
-    }
-  });
+    })
+  );
 
   // ------------------------------------------------------------------
   // POST /sandbox/:id/mount
   // ------------------------------------------------------------------
 
-  app.post(`${apiPrefix}/sandbox/:id/mount`, async (c) => {
-    let body: MountBucketRequest;
-    try {
-      body = await c.req.json<MountBucketRequest>();
-    } catch {
-      return errorJson('Invalid JSON body', 'invalid_request', 400);
-    }
+  app.post(
+    `${apiPrefix}/sandbox/:id/mount`,
+    traced('mount', async (c) => {
+      let body: MountBucketRequest;
+      try {
+        body = await c.req.json<MountBucketRequest>();
+      } catch {
+        return errorJson('Invalid JSON body', 'invalid_request', 400);
+      }
 
-    if (
-      body.bucket !== undefined &&
-      (typeof body.bucket !== 'string' || body.bucket === '')
-    ) {
-      return errorJson(
-        'bucket must be a non-empty string',
-        'invalid_request',
-        400
-      );
-    }
-    if (!body.mountPath || typeof body.mountPath !== 'string') {
-      return errorJson(
-        'mountPath must be a non-empty string',
-        'invalid_request',
-        400
-      );
-    }
-    if (!body.mountPath.startsWith('/')) {
-      return errorJson(
-        'mountPath must be an absolute path (start with /)',
-        'invalid_request',
-        400
-      );
-    }
-    if (
-      !body.options ||
-      typeof body.options !== 'object' ||
-      Array.isArray(body.options)
-    ) {
-      return errorJson('options must be an object', 'invalid_request', 400);
-    }
-    const optionsError = validateMountOptions(body.options, body.binding);
-    if (optionsError) return optionsError;
-    const bucketName = resolveMountBucketName(body);
-    if (bucketName instanceof Response) return bucketName;
+      if (
+        body.bucket !== undefined &&
+        (typeof body.bucket !== 'string' || body.bucket === '')
+      ) {
+        return errorJson(
+          'bucket must be a non-empty string',
+          'invalid_request',
+          400
+        );
+      }
+      if (!body.mountPath || typeof body.mountPath !== 'string') {
+        return errorJson(
+          'mountPath must be a non-empty string',
+          'invalid_request',
+          400
+        );
+      }
+      if (!body.mountPath.startsWith('/')) {
+        return errorJson(
+          'mountPath must be an absolute path (start with /)',
+          'invalid_request',
+          400
+        );
+      }
+      if (
+        !body.options ||
+        typeof body.options !== 'object' ||
+        Array.isArray(body.options)
+      ) {
+        return errorJson('options must be an object', 'invalid_request', 400);
+      }
+      const optionsError = validateMountOptions(body.options, body.binding);
+      if (optionsError) return optionsError;
+      const bucketName = resolveMountBucketName(body);
+      if (bucketName instanceof Response) return bucketName;
 
-    const sandbox = getSandboxWithoutDefaultSession(
-      getSandboxNs(c.env),
-      c.get('containerUUID')
-    );
-    const sdkOptions = toSDKMountOptions(body.options);
+      annotate(c, 'mount.bucket', bucketName);
+      annotate(c, 'mount.path', body.mountPath);
 
-    try {
-      await sandbox.mountBucket(bucketName, body.mountPath, sdkOptions);
-      return c.json({ ok: true });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(`mount failed: ${msg}`, 'mount_error', 502);
-    }
-  });
+      const sandbox = getSandboxWithoutDefaultSession(
+        getSandboxNs(c.env),
+        c.get('containerUUID')
+      );
+      const sdkOptions = toSDKMountOptions(body.options);
+
+      try {
+        await sandbox.mountBucket(bucketName, body.mountPath, sdkOptions);
+        return c.json({ ok: true });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(`mount failed: ${msg}`, 'mount_error', 502);
+      }
+    })
+  );
 
   // ------------------------------------------------------------------
   // POST /sandbox/:id/unmount
   // ------------------------------------------------------------------
 
-  app.post(`${apiPrefix}/sandbox/:id/unmount`, async (c) => {
-    let body: UnmountBucketRequest;
-    try {
-      body = await c.req.json<UnmountBucketRequest>();
-    } catch {
-      return errorJson('Invalid JSON body', 'invalid_request', 400);
-    }
-
-    if (!body.mountPath || typeof body.mountPath !== 'string') {
-      return errorJson(
-        'mountPath must be a non-empty string',
-        'invalid_request',
-        400
-      );
-    }
-    if (!body.mountPath.startsWith('/')) {
-      return errorJson(
-        'mountPath must be an absolute path (start with /)',
-        'invalid_request',
-        400
-      );
-    }
-
-    // Normalize to resolve '..' / '.' segments, then reject the filesystem
-    // root so the post-unmount rm -rf cleanup cannot be destructive.
-    const normalizedPath = new URL(body.mountPath, 'file:///').pathname;
-    if (normalizedPath === '/') {
-      return errorJson(
-        'mountPath must not resolve to / (filesystem root)',
-        'invalid_request',
-        400
-      );
-    }
-
-    const sandbox = getSandboxWithoutDefaultSession(
-      getSandboxNs(c.env),
-      c.get('containerUUID')
-    );
-
-    try {
-      await sandbox.unmountBucket(normalizedPath);
-
-      // The SDK unmounts the filesystem but does not remove the mount point
-      // directory. Verify the path is no longer an active mount before removing
-      // it — if fusermount failed silently we must not delete bucket contents.
-      const quoted = shellQuote(normalizedPath);
+  app.post(
+    `${apiPrefix}/sandbox/:id/unmount`,
+    traced('unmount', async (c) => {
+      let body: UnmountBucketRequest;
       try {
-        await sandbox.exec(`mountpoint -q ${quoted} || rmdir ${quoted}`);
+        body = await c.req.json<UnmountBucketRequest>();
       } catch {
-        // Best-effort — the unmount itself already succeeded
+        return errorJson('Invalid JSON body', 'invalid_request', 400);
       }
 
-      return c.json({ ok: true });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(`unmount failed: ${msg}`, 'unmount_error', 502);
-    }
-  });
+      if (!body.mountPath || typeof body.mountPath !== 'string') {
+        return errorJson(
+          'mountPath must be a non-empty string',
+          'invalid_request',
+          400
+        );
+      }
+      if (!body.mountPath.startsWith('/')) {
+        return errorJson(
+          'mountPath must be an absolute path (start with /)',
+          'invalid_request',
+          400
+        );
+      }
+
+      // Normalize to resolve '..' / '.' segments, then reject the filesystem
+      // root so the post-unmount rm -rf cleanup cannot be destructive.
+      const normalizedPath = new URL(body.mountPath, 'file:///').pathname;
+      if (normalizedPath === '/') {
+        return errorJson(
+          'mountPath must not resolve to / (filesystem root)',
+          'invalid_request',
+          400
+        );
+      }
+
+      annotate(c, 'mount.path', normalizedPath);
+
+      const sandbox = getSandboxWithoutDefaultSession(
+        getSandboxNs(c.env),
+        c.get('containerUUID')
+      );
+
+      try {
+        await sandbox.unmountBucket(normalizedPath);
+
+        // The SDK unmounts the filesystem but does not remove the mount point
+        // directory. Verify the path is no longer an active mount before removing
+        // it — if fusermount failed silently we must not delete bucket contents.
+        const quoted = shellQuote(normalizedPath);
+        try {
+          await sandbox.exec(`mountpoint -q ${quoted} || rmdir ${quoted}`);
+        } catch {
+          // Best-effort — the unmount itself already succeeded
+        }
+
+        return c.json({ ok: true });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(`unmount failed: ${msg}`, 'unmount_error', 502);
+      }
+    })
+  );
 
   // ------------------------------------------------------------------
   // POST /sandbox/:id/session
   // ------------------------------------------------------------------
 
-  app.post(`${apiPrefix}/sandbox/:id/session`, async (c) => {
-    const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
+  app.post(
+    `${apiPrefix}/sandbox/:id/session`,
+    traced('session_create', async (c) => {
+      const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
 
-    let body: { id?: string; cwd?: string; env?: Record<string, string> } = {};
-    try {
-      body = await c.req.json();
-    } catch {
-      // Empty body is fine — all fields are optional
-    }
+      let body: { id?: string; cwd?: string; env?: Record<string, string> } =
+        {};
+      try {
+        body = await c.req.json();
+      } catch {
+        // Empty body is fine — all fields are optional
+      }
 
-    try {
-      const session = await sandbox.createSession(body);
-      return c.json({ id: session.id });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(`session create failed: ${msg}`, 'session_error', 502);
-    }
-  });
+      if (body.cwd) annotate(c, 'session.cwd', body.cwd);
+
+      try {
+        const session = await sandbox.createSession(body);
+        annotate(c, 'session.id', session.id);
+        return c.json({ id: session.id });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(`session create failed: ${msg}`, 'session_error', 502);
+      }
+    })
+  );
 
   // ------------------------------------------------------------------
   // DELETE /sandbox/:id/session/:sid
   // ------------------------------------------------------------------
 
-  app.delete(`${apiPrefix}/sandbox/:id/session/:sid`, async (c) => {
-    const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
-    const sid = c.req.param('sid');
+  app.delete(
+    `${apiPrefix}/sandbox/:id/session/:sid`,
+    traced('session_delete', async (c) => {
+      const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
+      const sid = c.req.param('sid');
+      if (!sid) {
+        return errorJson(
+          'session ID must not be empty',
+          'invalid_request',
+          400
+        );
+      }
+      annotate(c, 'session.id', sid);
 
-    try {
-      const result = await sandbox.deleteSession(sid);
-      return c.json(result);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(`session delete failed: ${msg}`, 'session_error', 502);
-    }
-  });
+      try {
+        const result = await sandbox.deleteSession(sid);
+        return c.json(result);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(`session delete failed: ${msg}`, 'session_error', 502);
+      }
+    })
+  );
 
   // ------------------------------------------------------------------
   // DELETE /sandbox/:id
   // ------------------------------------------------------------------
 
-  app.delete(`${apiPrefix}/sandbox/:id`, async (c) => {
-    const containerUUID = c.get('containerUUID');
-    const sandbox = getSandboxWithoutDefaultSession(
-      getSandboxNs(c.env),
-      containerUUID
-    );
+  app.delete(
+    `${apiPrefix}/sandbox/:id`,
+    traced('destroy_sandbox', async (c) => {
+      const containerUUID = c.get('containerUUID');
+      const sandbox = getSandboxWithoutDefaultSession(
+        getSandboxNs(c.env),
+        containerUUID
+      );
 
-    try {
-      await sandbox.destroy();
-    } catch {
-      // Best-effort — container may already be gone
-    }
+      try {
+        await sandbox.destroy();
+      } catch {
+        // Best-effort — container may already be gone
+      }
 
-    // Release the WarmPool assignment so it doesn't track a dead container
-    try {
-      const poolNs = getWarmPoolNs(c.env);
-      const poolId = poolNs.idFromName('global-pool');
-      const poolStub = poolNs.get(poolId);
-      await (poolStub as any).reportStopped(containerUUID);
-    } catch {
-      // Best-effort
-    }
+      // Release the WarmPool assignment so it doesn't track a dead container
+      try {
+        const poolNs = getWarmPoolNs(c.env);
+        const poolId = poolNs.idFromName('global-pool');
+        const poolStub = poolNs.get(poolId);
+        await (poolStub as any).reportStopped(containerUUID);
+      } catch {
+        // Best-effort
+      }
 
-    return new Response(null, { status: 204 });
-  });
+      return new Response(null, { status: 204 });
+    })
+  );
 
   // ------------------------------------------------------------------
   // Health check
@@ -1186,40 +1284,55 @@ export function createBridgeApp(
     return next();
   });
 
-  app.get(`${apiPrefix}/pool/stats`, async (c) => {
-    const poolNs = getWarmPoolNs(c.env);
-    const poolId = poolNs.idFromName('global-pool');
-    const poolStub = poolNs.get(poolId);
+  app.get(
+    `${apiPrefix}/pool/stats`,
+    traced('pool_stats', async (c) => {
+      const poolNs = getWarmPoolNs(c.env);
+      const poolId = poolNs.idFromName('global-pool');
+      const poolStub = poolNs.get(poolId);
 
-    try {
-      await (poolStub as any).configure(parsePoolConfig(c.env));
-    } catch {
-      // Continue — stats should still be readable even if config push fails.
-    }
+      try {
+        await (poolStub as any).configure(parsePoolConfig(c.env));
+      } catch {
+        // Continue — stats should still be readable even if config push fails.
+      }
 
-    const stats = await (poolStub as any).getStats();
-    return c.json(stats);
-  });
+      const stats = await (poolStub as any).getStats();
+      annotate(c, 'pool.warm', stats.warm);
+      annotate(c, 'pool.assigned', stats.assigned);
+      annotate(c, 'pool.total', stats.total);
+      if (stats.maxInstances !== null) {
+        annotate(c, 'pool.max_instances', stats.maxInstances);
+      }
+      return c.json(stats);
+    })
+  );
 
-  app.post(`${apiPrefix}/pool/shutdown-prewarmed`, async (c) => {
-    const poolNs = getWarmPoolNs(c.env);
-    const poolId = poolNs.idFromName('global-pool');
-    const poolStub = poolNs.get(poolId);
+  app.post(
+    `${apiPrefix}/pool/shutdown-prewarmed`,
+    traced('pool_shutdown_prewarmed', async (c) => {
+      const poolNs = getWarmPoolNs(c.env);
+      const poolId = poolNs.idFromName('global-pool');
+      const poolStub = poolNs.get(poolId);
 
-    try {
-      await (poolStub as any).configure(parsePoolConfig(c.env));
-    } catch {
-      // Continue.
-    }
+      try {
+        await (poolStub as any).configure(parsePoolConfig(c.env));
+      } catch {
+        // Continue.
+      }
 
-    await (poolStub as any).shutdownPrewarmed();
-    return c.json({ ok: true });
-  });
+      await (poolStub as any).shutdownPrewarmed();
+      return c.json({ ok: true });
+    })
+  );
 
-  app.post(`${apiPrefix}/pool/prime`, async (c) => {
-    await primePool(c.env, warmPoolBinding);
-    return c.json({ ok: true });
-  });
+  app.post(
+    `${apiPrefix}/pool/prime`,
+    traced('pool_prime', async (c) => {
+      await primePool(c.env, warmPoolBinding);
+      return c.json({ ok: true });
+    })
+  );
 
   // ------------------------------------------------------------------
   // OpenAPI routes

--- a/packages/sandbox/src/bridge/tracing.ts
+++ b/packages/sandbox/src/bridge/tracing.ts
@@ -1,0 +1,83 @@
+/**
+ * Custom span instrumentation for the bridge API.
+ *
+ * Wraps each Hono route handler in a Cloudflare custom span
+ * (`tracing.enterSpan`) named `bridge.<operation>`, seeding common attributes
+ * (sandbox ID, container UUID, HTTP method/route, response status) and exposing
+ * the active span so handlers can attach operation-specific metadata.
+ *
+ * See https://developers.cloudflare.com/workers/observability/traces/custom-spans/
+ */
+
+import { tracing } from 'cloudflare:workers';
+import type { Context } from 'hono';
+import type { BridgeEnv } from './types';
+
+/**
+ * Span shape exposed to handlers. Mirrors the `cloudflare:workers` Span without
+ * importing the class value, so the type is usable wherever the import isn't.
+ */
+export interface BridgeSpan {
+  readonly isTraced: boolean;
+  setAttribute(key: string, value?: boolean | number | string): void;
+}
+
+/** Hono environment shared by all bridge routes. */
+export interface BridgeHonoEnv {
+  Bindings: BridgeEnv;
+  Variables: { containerUUID: string; span?: BridgeSpan };
+}
+
+type BridgeContext = Context<BridgeHonoEnv>;
+type BridgeHandler = (c: BridgeContext) => Response | Promise<Response>;
+
+/** True when the runtime exposes the custom-span API. */
+function tracingAvailable(): boolean {
+  return (
+    typeof tracing === 'object' &&
+    tracing !== null &&
+    typeof tracing.enterSpan === 'function'
+  );
+}
+
+/**
+ * Wrap a route handler in a `bridge.<name>` span. Seeds common attributes and
+ * stashes the span on the context for `annotate()`. When tracing is
+ * unavailable the handler runs unchanged.
+ */
+export function traced(name: string, handler: BridgeHandler): BridgeHandler {
+  if (!tracingAvailable()) return handler;
+
+  return (c: BridgeContext) =>
+    tracing.enterSpan(`bridge.${name}`, async (span) => {
+      span.setAttribute('bridge.operation', name);
+      span.setAttribute('http.request.method', c.req.method);
+      span.setAttribute('http.route', c.req.routePath);
+
+      const sandboxId = c.req.param('id');
+      if (sandboxId) span.setAttribute('sandbox.id', sandboxId);
+
+      const containerUUID = c.get('containerUUID');
+      if (containerUUID) {
+        span.setAttribute('sandbox.container_uuid', containerUUID);
+      }
+
+      c.set('span', span);
+
+      const response = await handler(c);
+      span.setAttribute('http.response.status_code', response.status);
+      return response;
+    });
+}
+
+/**
+ * Attach an attribute to the active bridge span, if any. No-op when tracing is
+ * disabled or the request is not sampled.
+ */
+export function annotate(
+  c: BridgeContext,
+  key: string,
+  value?: boolean | number | string
+): void {
+  c.get('span')?.setAttribute(key, value);
+}

--- a/packages/sandbox/src/bridge/types.ts
+++ b/packages/sandbox/src/bridge/types.ts
@@ -78,6 +78,7 @@ export interface BridgeEnv {
   SANDBOX_API_KEY?: string;
   WARM_POOL_TARGET?: string;
   WARM_POOL_REFRESH_INTERVAL?: string;
+  WARM_POOL_MAX_INSTANCES?: string;
   [key: string]: unknown;
 }
 

--- a/packages/sandbox/src/bridge/types.ts
+++ b/packages/sandbox/src/bridge/types.ts
@@ -79,6 +79,7 @@ export interface BridgeEnv {
   WARM_POOL_TARGET?: string;
   WARM_POOL_REFRESH_INTERVAL?: string;
   WARM_POOL_MAX_INSTANCES?: string;
+  WARM_POOL_SCALE_BATCH_SIZE?: string;
   [key: string]: unknown;
 }
 

--- a/packages/sandbox/src/bridge/warm-pool.ts
+++ b/packages/sandbox/src/bridge/warm-pool.ts
@@ -31,6 +31,12 @@ export interface WarmPoolConfig {
    * @default 0
    */
   maxInstances?: number;
+  /**
+   * Number of containers to start in parallel per scale-up batch. Higher
+   * values fill the pool faster but risk the platform throttling a cold-start
+   * stampede. Clamped to [1, MAX_BATCH_SIZE]. @default 5
+   */
+  scaleBatchSize?: number;
 }
 
 export interface PoolStats {
@@ -70,10 +76,16 @@ interface ContainerWithState {
 // Defaults
 // ---------------------------------------------------------------------------
 
+const DEFAULT_BATCH_SIZE = 5;
+
+/** Upper bound on parallel starts per batch to avoid a cold-start stampede. */
+const MAX_BATCH_SIZE = 20;
+
 const DEFAULT_CONFIG: Required<WarmPoolConfig> = {
   warmTarget: 0,
   refreshInterval: 10_000,
-  maxInstances: 0
+  maxInstances: 0,
+  scaleBatchSize: DEFAULT_BATCH_SIZE
 };
 
 // ---------------------------------------------------------------------------
@@ -214,6 +226,13 @@ export class WarmPool extends DurableObject<WarmPoolEnv> {
   async configure(config: WarmPoolConfig): Promise<void> {
     await this.init();
     this.config = { ...DEFAULT_CONFIG, ...config };
+
+    // Clamp the batch size to a sane range so a misconfigured var can't
+    // re-introduce the cold-start stampede (or stall scale-up entirely).
+    this.config.scaleBatchSize = Math.min(
+      MAX_BATCH_SIZE,
+      Math.max(1, this.config.scaleBatchSize || DEFAULT_BATCH_SIZE)
+    );
 
     // Seed the ceiling if the operator declared one. The configured value is an
     // upper bound the operator promises; the platform may still impose a lower
@@ -490,25 +509,28 @@ export class WarmPool extends DurableObject<WarmPoolEnv> {
         return;
       }
 
+      const batchSize = this.config.scaleBatchSize;
       console.info({
         message: 'Scaling up pool',
         component: 'warm-pool',
         starting: toStart,
         needed: diff,
-        capacity: this.remainingCapacity()
+        capacity: this.remainingCapacity(),
+        batchSize
       });
-      for (let i = 0; i < toStart; i++) {
-        if (this.capacityExhausted) {
-          console.log({
-            message: 'Capacity exhausted mid-loop, stopping further starts',
-            component: 'warm-pool'
-          });
-          break;
+      // Start in bounded-parallel batches: faster fill than one-at-a-time while
+      // re-checking capacity between batches so a straddling batch overshoots
+      // the ceiling by at most batchSize - 1 doomed starts.
+      for (let i = 0; i < toStart && !this.capacityExhausted; i += batchSize) {
+        const n = Math.min(batchSize, toStart - i);
+        const results = await Promise.all(
+          Array.from({ length: n }, () => this.startContainer())
+        );
+        for (const uuid of results) {
+          if (uuid) this.warmContainers.add(uuid);
         }
-        const uuid = await this.startContainer();
-        if (uuid) this.warmContainers.add(uuid);
+        await this.persist();
       }
-      await this.persist();
     } else if (diff < 0) {
       const excess = -diff;
       console.info({

--- a/packages/sandbox/src/bridge/warm-pool.ts
+++ b/packages/sandbox/src/bridge/warm-pool.ts
@@ -108,6 +108,15 @@ export class WarmPool extends DurableObject<WarmPoolEnv> {
   private capacityExhausted = false;
   private initialized = false;
 
+  /** Guards against overlapping eager refills triggered by concurrent pops. */
+  private refillInFlight = false;
+
+  /**
+   * The currently in-flight eager refill, or null. Exposed for tests to await
+   * the otherwise fire-and-forget refill deterministically.
+   */
+  private refillPromise: Promise<void> | null = null;
+
   // =======================================================================
   // Public RPC methods
   // =======================================================================
@@ -134,6 +143,8 @@ export class WarmPool extends DurableObject<WarmPoolEnv> {
       this.warmContainers.delete(containerUUID);
       this.assignments.set(sandboxId, containerUUID);
       await this.persist();
+      // Refill the slot we just consumed without waiting for the alarm tick.
+      this.requestRefill();
       return containerUUID;
     }
 
@@ -147,6 +158,8 @@ export class WarmPool extends DurableObject<WarmPoolEnv> {
     if (containerUUID) {
       this.assignments.set(sandboxId, containerUUID);
       await this.persist();
+      // Pool was empty — start replenishing toward warmTarget eagerly.
+      this.requestRefill();
       return containerUUID;
     }
 
@@ -241,6 +254,38 @@ export class WarmPool extends DurableObject<WarmPoolEnv> {
     }
 
     await this.persist();
+  }
+
+  // =======================================================================
+  // Eager refill
+  // =======================================================================
+
+  /**
+   * Kick a non-blocking refill toward warmTarget. Debounced via refillInFlight
+   * so a burst of concurrent pops triggers at most one adjustPool sweep at a
+   * time; capacity is respected because adjustPool clamps to remainingCapacity.
+   * Errors are swallowed so a failed refill never rejects the triggering call.
+   */
+  private requestRefill(): void {
+    if (this.refillInFlight) return;
+    if (this.warmContainers.size >= this.config.warmTarget) return;
+    if (this.remainingCapacity() <= 0) return;
+
+    this.refillInFlight = true;
+    this.refillPromise = (async () => {
+      try {
+        await this.adjustPool();
+      } catch (error) {
+        console.error({
+          message: 'Eager refill failed',
+          component: 'warm-pool',
+          error
+        });
+      } finally {
+        this.refillInFlight = false;
+      }
+    })();
+    this.ctx.waitUntil(this.refillPromise);
   }
 
   // =======================================================================

--- a/packages/sandbox/src/bridge/warm-pool.ts
+++ b/packages/sandbox/src/bridge/warm-pool.ts
@@ -529,6 +529,13 @@ export class WarmPool extends DurableObject<WarmPoolEnv> {
         for (const uuid of results) {
           if (uuid) this.warmContainers.add(uuid);
         }
+        // A start hitting the cap calls recordCapacityLimit() mid-batch, before
+        // this batch's successes were tracked, so it infers a ceiling that is
+        // too low. Re-derive it from the now-accurate total.
+        if (this.capacityExhausted) {
+          this.knownMaxInstances =
+            this.warmContainers.size + this.assignments.size;
+        }
         await this.persist();
       }
     } else if (diff < 0) {

--- a/packages/sandbox/src/bridge/warm-pool.ts
+++ b/packages/sandbox/src/bridge/warm-pool.ts
@@ -23,6 +23,14 @@ export interface WarmPoolConfig {
   warmTarget?: number;
   /** How often to check and replenish warm containers (ms). @default 10000 */
   refreshInterval?: number;
+  /**
+   * Operator-declared max_instances ceiling, mirroring
+   * `containers[].max_instances` in wrangler.jsonc. Seeds the pool's capacity
+   * math so it never blindly attempts doomed starts. 0/undefined = auto-learn
+   * the ceiling reactively from platform errors (legacy behaviour).
+   * @default 0
+   */
+  maxInstances?: number;
 }
 
 export interface PoolStats {
@@ -64,7 +72,8 @@ interface ContainerWithState {
 
 const DEFAULT_CONFIG: Required<WarmPoolConfig> = {
   warmTarget: 0,
-  refreshInterval: 10_000
+  refreshInterval: 10_000,
+  maxInstances: 0
 };
 
 // ---------------------------------------------------------------------------
@@ -192,6 +201,20 @@ export class WarmPool extends DurableObject<WarmPoolEnv> {
   async configure(config: WarmPoolConfig): Promise<void> {
     await this.init();
     this.config = { ...DEFAULT_CONFIG, ...config };
+
+    // Seed the ceiling if the operator declared one. The configured value is an
+    // upper bound the operator promises; the platform may still impose a lower
+    // one, so never clobber a *lower* limit learned from a real capacity error.
+    // Re-seeding here (configure runs on every request) makes a probe-cleared
+    // ceiling self-healing.
+    if (this.config.maxInstances > 0) {
+      this.knownMaxInstances =
+        this.knownMaxInstances === null
+          ? this.config.maxInstances
+          : Math.min(this.knownMaxInstances, this.config.maxInstances);
+      await this.ctx.storage.put('knownMaxInstances', this.knownMaxInstances);
+    }
+
     await this.ctx.storage.put('config', this.config);
   }
 


### PR DESCRIPTION
Benchmarking the bridge warm pool surfaced two reliability problems and one speed problem. A cold burst of one hundred sandboxes failed roughly a third of the time, a primed pool still developed a latency tail beyond ten seconds for requests that overflowed the warm target, and priming an empty pool took over a minute because containers started one at a time. Underneath all of this, bridge requests were largely invisible in traces.

The pool now accepts its capacity ceiling up front through the `WARM_POOL_MAX_INSTANCES` variable instead of discovering it by failing a start and parsing the error, so its capacity math is correct from the first request. It refills the instant a warm container is taken rather than waiting for the next background sweep, with a guard so concurrent requests trigger at most one refill at a time and never exceed the ceiling. It also fills in small parallel batches instead of one container at a time, with capacity re-checked between batches; the batch size defaults to five and is tunable through `WARM_POOL_SCALE_BATCH_SIZE`. Together these took the same hundred-sandbox burst from a dozen slow sandboxes to none, with wall-clock time roughly halved.

Every bridge request is now wrapped in a custom span named for its operation and annotated with the sandbox identifier, the container identifier, and call-specific metadata such as the command, file path, tunnel port, or session. Tracing is enabled in the worker configuration with a tunable sampling rate, the container instance size is raised to `standard-1`, and the span instrumentation falls back to doing nothing where the runtime does not support it.

To verify, set `WARM_POOL_TARGET` and `WARM_POOL_MAX_INSTANCES`, deploy, and watch `GET /v1/pool/stats` during a burst: the reported ceiling is correct before any start is attempted and the warm count recovers immediately rather than after the refresh interval. Spans for each operation appear in the dashboard carrying the sandbox identifier and metadata. The change is covered by unit tests for the seeded ceiling, eager refill and its concurrency guard, batched scale-up, and the tracing helper, with the existing bridge and software development kit suites unchanged.

The streaming command and terminal endpoints record their setup metadata but close their spans when the handler returns rather than when the stream completes, a limitation of the callback-scoped span interface.
