### PR TITLE
Preserve exec thenable methods

### DIFF
--- a/.changeset/preserve-exec-thenable-methods.md
+++ b/.changeset/preserve-exec-thenable-methods.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Fix `sandbox.exec(...).output()` / `.text()` / `.json()` / `.kill()` throwing `TypeError: ... is not a function`. The client-side wrapper that translates platform interruptions was replacing the returned thenable with a bare promise, which stripped the convenience methods the unified `exec()` surface attaches to its result.

--- a/examples/vite-sandbox/src/worker.js
+++ b/examples/vite-sandbox/src/worker.js
@@ -19,9 +19,12 @@ export default {
 async function handleAPISandboxRoute(env) {
   const sandbox = getSandbox(env.Sandbox, 'vite-sandbox');
 
-  const proc = await sandbox.getProcess('vite-dev-server');
+  let proc = await sandbox.getProcess('vite-dev-server');
   if (!proc) {
-    const proc = await sandbox.startProcess('npm run dev', {
+    // Unified exec surface: pass `processId` to make the background process
+    // addressable via `sandbox.getProcess()` on later requests. Replaces the
+    // legacy `sandbox.startProcess()` entrypoint.
+    proc = await sandbox.exec('npm run dev', {
       processId: 'vite-dev-server',
       cwd: '/app',
       env: {

--- a/examples/vite-sandbox/src/worker.js
+++ b/examples/vite-sandbox/src/worker.js
@@ -21,9 +21,8 @@ async function handleAPISandboxRoute(env) {
 
   let proc = await sandbox.getProcess('vite-dev-server');
   if (!proc) {
-    // Unified exec surface: pass `processId` to make the background process
-    // addressable via `sandbox.getProcess()` on later requests. Replaces the
-    // legacy `sandbox.startProcess()` entrypoint.
+    // `processId` makes the background process addressable via
+    // `sandbox.getProcess()` on later requests.
     proc = await sandbox.exec('npm run dev', {
       processId: 'vite-dev-server',
       cwd: '/app',

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -390,9 +390,15 @@ function withSandboxOperationContext<TArgs extends unknown[], TResult>(
         result != null &&
         typeof (result as { then?: unknown }).then === 'function'
       ) {
-        return (result as unknown as Promise<unknown>).catch((error: unknown) =>
-          translatePlatformInterruption(error, operation)
-        ) as TResult;
+        const caught = (result as unknown as Promise<unknown>).catch(
+          (error: unknown) => translatePlatformInterruption(error, operation)
+        );
+        // Preserve any own properties the source thenable attached to itself
+        // (e.g. `SandboxProcessPromise.output` / `.text` / `.json` / `.kill`).
+        // `Promise.prototype.catch` returns a bare promise, so without this
+        // copy those thenable-augmenting methods disappear.
+        Object.assign(caught, result);
+        return caught as TResult;
       }
       return result;
     } catch (error) {


### PR DESCRIPTION
# Summary

Patched `sandbox.exec(...).output()` (and `.text()` / `.json()` / `.kill()`) was throwing `TypeError: ... is not a function.` The client-side error-translation wrapper did a `.catch()` on the returned thenable, which quietly dropped the convenience methods that the unified `exec()` surface attaches to it. Now we copy those own-properties onto the caught promise so the shape survives.
                                          
Also patched `vite-sandbox` example as it still called `sandbox.startProcess(...)`, which went away with the unified exec refactor. Swapped to `sandbox.exec(cmd, { processId, ... })`