### PR TITLE
Skip already released stable versions

### DIFF
--- a/.github/detect-stable-release-needed.sh
+++ b/.github/detect-stable-release-needed.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+version="${1:?version is required}"
+commit_sha="${2:?commit sha is required}"
+git_tag="@cloudflare/sandbox@$version"
+
+if git rev-parse --verify --quiet "refs/tags/$git_tag" >/dev/null; then
+  tag_sha=$(git rev-list -n 1 "$git_tag")
+  echo "tag_sha=$tag_sha"
+
+  if [[ "$tag_sha" == "$commit_sha" ]]; then
+    echo "publish=true"
+    echo "reason=tag_matches_commit"
+    exit 0
+  fi
+
+  echo "Stable release $git_tag already points to $tag_sha, not $commit_sha; skipping publish." >&2
+  echo "publish=false"
+  echo "reason=tag_points_elsewhere"
+  exit 0
+fi
+
+echo "publish=true"
+echo "reason=tag_missing"

--- a/.github/detect-stable-release-needed.test.sh
+++ b/.github/detect-stable-release-needed.test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+script=$(pwd)/.github/detect-stable-release-needed.sh
+repo=$(mktemp -d)
+trap 'rm -rf "$repo"' EXIT
+
+cd "$repo"
+git init >/dev/null
+git config user.email test@example.com
+git config user.name 'Test User'
+
+git commit --allow-empty -m 'Release commit' >/dev/null
+release_sha=$(git rev-parse HEAD)
+git tag '@cloudflare/sandbox@1.0.0'
+
+git commit --allow-empty -m 'Non-version change' >/dev/null
+later_sha=$(git rev-parse HEAD)
+
+matches_output=$(bash "$script" 1.0.0 "$release_sha")
+if ! grep -Fxq 'publish=true' <<<"$matches_output"; then
+  echo 'Existing tag at current commit must publish to converge missing artifacts' >&2
+  exit 1
+fi
+if ! grep -Fxq 'reason=tag_matches_commit' <<<"$matches_output"; then
+  echo 'Expected tag_matches_commit reason' >&2
+  exit 1
+fi
+
+skip_output=$(bash "$script" 1.0.0 "$later_sha")
+if ! grep -Fxq 'publish=false' <<<"$skip_output"; then
+  echo 'Existing tag at another commit must skip publish' >&2
+  exit 1
+fi
+if ! grep -Fxq 'reason=tag_points_elsewhere' <<<"$skip_output"; then
+  echo 'Expected tag_points_elsewhere reason' >&2
+  exit 1
+fi
+if ! grep -Fxq "tag_sha=$release_sha" <<<"$skip_output"; then
+  echo 'Expected output to include the existing tag SHA' >&2
+  exit 1
+fi
+
+missing_output=$(bash "$script" 1.0.1 "$later_sha")
+if ! grep -Fxq 'publish=true' <<<"$missing_output"; then
+  echo 'Missing tag must publish a new release' >&2
+  exit 1
+fi
+if ! grep -Fxq 'reason=tag_missing' <<<"$missing_output"; then
+  echo 'Expected tag_missing reason' >&2
+  exit 1
+fi

--- a/.github/reusable-prerelease.test.sh
+++ b/.github/reusable-prerelease.test.sh
@@ -39,6 +39,8 @@ assert_workflow_contains() {
 }
 
 assert_workflow_contains ".github/workflows/release.yml" "npx tsx .github/release-orchestrator.ts stable"
+assert_workflow_contains ".github/workflows/release.yml" "bash .github/detect-stable-release-needed.sh"
+assert_workflow_contains ".github/workflows/release.yml" "steps.stable-release.outputs.publish == 'true'"
 assert_workflow_contains ".github/workflows/release.yml" 'GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}'
 assert_workflow_contains ".github/workflows/release.yml" "for file in .changeset/*.md; do"
 assert_workflow_contains ".github/workflows/release.yml" '[[ "$file" == ".changeset/README.md" ]]'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,8 +226,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      - name: Publish stable release
+      - name: Detect stable release target
+        id: stable-release
         if: steps.pending-changesets.outputs.present == 'false'
+        run: |
+          bash .github/detect-stable-release-needed.sh \
+            "${{ needs.build.outputs.version }}" \
+            "${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish stable release
+        if: steps.pending-changesets.outputs.present == 'false' && steps.stable-release.outputs.publish == 'true'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -239,7 +247,7 @@ jobs:
             --commit-sha "${{ github.sha }}"
 
       - name: Update Docker Hub description
-        if: steps.pending-changesets.outputs.present == 'false'
+        if: steps.pending-changesets.outputs.present == 'false' && steps.stable-release.outputs.publish == 'true'
         uses: peter-evans/dockerhub-description@v4
         continue-on-error: true
         with:


### PR DESCRIPTION
Skip stable release publishing when the current package version already has a release tag on a different commit.

## Why

The Release workflow runs on every push to `main`, not only on Version Packages merges. After #800 merged, the workflow saw no pending changesets and invoked the stable release orchestrator for the current package version, `0.12.3`, using the #800 merge commit SHA.

That version had already been released by the Version Packages merge. The orchestrator correctly refused to converge `@cloudflare/sandbox@0.12.3` because the existing tag points at `696388b2`, not the later #800 merge commit. The workflow should not have invoked publish for a non-version main push.

## What

Add a small stable-release target detection step before publishing:

- If the version tag is missing, publish/converge the release.
- If the version tag points at the current commit, publish/converge missing artifacts for an idempotent rerun.
- If the version tag points at another commit, skip publish because this main push is not the version release commit.

The Docker Hub description update now follows the same publish decision, so non-version pushes do not perform release-only side effects.

## Verification

- `bash .github/test-release-tools.sh`
- `actionlint .github/workflows/release.yml`
- `npm run check`
