### PR TITLE
Add release artifact orchestration

### DIFF
--- a/.agents/skills/changesets/SKILL.md
+++ b/.agents/skills/changesets/SKILL.md
@@ -5,7 +5,7 @@ description: Use when creating a changeset, preparing a release, or bumping vers
 
 # Changesets & Releases
 
-This repository uses [changesets](https://github.com/changesets/changesets) to drive a fully automated release pipeline. Create a changeset whenever your change affects published packages.
+This repository uses [changesets](https://github.com/changesets/changesets) to create Version Packages PRs and maintain changelog/version files. Stable and prerelease artifact publishing are handled by the release orchestrator. Create a changeset whenever your change affects published packages.
 
 ## Creating a Changeset
 
@@ -63,11 +63,10 @@ Releases run via `.github/workflows/release.yml`. There is no manual publishing 
 
 1. Merge a PR that contains a changeset.
 2. The Changesets action opens (or updates) a **"Version Packages"** PR.
-3. Merging the Version Packages PR triggers:
-   1. Version bump in `package.json`
-   2. Docker images crane-copied from the CF registry to Docker Hub and the CF Registry public library (the exact images that passed E2E)
-   3. npm package publish with the bumped version
-   4. Standalone binaries extracted and uploaded to the GitHub Release
+3. Merging the Version Packages PR triggers the stable release workflow.
+4. The release orchestrator publishes and verifies the npm package, Docker Hub images, CF Registry public library images, GitHub Release, and standalone binary assets.
+5. Prerelease workflows also publish through the release orchestrator, which verifies the npm dist-tag, Docker Hub images, CF Registry public library images, and optional moving Docker aliases before succeeding.
+6. Release workflow reruns converge missing artifacts, so Docker images, GitHub releases, binaries, and prerelease aliases are not gated on npm being newly published in the current attempt.
 
 ## Version Synchronization
 

--- a/.github/changeset-publish.ts
+++ b/.github/changeset-publish.ts
@@ -1,8 +1,0 @@
-import { execSync } from 'node:child_process';
-
-execSync('npx tsx ./.github/resolve-workspace-versions.ts', {
-  stdio: 'inherit'
-});
-execSync('npx changeset publish', {
-  stdio: 'inherit'
-});

--- a/.github/release-command-runner.ts
+++ b/.github/release-command-runner.ts
@@ -1,0 +1,595 @@
+import { execFileSync } from 'node:child_process';
+import type {
+  PrereleaseReleaseState,
+  StableReleaseState
+} from './release-state.ts';
+
+export interface CommandRunner {
+  exists(ref: string): Promise<boolean>;
+  text(command: string, args: string[]): Promise<string>;
+  run(command: string, args: string[]): Promise<void>;
+}
+
+export interface VerificationResult {
+  ok: boolean;
+  missing: string[];
+}
+
+export class ExecCommandRunner implements CommandRunner {
+  async exists(ref: string): Promise<boolean> {
+    const [kind, value] = splitRef(ref);
+
+    try {
+      if (kind === 'docker') {
+        execFileSync('crane', ['manifest', value], { stdio: 'ignore' });
+        return true;
+      }
+
+      if (kind === 'npm') {
+        execFileSync('npm', ['view', value, 'version'], { stdio: 'ignore' });
+        return true;
+      }
+
+      if (kind === 'npm-dist-tag') {
+        return npmDistTagExists(value);
+      }
+
+      if (kind === 'git-tag') {
+        execFileSync('git', ['rev-parse', '--verify', `refs/tags/${value}`], {
+          stdio: 'ignore'
+        });
+        return true;
+      }
+
+      if (kind === 'github-release') {
+        execFileSync('gh', ['release', 'view', value], { stdio: 'ignore' });
+        return true;
+      }
+
+      if (kind === 'github-release-tag') {
+        return githubReleaseTagMatches(value);
+      }
+
+      if (kind === 'github-asset') {
+        return githubAssetExists(value);
+      }
+    } catch {
+      return false;
+    }
+
+    throw new Error(`Unknown ref kind: ${kind}`);
+  }
+
+  async text(command: string, args: string[]): Promise<string> {
+    return execFileSync(command, args, { encoding: 'utf8' });
+  }
+
+  async run(command: string, args: string[]): Promise<void> {
+    execFileSync(command, args, { stdio: 'inherit' });
+  }
+}
+
+export class FakeCommandRunner implements CommandRunner {
+  readonly commands: string[][] = [];
+
+  constructor(
+    private readonly options: {
+      presentRefs: Set<string>;
+      textByCommand?: Map<string, string>;
+    }
+  ) {}
+
+  async exists(ref: string): Promise<boolean> {
+    return this.options.presentRefs.has(ref);
+  }
+
+  async text(command: string, args: string[]): Promise<string> {
+    this.commands.push([command, ...args]);
+    return this.options.textByCommand?.get([command, ...args].join(' ')) ?? '';
+  }
+
+  async run(command: string, args: string[]): Promise<void> {
+    this.commands.push([command, ...args]);
+    this.recordCreatedRef(command, args);
+  }
+
+  private recordCreatedRef(command: string, args: string[]): void {
+    if (command === 'crane' && args[0] === 'copy') {
+      this.options.presentRefs.add(`docker:${args[2]}`);
+      return;
+    }
+
+    if (command === 'npm' && args[0] === 'dist-tag' && args[1] === 'add') {
+      const [pkg, version] = args[2].split('@').filter(Boolean);
+      const packageVersion = version ?? pkg;
+      this.options.presentRefs.add(`npm:@cloudflare/sandbox@${packageVersion}`);
+      this.options.presentRefs.add(`npm-dist-tag:${args[3]}=${packageVersion}`);
+      return;
+    }
+
+    if (command === 'git' && args[0] === 'tag' && args[1] === '-a') {
+      this.options.presentRefs.add(`git-tag:${args[2]}`);
+      return;
+    }
+
+    if (command === 'gh' && args[0] === 'release' && args[1] === 'create') {
+      this.options.presentRefs.add(`github-release:${args[2]}`);
+      this.options.presentRefs.add(`github-release-tag:${args[2]}=${args[2]}`);
+      return;
+    }
+
+    if (command === 'gh' && args[0] === 'release' && args[1] === 'upload') {
+      const releaseName = args[2];
+      for (const asset of args.slice(3).filter((arg) => arg !== '--clobber')) {
+        this.options.presentRefs.add(
+          `github-asset:${releaseName}:${asset.replace(/^\.\//, '')}`
+        );
+      }
+    }
+  }
+}
+
+export interface StableConvergenceOptions {
+  skipNpm?: boolean;
+  cloudflareAccountId?: string;
+}
+
+export interface PrereleaseConvergenceOptions {
+  skipNpm?: boolean;
+  cloudflareAccountId?: string;
+}
+
+export async function convergePrereleaseRelease(
+  state: PrereleaseReleaseState,
+  runner: CommandRunner,
+  options: PrereleaseConvergenceOptions = {}
+): Promise<void> {
+  if (!options.skipNpm) {
+    if (!(await runner.exists(`npm:${state.npmPackage}@${state.version}`))) {
+      await runner.run('npx', ['tsx', '.github/resolve-workspace-versions.ts']);
+      await runner.run('npm', [
+        'publish',
+        './packages/sandbox',
+        '--tag',
+        state.npmTag,
+        '--access',
+        'public'
+      ]);
+    }
+
+    if (
+      !(await runner.exists(`npm-dist-tag:${state.npmTag}=${state.version}`))
+    ) {
+      await runner.run('npm', [
+        'dist-tag',
+        'add',
+        `${state.npmPackage}@${state.version}`,
+        state.npmTag
+      ]);
+    }
+  }
+
+  const resolveSourceRef = createSourceRefResolver(options.cloudflareAccountId);
+
+  for (const mapping of state.dockerTags) {
+    let sourceRef: string | undefined;
+    const resolvedSourceRef = (): string => {
+      sourceRef ??= resolveSourceRef(mapping.sourceRef);
+      return sourceRef;
+    };
+
+    if (!(await runner.exists(`docker:${mapping.dockerHubRef}`))) {
+      await runner.run('crane', [
+        'copy',
+        resolvedSourceRef(),
+        mapping.dockerHubRef
+      ]);
+    }
+
+    if (!(await runner.exists(`docker:${mapping.cfLibraryRef}`))) {
+      await runner.run('crane', [
+        'copy',
+        resolvedSourceRef(),
+        mapping.cfLibraryRef
+      ]);
+    }
+
+    if (mapping.aliasTag !== undefined) {
+      await runner.run('crane', [
+        'copy',
+        resolvedSourceRef(),
+        `docker.io/cloudflare/sandbox:${mapping.aliasTag}`
+      ]);
+      await runner.run('crane', [
+        'copy',
+        resolvedSourceRef(),
+        `registry.cloudflare.com/library/sandbox:${mapping.aliasTag}`
+      ]);
+    }
+  }
+
+  const result = await verifyPrereleaseRelease(state, runner);
+  if (!result.ok) {
+    throw new Error(
+      `Prerelease convergence failed. Missing artifacts:\n${result.missing.join('\n')}`
+    );
+  }
+}
+
+export async function convergeStableRelease(
+  state: StableReleaseState,
+  runner: CommandRunner,
+  options: StableConvergenceOptions = {}
+): Promise<void> {
+  if (!options.skipNpm) {
+    if (!(await runner.exists(`npm:${state.npmPackage}@${state.version}`))) {
+      await runner.run('npx', ['tsx', '.github/resolve-workspace-versions.ts']);
+      await runner.run('npm', [
+        'publish',
+        './packages/sandbox',
+        '--access',
+        'public'
+      ]);
+    }
+
+    if (
+      !(await runner.exists(`npm-dist-tag:${state.npmTag}=${state.version}`))
+    ) {
+      await runner.run('npm', [
+        'dist-tag',
+        'add',
+        `${state.npmPackage}@${state.version}`,
+        state.npmTag
+      ]);
+    }
+  }
+
+  await convergeGitTag(state, runner);
+  await convergeGitHubRelease(state, runner);
+
+  const resolveSourceRef = createSourceRefResolver(options.cloudflareAccountId);
+
+  for (const mapping of state.dockerTags) {
+    let sourceRef: string | undefined;
+    const resolvedSourceRef = (): string => {
+      sourceRef ??= resolveSourceRef(mapping.sourceRef);
+      return sourceRef;
+    };
+
+    if (!(await runner.exists(`docker:${mapping.dockerHubRef}`))) {
+      await runner.run('crane', [
+        'copy',
+        resolvedSourceRef(),
+        mapping.dockerHubRef
+      ]);
+    }
+
+    if (!(await runner.exists(`docker:${mapping.cfLibraryRef}`))) {
+      await runner.run('crane', [
+        'copy',
+        resolvedSourceRef(),
+        mapping.cfLibraryRef
+      ]);
+    }
+  }
+
+  const missingAssets: string[] = [];
+  for (const asset of state.releaseAssets) {
+    if (
+      !(await runner.exists(`github-asset:${state.githubReleaseName}:${asset}`))
+    ) {
+      missingAssets.push(asset);
+    }
+  }
+
+  if (missingAssets.length > 0) {
+    await extractStableReleaseAssets(
+      state,
+      runner,
+      createSourceRefResolver(options.cloudflareAccountId)
+    );
+
+    await runner.run('gh', [
+      'release',
+      'upload',
+      state.githubReleaseName,
+      ...missingAssets.flatMap((asset) => [`./${asset}`]),
+      '--clobber'
+    ]);
+  }
+
+  const result = await verifyStableRelease(state, runner);
+  if (!result.ok) {
+    throw new Error(
+      `Stable release convergence failed. Missing artifacts:\n${result.missing.join('\n')}`
+    );
+  }
+}
+
+export async function verifyStableRelease(
+  state: StableReleaseState,
+  runner: CommandRunner
+): Promise<VerificationResult> {
+  const refs = [
+    `npm:${state.npmPackage}@${state.version}`,
+    `npm-dist-tag:${state.npmTag}=${state.version}`,
+    `git-tag:${state.gitTag}`,
+    `github-release:${state.githubReleaseName}`,
+    `github-release-tag:${state.githubReleaseName}=${state.gitTag}`,
+    ...state.dockerTags.flatMap((mapping) => [
+      `docker:${mapping.dockerHubRef}`,
+      `docker:${mapping.cfLibraryRef}`
+    ]),
+    ...state.releaseAssets.map(
+      (asset) => `github-asset:${state.githubReleaseName}:${asset}`
+    )
+  ];
+
+  return verifyRefs(refs, runner);
+}
+
+export async function verifyPrereleaseRelease(
+  state: PrereleaseReleaseState,
+  runner: CommandRunner
+): Promise<VerificationResult> {
+  const dockerRefs = state.dockerTags.flatMap((mapping) => {
+    const refs = [
+      `docker:${mapping.dockerHubRef}`,
+      `docker:${mapping.cfLibraryRef}`
+    ];
+
+    if (mapping.aliasTag !== undefined) {
+      refs.push(`docker:docker.io/cloudflare/sandbox:${mapping.aliasTag}`);
+      refs.push(
+        `docker:registry.cloudflare.com/library/sandbox:${mapping.aliasTag}`
+      );
+    }
+
+    return refs;
+  });
+
+  return verifyRefs(
+    [
+      `npm:${state.npmPackage}@${state.version}`,
+      `npm-dist-tag:${state.npmTag}=${state.version}`,
+      ...dockerRefs
+    ],
+    runner
+  );
+}
+
+async function convergeGitTag(
+  state: StableReleaseState,
+  runner: CommandRunner
+): Promise<void> {
+  if (await runner.exists(`git-tag:${state.gitTag}`)) {
+    const taggedCommit = (
+      await runner.text('git', ['rev-list', '-n', '1', state.gitTag])
+    ).trim();
+
+    if (taggedCommit.length > 0 && taggedCommit !== state.commitSha) {
+      throw new Error(
+        `Git tag ${state.gitTag} points to ${taggedCommit}, expected ${state.commitSha}`
+      );
+    }
+    return;
+  }
+
+  await runner.run('git', [
+    'tag',
+    '-a',
+    state.gitTag,
+    state.commitSha,
+    '-m',
+    state.gitTag
+  ]);
+  await runner.run('git', ['push', 'origin', state.gitTag]);
+}
+
+async function extractStableReleaseAssets(
+  state: StableReleaseState,
+  runner: CommandRunner,
+  resolveSourceRef: (sourceRef: string) => string
+): Promise<void> {
+  const normal = requiredDockerMapping(state, 'sandbox');
+  const musl = requiredDockerMapping(state, 'sandbox-musl');
+
+  await extractStableReleaseAsset(
+    runner,
+    resolveSourceRef(normal.sourceRef),
+    './sandbox-linux-x64'
+  );
+  await extractStableReleaseAsset(
+    runner,
+    resolveSourceRef(musl.sourceRef),
+    './sandbox-linux-x64-musl'
+  );
+  await runner.run('sh', [
+    '-c',
+    'sha256sum sandbox-linux-x64 > sandbox-linux-x64.sha256'
+  ]);
+  await runner.run('sh', [
+    '-c',
+    'sha256sum sandbox-linux-x64-musl > sandbox-linux-x64-musl.sha256'
+  ]);
+}
+
+async function extractStableReleaseAsset(
+  runner: CommandRunner,
+  sourceRef: string,
+  outputPath: string
+): Promise<void> {
+  await runner.run('docker', ['pull', sourceRef]);
+  const containerId = (
+    await runner.text('docker', ['create', sourceRef])
+  ).trim();
+  await runner.run('docker', [
+    'cp',
+    `${containerId}:/container-server/sandbox`,
+    outputPath
+  ]);
+  await runner.run('docker', ['rm', containerId]);
+}
+
+function createSourceRefResolver(
+  cloudflareAccountId = process.env.CLOUDFLARE_ACCOUNT_ID
+): (sourceRef: string) => string {
+  return (sourceRef: string) => {
+    const accountId = cloudflareAccountId?.trim();
+
+    if (accountId === undefined || accountId.length === 0) {
+      throw new Error(
+        'CLOUDFLARE_ACCOUNT_ID is required to resolve Docker source image refs'
+      );
+    }
+
+    return sourceRef.replace('$CLOUDFLARE_ACCOUNT_ID', accountId);
+  };
+}
+
+function requiredDockerMapping(
+  state: StableReleaseState,
+  image: string
+): StableReleaseState['dockerTags'][number] {
+  const mapping = state.dockerTags.find((item) => item.image === image);
+
+  if (mapping === undefined) {
+    throw new Error(`Stable release assets require Docker image: ${image}`);
+  }
+
+  return mapping;
+}
+
+async function convergeGitHubRelease(
+  state: StableReleaseState,
+  runner: CommandRunner
+): Promise<void> {
+  if (await runner.exists(`github-release:${state.githubReleaseName}`)) {
+    if (
+      !(await runner.exists(
+        `github-release-tag:${state.githubReleaseName}=${state.gitTag}`
+      ))
+    ) {
+      throw new Error(
+        `GitHub Release ${state.githubReleaseName} is not attached to expected tag ${state.gitTag}`
+      );
+    }
+    return;
+  }
+
+  await runner.run('gh', [
+    'release',
+    'create',
+    state.githubReleaseName,
+    '--target',
+    state.commitSha,
+    '--title',
+    state.githubReleaseName,
+    '--notes',
+    state.changelogBody
+  ]);
+}
+
+async function verifyRefs(
+  refs: string[],
+  runner: CommandRunner
+): Promise<VerificationResult> {
+  const missing: string[] = [];
+
+  for (const ref of refs) {
+    if (!(await runner.exists(ref))) {
+      missing.push(ref);
+    }
+  }
+
+  return { ok: missing.length === 0, missing };
+}
+
+function splitRef(ref: string): [string, string] {
+  const index = ref.indexOf(':');
+
+  if (index === -1) {
+    throw new Error(`Invalid ref: ${ref}`);
+  }
+
+  return [ref.slice(0, index), ref.slice(index + 1)];
+}
+
+function npmDistTagExists(value: string): boolean {
+  const [tag, version] = splitDistTagRef(value);
+  const output = execFileSync(
+    'npm',
+    ['dist-tag', 'ls', '@cloudflare/sandbox'],
+    {
+      encoding: 'utf8'
+    }
+  );
+
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .some((line) => line === `${tag}: ${version}`);
+}
+
+function splitDistTagRef(value: string): [string, string] {
+  const index = value.indexOf('=');
+
+  if (index === -1) {
+    throw new Error(`Invalid npm dist-tag ref: ${value}`);
+  }
+
+  return [value.slice(0, index), value.slice(index + 1)];
+}
+
+function githubReleaseTagMatches(value: string): boolean {
+  const [releaseName, tagName] = splitGitHubReleaseTagRef(value);
+  const output = execFileSync(
+    'gh',
+    ['release', 'view', releaseName, '--json', 'tagName', '--jq', '.tagName'],
+    { encoding: 'utf8' }
+  );
+
+  return output.trim() === tagName;
+}
+
+function githubAssetExists(value: string): boolean {
+  const [releaseName, assetName] = splitGitHubAssetRef(value);
+  const output = execFileSync(
+    'gh',
+    [
+      'release',
+      'view',
+      releaseName,
+      '--json',
+      'assets',
+      '--jq',
+      '.assets[].name'
+    ],
+    { encoding: 'utf8' }
+  );
+
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .includes(assetName);
+}
+
+function splitGitHubAssetRef(value: string): [string, string] {
+  const index = value.lastIndexOf(':');
+
+  if (index === -1) {
+    throw new Error(`Invalid GitHub asset ref: ${value}`);
+  }
+
+  return [value.slice(0, index), value.slice(index + 1)];
+}
+
+function splitGitHubReleaseTagRef(value: string): [string, string] {
+  const index = value.lastIndexOf('=');
+
+  if (index === -1) {
+    throw new Error(`Invalid GitHub release tag ref: ${value}`);
+  }
+
+  return [value.slice(0, index), value.slice(index + 1)];
+}

--- a/.github/release-orchestrator.test.ts
+++ b/.github/release-orchestrator.test.ts
@@ -1,0 +1,531 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { prereleaseReleaseState, stableReleaseState } from './release-state.ts';
+import {
+  convergePrereleaseRelease,
+  convergeStableRelease,
+  ExecCommandRunner,
+  FakeCommandRunner,
+  verifyPrereleaseRelease,
+  verifyStableRelease
+} from './release-command-runner.ts';
+import { parseCliArgs } from './release-orchestrator.ts';
+
+describe('ExecCommandRunner', () => {
+  test('recognizes lightweight and annotated git tags as existing tags', async () => {
+    const originalCwd = process.cwd();
+    const repoDir = mkdtempSync(join(tmpdir(), 'sandbox-release-tags-'));
+
+    try {
+      process.chdir(repoDir);
+      execFileSync('git', ['init'], { stdio: 'ignore' });
+      execFileSync('git', ['config', 'user.email', 'test@example.com']);
+      execFileSync('git', ['config', 'user.name', 'Test User']);
+      execFileSync('git', ['commit', '--allow-empty', '-m', 'Initial commit'], {
+        stdio: 'ignore'
+      });
+      execFileSync('git', ['tag', 'lightweight-tag']);
+      execFileSync('git', [
+        'tag',
+        '-a',
+        'annotated-tag',
+        '-m',
+        'annotated-tag'
+      ]);
+
+      const runner = new ExecCommandRunner();
+
+      assert.equal(await runner.exists('git-tag:lightweight-tag'), true);
+      assert.equal(await runner.exists('git-tag:annotated-tag'), true);
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  test('surfaces unknown ref kinds instead of reporting them missing', async () => {
+    const runner = new ExecCommandRunner();
+
+    await assert.rejects(
+      runner.exists('bogus:some-value'),
+      /Unknown ref kind: bogus/
+    );
+  });
+});
+
+describe('verifyStableRelease', () => {
+  test('reports missing stable artifacts with exact refs', async () => {
+    const state = stableReleaseState({
+      version: '0.12.2',
+      sourceTag: 'ci-hash',
+      commitSha: 'abc123',
+      images: ['sandbox', 'sandbox-musl'],
+      changelogBody: '### Patch Changes\n\n- Fix thing'
+    });
+    const runner = new FakeCommandRunner({ presentRefs: new Set() });
+
+    const result = await verifyStableRelease(state, runner);
+
+    assert.equal(result.ok, false);
+    assert.deepEqual(
+      result.missing.sort(),
+      [
+        'docker:docker.io/cloudflare/sandbox:0.12.2',
+        'docker:docker.io/cloudflare/sandbox:0.12.2-musl',
+        'docker:registry.cloudflare.com/library/sandbox:0.12.2',
+        'docker:registry.cloudflare.com/library/sandbox:0.12.2-musl',
+        'github-asset:@cloudflare/sandbox@0.12.2:sandbox-linux-x64',
+        'github-asset:@cloudflare/sandbox@0.12.2:sandbox-linux-x64-musl',
+        'github-asset:@cloudflare/sandbox@0.12.2:sandbox-linux-x64-musl.sha256',
+        'github-asset:@cloudflare/sandbox@0.12.2:sandbox-linux-x64.sha256',
+        'github-release-tag:@cloudflare/sandbox@0.12.2=@cloudflare/sandbox@0.12.2',
+        'github-release:@cloudflare/sandbox@0.12.2',
+        'git-tag:@cloudflare/sandbox@0.12.2',
+        'npm:@cloudflare/sandbox@0.12.2',
+        'npm-dist-tag:latest=0.12.2'
+      ].sort()
+    );
+  });
+});
+
+describe('parseCliArgs', () => {
+  test('parses verify-stable args', () => {
+    assert.deepEqual(
+      parseCliArgs([
+        'verify-stable',
+        '--version',
+        '0.12.2',
+        '--source-tag',
+        'ci-hash',
+        '--commit-sha',
+        'abc123'
+      ]),
+      {
+        command: 'verify-stable',
+        version: '0.12.2',
+        sourceTag: 'ci-hash',
+        commitSha: 'abc123'
+      }
+    );
+  });
+
+  test('parses stable args with skip npm', () => {
+    assert.deepEqual(
+      parseCliArgs([
+        'stable',
+        '--version',
+        '0.12.2',
+        '--source-tag',
+        'ci-hash',
+        '--commit-sha',
+        'abc123',
+        '--skip-npm',
+        'true'
+      ]),
+      {
+        command: 'stable',
+        version: '0.12.2',
+        sourceTag: 'ci-hash',
+        commitSha: 'abc123',
+        skipNpm: true
+      }
+    );
+  });
+
+  test('parses stable args with skip npm flag', () => {
+    assert.deepEqual(
+      parseCliArgs([
+        'stable',
+        '--version',
+        '0.12.2',
+        '--source-tag',
+        'ci-hash',
+        '--commit-sha',
+        'abc123',
+        '--skip-npm'
+      ]),
+      {
+        command: 'stable',
+        version: '0.12.2',
+        sourceTag: 'ci-hash',
+        commitSha: 'abc123',
+        skipNpm: true
+      }
+    );
+  });
+
+  test('parses prerelease args with optional docker alias', () => {
+    assert.deepEqual(
+      parseCliArgs([
+        'prerelease',
+        '--version',
+        '0.13.0-next.1.1',
+        '--source-tag',
+        'prerelease-next-0.13.0-next.1.1',
+        '--npm-tag',
+        'next',
+        '--docker-alias',
+        'next'
+      ]),
+      {
+        command: 'prerelease',
+        version: '0.13.0-next.1.1',
+        sourceTag: 'prerelease-next-0.13.0-next.1.1',
+        npmTag: 'next',
+        dockerAlias: 'next'
+      }
+    );
+  });
+
+  test('parses verify-prerelease args with optional docker alias', () => {
+    assert.deepEqual(
+      parseCliArgs([
+        'verify-prerelease',
+        '--version',
+        '0.13.0-next.1.1',
+        '--source-tag',
+        'prerelease-next-0.13.0-next.1.1',
+        '--npm-tag',
+        'next',
+        '--docker-alias',
+        'next'
+      ]),
+      {
+        command: 'verify-prerelease',
+        version: '0.13.0-next.1.1',
+        sourceTag: 'prerelease-next-0.13.0-next.1.1',
+        npmTag: 'next',
+        dockerAlias: 'next'
+      }
+    );
+  });
+
+  test('requires source tag', () => {
+    assert.throws(
+      () =>
+        parseCliArgs([
+          'verify-stable',
+          '--version',
+          '0.12.2',
+          '--commit-sha',
+          'abc123'
+        ]),
+      /--source-tag is required/
+    );
+  });
+});
+
+describe('convergeStableRelease', () => {
+  test('throws before changing commands when existing tag points elsewhere', async () => {
+    const state = stableReleaseState({
+      version: '0.12.2',
+      sourceTag: 'ci-hash',
+      commitSha: 'abc123',
+      images: ['sandbox', 'sandbox-musl'],
+      changelogBody: '### Patch Changes\n\n- Fix thing'
+    });
+    const runner = new FakeCommandRunner({
+      textByCommand: new Map([
+        ['git rev-list -n 1 @cloudflare/sandbox@0.12.2', 'def456\n']
+      ]),
+      presentRefs: new Set([
+        'npm:@cloudflare/sandbox@0.12.2',
+        'npm-dist-tag:latest=0.12.2',
+        'git-tag:@cloudflare/sandbox@0.12.2'
+      ])
+    });
+
+    await assert.rejects(
+      convergeStableRelease(state, runner, { skipNpm: true }),
+      /Git tag @cloudflare\/sandbox@0\.12\.2 points to def456, expected abc123/
+    );
+    assert.deepEqual(runner.commands, [
+      ['git', 'rev-list', '-n', '1', '@cloudflare/sandbox@0.12.2']
+    ]);
+  });
+
+  test('pushes a newly-created annotated tag before creating release', async () => {
+    const state = stableReleaseState({
+      version: '0.12.2',
+      sourceTag: 'ci-hash',
+      commitSha: 'abc123',
+      images: ['sandbox', 'sandbox-musl'],
+      changelogBody: '### Patch Changes\n\n- Fix thing'
+    });
+    const runner = new FakeCommandRunner({
+      presentRefs: new Set([
+        'npm:@cloudflare/sandbox@0.12.2',
+        'npm-dist-tag:latest=0.12.2',
+        'docker:docker.io/cloudflare/sandbox:0.12.2',
+        'docker:docker.io/cloudflare/sandbox:0.12.2-musl',
+        'docker:registry.cloudflare.com/library/sandbox:0.12.2',
+        'docker:registry.cloudflare.com/library/sandbox:0.12.2-musl',
+        'github-asset:@cloudflare/sandbox@0.12.2:sandbox-linux-x64',
+        'github-asset:@cloudflare/sandbox@0.12.2:sandbox-linux-x64.sha256',
+        'github-asset:@cloudflare/sandbox@0.12.2:sandbox-linux-x64-musl',
+        'github-asset:@cloudflare/sandbox@0.12.2:sandbox-linux-x64-musl.sha256'
+      ])
+    });
+
+    await convergeStableRelease(state, runner, { skipNpm: true });
+
+    assert.deepEqual(runner.commands, [
+      [
+        'git',
+        'tag',
+        '-a',
+        '@cloudflare/sandbox@0.12.2',
+        'abc123',
+        '-m',
+        '@cloudflare/sandbox@0.12.2'
+      ],
+      ['git', 'push', 'origin', '@cloudflare/sandbox@0.12.2'],
+      [
+        'gh',
+        'release',
+        'create',
+        '@cloudflare/sandbox@0.12.2',
+        '--target',
+        'abc123',
+        '--title',
+        '@cloudflare/sandbox@0.12.2',
+        '--notes',
+        '### Patch Changes\n\n- Fix thing'
+      ]
+    ]);
+  });
+
+  test('throws when an existing GitHub Release targets the wrong tag', async () => {
+    const state = stableReleaseState({
+      version: '0.12.2',
+      sourceTag: 'ci-hash',
+      commitSha: 'abc123',
+      images: ['sandbox', 'sandbox-musl'],
+      changelogBody: '### Patch Changes\n\n- Fix thing'
+    });
+    const runner = new FakeCommandRunner({
+      textByCommand: new Map([
+        ['git rev-list -n 1 @cloudflare/sandbox@0.12.2', 'abc123\n']
+      ]),
+      presentRefs: new Set([
+        'npm:@cloudflare/sandbox@0.12.2',
+        'npm-dist-tag:latest=0.12.2',
+        'git-tag:@cloudflare/sandbox@0.12.2',
+        'github-release:@cloudflare/sandbox@0.12.2'
+      ])
+    });
+
+    await assert.rejects(
+      convergeStableRelease(state, runner, { skipNpm: true }),
+      /GitHub Release @cloudflare\/sandbox@0\.12\.2 is not attached to expected tag @cloudflare\/sandbox@0\.12\.2/
+    );
+  });
+
+  test('copies missing docker tags and uploads stable assets', async () => {
+    const state = stableReleaseState({
+      version: '0.12.2',
+      sourceTag: 'ci-hash',
+      commitSha: 'abc123',
+      images: ['sandbox', 'sandbox-musl'],
+      changelogBody: '### Patch Changes\n\n- Fix thing'
+    });
+    const runner = new FakeCommandRunner({
+      textByCommand: new Map([
+        ['git rev-list -n 1 @cloudflare/sandbox@0.12.2', 'abc123\n'],
+        [
+          'docker create registry.cloudflare.com/cf-account-123/sandbox:ci-hash',
+          'normal-container\n'
+        ],
+        [
+          'docker create registry.cloudflare.com/cf-account-123/sandbox-musl:ci-hash',
+          'musl-container\n'
+        ]
+      ]),
+      presentRefs: new Set([
+        'npm:@cloudflare/sandbox@0.12.2',
+        'npm-dist-tag:latest=0.12.2',
+        'git-tag:@cloudflare/sandbox@0.12.2',
+        'github-release:@cloudflare/sandbox@0.12.2',
+        'github-release-tag:@cloudflare/sandbox@0.12.2=@cloudflare/sandbox@0.12.2'
+      ])
+    });
+
+    await convergeStableRelease(state, runner, {
+      skipNpm: true,
+      cloudflareAccountId: 'cf-account-123'
+    });
+
+    assert.deepEqual(runner.commands, [
+      ['git', 'rev-list', '-n', '1', '@cloudflare/sandbox@0.12.2'],
+      [
+        'crane',
+        'copy',
+        'registry.cloudflare.com/cf-account-123/sandbox:ci-hash',
+        'docker.io/cloudflare/sandbox:0.12.2'
+      ],
+      [
+        'crane',
+        'copy',
+        'registry.cloudflare.com/cf-account-123/sandbox:ci-hash',
+        'registry.cloudflare.com/library/sandbox:0.12.2'
+      ],
+      [
+        'crane',
+        'copy',
+        'registry.cloudflare.com/cf-account-123/sandbox-musl:ci-hash',
+        'docker.io/cloudflare/sandbox:0.12.2-musl'
+      ],
+      [
+        'crane',
+        'copy',
+        'registry.cloudflare.com/cf-account-123/sandbox-musl:ci-hash',
+        'registry.cloudflare.com/library/sandbox:0.12.2-musl'
+      ],
+      [
+        'docker',
+        'pull',
+        'registry.cloudflare.com/cf-account-123/sandbox:ci-hash'
+      ],
+      [
+        'docker',
+        'create',
+        'registry.cloudflare.com/cf-account-123/sandbox:ci-hash'
+      ],
+      [
+        'docker',
+        'cp',
+        'normal-container:/container-server/sandbox',
+        './sandbox-linux-x64'
+      ],
+      ['docker', 'rm', 'normal-container'],
+      [
+        'docker',
+        'pull',
+        'registry.cloudflare.com/cf-account-123/sandbox-musl:ci-hash'
+      ],
+      [
+        'docker',
+        'create',
+        'registry.cloudflare.com/cf-account-123/sandbox-musl:ci-hash'
+      ],
+      [
+        'docker',
+        'cp',
+        'musl-container:/container-server/sandbox',
+        './sandbox-linux-x64-musl'
+      ],
+      ['docker', 'rm', 'musl-container'],
+      ['sh', '-c', 'sha256sum sandbox-linux-x64 > sandbox-linux-x64.sha256'],
+      [
+        'sh',
+        '-c',
+        'sha256sum sandbox-linux-x64-musl > sandbox-linux-x64-musl.sha256'
+      ],
+      [
+        'gh',
+        'release',
+        'upload',
+        '@cloudflare/sandbox@0.12.2',
+        './sandbox-linux-x64',
+        './sandbox-linux-x64.sha256',
+        './sandbox-linux-x64-musl',
+        './sandbox-linux-x64-musl.sha256',
+        '--clobber'
+      ]
+    ]);
+  });
+});
+
+describe('convergePrereleaseRelease', () => {
+  test('publishes missing npm prerelease and docker aliases', async () => {
+    const state = prereleaseReleaseState({
+      version: '0.13.0-next.1.1',
+      sourceTag: 'prerelease-next-0.13.0-next.1.1',
+      npmTag: 'next',
+      dockerAlias: 'next',
+      images: ['sandbox']
+    });
+    const runner = new FakeCommandRunner({ presentRefs: new Set() });
+
+    await convergePrereleaseRelease(state, runner, {
+      skipNpm: false,
+      cloudflareAccountId: 'cf-account-123'
+    });
+
+    assert.deepEqual(runner.commands.slice(0, 4), [
+      ['npx', 'tsx', '.github/resolve-workspace-versions.ts'],
+      [
+        'npm',
+        'publish',
+        './packages/sandbox',
+        '--tag',
+        'next',
+        '--access',
+        'public'
+      ],
+      ['npm', 'dist-tag', 'add', '@cloudflare/sandbox@0.13.0-next.1.1', 'next'],
+      [
+        'crane',
+        'copy',
+        'registry.cloudflare.com/cf-account-123/sandbox:prerelease-next-0.13.0-next.1.1',
+        'docker.io/cloudflare/sandbox:0.13.0-next.1.1'
+      ]
+    ]);
+  });
+
+  test('requires Cloudflare account ID before Docker convergence', async () => {
+    const state = prereleaseReleaseState({
+      version: '0.13.0-next.1.1',
+      sourceTag: 'prerelease-next-0.13.0-next.1.1',
+      npmTag: 'next',
+      images: ['sandbox']
+    });
+    const runner = new FakeCommandRunner({
+      presentRefs: new Set([
+        'npm:@cloudflare/sandbox@0.13.0-next.1.1',
+        'npm-dist-tag:next=0.13.0-next.1.1'
+      ])
+    });
+
+    await assert.rejects(
+      convergePrereleaseRelease(state, runner, {
+        skipNpm: true,
+        cloudflareAccountId: ''
+      }),
+      /CLOUDFLARE_ACCOUNT_ID is required to resolve Docker source image refs/
+    );
+    assert.deepEqual(runner.commands, []);
+  });
+});
+
+describe('verifyPrereleaseRelease', () => {
+  test('checks npm dist-tag and docker aliases with exact refs', async () => {
+    const state = prereleaseReleaseState({
+      version: '0.13.0-next.1.1',
+      sourceTag: 'prerelease-next-0.13.0-next.1.1',
+      npmTag: 'next',
+      dockerAlias: 'next',
+      images: ['sandbox']
+    });
+    const runner = new FakeCommandRunner({ presentRefs: new Set() });
+
+    const result = await verifyPrereleaseRelease(state, runner);
+
+    assert.equal(result.ok, false);
+    assert.deepEqual(
+      result.missing.sort(),
+      [
+        'docker:docker.io/cloudflare/sandbox:0.13.0-next.1.1',
+        'docker:docker.io/cloudflare/sandbox:next',
+        'docker:registry.cloudflare.com/library/sandbox:0.13.0-next.1.1',
+        'docker:registry.cloudflare.com/library/sandbox:next',
+        'npm:@cloudflare/sandbox@0.13.0-next.1.1',
+        'npm-dist-tag:next=0.13.0-next.1.1'
+      ].sort()
+    );
+  });
+});

--- a/.github/release-orchestrator.ts
+++ b/.github/release-orchestrator.ts
@@ -1,0 +1,205 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  extractChangelogSection,
+  loadDockerImages,
+  prereleaseReleaseState,
+  stableReleaseState
+} from './release-state.ts';
+import {
+  convergePrereleaseRelease,
+  convergeStableRelease,
+  ExecCommandRunner,
+  verifyPrereleaseRelease,
+  verifyStableRelease
+} from './release-command-runner.ts';
+
+export type CliArgs =
+  | {
+      command: 'verify-stable';
+      version: string;
+      sourceTag: string;
+      commitSha: string;
+    }
+  | {
+      command: 'verify-prerelease';
+      version: string;
+      sourceTag: string;
+      npmTag: string;
+      dockerAlias?: string;
+    }
+  | {
+      command: 'stable';
+      version: string;
+      sourceTag: string;
+      commitSha: string;
+      skipNpm: boolean;
+    }
+  | {
+      command: 'prerelease';
+      version: string;
+      sourceTag: string;
+      npmTag: string;
+      dockerAlias?: string;
+    };
+
+export function parseCliArgs(argv: string[]): CliArgs {
+  const command = argv[0];
+  const args = new Map<string, string>();
+
+  for (let index = 1; index < argv.length; index += 1) {
+    const key = argv[index];
+    const value = argv[index + 1];
+
+    if (!key.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${key}`);
+    }
+
+    if (!value || value.startsWith('--')) {
+      if (key === '--skip-npm') {
+        args.set(key, 'true');
+        continue;
+      }
+
+      throw new Error(`Missing value for ${key}`);
+    }
+
+    args.set(key, value);
+    index += 1;
+  }
+
+  const version = requireArg(args, '--version');
+  const sourceTag = requireArg(args, '--source-tag');
+
+  if (command === 'verify-stable') {
+    return {
+      command,
+      version,
+      sourceTag,
+      commitSha: requireArg(args, '--commit-sha')
+    };
+  }
+
+  if (command === 'verify-prerelease' || command === 'prerelease') {
+    return {
+      command,
+      version,
+      sourceTag,
+      npmTag: requireArg(args, '--npm-tag'),
+      dockerAlias: args.get('--docker-alias')
+    };
+  }
+
+  if (command === 'stable') {
+    return {
+      command,
+      version,
+      sourceTag,
+      commitSha: requireArg(args, '--commit-sha'),
+      skipNpm: args.get('--skip-npm') === 'true'
+    };
+  }
+
+  throw new Error(
+    'Command is required: stable, prerelease, verify-stable, or verify-prerelease'
+  );
+}
+
+async function main(): Promise<void> {
+  const cli = parseCliArgs(process.argv.slice(2));
+  const root = process.cwd();
+  const images = loadDockerImages(root);
+  const runner = new ExecCommandRunner();
+
+  if (cli.command === 'verify-stable') {
+    const changelog = readFileSync(
+      join(root, 'packages', 'sandbox', 'CHANGELOG.md'),
+      'utf8'
+    );
+    const state = stableReleaseState({
+      version: cli.version,
+      sourceTag: cli.sourceTag,
+      commitSha: cli.commitSha,
+      images,
+      changelogBody: extractChangelogSection(changelog, cli.version)
+    });
+    const result = await verifyStableRelease(state, runner);
+    reportAndExit(result.missing);
+  }
+
+  if (cli.command === 'stable') {
+    const changelog = readFileSync(
+      join(root, 'packages', 'sandbox', 'CHANGELOG.md'),
+      'utf8'
+    );
+    const state = stableReleaseState({
+      version: cli.version,
+      sourceTag: cli.sourceTag,
+      commitSha: cli.commitSha,
+      images,
+      changelogBody: extractChangelogSection(changelog, cli.version)
+    });
+    await convergeStableRelease(state, runner, { skipNpm: cli.skipNpm });
+    console.log('Stable release convergence passed');
+    process.exit(0);
+  }
+
+  if (cli.command === 'verify-prerelease') {
+    const state = prereleaseReleaseState({
+      version: cli.version,
+      sourceTag: cli.sourceTag,
+      npmTag: cli.npmTag,
+      dockerAlias: cli.dockerAlias,
+      images
+    });
+    const result = await verifyPrereleaseRelease(state, runner);
+    reportAndExit(result.missing);
+  }
+
+  if (cli.command === 'prerelease') {
+    const state = prereleaseReleaseState({
+      version: cli.version,
+      sourceTag: cli.sourceTag,
+      npmTag: cli.npmTag,
+      dockerAlias: cli.dockerAlias,
+      images
+    });
+    await convergePrereleaseRelease(state, runner);
+    console.log('Prerelease convergence passed');
+    process.exit(0);
+  }
+}
+
+function requireArg(args: Map<string, string>, key: string): string {
+  const value = args.get(key);
+
+  if (!value) {
+    throw new Error(`${key} is required`);
+  }
+
+  return value;
+}
+
+function reportAndExit(missing: string[]): never {
+  if (missing.length === 0) {
+    console.log('Release verification passed');
+    process.exit(0);
+  }
+
+  console.error('Release verification failed. Missing artifacts:');
+  for (const item of missing) {
+    console.error(`- ${item}`);
+  }
+  process.exit(1);
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/.github/release-state.test.ts
+++ b/.github/release-state.test.ts
@@ -1,0 +1,201 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  extractChangelogSection,
+  loadDockerImages,
+  prereleaseReleaseState,
+  publicDockerTags,
+  stableReleaseState
+} from './release-state.ts';
+
+describe('publicDockerTags', () => {
+  test('maps internal sandbox images to public version tags', () => {
+    const mappings = publicDockerTags('0.12.2', [
+      'sandbox',
+      'sandbox-python',
+      'sandbox-opencode',
+      'sandbox-musl',
+      'sandbox-standalone'
+    ]);
+
+    assert.deepEqual(
+      mappings.map((mapping) => ({ image: mapping.image, tag: mapping.tag })),
+      [
+        { image: 'sandbox', tag: '0.12.2' },
+        { image: 'sandbox-python', tag: '0.12.2-python' },
+        { image: 'sandbox-opencode', tag: '0.12.2-opencode' },
+        { image: 'sandbox-musl', tag: '0.12.2-musl' }
+      ]
+    );
+  });
+
+  test('adds alias tags for mutable prerelease channels', () => {
+    const mappings = publicDockerTags(
+      '0.13.0-next.1.1',
+      ['sandbox', 'sandbox-musl'],
+      'next'
+    );
+
+    assert.deepEqual(
+      mappings.map((mapping) => ({
+        image: mapping.image,
+        tag: mapping.tag,
+        alias: mapping.aliasTag
+      })),
+      [
+        { image: 'sandbox', tag: '0.13.0-next.1.1', alias: 'next' },
+        {
+          image: 'sandbox-musl',
+          tag: '0.13.0-next.1.1-musl',
+          alias: 'next-musl'
+        }
+      ]
+    );
+  });
+
+  test('rejects invalid image names', () => {
+    assert.throws(
+      () => publicDockerTags('0.12.2', ['sandbox', 'not-sandbox']),
+      /Invalid image name: not-sandbox/
+    );
+  });
+});
+
+function withDockerImagesFile(
+  content: string,
+  callback: (root: string) => void
+) {
+  const root = mkdtempSync(join(tmpdir(), 'release-state-'));
+
+  try {
+    writeFileSync(join(root, 'docker-images.txt'), content);
+    callback(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe('loadDockerImages', () => {
+  test('loads image names while ignoring comments and blank lines', () => {
+    withDockerImagesFile(
+      '# generated list\n\nsandbox\r\n  sandbox-python  \n# skip me\nsandbox-musl\n',
+      (root) => {
+        assert.deepEqual(loadDockerImages(root), [
+          'sandbox',
+          'sandbox-python',
+          'sandbox-musl'
+        ]);
+      }
+    );
+  });
+
+  test('rejects invalid image names', () => {
+    withDockerImagesFile('sandbox\nsandbox_bad\n', (root) => {
+      assert.throws(
+        () => loadDockerImages(root),
+        /Invalid image name in docker-images.txt: sandbox_bad/
+      );
+    });
+  });
+
+  test('rejects files with no image names', () => {
+    withDockerImagesFile('\n# no images\n  \n', (root) => {
+      assert.throws(
+        () => loadDockerImages(root),
+        /No images found in docker-images.txt/
+      );
+    });
+  });
+});
+
+describe('extractChangelogSection', () => {
+  test('extracts a single stable version body', () => {
+    const changelog = `# @cloudflare/sandbox\n\n## 0.12.2\n\n### Patch Changes\n\n- Fix thing\n\n## 0.12.1\n\n- Previous\n`;
+
+    assert.equal(
+      extractChangelogSection(changelog, '0.12.2'),
+      '### Patch Changes\n\n- Fix thing'
+    );
+  });
+
+  test('matches complete version headings only', () => {
+    const changelog = `# @cloudflare/sandbox\n\n## 0.12.20\n\n- Wrong version\n\n## 0.12.2\n\n- Right version\n`;
+
+    assert.equal(
+      extractChangelogSection(changelog, '0.12.2'),
+      '- Right version'
+    );
+  });
+});
+
+describe('stableReleaseState', () => {
+  test('constructs stable desired state', () => {
+    const state = stableReleaseState({
+      version: '0.12.2',
+      sourceTag: 'ci-hash',
+      commitSha: 'abc123',
+      images: ['sandbox', 'sandbox-musl'],
+      changelogBody: '### Patch Changes\n\n- Fix thing'
+    });
+
+    assert.equal(state.npmPackage, '@cloudflare/sandbox');
+    assert.equal(state.version, '0.12.2');
+    assert.equal(state.gitTag, '@cloudflare/sandbox@0.12.2');
+    assert.equal(state.npmTag, 'latest');
+    assert.deepEqual(state.releaseAssets, [
+      'sandbox-linux-x64',
+      'sandbox-linux-x64.sha256',
+      'sandbox-linux-x64-musl',
+      'sandbox-linux-x64-musl.sha256'
+    ]);
+  });
+});
+
+describe('prereleaseReleaseState', () => {
+  test('constructs prerelease desired state with source refs and aliases', () => {
+    const state = prereleaseReleaseState({
+      version: '0.13.0-next.1.1',
+      sourceTag: 'ci-hash',
+      npmTag: 'next',
+      dockerAlias: 'next',
+      images: ['sandbox', 'sandbox-musl', 'sandbox-standalone']
+    });
+
+    assert.equal(state.mode, 'prerelease');
+    assert.equal(state.npmPackage, '@cloudflare/sandbox');
+    assert.equal(state.version, '0.13.0-next.1.1');
+    assert.equal(state.sourceTag, 'ci-hash');
+    assert.equal(state.npmTag, 'next');
+    assert.equal(state.dockerAlias, 'next');
+    assert.deepEqual(
+      state.dockerTags.map((mapping) => ({
+        image: mapping.image,
+        sourceTag: mapping.sourceTag,
+        tag: mapping.tag,
+        aliasTag: mapping.aliasTag,
+        sourceRef: mapping.sourceRef
+      })),
+      [
+        {
+          image: 'sandbox',
+          sourceTag: 'ci-hash',
+          tag: '0.13.0-next.1.1',
+          aliasTag: 'next',
+          sourceRef:
+            'registry.cloudflare.com/$CLOUDFLARE_ACCOUNT_ID/sandbox:ci-hash'
+        },
+        {
+          image: 'sandbox-musl',
+          sourceTag: 'ci-hash',
+          tag: '0.13.0-next.1.1-musl',
+          aliasTag: 'next-musl',
+          sourceRef:
+            'registry.cloudflare.com/$CLOUDFLARE_ACCOUNT_ID/sandbox-musl:ci-hash'
+        }
+      ]
+    );
+  });
+});

--- a/.github/release-state.ts
+++ b/.github/release-state.ts
@@ -1,0 +1,177 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export type ReleaseMode = 'stable' | 'prerelease';
+
+export interface DockerTagMapping {
+  image: string;
+  sourceTag: string;
+  tag: string;
+  aliasTag?: string;
+  dockerHubRef: string;
+  cfLibraryRef: string;
+  sourceRef: string;
+}
+
+export interface StableReleaseState {
+  mode: 'stable';
+  npmPackage: '@cloudflare/sandbox';
+  version: string;
+  sourceTag: string;
+  commitSha: string;
+  npmTag: 'latest';
+  gitTag: string;
+  githubReleaseName: string;
+  changelogBody: string;
+  dockerTags: DockerTagMapping[];
+  releaseAssets: string[];
+}
+
+export interface PrereleaseReleaseState {
+  mode: 'prerelease';
+  npmPackage: '@cloudflare/sandbox';
+  version: string;
+  sourceTag: string;
+  npmTag: string;
+  dockerAlias?: string;
+  dockerTags: DockerTagMapping[];
+}
+
+function validateImageName(image: string, source: string): void {
+  if (!/^sandbox(-[a-z0-9]+)*$/.test(image)) {
+    throw new Error(`Invalid image name${source}: ${image}`);
+  }
+}
+
+export function loadDockerImages(root: string): string[] {
+  const content = readFileSync(join(root, 'docker-images.txt'), 'utf8');
+  const images = content
+    .split('\n')
+    .map((line) => line.replace(/\r$/, '').trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#'));
+
+  for (const image of images) {
+    validateImageName(image, ' in docker-images.txt');
+  }
+
+  if (images.length === 0) {
+    throw new Error('No images found in docker-images.txt');
+  }
+
+  return images;
+}
+
+export function publicDockerTags(
+  version: string,
+  images: string[],
+  alias?: string,
+  sourceTag = ''
+): DockerTagMapping[] {
+  for (const image of images) {
+    validateImageName(image, '');
+  }
+
+  return images
+    .filter((image) => image !== 'sandbox-standalone')
+    .map((image) => {
+      const suffix = image.slice('sandbox'.length);
+      const tag = `${version}${suffix}`;
+      const aliasTag = alias ? `${alias}${suffix}` : undefined;
+
+      return {
+        image,
+        sourceTag,
+        tag,
+        aliasTag,
+        dockerHubRef: `docker.io/cloudflare/sandbox:${tag}`,
+        cfLibraryRef: `registry.cloudflare.com/library/sandbox:${tag}`,
+        sourceRef: sourceTag
+          ? `registry.cloudflare.com/$CLOUDFLARE_ACCOUNT_ID/${image}:${sourceTag}`
+          : ''
+      };
+    });
+}
+
+export function extractChangelogSection(
+  changelog: string,
+  version: string
+): string {
+  const headingPattern = new RegExp(
+    `(^|\\n)## ${version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?=\\s*(?:\\n|$))`
+  );
+  const match = headingPattern.exec(changelog);
+
+  if (match === null) {
+    throw new Error(`Could not find changelog section for ${version}`);
+  }
+
+  const start = match.index + match[1].length;
+  const bodyStart = start + match[0].length - match[1].length;
+  const nextHeader = changelog.indexOf('\n## ', bodyStart);
+  const raw =
+    nextHeader === -1
+      ? changelog.slice(bodyStart)
+      : changelog.slice(bodyStart, nextHeader);
+  const body = raw.trim();
+
+  if (body.length === 0) {
+    throw new Error(`Changelog section for ${version} is empty`);
+  }
+
+  return body;
+}
+
+export function stableReleaseState(options: {
+  version: string;
+  sourceTag: string;
+  commitSha: string;
+  images: string[];
+  changelogBody: string;
+}): StableReleaseState {
+  return {
+    mode: 'stable',
+    npmPackage: '@cloudflare/sandbox',
+    version: options.version,
+    sourceTag: options.sourceTag,
+    commitSha: options.commitSha,
+    npmTag: 'latest',
+    gitTag: `@cloudflare/sandbox@${options.version}`,
+    githubReleaseName: `@cloudflare/sandbox@${options.version}`,
+    changelogBody: options.changelogBody,
+    dockerTags: publicDockerTags(
+      options.version,
+      options.images,
+      undefined,
+      options.sourceTag
+    ),
+    releaseAssets: [
+      'sandbox-linux-x64',
+      'sandbox-linux-x64.sha256',
+      'sandbox-linux-x64-musl',
+      'sandbox-linux-x64-musl.sha256'
+    ]
+  };
+}
+
+export function prereleaseReleaseState(options: {
+  version: string;
+  sourceTag: string;
+  npmTag: string;
+  dockerAlias?: string;
+  images: string[];
+}): PrereleaseReleaseState {
+  return {
+    mode: 'prerelease',
+    npmPackage: '@cloudflare/sandbox',
+    version: options.version,
+    sourceTag: options.sourceTag,
+    npmTag: options.npmTag,
+    dockerAlias: options.dockerAlias,
+    dockerTags: publicDockerTags(
+      options.version,
+      options.images,
+      options.dockerAlias,
+      options.sourceTag
+    )
+  };
+}

--- a/.github/release-tooling.md
+++ b/.github/release-tooling.md
@@ -5,7 +5,9 @@ Release workflows keep orchestration in YAML and shared release mechanics in sma
 - `install-crane.sh` installs `crane` for image copying.
 - `login-release-registries.sh` logs in to Docker Hub and the Cloudflare registry.
 - `publish-sandbox-images.sh` copies sandbox image variants from the internal Cloudflare registry to public release tags.
-- `release.yml` is the trusted-publishing entry point for stable and prerelease channels.
+- `release-orchestrator.ts` publishes and verifies stable npm, Docker, CF Registry Library, GitHub Release, and binary assets, plus prerelease npm and Docker channel artifacts.
+- `release.yml` uses Changesets to create Version Packages PRs and the release orchestrator to publish stable artifacts.
+- `reusable-prerelease.yml` uses the release orchestrator to publish and verify prerelease npm dist-tags, Docker Hub images, CF Registry Library images, and moving Docker aliases.
 - `prerelease-channel.ts` computes and applies prerelease channel versions.
 
 Run the targeted release-tooling tests when changing these scripts or release publishing workflow blocks:
@@ -15,3 +17,7 @@ npm run test:release-tools
 ```
 
 These tests are a focused release-tooling check. The default `npm test` path stays scoped to workspace unit tests.
+
+## Release orchestrator
+
+`release-orchestrator.ts` models the desired release state for stable and prerelease artifacts. For stable releases, Changesets still creates Version Packages PRs with changelog and version-file updates, while the orchestrator publishes and verifies npm, Docker Hub, CF Registry Library, GitHub Release, and binary assets. The backfill workflow also converges the full stable desired state, except npm publish is skipped; it resolves the release commit from the existing release tag and requires an explicit release commit SHA before creating a missing tag. For prereleases, the orchestrator publishes and verifies the npm prerelease dist-tag, Docker Hub tags, CF Registry Library tags, and optional moving Docker aliases. Reruns converge missing artifacts instead of depending on whether npm was newly published in the current workflow attempt.

--- a/.github/reusable-prerelease.test.sh
+++ b/.github/reusable-prerelease.test.sh
@@ -25,9 +25,70 @@ assert_step_exports_account_id() {
   fi
 }
 
-assert_step_exports_account_id ".github/workflows/reusable-prerelease.yml" "Publish Docker images to Docker Hub" "      "
-assert_step_exports_account_id ".github/workflows/reusable-prerelease.yml" "Publish Docker images to CF Registry Library" "      "
-assert_step_exports_account_id ".github/workflows/release.yml" "Publish Docker images to Docker Hub" "      "
-assert_step_exports_account_id ".github/workflows/release.yml" "Publish Docker images to CF Registry Library" "      "
-assert_step_exports_account_id ".github/workflows/backfill-release-artifacts.yml" "Publish Docker images to Docker Hub" "      "
-assert_step_exports_account_id ".github/workflows/backfill-release-artifacts.yml" "Publish Docker images to CF Registry Library" "      "
+assert_step_exports_account_id ".github/workflows/reusable-prerelease.yml" "Publish prerelease" "      "
+assert_step_exports_account_id ".github/workflows/release.yml" "Publish stable release" "      "
+assert_step_exports_account_id ".github/workflows/backfill-release-artifacts.yml" "Backfill stable release artifacts" "      "
+
+assert_workflow_contains() {
+  local workflow="$1"
+  local needle="$2"
+  if ! grep -Fq "$needle" "$workflow"; then
+    echo "Workflow $workflow must contain: $needle" >&2
+    return 1
+  fi
+}
+
+assert_workflow_contains ".github/workflows/release.yml" "npx tsx .github/release-orchestrator.ts stable"
+assert_workflow_contains ".github/workflows/release.yml" 'GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}'
+assert_workflow_contains ".github/workflows/release.yml" "for file in .changeset/*.md; do"
+assert_workflow_contains ".github/workflows/release.yml" '[[ "$file" == ".changeset/README.md" ]]'
+assert_workflow_contains ".github/workflows/backfill-release-artifacts.yml" "npx tsx .github/release-orchestrator.ts stable"
+assert_workflow_contains ".github/workflows/backfill-release-artifacts.yml" "fetch-depth: 0"
+assert_workflow_contains ".github/workflows/backfill-release-artifacts.yml" "persist-credentials: true"
+assert_workflow_contains ".github/workflows/backfill-release-artifacts.yml" "release_commit_sha"
+assert_workflow_contains ".github/workflows/backfill-release-artifacts.yml" 'git rev-list -n 1 "$git_tag"'
+assert_workflow_contains ".github/workflows/backfill-release-artifacts.yml" 'Release tag $git_tag is missing; provide release_commit_sha'
+if grep -Fq -- '--commit-sha "${{ github.sha }}"' .github/workflows/backfill-release-artifacts.yml; then
+  echo "Backfill must resolve the release commit instead of passing github.sha" >&2
+  exit 1
+fi
+assert_workflow_contains ".github/workflows/reusable-prerelease.yml" "npx tsx .github/release-orchestrator.ts prerelease"
+
+detect_pending_changesets() {
+  local changeset_dir="$1"
+  local files=()
+  local file
+
+  shopt -s nullglob
+  for file in "$changeset_dir"/*.md; do
+    if [[ "${file##*/}" == "README.md" ]]; then
+      continue
+    fi
+    files+=("$file")
+  done
+
+  if [[ ${#files[@]} -gt 0 ]]; then
+    echo "present=true"
+  else
+    echo "present=false"
+  fi
+}
+
+changeset_test_dir=$(mktemp -d)
+trap 'rm -rf "$changeset_test_dir"' EXIT
+mkdir -p "$changeset_test_dir/.changeset"
+printf '# Changesets\n' > "$changeset_test_dir/.changeset/README.md"
+if [[ "$(detect_pending_changesets "$changeset_test_dir/.changeset")" != "present=false" ]]; then
+  echo "README-only changeset state must not count as pending" >&2
+  exit 1
+fi
+printf -- '---\n"@cloudflare/sandbox": patch\n---\n\nTest changeset\n' > "$changeset_test_dir/.changeset/real.md"
+if [[ "$(detect_pending_changesets "$changeset_test_dir/.changeset")" != "present=true" ]]; then
+  echo "Real changeset markdown must count as pending" >&2
+  exit 1
+fi
+
+if grep -Fq "steps.changesets.outputs.published == 'true'" .github/workflows/release.yml; then
+  echo "Stable release artifacts must not be gated by changesets.outputs.published" >&2
+  exit 1
+fi

--- a/.github/workflows/backfill-release-artifacts.yml
+++ b/.github/workflows/backfill-release-artifacts.yml
@@ -11,21 +11,10 @@ on:
         description: 'Internal registry source tag, for example ci-<docker hash>'
         required: true
         type: string
-      publish_docker_hub:
-        description: 'Copy Docker images to Docker Hub'
-        required: true
-        default: true
-        type: boolean
-      publish_cf_library:
-        description: 'Copy Docker images to CF Registry Library'
-        required: true
-        default: true
-        type: boolean
-      upload_binaries:
-        description: 'Extract standalone binaries and upload them to the GitHub release'
-        required: true
-        default: true
-        type: boolean
+      release_commit_sha:
+        description: 'Release commit SHA, required only if the release tag is missing'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -38,7 +27,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          persist-credentials: false
+          fetch-depth: 0
+          persist-credentials: true
 
       - name: Install crane
         run: .github/install-crane.sh
@@ -51,52 +41,35 @@ jobs:
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
 
-      - name: Publish Docker images to Docker Hub
-        if: ${{ inputs.publish_docker_hub }}
-        run: |
-          .github/publish-sandbox-images.sh \
-            --source-tag "${{ inputs.source_tag }}" \
-            --version "${{ inputs.version }}" \
-            --docker-hub
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - run: npm ci --prefer-offline --no-audit --no-fund
+
+      - name: Backfill stable release artifacts
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-      - name: Publish Docker images to CF Registry Library
-        if: ${{ inputs.publish_cf_library }}
-        run: |
-          .github/publish-sandbox-images.sh \
-            --source-tag "${{ inputs.source_tag }}" \
-            --version "${{ inputs.version }}" \
-            --cf-library
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-      - name: Extract standalone binaries
-        if: ${{ inputs.upload_binaries }}
-        run: |
-          REGISTRY="registry.cloudflare.com/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}"
-          SRC_TAG="${{ inputs.source_tag }}"
-          docker pull "${REGISTRY}/sandbox:${SRC_TAG}"
-          CID=$(docker create "${REGISTRY}/sandbox:${SRC_TAG}")
-          docker cp "$CID":/container-server/sandbox ./sandbox-linux-x64
-          docker rm "$CID"
-          docker pull "${REGISTRY}/sandbox-musl:${SRC_TAG}"
-          CID=$(docker create "${REGISTRY}/sandbox-musl:${SRC_TAG}")
-          docker cp "$CID":/container-server/sandbox ./sandbox-linux-x64-musl
-          docker rm "$CID"
-
-      - name: Upload binaries to GitHub Release
-        if: ${{ inputs.upload_binaries }}
-        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         run: |
-          VERSION="${{ inputs.version }}"
-          sha256sum sandbox-linux-x64 > sandbox-linux-x64.sha256
-          sha256sum sandbox-linux-x64-musl > sandbox-linux-x64-musl.sha256
-          gh release upload "@cloudflare/sandbox@${VERSION}" \
-            ./sandbox-linux-x64 ./sandbox-linux-x64.sha256 \
-            ./sandbox-linux-x64-musl ./sandbox-linux-x64-musl.sha256 \
-            --clobber
+          git_tag="@cloudflare/sandbox@${{ inputs.version }}"
+          release_commit_sha="${{ inputs.release_commit_sha }}"
+
+          if git rev-parse --verify --quiet "refs/tags/${git_tag}" >/dev/null; then
+            release_commit_sha="$(git rev-list -n 1 "$git_tag")"
+          elif [[ -z "$release_commit_sha" ]]; then
+            echo "Release tag $git_tag is missing; provide release_commit_sha to create or converge the tag." >&2
+            exit 1
+          fi
+
+          npx tsx .github/release-orchestrator.ts stable \
+            --version "${{ inputs.version }}" \
+            --source-tag "${{ inputs.source_tag }}" \
+            --commit-sha "$release_commit_sha" \
+            --skip-npm true
 
       - name: Summarize backfill
         run: |
@@ -104,7 +77,5 @@ jobs:
             echo "## Release artifact backfill"
             echo "Version: \`${{ inputs.version }}\`"
             echo "Source tag: \`${{ inputs.source_tag }}\`"
-            echo "Docker Hub: \`${{ inputs.publish_docker_hub }}\`"
-            echo "CF Registry Library: \`${{ inputs.publish_cf_library }}\`"
-            echo "GitHub release binaries: \`${{ inputs.upload_binaries }}\`"
+            echo "Convergence: full stable release state, except npm publish is skipped"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
 
       - uses: actions/setup-node@v6
         with:
@@ -201,16 +201,45 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
+      - name: Detect pending changesets
+        id: pending-changesets
+        run: |
+          shopt -s nullglob
+          files=()
+          for file in .changeset/*.md; do
+            if [[ "$file" == ".changeset/README.md" ]]; then
+              continue
+            fi
+            files+=("$file")
+          done
+          if [[ ${#files[@]} -gt 0 ]]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - id: changesets
+        if: steps.pending-changesets.outputs.present == 'true'
         uses: changesets/action@v1
         with:
           version: npx tsx .github/changeset-version.ts
-          publish: npx tsx .github/changeset-publish.ts
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Publish stable release
+        if: steps.pending-changesets.outputs.present == 'false'
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+        run: |
+          npx tsx .github/release-orchestrator.ts stable \
+            --version "${{ needs.build.outputs.version }}" \
+            --source-tag "ci-${{ needs.hashes.outputs.docker }}" \
+            --commit-sha "${{ github.sha }}"
 
       - name: Update Docker Hub description
+        if: steps.pending-changesets.outputs.present == 'false'
         uses: peter-evans/dockerhub-description@v4
         continue-on-error: true
         with:
@@ -219,73 +248,3 @@ jobs:
           repository: cloudflare/sandbox
           readme-filepath: ./DOCKER_README.md
           short-description: ${{ github.event.repository.description }}
-
-      - name: Publish Docker images to Docker Hub
-        if: steps.changesets.outputs.published == 'true'
-        run: |
-          .github/publish-sandbox-images.sh \
-            --source-tag "ci-${{ needs.hashes.outputs.docker }}" \
-            --version "${{ needs.build.outputs.version }}" \
-            --docker-hub
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-      - name: Publish Docker images to CF Registry Library
-        if: steps.changesets.outputs.published == 'true'
-        continue-on-error: true
-        id: library-publish
-        run: |
-          VERSION="${{ needs.build.outputs.version }}"
-          if ! .github/publish-sandbox-images.sh \
-            --source-tag "ci-${{ needs.hashes.outputs.docker }}" \
-            --version "$VERSION" \
-            --cf-library; then
-            echo "::warning::Some images failed to publish to CF Registry Library"
-            {
-              echo "## ⚠️ CF Registry Library publish partially failed"
-              echo "Some sandbox images could not be copied to \`registry.cloudflare.com/library/\`."
-              echo "Docker Hub publish was not affected."
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-          {
-            echo "## ✅ CF Registry Library publish succeeded"
-            printf "Published \`registry.cloudflare.com/library/sandbox:%s\` (+ variants)\n" "$VERSION"
-          } >> "$GITHUB_STEP_SUMMARY"
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-      - name: Warn if library publish failed
-        if: steps.library-publish.outcome == 'failure'
-        run: |
-          echo "::warning::CF Registry Library publish failed — Docker Hub and npm releases are unaffected"
-
-      - name: Extract standalone binaries
-        if: steps.changesets.outputs.published == 'true'
-        run: |
-          REGISTRY="registry.cloudflare.com/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}"
-          HASH="${{ needs.hashes.outputs.docker }}"
-          SRC_TAG="ci-${HASH}"
-          # Default variant
-          docker pull "${REGISTRY}/sandbox:${SRC_TAG}"
-          CID=$(docker create "${REGISTRY}/sandbox:${SRC_TAG}")
-          docker cp "$CID":/container-server/sandbox ./sandbox-linux-x64
-          docker rm "$CID"
-          # Musl variant
-          docker pull "${REGISTRY}/sandbox-musl:${SRC_TAG}"
-          CID=$(docker create "${REGISTRY}/sandbox-musl:${SRC_TAG}")
-          docker cp "$CID":/container-server/sandbox ./sandbox-linux-x64-musl
-          docker rm "$CID"
-
-      - name: Upload binaries to GitHub Release
-        if: steps.changesets.outputs.published == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION="${{ needs.build.outputs.version }}"
-          sha256sum sandbox-linux-x64 > sandbox-linux-x64.sha256
-          sha256sum sandbox-linux-x64-musl > sandbox-linux-x64-musl.sha256
-          gh release upload "@cloudflare/sandbox@${VERSION}" \
-            ./sandbox-linux-x64 ./sandbox-linux-x64.sha256 \
-            ./sandbox-linux-x64-musl ./sandbox-linux-x64-musl.sha256 \
-            --clobber

--- a/.github/workflows/reusable-prerelease.yml
+++ b/.github/workflows/reusable-prerelease.yml
@@ -209,45 +209,20 @@ jobs:
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
 
-      - name: Publish npm prerelease
-        run: npm publish ./packages/sandbox --tag "${{ needs.version.outputs.channel }}" --access public
+      - name: Publish prerelease
         env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           NPM_CONFIG_PROVENANCE: true
-
-      - name: Publish Docker images to Docker Hub
         run: |
           alias_args=()
           if [[ "${{ inputs.publish_docker_alias }}" == "true" ]]; then
-            alias_args=(--alias "${{ needs.version.outputs.channel }}")
+            alias_args=(--docker-alias "${{ needs.version.outputs.channel }}")
           fi
-          .github/publish-sandbox-images.sh \
-            --source-tag "${{ needs.version.outputs.image_tag }}" \
+          npx tsx .github/release-orchestrator.ts prerelease \
             --version "${{ needs.version.outputs.version }}" \
-            "${alias_args[@]}" \
-            --docker-hub
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-      - name: Publish Docker images to CF Registry Library
-        continue-on-error: true
-        id: library-publish
-        run: |
-          alias_args=()
-          if [[ "${{ inputs.publish_docker_alias }}" == "true" ]]; then
-            alias_args=(--alias "${{ needs.version.outputs.channel }}")
-          fi
-          .github/publish-sandbox-images.sh \
             --source-tag "${{ needs.version.outputs.image_tag }}" \
-            --version "${{ needs.version.outputs.version }}" \
-            "${alias_args[@]}" \
-            --cf-library
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-      - name: Warn if library publish failed
-        if: steps.library-publish.outcome == 'failure'
-        run: |
-          echo "::warning::CF Registry Library publish failed — Docker Hub and npm prereleases are unaffected"
+            --npm-tag "${{ needs.version.outputs.channel }}" \
+            "${alias_args[@]}"
 
       - name: Summarize prerelease
         run: |


### PR DESCRIPTION
Move stable, prerelease, and backfill artifact publishing through a single desired-state orchestrator so a release is "done" only when all required artifacts exist and verify.

## Why

Issue #792: `docker.io/cloudflare/sandbox:0.12.2` was missing after a release. npm had already published, so `changesets.outputs.published` was `false` on the rerun and the workflow skipped Docker image promotion and GitHub Release asset upload. The publish pipeline treated "published in this run" as a proxy for "release is complete", so any partial failure left a permanently incomplete release that reruns could not repair.

## What

Introduce a desired-state release model. Instead of gating artifact work on whether npm was newly published in the current attempt, the orchestrator computes the required end state for a version and converges toward it, creating only the artifacts that are missing:

- `.github/release-state.ts` — declares the required artifacts for a stable or prerelease version (npm dist-tag, registry tags, git tag, GitHub Release, binary assets) as version-aware, verifiable refs.
- `.github/release-command-runner.ts` — `ExecCommandRunner` / `FakeCommandRunner`, plus `verify*`/`converge*` for stable and prerelease. Convergence creates/pushes missing annotated tags, creates/updates GitHub Releases, extracts or generates binary assets, promotes Docker tags, and re-verifies the final state.
- `.github/release-orchestrator.ts` — CLI with `verify-stable`, `verify-prerelease`, `stable`, and `prerelease` commands.

Wire the three workflows to the orchestrator:

- `release.yml` — stable publish converges instead of gating on `changesets.outputs.published`; pending-changeset detection ignores `.changeset/README.md`.
- `reusable-prerelease.yml` — prerelease publish converges; preserves the optional mutable channel alias via `--docker-alias`.
- `backfill-release-artifacts.yml` — now a thin wrapper over the stable orchestrator. It resolves the release commit from the existing tag (`git rev-list -n 1 "$git_tag"`) or requires an explicit `release_commit_sha`, rather than trusting the raw dispatch SHA, and fetches tags with full history plus persisted push credentials.

Changesets still owns Version Packages PRs, version bumps, changelog, and lockfile updates; only publish-time orchestration moved. The now-unused `.github/changeset-publish.ts` is removed.

## Safety / decisions

- Reruns are idempotent: existing correct artifacts are left untouched; only missing ones are created.
- Convergence refuses to proceed when an existing tag or GitHub Release points at the wrong commit, failing before any mutating command runs rather than silently overwriting a released ref.
- Both Docker Hub and `registry.cloudflare.com/library` tags are required by default so a "complete" release is unambiguous.

## Shortcomings / follow-ups

- This is a large single change to the release pipeline; it concentrates release-automation risk, so the first stable release after merge should be watched closely.

## Verification

- `bash .github/test-release-tools.sh`
- `node --import tsx --test .github/release-state.test.ts .github/release-orchestrator.test.ts` (30 tests)
- `actionlint` on all three workflows
- `npm run check`

Closes #792
