### PR TITLE
Add release artifact backfill workflow

### DIFF
--- a/.github/reusable-prerelease.test.sh
+++ b/.github/reusable-prerelease.test.sh
@@ -1,29 +1,33 @@
 #!/bin/bash
 set -euo pipefail
 
-workflow=.github/workflows/reusable-prerelease.yml
-
 assert_step_exports_account_id() {
-  local step_name="$1"
+  local workflow="$1"
+  local step_name="$2"
+  local indent="$3"
   local step_block
 
-  step_block=$(awk -v step="$step_name" '
-    $0 == "      - name: " step { in_step = 1; print; next }
-    in_step && /^      - name: / { exit }
+  step_block=$(awk -v step="$step_name" -v indent="$indent" '
+    $0 == indent "- name: " step { in_step = 1; print; next }
+    in_step && index($0, indent "- name: ") == 1 { exit }
     in_step { print }
   ' "$workflow")
 
   if [[ -z "$step_block" ]]; then
-    echo "Missing workflow step: $step_name" >&2
+    echo "Missing workflow step '$step_name' in $workflow" >&2
     return 1
   fi
 
   # shellcheck disable=SC2016
   if ! grep -Fq 'CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}' <<<"$step_block"; then
-    echo "Workflow step '$step_name' must export CLOUDFLARE_ACCOUNT_ID" >&2
+    echo "Workflow step '$step_name' in $workflow must export CLOUDFLARE_ACCOUNT_ID" >&2
     return 1
   fi
 }
 
-assert_step_exports_account_id "Publish Docker images to Docker Hub"
-assert_step_exports_account_id "Publish Docker images to CF Registry Library"
+assert_step_exports_account_id ".github/workflows/reusable-prerelease.yml" "Publish Docker images to Docker Hub" "      "
+assert_step_exports_account_id ".github/workflows/reusable-prerelease.yml" "Publish Docker images to CF Registry Library" "      "
+assert_step_exports_account_id ".github/workflows/release.yml" "Publish Docker images to Docker Hub" "      "
+assert_step_exports_account_id ".github/workflows/release.yml" "Publish Docker images to CF Registry Library" "      "
+assert_step_exports_account_id ".github/workflows/backfill-release-artifacts.yml" "Publish Docker images to Docker Hub" "      "
+assert_step_exports_account_id ".github/workflows/backfill-release-artifacts.yml" "Publish Docker images to CF Registry Library" "      "

--- a/.github/workflows/backfill-release-artifacts.yml
+++ b/.github/workflows/backfill-release-artifacts.yml
@@ -1,0 +1,110 @@
+name: Backfill Release Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version to backfill, for example 0.12.2'
+        required: true
+        type: string
+      source_tag:
+        description: 'Internal registry source tag, for example ci-<docker hash>'
+        required: true
+        type: string
+      publish_docker_hub:
+        description: 'Copy Docker images to Docker Hub'
+        required: true
+        default: true
+        type: boolean
+      publish_cf_library:
+        description: 'Copy Docker images to CF Registry Library'
+        required: true
+        default: true
+        type: boolean
+      upload_binaries:
+        description: 'Extract standalone binaries and upload them to the GitHub release'
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  backfill:
+    if: ${{ github.repository_owner == 'cloudflare' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install crane
+        run: .github/install-crane.sh
+
+      - name: Login to registries
+        run: .github/login-release-registries.sh
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+
+      - name: Publish Docker images to Docker Hub
+        if: ${{ inputs.publish_docker_hub }}
+        run: |
+          .github/publish-sandbox-images.sh \
+            --source-tag "${{ inputs.source_tag }}" \
+            --version "${{ inputs.version }}" \
+            --docker-hub
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Publish Docker images to CF Registry Library
+        if: ${{ inputs.publish_cf_library }}
+        run: |
+          .github/publish-sandbox-images.sh \
+            --source-tag "${{ inputs.source_tag }}" \
+            --version "${{ inputs.version }}" \
+            --cf-library
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Extract standalone binaries
+        if: ${{ inputs.upload_binaries }}
+        run: |
+          REGISTRY="registry.cloudflare.com/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}"
+          SRC_TAG="${{ inputs.source_tag }}"
+          docker pull "${REGISTRY}/sandbox:${SRC_TAG}"
+          CID=$(docker create "${REGISTRY}/sandbox:${SRC_TAG}")
+          docker cp "$CID":/container-server/sandbox ./sandbox-linux-x64
+          docker rm "$CID"
+          docker pull "${REGISTRY}/sandbox-musl:${SRC_TAG}"
+          CID=$(docker create "${REGISTRY}/sandbox-musl:${SRC_TAG}")
+          docker cp "$CID":/container-server/sandbox ./sandbox-linux-x64-musl
+          docker rm "$CID"
+
+      - name: Upload binaries to GitHub Release
+        if: ${{ inputs.upload_binaries }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ inputs.version }}"
+          sha256sum sandbox-linux-x64 > sandbox-linux-x64.sha256
+          sha256sum sandbox-linux-x64-musl > sandbox-linux-x64-musl.sha256
+          gh release upload "@cloudflare/sandbox@${VERSION}" \
+            ./sandbox-linux-x64 ./sandbox-linux-x64.sha256 \
+            ./sandbox-linux-x64-musl ./sandbox-linux-x64-musl.sha256 \
+            --clobber
+
+      - name: Summarize backfill
+        run: |
+          {
+            echo "## Release artifact backfill"
+            echo "Version: \`${{ inputs.version }}\`"
+            echo "Source tag: \`${{ inputs.source_tag }}\`"
+            echo "Docker Hub: \`${{ inputs.publish_docker_hub }}\`"
+            echo "CF Registry Library: \`${{ inputs.publish_cf_library }}\`"
+            echo "GitHub release binaries: \`${{ inputs.upload_binaries }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,6 +227,8 @@ jobs:
             --source-tag "ci-${{ needs.hashes.outputs.docker }}" \
             --version "${{ needs.build.outputs.version }}" \
             --docker-hub
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Publish Docker images to CF Registry Library
         if: steps.changesets.outputs.published == 'true'
@@ -250,6 +252,8 @@ jobs:
             echo "## ✅ CF Registry Library publish succeeded"
             printf "Published \`registry.cloudflare.com/library/sandbox:%s\` (+ variants)\n" "$VERSION"
           } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Warn if library publish failed
         if: steps.library-publish.outcome == 'failure'


### PR DESCRIPTION
Add a manual GitHub Actions workflow for backfilling release artifacts when npm has already published but Docker images or release binaries did not finish.

The 0.12.2 release hit this state after npm publishing succeeded and Docker image copying failed without CLOUDFLARE_ACCOUNT_ID in the publish step environment. Rerunning the release could not recover because changesets skipped the downstream artifact steps once npm already had the version.

This also exports CLOUDFLARE_ACCOUNT_ID in the stable release Docker publish steps, matching the prerelease workflow, so future stable releases can copy images successfully.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->