### PR TITLE
Port main updates to next

### DIFF
--- a/.agents/skills/changesets/SKILL.md
+++ b/.agents/skills/changesets/SKILL.md
@@ -5,7 +5,7 @@ description: Use when creating a changeset, preparing a release, or bumping vers
 
 # Changesets & Releases
 
-This repository uses [changesets](https://github.com/changesets/changesets) to drive a fully automated release pipeline. Create a changeset whenever your change affects published packages.
+This repository uses [changesets](https://github.com/changesets/changesets) to create Version Packages PRs and maintain changelog/version files. Stable and prerelease artifact publishing are handled by the release orchestrator. Create a changeset whenever your change affects published packages.
 
 ## Creating a Changeset
 
@@ -63,11 +63,10 @@ Releases run via `.github/workflows/release.yml`. There is no manual publishing 
 
 1. Merge a PR that contains a changeset.
 2. The Changesets action opens (or updates) a **"Version Packages"** PR.
-3. Merging the Version Packages PR triggers:
-   1. Version bump in `package.json`
-   2. Docker images crane-copied from the CF registry to Docker Hub and the CF Registry public library (the exact images that passed E2E)
-   3. npm package publish with the bumped version
-   4. Standalone binaries extracted and uploaded to the GitHub Release
+3. Merging the Version Packages PR triggers the stable release workflow.
+4. The release orchestrator publishes and verifies the npm package, Docker Hub images, CF Registry public library images, GitHub Release, and standalone binary assets.
+5. Prerelease workflows also publish through the release orchestrator, which verifies the npm dist-tag, Docker Hub images, CF Registry public library images, and optional moving Docker aliases before succeeding.
+6. Release workflow reruns converge missing artifacts, so Docker images, GitHub releases, binaries, and prerelease aliases are not gated on npm being newly published in the current attempt.
 
 ## Version Synchronization
 

--- a/.changeset/bridge-custom-spans.md
+++ b/.changeset/bridge-custom-spans.md
@@ -1,0 +1,9 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Instrument the bridge API with Cloudflare custom spans. Each endpoint now emits
+a `bridge.<operation>` span annotated with the sandbox ID, container UUID, and
+operation-specific metadata (command, file path, port, session ID, and so on),
+so requests are traceable end to end. Enable tracing with
+`observability.traces.enabled` in your Worker configuration.

--- a/.changeset/clever-sandboxes-label.md
+++ b/.changeset/clever-sandboxes-label.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Add `labels` to `SandboxOptions` so `getSandbox()` can attach Cloudflare Container labels for analytics and observability. Labels are applied on container start; updates while running apply on the next start.

--- a/.changeset/remove-default-session-option.md
+++ b/.changeset/remove-default-session-option.md
@@ -2,6 +2,6 @@
 '@cloudflare/sandbox': minor
 ---
 
-Top-level execution is now stateless by default. `exec()`, `startProcess()`, file, watch, git, and backup calls no longer reuse a hidden default session; pass an explicit `sessionId` or `sandbox.createSession()` when commands need to share shell state. Process reads use `listProcesses({ sessionId })` / `getProcess(id, { sessionId })`, and process kill methods no longer accept signal arguments.
+Top-level execution is now stateless by default. `exec()`, `startProcess()`, file, watch, git, and backup calls no longer reuse a hidden default session; pass an explicit `sessionId` or `sandbox.createSession()` when commands need to share shell state. The temporary `enableDefaultSession` option has been removed from `SandboxOptions`. Process reads use `listProcesses({ sessionId })` / `getProcess(id, { sessionId })`, and process kill methods no longer accept signal arguments.
 
 Streaming command execution has moved to `startProcess()` — `execStream()` and `exec({ stream, onOutput, onComplete, onError, signal })` are removed. Interactive terminals are now explicit resources: use `sandbox.terminal({ id, cwd, shell }).connect(request, { cols, rows })` instead of the removed `ExecutionSession.terminal()`.

--- a/.changeset/warm-pool-batched-scale-up.md
+++ b/.changeset/warm-pool-batched-scale-up.md
@@ -1,0 +1,7 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Fill the warm pool in bounded-parallel batches instead of one container at a
+time, so it primes and recovers far faster after a burst. Tune the batch size
+with `WARM_POOL_SCALE_BATCH_SIZE` (default 5, clamped to 20).

--- a/.changeset/warm-pool-eager-refill.md
+++ b/.changeset/warm-pool-eager-refill.md
@@ -1,0 +1,8 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Refill the warm pool the moment it drains instead of waiting for the next
+background tick. After a burst consumes warm containers, replenishment now
+starts immediately, cutting the latency tail for sandboxes created during
+sustained or back-to-back bursts.

--- a/.changeset/warm-pool-max-instances.md
+++ b/.changeset/warm-pool-max-instances.md
@@ -1,0 +1,9 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Let the warm pool know its instance ceiling up front via the
+`WARM_POOL_MAX_INSTANCES` bridge variable. Set it to match your container's
+`max_instances` so the pool makes correct capacity decisions without first
+crashing into the limit. `0` (the default) preserves the existing auto-learn
+behaviour.

--- a/.github/changeset-publish.ts
+++ b/.github/changeset-publish.ts
@@ -1,8 +1,0 @@
-import { execSync } from 'node:child_process';
-
-execSync('npx tsx ./.github/resolve-workspace-versions.ts', {
-  stdio: 'inherit'
-});
-execSync('npx changeset publish', {
-  stdio: 'inherit'
-});

--- a/.github/detect-stable-release-needed.sh
+++ b/.github/detect-stable-release-needed.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+version="${1:?version is required}"
+commit_sha="${2:?commit sha is required}"
+git_tag="@cloudflare/sandbox@$version"
+
+if git rev-parse --verify --quiet "refs/tags/$git_tag" >/dev/null; then
+  tag_sha=$(git rev-list -n 1 "$git_tag")
+  echo "tag_sha=$tag_sha"
+
+  if [[ "$tag_sha" == "$commit_sha" ]]; then
+    echo "publish=true"
+    echo "reason=tag_matches_commit"
+    exit 0
+  fi
+
+  echo "Stable release $git_tag already points to $tag_sha, not $commit_sha; skipping publish." >&2
+  echo "publish=false"
+  echo "reason=tag_points_elsewhere"
+  exit 0
+fi
+
+echo "publish=true"
+echo "reason=tag_missing"

--- a/.github/detect-stable-release-needed.test.sh
+++ b/.github/detect-stable-release-needed.test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+script=$(pwd)/.github/detect-stable-release-needed.sh
+repo=$(mktemp -d)
+trap 'rm -rf "$repo"' EXIT
+
+cd "$repo"
+git init >/dev/null
+git config user.email test@example.com
+git config user.name 'Test User'
+
+git commit --allow-empty -m 'Release commit' >/dev/null
+release_sha=$(git rev-parse HEAD)
+git tag '@cloudflare/sandbox@1.0.0'
+
+git commit --allow-empty -m 'Non-version change' >/dev/null
+later_sha=$(git rev-parse HEAD)
+
+matches_output=$(bash "$script" 1.0.0 "$release_sha")
+if ! grep -Fxq 'publish=true' <<<"$matches_output"; then
+  echo 'Existing tag at current commit must publish to converge missing artifacts' >&2
+  exit 1
+fi
+if ! grep -Fxq 'reason=tag_matches_commit' <<<"$matches_output"; then
+  echo 'Expected tag_matches_commit reason' >&2
+  exit 1
+fi
+
+skip_output=$(bash "$script" 1.0.0 "$later_sha")
+if ! grep -Fxq 'publish=false' <<<"$skip_output"; then
+  echo 'Existing tag at another commit must skip publish' >&2
+  exit 1
+fi
+if ! grep -Fxq 'reason=tag_points_elsewhere' <<<"$skip_output"; then
+  echo 'Expected tag_points_elsewhere reason' >&2
+  exit 1
+fi
+if ! grep -Fxq "tag_sha=$release_sha" <<<"$skip_output"; then
+  echo 'Expected output to include the existing tag SHA' >&2
+  exit 1
+fi
+
+missing_output=$(bash "$script" 1.0.1 "$later_sha")
+if ! grep -Fxq 'publish=true' <<<"$missing_output"; then
+  echo 'Missing tag must publish a new release' >&2
+  exit 1
+fi
+if ! grep -Fxq 'reason=tag_missing' <<<"$missing_output"; then
+  echo 'Expected tag_missing reason' >&2
+  exit 1
+fi

--- a/.github/release-command-runner.ts
+++ b/.github/release-command-runner.ts
@@ -1,0 +1,595 @@
+import { execFileSync } from 'node:child_process';
+import type {
+  PrereleaseReleaseState,
+  StableReleaseState
+} from './release-state.ts';
+
+export interface CommandRunner {
+  exists(ref: string): Promise<boolean>;
+  text(command: string, args: string[]): Promise<string>;
+  run(command: string, args: string[]): Promise<void>;
+}
+
+export interface VerificationResult {
+  ok: boolean;
+  missing: string[];
+}
+
+export class ExecCommandRunner implements CommandRunner {
+  async exists(ref: string): Promise<boolean> {
+    const [kind, value] = splitRef(ref);
+
+    try {
+      if (kind === 'docker') {
+        execFileSync('crane', ['manifest', value], { stdio: 'ignore' });
+        return true;
+      }
+
+      if (kind === 'npm') {
+        execFileSync('npm', ['view', value, 'version'], { stdio: 'ignore' });
+        return true;
+      }
+
+      if (kind === 'npm-dist-tag') {
+        return npmDistTagExists(value);
+      }
+
+      if (kind === 'git-tag') {
+        execFileSync('git', ['rev-parse', '--verify', `refs/tags/${value}`], {
+          stdio: 'ignore'
+        });
+        return true;
+      }
+
+      if (kind === 'github-release') {
+        execFileSync('gh', ['release', 'view', value], { stdio: 'ignore' });
+        return true;
+      }
+
+      if (kind === 'github-release-tag') {
+        return githubReleaseTagMatches(value);
+      }
+
+      if (kind === 'github-asset') {
+        return githubAssetExists(value);
+      }
+    } catch {
+      return false;
+    }
+
+    throw new Error(`Unknown ref kind: ${kind}`);
+  }
+
+  async text(command: string, args: string[]): Promise<string> {
+    return execFileSync(command, args, { encoding: 'utf8' });
+  }
+
+  async run(command: string, args: string[]): Promise<void> {
+    execFileSync(command, args, { stdio: 'inherit' });
+  }
+}
+
+export class FakeCommandRunner implements CommandRunner {
+  readonly commands: string[][] = [];
+
+  constructor(
+    private readonly options: {
+      presentRefs: Set<string>;
+      textByCommand?: Map<string, string>;
+    }
+  ) {}
+
+  async exists(ref: string): Promise<boolean> {
+    return this.options.presentRefs.has(ref);
+  }
+
+  async text(command: string, args: string[]): Promise<string> {
+    this.commands.push([command, ...args]);
+    return this.options.textByCommand?.get([command, ...args].join(' ')) ?? '';
+  }
+
+  async run(command: string, args: string[]): Promise<void> {
+    this.commands.push([command, ...args]);
+    this.recordCreatedRef(command, args);
+  }
+
+  private recordCreatedRef(command: string, args: string[]): void {
+    if (command === 'crane' && args[0] === 'copy') {
+      this.options.presentRefs.add(`docker:${args[2]}`);
+      return;
+    }
+
+    if (command === 'npm' && args[0] === 'dist-tag' && args[1] === 'add') {
+      const [pkg, version] = args[2].split('@').filter(Boolean);
+      const packageVersion = version ?? pkg;
+      this.options.presentRefs.add(`npm:@cloudflare/sandbox@${packageVersion}`);
+      this.options.presentRefs.add(`npm-dist-tag:${args[3]}=${packageVersion}`);
+      return;
+    }
+
+    if (command === 'git' && args[0] === 'tag' && args[1] === '-a') {
+      this.options.presentRefs.add(`git-tag:${args[2]}`);
+      return;
+    }
+
+    if (command === 'gh' && args[0] === 'release' && args[1] === 'create') {
+      this.options.presentRefs.add(`github-release:${args[2]}`);
+      this.options.presentRefs.add(`github-release-tag:${args[2]}=${args[2]}`);
+      return;
+    }
+
+    if (command === 'gh' && args[0] === 'release' && args[1] === 'upload') {
+      const releaseName = args[2];
+      for (const asset of args.slice(3).filter((arg) => arg !== '--clobber')) {
+        this.options.presentRefs.add(
+          `github-asset:${releaseName}:${asset.replace(/^\.\//, '')}`
+        );
+      }
+    }
+  }
+}
+
+export interface StableConvergenceOptions {
+  skipNpm?: boolean;
+  cloudflareAccountId?: string;
+}
+
+export interface PrereleaseConvergenceOptions {
+  skipNpm?: boolean;
+  cloudflareAccountId?: string;
+}
+
+export async function convergePrereleaseRelease(
+  state: PrereleaseReleaseState,
+  runner: CommandRunner,
+  options: PrereleaseConvergenceOptions = {}
+): Promise<void> {
+  if (!options.skipNpm) {
+    if (!(await runner.exists(`npm:${state.npmPackage}@${state.version}`))) {
+      await runner.run('npx', ['tsx', '.github/resolve-workspace-versions.ts']);
+      await runner.run('npm', [
+        'publish',
+        './packages/sandbox',
+        '--tag',
+        state.npmTag,
+        '--access',
+        'public'
+      ]);
+    }
+
+    if (
+      !(await runner.exists(`npm-dist-tag:${state.npmTag}=${state.version}`))
+    ) {
+      await runner.run('npm', [
+        'dist-tag',
+        'add',
+        `${state.npmPackage}@${state.version}`,
+        state.npmTag
+      ]);
+    }
+  }
+
+  const resolveSourceRef = createSourceRefResolver(options.cloudflareAccountId);
+
+  for (const mapping of state.dockerTags) {
+    let sourceRef: string | undefined;
+    const resolvedSourceRef = (): string => {
+      sourceRef ??= resolveSourceRef(mapping.sourceRef);
+      return sourceRef;
+    };
+
+    if (!(await runner.exists(`docker:${mapping.dockerHubRef}`))) {
+      await runner.run('crane', [
+        'copy',
+        resolvedSourceRef(),
+        mapping.dockerHubRef
+      ]);
+    }
+
+    if (!(await runner.exists(`docker:${mapping.cfLibraryRef}`))) {
+      await runner.run('crane', [
+        'copy',
+        resolvedSourceRef(),
+        mapping.cfLibraryRef
+      ]);
+    }
+
+    if (mapping.aliasTag !== undefined) {
+      await runner.run('crane', [
+        'copy',
+        resolvedSourceRef(),
+        `docker.io/cloudflare/sandbox:${mapping.aliasTag}`
+      ]);
+      await runner.run('crane', [
+        'copy',
+        resolvedSourceRef(),
+        `registry.cloudflare.com/library/sandbox:${mapping.aliasTag}`
+      ]);
+    }
+  }
+
+  const result = await verifyPrereleaseRelease(state, runner);
+  if (!result.ok) {
+    throw new Error(
+      `Prerelease convergence failed. Missing artifacts:\n${result.missing.join('\n')}`
+    );
+  }
+}
+
+export async function convergeStableRelease(
+  state: StableReleaseState,
+  runner: CommandRunner,
+  options: StableConvergenceOptions = {}
+): Promise<void> {
+  if (!options.skipNpm) {
+    if (!(await runner.exists(`npm:${state.npmPackage}@${state.version}`))) {
+      await runner.run('npx', ['tsx', '.github/resolve-workspace-versions.ts']);
+      await runner.run('npm', [
+        'publish',
+        './packages/sandbox',
+        '--access',
+        'public'
+      ]);
+    }
+
+    if (
+      !(await runner.exists(`npm-dist-tag:${state.npmTag}=${state.version}`))
+    ) {
+      await runner.run('npm', [
+        'dist-tag',
+        'add',
+        `${state.npmPackage}@${state.version}`,
+        state.npmTag
+      ]);
+    }
+  }
+
+  await convergeGitTag(state, runner);
+  await convergeGitHubRelease(state, runner);
+
+  const resolveSourceRef = createSourceRefResolver(options.cloudflareAccountId);
+
+  for (const mapping of state.dockerTags) {
+    let sourceRef: string | undefined;
+    const resolvedSourceRef = (): string => {
+      sourceRef ??= resolveSourceRef(mapping.sourceRef);
+      return sourceRef;
+    };
+
+    if (!(await runner.exists(`docker:${mapping.dockerHubRef}`))) {
+      await runner.run('crane', [
+        'copy',
+        resolvedSourceRef(),
+        mapping.dockerHubRef
+      ]);
+    }
+
+    if (!(await runner.exists(`docker:${mapping.cfLibraryRef}`))) {
+      await runner.run('crane', [
+        'copy',
+        resolvedSourceRef(),
+        mapping.cfLibraryRef
+      ]);
+    }
+  }
+
+  const missingAssets: string[] = [];
+  for (const asset of state.releaseAssets) {
+    if (
+      !(await runner.exists(`github-asset:${state.githubReleaseName}:${asset}`))
+    ) {
+      missingAssets.push(asset);
+    }
+  }
+
+  if (missingAssets.length > 0) {
+    await extractStableReleaseAssets(
+      state,
+      runner,
+      createSourceRefResolver(options.cloudflareAccountId)
+    );
+
+    await runner.run('gh', [
+      'release',
+      'upload',
+      state.githubReleaseName,
+      ...missingAssets.flatMap((asset) => [`./${asset}`]),
+      '--clobber'
+    ]);
+  }
+
+  const result = await verifyStableRelease(state, runner);
+  if (!result.ok) {
+    throw new Error(
+      `Stable release convergence failed. Missing artifacts:\n${result.missing.join('\n')}`
+    );
+  }
+}
+
+export async function verifyStableRelease(
+  state: StableReleaseState,
+  runner: CommandRunner
+): Promise<VerificationResult> {
+  const refs = [
+    `npm:${state.npmPackage}@${state.version}`,
+    `npm-dist-tag:${state.npmTag}=${state.version}`,
+    `git-tag:${state.gitTag}`,
+    `github-release:${state.githubReleaseName}`,
+    `github-release-tag:${state.githubReleaseName}=${state.gitTag}`,
+    ...state.dockerTags.flatMap((mapping) => [
+      `docker:${mapping.dockerHubRef}`,
+      `docker:${mapping.cfLibraryRef}`
+    ]),
+    ...state.releaseAssets.map(
+      (asset) => `github-asset:${state.githubReleaseName}:${asset}`
+    )
+  ];
+
+  return verifyRefs(refs, runner);
+}
+
+export async function verifyPrereleaseRelease(
+  state: PrereleaseReleaseState,
+  runner: CommandRunner
+): Promise<VerificationResult> {
+  const dockerRefs = state.dockerTags.flatMap((mapping) => {
+    const refs = [
+      `docker:${mapping.dockerHubRef}`,
+      `docker:${mapping.cfLibraryRef}`
+    ];
+
+    if (mapping.aliasTag !== undefined) {
+      refs.push(`docker:docker.io/cloudflare/sandbox:${mapping.aliasTag}`);
+      refs.push(
+        `docker:registry.cloudflare.com/library/sandbox:${mapping.aliasTag}`
+      );
+    }
+
+    return refs;
+  });
+
+  return verifyRefs(
+    [
+      `npm:${state.npmPackage}@${state.version}`,
+      `npm-dist-tag:${state.npmTag}=${state.version}`,
+      ...dockerRefs
+    ],
+    runner
+  );
+}
+
+async function convergeGitTag(
+  state: StableReleaseState,
+  runner: CommandRunner
+): Promise<void> {
+  if (await runner.exists(`git-tag:${state.gitTag}`)) {
+    const taggedCommit = (
+      await runner.text('git', ['rev-list', '-n', '1', state.gitTag])
+    ).trim();
+
+    if (taggedCommit.length > 0 && taggedCommit !== state.commitSha) {
+      throw new Error(
+        `Git tag ${state.gitTag} points to ${taggedCommit}, expected ${state.commitSha}`
+      );
+    }
+    return;
+  }
+
+  await runner.run('git', [
+    'tag',
+    '-a',
+    state.gitTag,
+    state.commitSha,
+    '-m',
+    state.gitTag
+  ]);
+  await runner.run('git', ['push', 'origin', state.gitTag]);
+}
+
+async function extractStableReleaseAssets(
+  state: StableReleaseState,
+  runner: CommandRunner,
+  resolveSourceRef: (sourceRef: string) => string
+): Promise<void> {
+  const normal = requiredDockerMapping(state, 'sandbox');
+  const musl = requiredDockerMapping(state, 'sandbox-musl');
+
+  await extractStableReleaseAsset(
+    runner,
+    resolveSourceRef(normal.sourceRef),
+    './sandbox-linux-x64'
+  );
+  await extractStableReleaseAsset(
+    runner,
+    resolveSourceRef(musl.sourceRef),
+    './sandbox-linux-x64-musl'
+  );
+  await runner.run('sh', [
+    '-c',
+    'sha256sum sandbox-linux-x64 > sandbox-linux-x64.sha256'
+  ]);
+  await runner.run('sh', [
+    '-c',
+    'sha256sum sandbox-linux-x64-musl > sandbox-linux-x64-musl.sha256'
+  ]);
+}
+
+async function extractStableReleaseAsset(
+  runner: CommandRunner,
+  sourceRef: string,
+  outputPath: string
+): Promise<void> {
+  await runner.run('docker', ['pull', sourceRef]);
+  const containerId = (
+    await runner.text('docker', ['create', sourceRef])
+  ).trim();
+  await runner.run('docker', [
+    'cp',
+    `${containerId}:/container-server/sandbox`,
+    outputPath
+  ]);
+  await runner.run('docker', ['rm', containerId]);
+}
+
+function createSourceRefResolver(
+  cloudflareAccountId = process.env.CLOUDFLARE_ACCOUNT_ID
+): (sourceRef: string) => string {
+  return (sourceRef: string) => {
+    const accountId = cloudflareAccountId?.trim();
+
+    if (accountId === undefined || accountId.length === 0) {
+      throw new Error(
+        'CLOUDFLARE_ACCOUNT_ID is required to resolve Docker source image refs'
+      );
+    }
+
+    return sourceRef.replace('$CLOUDFLARE_ACCOUNT_ID', accountId);
+  };
+}
+
+function requiredDockerMapping(
+  state: StableReleaseState,
+  image: string
+): StableReleaseState['dockerTags'][number] {
+  const mapping = state.dockerTags.find((item) => item.image === image);
+
+  if (mapping === undefined) {
+    throw new Error(`Stable release assets require Docker image: ${image}`);
+  }
+
+  return mapping;
+}
+
+async function convergeGitHubRelease(
+  state: StableReleaseState,
+  runner: CommandRunner
+): Promise<void> {
+  if (await runner.exists(`github-release:${state.githubReleaseName}`)) {
+    if (
+      !(await runner.exists(
+        `github-release-tag:${state.githubReleaseName}=${state.gitTag}`
+      ))
+    ) {
+      throw new Error(
+        `GitHub Release ${state.githubReleaseName} is not attached to expected tag ${state.gitTag}`
+      );
+    }
+    return;
+  }
+
+  await runner.run('gh', [
+    'release',
+    'create',
+    state.githubReleaseName,
+    '--target',
+    state.commitSha,
+    '--title',
+    state.githubReleaseName,
+    '--notes',
+    state.changelogBody
+  ]);
+}
+
+async function verifyRefs(
+  refs: string[],
+  runner: CommandRunner
+): Promise<VerificationResult> {
+  const missing: string[] = [];
+
+  for (const ref of refs) {
+    if (!(await runner.exists(ref))) {
+      missing.push(ref);
+    }
+  }
+
+  return { ok: missing.length === 0, missing };
+}
+
+function splitRef(ref: string): [string, string] {
+  const index = ref.indexOf(':');
+
+  if (index === -1) {
+    throw new Error(`Invalid ref: ${ref}`);
+  }
+
+  return [ref.slice(0, index), ref.slice(index + 1)];
+}
+
+function npmDistTagExists(value: string): boolean {
+  const [tag, version] = splitDistTagRef(value);
+  const output = execFileSync(
+    'npm',
+    ['dist-tag', 'ls', '@cloudflare/sandbox'],
+    {
+      encoding: 'utf8'
+    }
+  );
+
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .some((line) => line === `${tag}: ${version}`);
+}
+
+function splitDistTagRef(value: string): [string, string] {
+  const index = value.indexOf('=');
+
+  if (index === -1) {
+    throw new Error(`Invalid npm dist-tag ref: ${value}`);
+  }
+
+  return [value.slice(0, index), value.slice(index + 1)];
+}
+
+function githubReleaseTagMatches(value: string): boolean {
+  const [releaseName, tagName] = splitGitHubReleaseTagRef(value);
+  const output = execFileSync(
+    'gh',
+    ['release', 'view', releaseName, '--json', 'tagName', '--jq', '.tagName'],
+    { encoding: 'utf8' }
+  );
+
+  return output.trim() === tagName;
+}
+
+function githubAssetExists(value: string): boolean {
+  const [releaseName, assetName] = splitGitHubAssetRef(value);
+  const output = execFileSync(
+    'gh',
+    [
+      'release',
+      'view',
+      releaseName,
+      '--json',
+      'assets',
+      '--jq',
+      '.assets[].name'
+    ],
+    { encoding: 'utf8' }
+  );
+
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .includes(assetName);
+}
+
+function splitGitHubAssetRef(value: string): [string, string] {
+  const index = value.lastIndexOf(':');
+
+  if (index === -1) {
+    throw new Error(`Invalid GitHub asset ref: ${value}`);
+  }
+
+  return [value.slice(0, index), value.slice(index + 1)];
+}
+
+function splitGitHubReleaseTagRef(value: string): [string, string] {
+  const index = value.lastIndexOf('=');
+
+  if (index === -1) {
+    throw new Error(`Invalid GitHub release tag ref: ${value}`);
+  }
+
+  return [value.slice(0, index), value.slice(index + 1)];
+}

--- a/.github/release-orchestrator.test.ts
+++ b/.github/release-orchestrator.test.ts
@@ -1,0 +1,531 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { prereleaseReleaseState, stableReleaseState } from './release-state.ts';
+import {
+  convergePrereleaseRelease,
+  convergeStableRelease,
+  ExecCommandRunner,
+  FakeCommandRunner,
+  verifyPrereleaseRelease,
+  verifyStableRelease
+} from './release-command-runner.ts';
+import { parseCliArgs } from './release-orchestrator.ts';
+
+describe('ExecCommandRunner', () => {
+  test('recognizes lightweight and annotated git tags as existing tags', async () => {
+    const originalCwd = process.cwd();
+    const repoDir = mkdtempSync(join(tmpdir(), 'sandbox-release-tags-'));
+
+    try {
+      process.chdir(repoDir);
+      execFileSync('git', ['init'], { stdio: 'ignore' });
+      execFileSync('git', ['config', 'user.email', 'test@example.com']);
+      execFileSync('git', ['config', 'user.name', 'Test User']);
+      execFileSync('git', ['commit', '--allow-empty', '-m', 'Initial commit'], {
+        stdio: 'ignore'
+      });
+      execFileSync('git', ['tag', 'lightweight-tag']);
+      execFileSync('git', [
+        'tag',
+        '-a',
+        'annotated-tag',
+        '-m',
+        'annotated-tag'
+      ]);
+
+      const runner = new ExecCommandRunner();
+
+      assert.equal(await runner.exists('git-tag:lightweight-tag'), true);
+      assert.equal(await runner.exists('git-tag:annotated-tag'), true);
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  test('surfaces unknown ref kinds instead of reporting them missing', async () => {
+    const runner = new ExecCommandRunner();
+
+    await assert.rejects(
+      runner.exists('bogus:some-value'),
+      /Unknown ref kind: bogus/
+    );
+  });
+});
+
+describe('verifyStableRelease', () => {
+  test('reports missing stable artifacts with exact refs', async () => {
+    const state = stableReleaseState({
+      version: '0.12.2',
+      sourceTag: 'ci-hash',
+      commitSha: 'abc123',
+      images: ['sandbox', 'sandbox-musl'],
+      changelogBody: '### Patch Changes\n\n- Fix thing'
+    });
+    const runner = new FakeCommandRunner({ presentRefs: new Set() });
+
+    const result = await verifyStableRelease(state, runner);
+
+    assert.equal(result.ok, false);
+    assert.deepEqual(
+      result.missing.sort(),
+      [
+        'docker:docker.io/cloudflare/sandbox:0.12.2',
+        'docker:docker.io/cloudflare/sandbox:0.12.2-musl',
+        'docker:registry.cloudflare.com/library/sandbox:0.12.2',
+        'docker:registry.cloudflare.com/library/sandbox:0.12.2-musl',
+        'github-asset:@cloudflare/sandbox@0.12.2:sandbox-linux-x64',
+        'github-asset:@cloudflare/sandbox@0.12.2:sandbox-linux-x64-musl',
+        'github-asset:@cloudflare/sandbox@0.12.2:sandbox-linux-x64-musl.sha256',
+        'github-asset:@cloudflare/sandbox@0.12.2:sandbox-linux-x64.sha256',
+        'github-release-tag:@cloudflare/sandbox@0.12.2=@cloudflare/sandbox@0.12.2',
+        'github-release:@cloudflare/sandbox@0.12.2',
+        'git-tag:@cloudflare/sandbox@0.12.2',
+        'npm:@cloudflare/sandbox@0.12.2',
+        'npm-dist-tag:latest=0.12.2'
+      ].sort()
+    );
+  });
+});
+
+describe('parseCliArgs', () => {
+  test('parses verify-stable args', () => {
+    assert.deepEqual(
+      parseCliArgs([
+        'verify-stable',
+        '--version',
+        '0.12.2',
+        '--source-tag',
+        'ci-hash',
+        '--commit-sha',
+        'abc123'
+      ]),
+      {
+        command: 'verify-stable',
+        version: '0.12.2',
+        sourceTag: 'ci-hash',
+        commitSha: 'abc123'
+      }
+    );
+  });
+
+  test('parses stable args with skip npm', () => {
+    assert.deepEqual(
+      parseCliArgs([
+        'stable',
+        '--version',
+        '0.12.2',
+        '--source-tag',
+        'ci-hash',
+        '--commit-sha',
+        'abc123',
+        '--skip-npm',
+        'true'
+      ]),
+      {
+        command: 'stable',
+        version: '0.12.2',
+        sourceTag: 'ci-hash',
+        commitSha: 'abc123',
+        skipNpm: true
+      }
+    );
+  });
+
+  test('parses stable args with skip npm flag', () => {
+    assert.deepEqual(
+      parseCliArgs([
+        'stable',
+        '--version',
+        '0.12.2',
+        '--source-tag',
+        'ci-hash',
+        '--commit-sha',
+        'abc123',
+        '--skip-npm'
+      ]),
+      {
+        command: 'stable',
+        version: '0.12.2',
+        sourceTag: 'ci-hash',
+        commitSha: 'abc123',
+        skipNpm: true
+      }
+    );
+  });
+
+  test('parses prerelease args with optional docker alias', () => {
+    assert.deepEqual(
+      parseCliArgs([
+        'prerelease',
+        '--version',
+        '0.13.0-next.1.1',
+        '--source-tag',
+        'prerelease-next-0.13.0-next.1.1',
+        '--npm-tag',
+        'next',
+        '--docker-alias',
+        'next'
+      ]),
+      {
+        command: 'prerelease',
+        version: '0.13.0-next.1.1',
+        sourceTag: 'prerelease-next-0.13.0-next.1.1',
+        npmTag: 'next',
+        dockerAlias: 'next'
+      }
+    );
+  });
+
+  test('parses verify-prerelease args with optional docker alias', () => {
+    assert.deepEqual(
+      parseCliArgs([
+        'verify-prerelease',
+        '--version',
+        '0.13.0-next.1.1',
+        '--source-tag',
+        'prerelease-next-0.13.0-next.1.1',
+        '--npm-tag',
+        'next',
+        '--docker-alias',
+        'next'
+      ]),
+      {
+        command: 'verify-prerelease',
+        version: '0.13.0-next.1.1',
+        sourceTag: 'prerelease-next-0.13.0-next.1.1',
+        npmTag: 'next',
+        dockerAlias: 'next'
+      }
+    );
+  });
+
+  test('requires source tag', () => {
+    assert.throws(
+      () =>
+        parseCliArgs([
+          'verify-stable',
+          '--version',
+          '0.12.2',
+          '--commit-sha',
+          'abc123'
+        ]),
+      /--source-tag is required/
+    );
+  });
+});
+
+describe('convergeStableRelease', () => {
+  test('throws before changing commands when existing tag points elsewhere', async () => {
+    const state = stableReleaseState({
+      version: '0.12.2',
+      sourceTag: 'ci-hash',
+      commitSha: 'abc123',
+      images: ['sandbox', 'sandbox-musl'],
+      changelogBody: '### Patch Changes\n\n- Fix thing'
+    });
+    const runner = new FakeCommandRunner({
+      textByCommand: new Map([
+        ['git rev-list -n 1 @cloudflare/sandbox@0.12.2', 'def456\n']
+      ]),
+      presentRefs: new Set([
+        'npm:@cloudflare/sandbox@0.12.2',
+        'npm-dist-tag:latest=0.12.2',
+        'git-tag:@cloudflare/sandbox@0.12.2'
+      ])
+    });
+
+    await assert.rejects(
+      convergeStableRelease(state, runner, { skipNpm: true }),
+      /Git tag @cloudflare\/sandbox@0\.12\.2 points to def456, expected abc123/
+    );
+    assert.deepEqual(runner.commands, [
+      ['git', 'rev-list', '-n', '1', '@cloudflare/sandbox@0.12.2']
+    ]);
+  });
+
+  test('pushes a newly-created annotated tag before creating release', async () => {
+    const state = stableReleaseState({
+      version: '0.12.2',
+      sourceTag: 'ci-hash',
+      commitSha: 'abc123',
+      images: ['sandbox', 'sandbox-musl'],
+      changelogBody: '### Patch Changes\n\n- Fix thing'
+    });
+    const runner = new FakeCommandRunner({
+      presentRefs: new Set([
+        'npm:@cloudflare/sandbox@0.12.2',
+        'npm-dist-tag:latest=0.12.2',
+        'docker:docker.io/cloudflare/sandbox:0.12.2',
+        'docker:docker.io/cloudflare/sandbox:0.12.2-musl',
+        'docker:registry.cloudflare.com/library/sandbox:0.12.2',
+        'docker:registry.cloudflare.com/library/sandbox:0.12.2-musl',
+        'github-asset:@cloudflare/sandbox@0.12.2:sandbox-linux-x64',
+        'github-asset:@cloudflare/sandbox@0.12.2:sandbox-linux-x64.sha256',
+        'github-asset:@cloudflare/sandbox@0.12.2:sandbox-linux-x64-musl',
+        'github-asset:@cloudflare/sandbox@0.12.2:sandbox-linux-x64-musl.sha256'
+      ])
+    });
+
+    await convergeStableRelease(state, runner, { skipNpm: true });
+
+    assert.deepEqual(runner.commands, [
+      [
+        'git',
+        'tag',
+        '-a',
+        '@cloudflare/sandbox@0.12.2',
+        'abc123',
+        '-m',
+        '@cloudflare/sandbox@0.12.2'
+      ],
+      ['git', 'push', 'origin', '@cloudflare/sandbox@0.12.2'],
+      [
+        'gh',
+        'release',
+        'create',
+        '@cloudflare/sandbox@0.12.2',
+        '--target',
+        'abc123',
+        '--title',
+        '@cloudflare/sandbox@0.12.2',
+        '--notes',
+        '### Patch Changes\n\n- Fix thing'
+      ]
+    ]);
+  });
+
+  test('throws when an existing GitHub Release targets the wrong tag', async () => {
+    const state = stableReleaseState({
+      version: '0.12.2',
+      sourceTag: 'ci-hash',
+      commitSha: 'abc123',
+      images: ['sandbox', 'sandbox-musl'],
+      changelogBody: '### Patch Changes\n\n- Fix thing'
+    });
+    const runner = new FakeCommandRunner({
+      textByCommand: new Map([
+        ['git rev-list -n 1 @cloudflare/sandbox@0.12.2', 'abc123\n']
+      ]),
+      presentRefs: new Set([
+        'npm:@cloudflare/sandbox@0.12.2',
+        'npm-dist-tag:latest=0.12.2',
+        'git-tag:@cloudflare/sandbox@0.12.2',
+        'github-release:@cloudflare/sandbox@0.12.2'
+      ])
+    });
+
+    await assert.rejects(
+      convergeStableRelease(state, runner, { skipNpm: true }),
+      /GitHub Release @cloudflare\/sandbox@0\.12\.2 is not attached to expected tag @cloudflare\/sandbox@0\.12\.2/
+    );
+  });
+
+  test('copies missing docker tags and uploads stable assets', async () => {
+    const state = stableReleaseState({
+      version: '0.12.2',
+      sourceTag: 'ci-hash',
+      commitSha: 'abc123',
+      images: ['sandbox', 'sandbox-musl'],
+      changelogBody: '### Patch Changes\n\n- Fix thing'
+    });
+    const runner = new FakeCommandRunner({
+      textByCommand: new Map([
+        ['git rev-list -n 1 @cloudflare/sandbox@0.12.2', 'abc123\n'],
+        [
+          'docker create registry.cloudflare.com/cf-account-123/sandbox:ci-hash',
+          'normal-container\n'
+        ],
+        [
+          'docker create registry.cloudflare.com/cf-account-123/sandbox-musl:ci-hash',
+          'musl-container\n'
+        ]
+      ]),
+      presentRefs: new Set([
+        'npm:@cloudflare/sandbox@0.12.2',
+        'npm-dist-tag:latest=0.12.2',
+        'git-tag:@cloudflare/sandbox@0.12.2',
+        'github-release:@cloudflare/sandbox@0.12.2',
+        'github-release-tag:@cloudflare/sandbox@0.12.2=@cloudflare/sandbox@0.12.2'
+      ])
+    });
+
+    await convergeStableRelease(state, runner, {
+      skipNpm: true,
+      cloudflareAccountId: 'cf-account-123'
+    });
+
+    assert.deepEqual(runner.commands, [
+      ['git', 'rev-list', '-n', '1', '@cloudflare/sandbox@0.12.2'],
+      [
+        'crane',
+        'copy',
+        'registry.cloudflare.com/cf-account-123/sandbox:ci-hash',
+        'docker.io/cloudflare/sandbox:0.12.2'
+      ],
+      [
+        'crane',
+        'copy',
+        'registry.cloudflare.com/cf-account-123/sandbox:ci-hash',
+        'registry.cloudflare.com/library/sandbox:0.12.2'
+      ],
+      [
+        'crane',
+        'copy',
+        'registry.cloudflare.com/cf-account-123/sandbox-musl:ci-hash',
+        'docker.io/cloudflare/sandbox:0.12.2-musl'
+      ],
+      [
+        'crane',
+        'copy',
+        'registry.cloudflare.com/cf-account-123/sandbox-musl:ci-hash',
+        'registry.cloudflare.com/library/sandbox:0.12.2-musl'
+      ],
+      [
+        'docker',
+        'pull',
+        'registry.cloudflare.com/cf-account-123/sandbox:ci-hash'
+      ],
+      [
+        'docker',
+        'create',
+        'registry.cloudflare.com/cf-account-123/sandbox:ci-hash'
+      ],
+      [
+        'docker',
+        'cp',
+        'normal-container:/container-server/sandbox',
+        './sandbox-linux-x64'
+      ],
+      ['docker', 'rm', 'normal-container'],
+      [
+        'docker',
+        'pull',
+        'registry.cloudflare.com/cf-account-123/sandbox-musl:ci-hash'
+      ],
+      [
+        'docker',
+        'create',
+        'registry.cloudflare.com/cf-account-123/sandbox-musl:ci-hash'
+      ],
+      [
+        'docker',
+        'cp',
+        'musl-container:/container-server/sandbox',
+        './sandbox-linux-x64-musl'
+      ],
+      ['docker', 'rm', 'musl-container'],
+      ['sh', '-c', 'sha256sum sandbox-linux-x64 > sandbox-linux-x64.sha256'],
+      [
+        'sh',
+        '-c',
+        'sha256sum sandbox-linux-x64-musl > sandbox-linux-x64-musl.sha256'
+      ],
+      [
+        'gh',
+        'release',
+        'upload',
+        '@cloudflare/sandbox@0.12.2',
+        './sandbox-linux-x64',
+        './sandbox-linux-x64.sha256',
+        './sandbox-linux-x64-musl',
+        './sandbox-linux-x64-musl.sha256',
+        '--clobber'
+      ]
+    ]);
+  });
+});
+
+describe('convergePrereleaseRelease', () => {
+  test('publishes missing npm prerelease and docker aliases', async () => {
+    const state = prereleaseReleaseState({
+      version: '0.13.0-next.1.1',
+      sourceTag: 'prerelease-next-0.13.0-next.1.1',
+      npmTag: 'next',
+      dockerAlias: 'next',
+      images: ['sandbox']
+    });
+    const runner = new FakeCommandRunner({ presentRefs: new Set() });
+
+    await convergePrereleaseRelease(state, runner, {
+      skipNpm: false,
+      cloudflareAccountId: 'cf-account-123'
+    });
+
+    assert.deepEqual(runner.commands.slice(0, 4), [
+      ['npx', 'tsx', '.github/resolve-workspace-versions.ts'],
+      [
+        'npm',
+        'publish',
+        './packages/sandbox',
+        '--tag',
+        'next',
+        '--access',
+        'public'
+      ],
+      ['npm', 'dist-tag', 'add', '@cloudflare/sandbox@0.13.0-next.1.1', 'next'],
+      [
+        'crane',
+        'copy',
+        'registry.cloudflare.com/cf-account-123/sandbox:prerelease-next-0.13.0-next.1.1',
+        'docker.io/cloudflare/sandbox:0.13.0-next.1.1'
+      ]
+    ]);
+  });
+
+  test('requires Cloudflare account ID before Docker convergence', async () => {
+    const state = prereleaseReleaseState({
+      version: '0.13.0-next.1.1',
+      sourceTag: 'prerelease-next-0.13.0-next.1.1',
+      npmTag: 'next',
+      images: ['sandbox']
+    });
+    const runner = new FakeCommandRunner({
+      presentRefs: new Set([
+        'npm:@cloudflare/sandbox@0.13.0-next.1.1',
+        'npm-dist-tag:next=0.13.0-next.1.1'
+      ])
+    });
+
+    await assert.rejects(
+      convergePrereleaseRelease(state, runner, {
+        skipNpm: true,
+        cloudflareAccountId: ''
+      }),
+      /CLOUDFLARE_ACCOUNT_ID is required to resolve Docker source image refs/
+    );
+    assert.deepEqual(runner.commands, []);
+  });
+});
+
+describe('verifyPrereleaseRelease', () => {
+  test('checks npm dist-tag and docker aliases with exact refs', async () => {
+    const state = prereleaseReleaseState({
+      version: '0.13.0-next.1.1',
+      sourceTag: 'prerelease-next-0.13.0-next.1.1',
+      npmTag: 'next',
+      dockerAlias: 'next',
+      images: ['sandbox']
+    });
+    const runner = new FakeCommandRunner({ presentRefs: new Set() });
+
+    const result = await verifyPrereleaseRelease(state, runner);
+
+    assert.equal(result.ok, false);
+    assert.deepEqual(
+      result.missing.sort(),
+      [
+        'docker:docker.io/cloudflare/sandbox:0.13.0-next.1.1',
+        'docker:docker.io/cloudflare/sandbox:next',
+        'docker:registry.cloudflare.com/library/sandbox:0.13.0-next.1.1',
+        'docker:registry.cloudflare.com/library/sandbox:next',
+        'npm:@cloudflare/sandbox@0.13.0-next.1.1',
+        'npm-dist-tag:next=0.13.0-next.1.1'
+      ].sort()
+    );
+  });
+});

--- a/.github/release-orchestrator.ts
+++ b/.github/release-orchestrator.ts
@@ -1,0 +1,205 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  extractChangelogSection,
+  loadDockerImages,
+  prereleaseReleaseState,
+  stableReleaseState
+} from './release-state.ts';
+import {
+  convergePrereleaseRelease,
+  convergeStableRelease,
+  ExecCommandRunner,
+  verifyPrereleaseRelease,
+  verifyStableRelease
+} from './release-command-runner.ts';
+
+export type CliArgs =
+  | {
+      command: 'verify-stable';
+      version: string;
+      sourceTag: string;
+      commitSha: string;
+    }
+  | {
+      command: 'verify-prerelease';
+      version: string;
+      sourceTag: string;
+      npmTag: string;
+      dockerAlias?: string;
+    }
+  | {
+      command: 'stable';
+      version: string;
+      sourceTag: string;
+      commitSha: string;
+      skipNpm: boolean;
+    }
+  | {
+      command: 'prerelease';
+      version: string;
+      sourceTag: string;
+      npmTag: string;
+      dockerAlias?: string;
+    };
+
+export function parseCliArgs(argv: string[]): CliArgs {
+  const command = argv[0];
+  const args = new Map<string, string>();
+
+  for (let index = 1; index < argv.length; index += 1) {
+    const key = argv[index];
+    const value = argv[index + 1];
+
+    if (!key.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${key}`);
+    }
+
+    if (!value || value.startsWith('--')) {
+      if (key === '--skip-npm') {
+        args.set(key, 'true');
+        continue;
+      }
+
+      throw new Error(`Missing value for ${key}`);
+    }
+
+    args.set(key, value);
+    index += 1;
+  }
+
+  const version = requireArg(args, '--version');
+  const sourceTag = requireArg(args, '--source-tag');
+
+  if (command === 'verify-stable') {
+    return {
+      command,
+      version,
+      sourceTag,
+      commitSha: requireArg(args, '--commit-sha')
+    };
+  }
+
+  if (command === 'verify-prerelease' || command === 'prerelease') {
+    return {
+      command,
+      version,
+      sourceTag,
+      npmTag: requireArg(args, '--npm-tag'),
+      dockerAlias: args.get('--docker-alias')
+    };
+  }
+
+  if (command === 'stable') {
+    return {
+      command,
+      version,
+      sourceTag,
+      commitSha: requireArg(args, '--commit-sha'),
+      skipNpm: args.get('--skip-npm') === 'true'
+    };
+  }
+
+  throw new Error(
+    'Command is required: stable, prerelease, verify-stable, or verify-prerelease'
+  );
+}
+
+async function main(): Promise<void> {
+  const cli = parseCliArgs(process.argv.slice(2));
+  const root = process.cwd();
+  const images = loadDockerImages(root);
+  const runner = new ExecCommandRunner();
+
+  if (cli.command === 'verify-stable') {
+    const changelog = readFileSync(
+      join(root, 'packages', 'sandbox', 'CHANGELOG.md'),
+      'utf8'
+    );
+    const state = stableReleaseState({
+      version: cli.version,
+      sourceTag: cli.sourceTag,
+      commitSha: cli.commitSha,
+      images,
+      changelogBody: extractChangelogSection(changelog, cli.version)
+    });
+    const result = await verifyStableRelease(state, runner);
+    reportAndExit(result.missing);
+  }
+
+  if (cli.command === 'stable') {
+    const changelog = readFileSync(
+      join(root, 'packages', 'sandbox', 'CHANGELOG.md'),
+      'utf8'
+    );
+    const state = stableReleaseState({
+      version: cli.version,
+      sourceTag: cli.sourceTag,
+      commitSha: cli.commitSha,
+      images,
+      changelogBody: extractChangelogSection(changelog, cli.version)
+    });
+    await convergeStableRelease(state, runner, { skipNpm: cli.skipNpm });
+    console.log('Stable release convergence passed');
+    process.exit(0);
+  }
+
+  if (cli.command === 'verify-prerelease') {
+    const state = prereleaseReleaseState({
+      version: cli.version,
+      sourceTag: cli.sourceTag,
+      npmTag: cli.npmTag,
+      dockerAlias: cli.dockerAlias,
+      images
+    });
+    const result = await verifyPrereleaseRelease(state, runner);
+    reportAndExit(result.missing);
+  }
+
+  if (cli.command === 'prerelease') {
+    const state = prereleaseReleaseState({
+      version: cli.version,
+      sourceTag: cli.sourceTag,
+      npmTag: cli.npmTag,
+      dockerAlias: cli.dockerAlias,
+      images
+    });
+    await convergePrereleaseRelease(state, runner);
+    console.log('Prerelease convergence passed');
+    process.exit(0);
+  }
+}
+
+function requireArg(args: Map<string, string>, key: string): string {
+  const value = args.get(key);
+
+  if (!value) {
+    throw new Error(`${key} is required`);
+  }
+
+  return value;
+}
+
+function reportAndExit(missing: string[]): never {
+  if (missing.length === 0) {
+    console.log('Release verification passed');
+    process.exit(0);
+  }
+
+  console.error('Release verification failed. Missing artifacts:');
+  for (const item of missing) {
+    console.error(`- ${item}`);
+  }
+  process.exit(1);
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/.github/release-state.test.ts
+++ b/.github/release-state.test.ts
@@ -1,0 +1,201 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  extractChangelogSection,
+  loadDockerImages,
+  prereleaseReleaseState,
+  publicDockerTags,
+  stableReleaseState
+} from './release-state.ts';
+
+describe('publicDockerTags', () => {
+  test('maps internal sandbox images to public version tags', () => {
+    const mappings = publicDockerTags('0.12.2', [
+      'sandbox',
+      'sandbox-python',
+      'sandbox-opencode',
+      'sandbox-musl',
+      'sandbox-standalone'
+    ]);
+
+    assert.deepEqual(
+      mappings.map((mapping) => ({ image: mapping.image, tag: mapping.tag })),
+      [
+        { image: 'sandbox', tag: '0.12.2' },
+        { image: 'sandbox-python', tag: '0.12.2-python' },
+        { image: 'sandbox-opencode', tag: '0.12.2-opencode' },
+        { image: 'sandbox-musl', tag: '0.12.2-musl' }
+      ]
+    );
+  });
+
+  test('adds alias tags for mutable prerelease channels', () => {
+    const mappings = publicDockerTags(
+      '0.13.0-next.1.1',
+      ['sandbox', 'sandbox-musl'],
+      'next'
+    );
+
+    assert.deepEqual(
+      mappings.map((mapping) => ({
+        image: mapping.image,
+        tag: mapping.tag,
+        alias: mapping.aliasTag
+      })),
+      [
+        { image: 'sandbox', tag: '0.13.0-next.1.1', alias: 'next' },
+        {
+          image: 'sandbox-musl',
+          tag: '0.13.0-next.1.1-musl',
+          alias: 'next-musl'
+        }
+      ]
+    );
+  });
+
+  test('rejects invalid image names', () => {
+    assert.throws(
+      () => publicDockerTags('0.12.2', ['sandbox', 'not-sandbox']),
+      /Invalid image name: not-sandbox/
+    );
+  });
+});
+
+function withDockerImagesFile(
+  content: string,
+  callback: (root: string) => void
+) {
+  const root = mkdtempSync(join(tmpdir(), 'release-state-'));
+
+  try {
+    writeFileSync(join(root, 'docker-images.txt'), content);
+    callback(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe('loadDockerImages', () => {
+  test('loads image names while ignoring comments and blank lines', () => {
+    withDockerImagesFile(
+      '# generated list\n\nsandbox\r\n  sandbox-python  \n# skip me\nsandbox-musl\n',
+      (root) => {
+        assert.deepEqual(loadDockerImages(root), [
+          'sandbox',
+          'sandbox-python',
+          'sandbox-musl'
+        ]);
+      }
+    );
+  });
+
+  test('rejects invalid image names', () => {
+    withDockerImagesFile('sandbox\nsandbox_bad\n', (root) => {
+      assert.throws(
+        () => loadDockerImages(root),
+        /Invalid image name in docker-images.txt: sandbox_bad/
+      );
+    });
+  });
+
+  test('rejects files with no image names', () => {
+    withDockerImagesFile('\n# no images\n  \n', (root) => {
+      assert.throws(
+        () => loadDockerImages(root),
+        /No images found in docker-images.txt/
+      );
+    });
+  });
+});
+
+describe('extractChangelogSection', () => {
+  test('extracts a single stable version body', () => {
+    const changelog = `# @cloudflare/sandbox\n\n## 0.12.2\n\n### Patch Changes\n\n- Fix thing\n\n## 0.12.1\n\n- Previous\n`;
+
+    assert.equal(
+      extractChangelogSection(changelog, '0.12.2'),
+      '### Patch Changes\n\n- Fix thing'
+    );
+  });
+
+  test('matches complete version headings only', () => {
+    const changelog = `# @cloudflare/sandbox\n\n## 0.12.20\n\n- Wrong version\n\n## 0.12.2\n\n- Right version\n`;
+
+    assert.equal(
+      extractChangelogSection(changelog, '0.12.2'),
+      '- Right version'
+    );
+  });
+});
+
+describe('stableReleaseState', () => {
+  test('constructs stable desired state', () => {
+    const state = stableReleaseState({
+      version: '0.12.2',
+      sourceTag: 'ci-hash',
+      commitSha: 'abc123',
+      images: ['sandbox', 'sandbox-musl'],
+      changelogBody: '### Patch Changes\n\n- Fix thing'
+    });
+
+    assert.equal(state.npmPackage, '@cloudflare/sandbox');
+    assert.equal(state.version, '0.12.2');
+    assert.equal(state.gitTag, '@cloudflare/sandbox@0.12.2');
+    assert.equal(state.npmTag, 'latest');
+    assert.deepEqual(state.releaseAssets, [
+      'sandbox-linux-x64',
+      'sandbox-linux-x64.sha256',
+      'sandbox-linux-x64-musl',
+      'sandbox-linux-x64-musl.sha256'
+    ]);
+  });
+});
+
+describe('prereleaseReleaseState', () => {
+  test('constructs prerelease desired state with source refs and aliases', () => {
+    const state = prereleaseReleaseState({
+      version: '0.13.0-next.1.1',
+      sourceTag: 'ci-hash',
+      npmTag: 'next',
+      dockerAlias: 'next',
+      images: ['sandbox', 'sandbox-musl', 'sandbox-standalone']
+    });
+
+    assert.equal(state.mode, 'prerelease');
+    assert.equal(state.npmPackage, '@cloudflare/sandbox');
+    assert.equal(state.version, '0.13.0-next.1.1');
+    assert.equal(state.sourceTag, 'ci-hash');
+    assert.equal(state.npmTag, 'next');
+    assert.equal(state.dockerAlias, 'next');
+    assert.deepEqual(
+      state.dockerTags.map((mapping) => ({
+        image: mapping.image,
+        sourceTag: mapping.sourceTag,
+        tag: mapping.tag,
+        aliasTag: mapping.aliasTag,
+        sourceRef: mapping.sourceRef
+      })),
+      [
+        {
+          image: 'sandbox',
+          sourceTag: 'ci-hash',
+          tag: '0.13.0-next.1.1',
+          aliasTag: 'next',
+          sourceRef:
+            'registry.cloudflare.com/$CLOUDFLARE_ACCOUNT_ID/sandbox:ci-hash'
+        },
+        {
+          image: 'sandbox-musl',
+          sourceTag: 'ci-hash',
+          tag: '0.13.0-next.1.1-musl',
+          aliasTag: 'next-musl',
+          sourceRef:
+            'registry.cloudflare.com/$CLOUDFLARE_ACCOUNT_ID/sandbox-musl:ci-hash'
+        }
+      ]
+    );
+  });
+});

--- a/.github/release-state.ts
+++ b/.github/release-state.ts
@@ -1,0 +1,177 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export type ReleaseMode = 'stable' | 'prerelease';
+
+export interface DockerTagMapping {
+  image: string;
+  sourceTag: string;
+  tag: string;
+  aliasTag?: string;
+  dockerHubRef: string;
+  cfLibraryRef: string;
+  sourceRef: string;
+}
+
+export interface StableReleaseState {
+  mode: 'stable';
+  npmPackage: '@cloudflare/sandbox';
+  version: string;
+  sourceTag: string;
+  commitSha: string;
+  npmTag: 'latest';
+  gitTag: string;
+  githubReleaseName: string;
+  changelogBody: string;
+  dockerTags: DockerTagMapping[];
+  releaseAssets: string[];
+}
+
+export interface PrereleaseReleaseState {
+  mode: 'prerelease';
+  npmPackage: '@cloudflare/sandbox';
+  version: string;
+  sourceTag: string;
+  npmTag: string;
+  dockerAlias?: string;
+  dockerTags: DockerTagMapping[];
+}
+
+function validateImageName(image: string, source: string): void {
+  if (!/^sandbox(-[a-z0-9]+)*$/.test(image)) {
+    throw new Error(`Invalid image name${source}: ${image}`);
+  }
+}
+
+export function loadDockerImages(root: string): string[] {
+  const content = readFileSync(join(root, 'docker-images.txt'), 'utf8');
+  const images = content
+    .split('\n')
+    .map((line) => line.replace(/\r$/, '').trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#'));
+
+  for (const image of images) {
+    validateImageName(image, ' in docker-images.txt');
+  }
+
+  if (images.length === 0) {
+    throw new Error('No images found in docker-images.txt');
+  }
+
+  return images;
+}
+
+export function publicDockerTags(
+  version: string,
+  images: string[],
+  alias?: string,
+  sourceTag = ''
+): DockerTagMapping[] {
+  for (const image of images) {
+    validateImageName(image, '');
+  }
+
+  return images
+    .filter((image) => image !== 'sandbox-standalone')
+    .map((image) => {
+      const suffix = image.slice('sandbox'.length);
+      const tag = `${version}${suffix}`;
+      const aliasTag = alias ? `${alias}${suffix}` : undefined;
+
+      return {
+        image,
+        sourceTag,
+        tag,
+        aliasTag,
+        dockerHubRef: `docker.io/cloudflare/sandbox:${tag}`,
+        cfLibraryRef: `registry.cloudflare.com/library/sandbox:${tag}`,
+        sourceRef: sourceTag
+          ? `registry.cloudflare.com/$CLOUDFLARE_ACCOUNT_ID/${image}:${sourceTag}`
+          : ''
+      };
+    });
+}
+
+export function extractChangelogSection(
+  changelog: string,
+  version: string
+): string {
+  const headingPattern = new RegExp(
+    `(^|\\n)## ${version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?=\\s*(?:\\n|$))`
+  );
+  const match = headingPattern.exec(changelog);
+
+  if (match === null) {
+    throw new Error(`Could not find changelog section for ${version}`);
+  }
+
+  const start = match.index + match[1].length;
+  const bodyStart = start + match[0].length - match[1].length;
+  const nextHeader = changelog.indexOf('\n## ', bodyStart);
+  const raw =
+    nextHeader === -1
+      ? changelog.slice(bodyStart)
+      : changelog.slice(bodyStart, nextHeader);
+  const body = raw.trim();
+
+  if (body.length === 0) {
+    throw new Error(`Changelog section for ${version} is empty`);
+  }
+
+  return body;
+}
+
+export function stableReleaseState(options: {
+  version: string;
+  sourceTag: string;
+  commitSha: string;
+  images: string[];
+  changelogBody: string;
+}): StableReleaseState {
+  return {
+    mode: 'stable',
+    npmPackage: '@cloudflare/sandbox',
+    version: options.version,
+    sourceTag: options.sourceTag,
+    commitSha: options.commitSha,
+    npmTag: 'latest',
+    gitTag: `@cloudflare/sandbox@${options.version}`,
+    githubReleaseName: `@cloudflare/sandbox@${options.version}`,
+    changelogBody: options.changelogBody,
+    dockerTags: publicDockerTags(
+      options.version,
+      options.images,
+      undefined,
+      options.sourceTag
+    ),
+    releaseAssets: [
+      'sandbox-linux-x64',
+      'sandbox-linux-x64.sha256',
+      'sandbox-linux-x64-musl',
+      'sandbox-linux-x64-musl.sha256'
+    ]
+  };
+}
+
+export function prereleaseReleaseState(options: {
+  version: string;
+  sourceTag: string;
+  npmTag: string;
+  dockerAlias?: string;
+  images: string[];
+}): PrereleaseReleaseState {
+  return {
+    mode: 'prerelease',
+    npmPackage: '@cloudflare/sandbox',
+    version: options.version,
+    sourceTag: options.sourceTag,
+    npmTag: options.npmTag,
+    dockerAlias: options.dockerAlias,
+    dockerTags: publicDockerTags(
+      options.version,
+      options.images,
+      options.dockerAlias,
+      options.sourceTag
+    )
+  };
+}

--- a/.github/release-tooling.md
+++ b/.github/release-tooling.md
@@ -5,7 +5,9 @@ Release workflows keep orchestration in YAML and shared release mechanics in sma
 - `install-crane.sh` installs `crane` for image copying.
 - `login-release-registries.sh` logs in to Docker Hub and the Cloudflare registry.
 - `publish-sandbox-images.sh` copies sandbox image variants from the internal Cloudflare registry to public release tags.
-- `release.yml` is the trusted-publishing entry point for stable and prerelease channels.
+- `release-orchestrator.ts` publishes and verifies stable npm, Docker, CF Registry Library, GitHub Release, and binary assets, plus prerelease npm and Docker channel artifacts.
+- `release.yml` uses Changesets to create Version Packages PRs and the release orchestrator to publish stable artifacts.
+- `reusable-prerelease.yml` uses the release orchestrator to publish and verify prerelease npm dist-tags, Docker Hub images, CF Registry Library images, and moving Docker aliases.
 - `prerelease-channel.ts` computes and applies prerelease channel versions.
 
 Run the targeted release-tooling tests when changing these scripts or release publishing workflow blocks:
@@ -15,3 +17,7 @@ npm run test:release-tools
 ```
 
 These tests are a focused release-tooling check. The default `npm test` path stays scoped to workspace unit tests.
+
+## Release orchestrator
+
+`release-orchestrator.ts` models the desired release state for stable and prerelease artifacts. For stable releases, Changesets still creates Version Packages PRs with changelog and version-file updates, while the orchestrator publishes and verifies npm, Docker Hub, CF Registry Library, GitHub Release, and binary assets. The backfill workflow also converges the full stable desired state, except npm publish is skipped; it resolves the release commit from the existing release tag and requires an explicit release commit SHA before creating a missing tag. For prereleases, the orchestrator publishes and verifies the npm prerelease dist-tag, Docker Hub tags, CF Registry Library tags, and optional moving Docker aliases. Reruns converge missing artifacts instead of depending on whether npm was newly published in the current workflow attempt.

--- a/.github/reusable-prerelease.test.sh
+++ b/.github/reusable-prerelease.test.sh
@@ -1,29 +1,96 @@
 #!/bin/bash
 set -euo pipefail
 
-workflow=.github/workflows/reusable-prerelease.yml
-
 assert_step_exports_account_id() {
-  local step_name="$1"
+  local workflow="$1"
+  local step_name="$2"
+  local indent="$3"
   local step_block
 
-  step_block=$(awk -v step="$step_name" '
-    $0 == "      - name: " step { in_step = 1; print; next }
-    in_step && /^      - name: / { exit }
+  step_block=$(awk -v step="$step_name" -v indent="$indent" '
+    $0 == indent "- name: " step { in_step = 1; print; next }
+    in_step && index($0, indent "- name: ") == 1 { exit }
     in_step { print }
   ' "$workflow")
 
   if [[ -z "$step_block" ]]; then
-    echo "Missing workflow step: $step_name" >&2
+    echo "Missing workflow step '$step_name' in $workflow" >&2
     return 1
   fi
 
   # shellcheck disable=SC2016
   if ! grep -Fq 'CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}' <<<"$step_block"; then
-    echo "Workflow step '$step_name' must export CLOUDFLARE_ACCOUNT_ID" >&2
+    echo "Workflow step '$step_name' in $workflow must export CLOUDFLARE_ACCOUNT_ID" >&2
     return 1
   fi
 }
 
-assert_step_exports_account_id "Publish Docker images to Docker Hub"
-assert_step_exports_account_id "Publish Docker images to CF Registry Library"
+assert_step_exports_account_id ".github/workflows/reusable-prerelease.yml" "Publish prerelease" "      "
+assert_step_exports_account_id ".github/workflows/release.yml" "Publish stable release" "      "
+assert_step_exports_account_id ".github/workflows/backfill-release-artifacts.yml" "Backfill stable release artifacts" "      "
+
+assert_workflow_contains() {
+  local workflow="$1"
+  local needle="$2"
+  if ! grep -Fq "$needle" "$workflow"; then
+    echo "Workflow $workflow must contain: $needle" >&2
+    return 1
+  fi
+}
+
+assert_workflow_contains ".github/workflows/release.yml" "npx tsx .github/release-orchestrator.ts stable"
+assert_workflow_contains ".github/workflows/release.yml" "bash .github/detect-stable-release-needed.sh"
+assert_workflow_contains ".github/workflows/release.yml" "steps.stable-release.outputs.publish == 'true'"
+assert_workflow_contains ".github/workflows/release.yml" 'GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}'
+assert_workflow_contains ".github/workflows/release.yml" "for file in .changeset/*.md; do"
+assert_workflow_contains ".github/workflows/release.yml" '[[ "$file" == ".changeset/README.md" ]]'
+assert_workflow_contains ".github/workflows/backfill-release-artifacts.yml" "npx tsx .github/release-orchestrator.ts stable"
+assert_workflow_contains ".github/workflows/backfill-release-artifacts.yml" "fetch-depth: 0"
+assert_workflow_contains ".github/workflows/backfill-release-artifacts.yml" "persist-credentials: true"
+assert_workflow_contains ".github/workflows/backfill-release-artifacts.yml" "release_commit_sha"
+assert_workflow_contains ".github/workflows/backfill-release-artifacts.yml" 'git rev-list -n 1 "$git_tag"'
+assert_workflow_contains ".github/workflows/backfill-release-artifacts.yml" 'Release tag $git_tag is missing; provide release_commit_sha'
+if grep -Fq -- '--commit-sha "${{ github.sha }}"' .github/workflows/backfill-release-artifacts.yml; then
+  echo "Backfill must resolve the release commit instead of passing github.sha" >&2
+  exit 1
+fi
+assert_workflow_contains ".github/workflows/reusable-prerelease.yml" "npx tsx .github/release-orchestrator.ts prerelease"
+
+detect_pending_changesets() {
+  local changeset_dir="$1"
+  local files=()
+  local file
+
+  shopt -s nullglob
+  for file in "$changeset_dir"/*.md; do
+    if [[ "${file##*/}" == "README.md" ]]; then
+      continue
+    fi
+    files+=("$file")
+  done
+
+  if [[ ${#files[@]} -gt 0 ]]; then
+    echo "present=true"
+  else
+    echo "present=false"
+  fi
+}
+
+changeset_test_dir=$(mktemp -d)
+trap 'rm -rf "$changeset_test_dir"' EXIT
+mkdir -p "$changeset_test_dir/.changeset"
+printf '# Changesets\n' > "$changeset_test_dir/.changeset/README.md"
+if [[ "$(detect_pending_changesets "$changeset_test_dir/.changeset")" != "present=false" ]]; then
+  echo "README-only changeset state must not count as pending" >&2
+  exit 1
+fi
+printf -- '---\n"@cloudflare/sandbox": patch\n---\n\nTest changeset\n' > "$changeset_test_dir/.changeset/real.md"
+if [[ "$(detect_pending_changesets "$changeset_test_dir/.changeset")" != "present=true" ]]; then
+  echo "Real changeset markdown must count as pending" >&2
+  exit 1
+fi
+
+if grep -Fq "steps.changesets.outputs.published == 'true'" .github/workflows/release.yml; then
+  echo "Stable release artifacts must not be gated by changesets.outputs.published" >&2
+  exit 1
+fi

--- a/.github/workflows/backfill-release-artifacts.yml
+++ b/.github/workflows/backfill-release-artifacts.yml
@@ -1,0 +1,81 @@
+name: Backfill Release Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version to backfill, for example 0.12.2'
+        required: true
+        type: string
+      source_tag:
+        description: 'Internal registry source tag, for example ci-<docker hash>'
+        required: true
+        type: string
+      release_commit_sha:
+        description: 'Release commit SHA, required only if the release tag is missing'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  backfill:
+    if: ${{ github.repository_owner == 'cloudflare' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Install crane
+        run: .github/install-crane.sh
+
+      - name: Login to registries
+        run: .github/login-release-registries.sh
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - run: npm ci --prefer-offline --no-audit --no-fund
+
+      - name: Backfill stable release artifacts
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+        run: |
+          git_tag="@cloudflare/sandbox@${{ inputs.version }}"
+          release_commit_sha="${{ inputs.release_commit_sha }}"
+
+          if git rev-parse --verify --quiet "refs/tags/${git_tag}" >/dev/null; then
+            release_commit_sha="$(git rev-list -n 1 "$git_tag")"
+          elif [[ -z "$release_commit_sha" ]]; then
+            echo "Release tag $git_tag is missing; provide release_commit_sha to create or converge the tag." >&2
+            exit 1
+          fi
+
+          npx tsx .github/release-orchestrator.ts stable \
+            --version "${{ inputs.version }}" \
+            --source-tag "${{ inputs.source_tag }}" \
+            --commit-sha "$release_commit_sha" \
+            --skip-npm true
+
+      - name: Summarize backfill
+        run: |
+          {
+            echo "## Release artifact backfill"
+            echo "Version: \`${{ inputs.version }}\`"
+            echo "Source tag: \`${{ inputs.source_tag }}\`"
+            echo "Convergence: full stable release state, except npm publish is skipped"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
 
       - uses: actions/setup-node@v6
         with:
@@ -201,16 +201,53 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
+      - name: Detect pending changesets
+        id: pending-changesets
+        run: |
+          shopt -s nullglob
+          files=()
+          for file in .changeset/*.md; do
+            if [[ "$file" == ".changeset/README.md" ]]; then
+              continue
+            fi
+            files+=("$file")
+          done
+          if [[ ${#files[@]} -gt 0 ]]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - id: changesets
+        if: steps.pending-changesets.outputs.present == 'true'
         uses: changesets/action@v1
         with:
           version: npx tsx .github/changeset-version.ts
-          publish: npx tsx .github/changeset-publish.ts
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Detect stable release target
+        id: stable-release
+        if: steps.pending-changesets.outputs.present == 'false'
+        run: |
+          bash .github/detect-stable-release-needed.sh \
+            "${{ needs.build.outputs.version }}" \
+            "${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish stable release
+        if: steps.pending-changesets.outputs.present == 'false' && steps.stable-release.outputs.publish == 'true'
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+        run: |
+          npx tsx .github/release-orchestrator.ts stable \
+            --version "${{ needs.build.outputs.version }}" \
+            --source-tag "ci-${{ needs.hashes.outputs.docker }}" \
+            --commit-sha "${{ github.sha }}"
 
       - name: Update Docker Hub description
+        if: steps.pending-changesets.outputs.present == 'false' && steps.stable-release.outputs.publish == 'true'
         uses: peter-evans/dockerhub-description@v4
         continue-on-error: true
         with:
@@ -219,69 +256,3 @@ jobs:
           repository: cloudflare/sandbox
           readme-filepath: ./DOCKER_README.md
           short-description: ${{ github.event.repository.description }}
-
-      - name: Publish Docker images to Docker Hub
-        if: steps.changesets.outputs.published == 'true'
-        run: |
-          .github/publish-sandbox-images.sh \
-            --source-tag "ci-${{ needs.hashes.outputs.docker }}" \
-            --version "${{ needs.build.outputs.version }}" \
-            --docker-hub
-
-      - name: Publish Docker images to CF Registry Library
-        if: steps.changesets.outputs.published == 'true'
-        continue-on-error: true
-        id: library-publish
-        run: |
-          VERSION="${{ needs.build.outputs.version }}"
-          if ! .github/publish-sandbox-images.sh \
-            --source-tag "ci-${{ needs.hashes.outputs.docker }}" \
-            --version "$VERSION" \
-            --cf-library; then
-            echo "::warning::Some images failed to publish to CF Registry Library"
-            {
-              echo "## ⚠️ CF Registry Library publish partially failed"
-              echo "Some sandbox images could not be copied to \`registry.cloudflare.com/library/\`."
-              echo "Docker Hub publish was not affected."
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-          {
-            echo "## ✅ CF Registry Library publish succeeded"
-            printf "Published \`registry.cloudflare.com/library/sandbox:%s\` (+ variants)\n" "$VERSION"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Warn if library publish failed
-        if: steps.library-publish.outcome == 'failure'
-        run: |
-          echo "::warning::CF Registry Library publish failed — Docker Hub and npm releases are unaffected"
-
-      - name: Extract standalone binaries
-        if: steps.changesets.outputs.published == 'true'
-        run: |
-          REGISTRY="registry.cloudflare.com/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}"
-          HASH="${{ needs.hashes.outputs.docker }}"
-          SRC_TAG="ci-${HASH}"
-          # Default variant
-          docker pull "${REGISTRY}/sandbox:${SRC_TAG}"
-          CID=$(docker create "${REGISTRY}/sandbox:${SRC_TAG}")
-          docker cp "$CID":/container-server/sandbox ./sandbox-linux-x64
-          docker rm "$CID"
-          # Musl variant
-          docker pull "${REGISTRY}/sandbox-musl:${SRC_TAG}"
-          CID=$(docker create "${REGISTRY}/sandbox-musl:${SRC_TAG}")
-          docker cp "$CID":/container-server/sandbox ./sandbox-linux-x64-musl
-          docker rm "$CID"
-
-      - name: Upload binaries to GitHub Release
-        if: steps.changesets.outputs.published == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION="${{ needs.build.outputs.version }}"
-          sha256sum sandbox-linux-x64 > sandbox-linux-x64.sha256
-          sha256sum sandbox-linux-x64-musl > sandbox-linux-x64-musl.sha256
-          gh release upload "@cloudflare/sandbox@${VERSION}" \
-            ./sandbox-linux-x64 ./sandbox-linux-x64.sha256 \
-            ./sandbox-linux-x64-musl ./sandbox-linux-x64-musl.sha256 \
-            --clobber

--- a/.github/workflows/reusable-prerelease.yml
+++ b/.github/workflows/reusable-prerelease.yml
@@ -209,45 +209,20 @@ jobs:
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
 
-      - name: Publish npm prerelease
-        run: npm publish ./packages/sandbox --tag "${{ needs.version.outputs.channel }}" --access public
+      - name: Publish prerelease
         env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           NPM_CONFIG_PROVENANCE: true
-
-      - name: Publish Docker images to Docker Hub
         run: |
           alias_args=()
           if [[ "${{ inputs.publish_docker_alias }}" == "true" ]]; then
-            alias_args=(--alias "${{ needs.version.outputs.channel }}")
+            alias_args=(--docker-alias "${{ needs.version.outputs.channel }}")
           fi
-          .github/publish-sandbox-images.sh \
-            --source-tag "${{ needs.version.outputs.image_tag }}" \
+          npx tsx .github/release-orchestrator.ts prerelease \
             --version "${{ needs.version.outputs.version }}" \
-            "${alias_args[@]}" \
-            --docker-hub
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-      - name: Publish Docker images to CF Registry Library
-        continue-on-error: true
-        id: library-publish
-        run: |
-          alias_args=()
-          if [[ "${{ inputs.publish_docker_alias }}" == "true" ]]; then
-            alias_args=(--alias "${{ needs.version.outputs.channel }}")
-          fi
-          .github/publish-sandbox-images.sh \
             --source-tag "${{ needs.version.outputs.image_tag }}" \
-            --version "${{ needs.version.outputs.version }}" \
-            "${alias_args[@]}" \
-            --cf-library
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-      - name: Warn if library publish failed
-        if: steps.library-publish.outcome == 'failure'
-        run: |
-          echo "::warning::CF Registry Library publish failed — Docker Hub and npm prereleases are unaffected"
+            --npm-tag "${{ needs.version.outputs.channel }}" \
+            "${alias_args[@]}"
 
       - name: Summarize prerelease
         run: |

--- a/bridge/examples/workspace-chat/frontend/package-lock.json
+++ b/bridge/examples/workspace-chat/frontend/package-lock.json
@@ -2493,14 +2493,14 @@
       }
     },
     "node_modules/echarts": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
-      "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
+      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "6.0.0"
+        "zrender": "6.1.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -5166,9 +5166,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
-      "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
+      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {

--- a/bridge/worker/README.md
+++ b/bridge/worker/README.md
@@ -151,7 +151,6 @@ curl -X POST http://localhost:8787/v1/sandbox/mfrggzdfmy2tqnrz/exec \
 
 Read a file from the sandbox filesystem. The file path is given in the URL after `/file/` as an absolute path without the leading slash (e.g. `workspace/main.py` for `/workspace/main.py`). Must resolve within `/workspace`. Returns raw bytes (`application/octet-stream`).
 
-
 ```sh
 curl -X GET http://localhost:8787/v1/sandbox/mfrggzdfmy2tqnrz/file/workspace/main.py \
   -H "Authorization: Bearer $SANDBOX_API_KEY"
@@ -428,10 +427,12 @@ The pool is primed (its alarm loop started) in two ways:
 
 Set these variables in `wrangler.jsonc` (under `vars`) or via `wrangler secret put`:
 
-| Variable                     | Default   | Description                                                                          |
-| ---------------------------- | --------- | ------------------------------------------------------------------------------------ |
-| `WARM_POOL_TARGET`           | `"0"`     | Number of idle containers to keep warm. **0 disables the pool** (no surprise bills). |
-| `WARM_POOL_REFRESH_INTERVAL` | `"10000"` | Milliseconds between pool health-check / replenishment cycles.                       |
+| Variable                     | Default   | Description                                                                                                                                         |
+| ---------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `WARM_POOL_TARGET`           | `"0"`     | Number of idle containers to keep warm. **0 disables the pool** (no surprise bills).                                                                |
+| `WARM_POOL_REFRESH_INTERVAL` | `"10000"` | Milliseconds between pool health-check / replenishment cycles.                                                                                      |
+| `WARM_POOL_MAX_INSTANCES`    | `"0"`     | Capacity ceiling the pool plans against. Set it to match `containers[].max_instances`. **0 leaves the ceiling to be learned from capacity errors.** |
+| `WARM_POOL_SCALE_BATCH_SIZE` | `"5"`     | Number of containers started in parallel per scale-up batch. Clamped to `[1, 20]`.                                                                  |
 
 The cron trigger frequency can be adjusted in `wrangler.jsonc` under `triggers.crons`. Remove the cron entirely if you only want manual priming via `POST /v1/pool/prime`.
 

--- a/bridge/worker/src/__tests__/tracing.test.ts
+++ b/bridge/worker/src/__tests__/tracing.test.ts
@@ -1,0 +1,99 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Capture every setAttribute call across all spans created during a test.
+const attributeCalls: Array<[string, unknown]> = [];
+let traced = false;
+
+vi.mock('cloudflare:workers', () => ({
+  tracing: {
+    enterSpan: async (_name: string, callback: (span: unknown) => unknown) => {
+      const span = {
+        isTraced: traced,
+        setAttribute: (key: string, value?: unknown) => {
+          attributeCalls.push([key, value]);
+        }
+      };
+      return callback(span);
+    }
+  }
+}));
+
+const { annotate, traced: tracedWrap } = await import('../../../../packages/sandbox/src/bridge/tracing');
+
+type TestEnv = {
+  Bindings: Record<string, unknown>;
+  Variables: { containerUUID: string; span?: unknown };
+};
+
+function attr(key: string): unknown {
+  return attributeCalls.find(([k]) => k === key)?.[1];
+}
+
+describe('bridge tracing helper', () => {
+  beforeEach(() => {
+    attributeCalls.length = 0;
+    traced = true;
+  });
+
+  it('wraps a handler in a span seeded with common attributes', async () => {
+    const app = new Hono<TestEnv>();
+    app.use('/v1/sandbox/:id/thing', async (c, next) => {
+      c.set('containerUUID', 'container-xyz');
+      return next();
+    });
+    app.get(
+      '/v1/sandbox/:id/thing',
+      tracedWrap('thing', async (c) => c.json({ ok: true }))
+    );
+
+    const res = await app.request('/v1/sandbox/abc/thing');
+    expect(res.status).toBe(200);
+
+    expect(attr('bridge.operation')).toBe('thing');
+    expect(attr('http.request.method')).toBe('GET');
+    expect(attr('http.route')).toBe('/v1/sandbox/:id/thing');
+    expect(attr('sandbox.id')).toBe('abc');
+    expect(attr('sandbox.container_uuid')).toBe('container-xyz');
+    expect(attr('http.response.status_code')).toBe(200);
+  });
+
+  it('exposes the active span to annotate()', async () => {
+    const app = new Hono<TestEnv>();
+    app.get(
+      '/v1/sandbox/:id/thing',
+      tracedWrap('thing', async (c) => {
+        annotate(c, 'custom.key', 42);
+        return c.json({ ok: true });
+      })
+    );
+
+    await app.request('/v1/sandbox/abc/thing');
+    expect(attr('custom.key')).toBe(42);
+  });
+
+  it('records the response status for error responses', async () => {
+    const app = new Hono<TestEnv>();
+    app.get(
+      '/v1/sandbox/:id/thing',
+      tracedWrap('thing', async (c) => c.json({ error: 'nope' }, 502))
+    );
+
+    const res = await app.request('/v1/sandbox/abc/thing');
+    expect(res.status).toBe(502);
+    expect(attr('http.response.status_code')).toBe(502);
+  });
+
+  it('annotate() is a no-op when no span is set', async () => {
+    const app = new Hono<TestEnv>();
+    app.get('/plain', async (c) => {
+      // No traced() wrapper, so no span on the context.
+      annotate(c, 'should.not.appear', 'x');
+      return c.json({ ok: true });
+    });
+
+    const res = await app.request('/plain');
+    expect(res.status).toBe(200);
+    expect(attr('should.not.appear')).toBeUndefined();
+  });
+});

--- a/bridge/worker/src/__tests__/warm-pool.test.ts
+++ b/bridge/worker/src/__tests__/warm-pool.test.ts
@@ -56,6 +56,10 @@ async function withPool(
   opts: {
     warmTarget?: number;
     maxInstances?: number | null;
+    /** Operator-declared ceiling passed through configure() (Proposal 1). */
+    configuredMaxInstances?: number;
+    /** Bounded-parallel batch size passed through configure() (TICKET2). */
+    scaleBatchSize?: number;
     warmContainers?: string[];
     assignments?: [string, string][];
     containerBehavior?: {
@@ -94,7 +98,9 @@ async function withPool(
     // Configure
     await instance.configure({
       warmTarget: opts.warmTarget ?? 0,
-      refreshInterval: 60_000
+      refreshInterval: 60_000,
+      ...(opts.configuredMaxInstances !== undefined ? { maxInstances: opts.configuredMaxInstances } : {}),
+      ...(opts.scaleBatchSize !== undefined ? { scaleBatchSize: opts.scaleBatchSize } : {})
     });
 
     await callback(instance, mock);
@@ -221,6 +227,183 @@ describe('WarmPool', () => {
         async (pool) => {
           await pool.alarm();
           expect(startCount).toBe(0);
+        }
+      );
+    });
+  });
+
+  // ── batched scale-up (TICKET2) ─────────────────────────────────────────
+
+  describe('batched scale-up', () => {
+    /**
+     * Behavior wrapper that records the peak number of concurrent
+     * startAndWaitForPorts calls in flight at once.
+     */
+    function concurrencyTracker() {
+      let inFlight = 0;
+      let maxInFlight = 0;
+      let startCount = 0;
+      return {
+        startCount: () => startCount,
+        maxInFlight: () => maxInFlight,
+        behavior: {
+          startAndWaitForPorts: vi.fn(async () => {
+            startCount++;
+            inFlight++;
+            maxInFlight = Math.max(maxInFlight, inFlight);
+            // Yield so siblings in the same batch can also enter.
+            await Promise.resolve();
+            await Promise.resolve();
+            inFlight--;
+          }),
+          getState: vi.fn(async () => ({ status: 'running' as const }))
+        }
+      };
+    }
+
+    it('starts containers in bounded-parallel batches', async () => {
+      const tracker = concurrencyTracker();
+      await withPool(
+        {
+          warmTarget: 10,
+          configuredMaxInstances: 100,
+          scaleBatchSize: 5,
+          containerBehavior: tracker.behavior
+        },
+        async (pool) => {
+          await pool.alarm();
+          const stats = await pool.getStats();
+          expect(stats.warm).toBe(10);
+          expect(tracker.startCount()).toBe(10);
+          // Bounded: never more than batch size in flight at once.
+          expect(tracker.maxInFlight()).toBe(5);
+        }
+      );
+    });
+
+    it('batch size of 1 reproduces serial behaviour', async () => {
+      const tracker = concurrencyTracker();
+      await withPool(
+        {
+          warmTarget: 4,
+          configuredMaxInstances: 100,
+          scaleBatchSize: 1,
+          containerBehavior: tracker.behavior
+        },
+        async (pool) => {
+          await pool.alarm();
+          expect((await pool.getStats()).warm).toBe(4);
+          expect(tracker.maxInFlight()).toBe(1);
+        }
+      );
+    });
+
+    it('clamps batch size to a safe maximum', async () => {
+      const tracker = concurrencyTracker();
+      await withPool(
+        {
+          warmTarget: 30,
+          configuredMaxInstances: 100,
+          scaleBatchSize: 1000,
+          containerBehavior: tracker.behavior
+        },
+        async (pool) => {
+          await pool.alarm();
+          // Clamped to the documented max of 20, not 1000.
+          expect(tracker.maxInFlight()).toBe(20);
+        }
+      );
+    });
+
+    it('stops launching batches once capacity is exhausted mid-fill', async () => {
+      let startCount = 0;
+      await withPool(
+        {
+          warmTarget: 20,
+          scaleBatchSize: 5,
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {
+              startCount++;
+              // First batch of 5 succeeds; the second batch hits the cap.
+              if (startCount > 5) {
+                throw new Error(MAX_INSTANCES_ERROR);
+              }
+            }),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          await pool.alarm();
+          // 5 succeed, the straddling batch of 5 all fail (bounded overshoot),
+          // then the loop stops — no third batch.
+          expect(startCount).toBe(10);
+          const stats = await pool.getStats();
+          expect(stats.warm).toBe(5);
+        }
+      );
+    });
+
+    it('records the accurate ceiling after a partial-capacity batch', async () => {
+      // Regression: with parallel batches, recordCapacityLimit() runs while a
+      // batch's successful starts are not yet in warmContainers, so it would
+      // infer a ceiling lower than reality and reject available capacity.
+      let startCount = 0;
+      await withPool(
+        {
+          warmTarget: 10,
+          scaleBatchSize: 5,
+          // Two slots already taken by live assignments.
+          assignments: [
+            ['s1', 'a1'],
+            ['s2', 'a2']
+          ],
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {
+              startCount++;
+              // Only the first 3 starts succeed; the rest hit the cap.
+              if (startCount > 3) {
+                throw new Error(MAX_INSTANCES_ERROR);
+              }
+            }),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          await pool.alarm();
+          const stats = await pool.getStats();
+          // 3 warm + 2 assigned = 5 real containers running.
+          expect(stats.warm).toBe(3);
+          expect(stats.total).toBe(5);
+          // The inferred ceiling must reflect the true total, not the stale
+          // pre-batch count of 2.
+          expect(stats.maxInstances).toBe(5);
+        }
+      );
+    });
+
+    it('adds only successful UUIDs from a partial-failure batch', async () => {
+      let startCount = 0;
+      await withPool(
+        {
+          warmTarget: 4,
+          configuredMaxInstances: 100,
+          scaleBatchSize: 5,
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {
+              startCount++;
+              // Odd-numbered starts fail with a non-capacity error.
+              if (startCount % 2 === 1) {
+                throw new Error('transient boot failure');
+              }
+            }),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          await pool.alarm();
+          const stats = await pool.getStats();
+          // 2 of the 4 attempted succeeded; pool not corrupted.
+          expect(stats.warm).toBe(2);
         }
       );
     });
@@ -356,6 +539,123 @@ describe('WarmPool', () => {
 
   // ── startContainer error detection ─────────────────────────────────────
 
+  describe('eager refill', () => {
+    it('refills the warm pool after a pop without waiting for the alarm', async () => {
+      let startCount = 0;
+      await withPool(
+        {
+          warmTarget: 2,
+          configuredMaxInstances: 10,
+          warmContainers: ['w1', 'w2'],
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {
+              startCount++;
+            }),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          await pool.getContainer('user1');
+          // Wait for the fire-and-forget refill to settle.
+          await (pool as unknown as { refillPromise: Promise<void> | null }).refillPromise;
+          const stats = await pool.getStats();
+          expect(stats.warm).toBe(2);
+          expect(startCount).toBe(1);
+        }
+      );
+    });
+
+    it('debounces concurrent pops to a single in-flight refill', async () => {
+      let release: () => void = () => {};
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      await withPool(
+        {
+          warmTarget: 5,
+          configuredMaxInstances: 10,
+          warmContainers: ['w1', 'w2', 'w3'],
+          assignments: [
+            ['user1', 'c1'],
+            ['user2', 'c2']
+          ],
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {
+              await gate;
+            }),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          let adjustCount = 0;
+          const wrapped = pool as unknown as {
+            adjustPool: () => Promise<void>;
+            refillPromise: Promise<void> | null;
+          };
+          const orig = wrapped.adjustPool.bind(pool);
+          wrapped.adjustPool = async () => {
+            adjustCount++;
+            return orig();
+          };
+
+          await Promise.all([pool.getContainer('user3'), pool.getContainer('user4')]);
+
+          // Two pops, but only one refill should be in flight.
+          expect(adjustCount).toBe(1);
+
+          release();
+          await wrapped.refillPromise;
+        }
+      );
+    });
+
+    it('eager refill never exceeds remaining capacity', async () => {
+      let startCount = 0;
+      await withPool(
+        {
+          warmTarget: 5,
+          configuredMaxInstances: 3,
+          warmContainers: ['w1'],
+          assignments: [['user1', 'c1']],
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {
+              startCount++;
+            }),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          // Pop w1 → warm 0, assigned 2, total 2. Ceiling 3 leaves room for 1.
+          await pool.getContainer('user2');
+          await (pool as unknown as { refillPromise: Promise<void> | null }).refillPromise;
+          expect(startCount).toBe(1);
+          const stats = await pool.getStats();
+          expect(stats.warm).toBe(1);
+        }
+      );
+    });
+
+    it('refill failure does not reject getContainer', async () => {
+      await withPool(
+        {
+          warmTarget: 2,
+          configuredMaxInstances: 10,
+          warmContainers: ['w1', 'w2'],
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {
+              throw new Error('boom');
+            }),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          await expect(pool.getContainer('user1')).resolves.toBeDefined();
+          await (pool as unknown as { refillPromise: Promise<void> | null }).refillPromise;
+        }
+      );
+    });
+  });
+
   describe('startContainer / error detection', () => {
     it('records knownMaxInstances when max_instances error is thrown', async () => {
       await withPool(
@@ -463,6 +763,8 @@ describe('WarmPool', () => {
       await withPool(
         {
           warmTarget: 5,
+          // Serial batches isolate the mid-loop capacity stop.
+          scaleBatchSize: 1,
           containerBehavior: {
             startAndWaitForPorts: vi.fn(async () => {
               startCount++;
@@ -567,6 +869,139 @@ describe('WarmPool', () => {
     });
   });
 
+  // ── Configured max_instances (Proposal 1) ──────────────────────────────
+
+  describe('configured max_instances', () => {
+    it('seeds knownMaxInstances from config before any container start', async () => {
+      await withPool(
+        {
+          warmTarget: 0,
+          configuredMaxInstances: 100
+        },
+        async (pool) => {
+          const stats = await pool.getStats();
+          expect(stats.maxInstances).toBe(100);
+        }
+      );
+    });
+
+    it('does not require a discovery 502 to learn the ceiling', async () => {
+      let startCount = 0;
+      await withPool(
+        {
+          warmTarget: 5,
+          configuredMaxInstances: 2,
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {
+              startCount++;
+            }),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          await pool.alarm();
+          // Clamped to configured ceiling of 2 — no failed start needed.
+          expect(startCount).toBe(2);
+        }
+      );
+    });
+
+    it('keeps a learned-lower ceiling over a higher configured value', async () => {
+      await withPool(
+        {
+          warmTarget: 0,
+          maxInstances: 3,
+          configuredMaxInstances: 100
+        },
+        async (pool) => {
+          const stats = await pool.getStats();
+          expect(stats.maxInstances).toBe(3);
+        }
+      );
+    });
+
+    it('keeps a configured-lower ceiling over a higher learned value', async () => {
+      await withPool(
+        {
+          warmTarget: 0,
+          maxInstances: 50,
+          configuredMaxInstances: 10
+        },
+        async (pool) => {
+          const stats = await pool.getStats();
+          expect(stats.maxInstances).toBe(10);
+        }
+      );
+    });
+
+    it('treats 0 as auto-learn (preserves null ceiling)', async () => {
+      await withPool(
+        {
+          warmTarget: 0,
+          configuredMaxInstances: 0
+        },
+        async (pool) => {
+          const stats = await pool.getStats();
+          expect(stats.maxInstances).toBeNull();
+        }
+      );
+    });
+
+    it('never starts beyond the configured ceiling in getContainer', async () => {
+      await withPool(
+        {
+          warmTarget: 0,
+          configuredMaxInstances: 2,
+          assignments: [
+            ['user1', 'c1'],
+            ['user2', 'c2']
+          ],
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {}),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          await expect(pool.getContainer('user3')).rejects.toThrow('instance limit reached');
+        }
+      );
+    });
+
+    it('re-seeds the configured ceiling after a successful probe clears it', async () => {
+      let startCount = 0;
+      await withPool(
+        {
+          warmTarget: 3,
+          maxInstances: 2,
+          configuredMaxInstances: 5,
+          assignments: [
+            ['user1', 'c1'],
+            ['user2', 'c2']
+          ],
+          containerBehavior: {
+            startAndWaitForPorts: vi.fn(async () => {
+              startCount++;
+            }),
+            getState: vi.fn(async () => ({ status: 'running' }))
+          }
+        },
+        async (pool) => {
+          // Probe succeeds, clears the learned limit of 2.
+          await pool.alarm();
+          expect((await pool.getStats()).maxInstances).toBeNull();
+          // Next configure() (every request) re-seeds the configured ceiling.
+          await pool.configure({
+            warmTarget: 3,
+            refreshInterval: 60_000,
+            maxInstances: 5
+          });
+          const stats = await pool.getStats();
+          expect(stats.maxInstances).toBe(5);
+        }
+      );
+    });
+  });
+
   // ── Multiple alarm cycles ──────────────────────────────────────────────
 
   describe('multiple alarm cycles', () => {
@@ -577,6 +1012,9 @@ describe('WarmPool', () => {
       await withPool(
         {
           warmTarget: 3,
+          // Reactive discovery counts on serial starts; batch size 1 keeps the
+          // inferred ceiling accurate for the learn-by-crashing path.
+          scaleBatchSize: 1,
           containerBehavior: {
             startAndWaitForPorts: vi.fn(async () => {
               totalStarted++;

--- a/bridge/worker/wrangler.jsonc
+++ b/bridge/worker/wrangler.jsonc
@@ -5,7 +5,17 @@
   "compatibility_date": "2025-05-06",
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
-    "enabled": true
+    "enabled": true,
+    // Enable distributed tracing so the bridge's custom spans
+    // (bridge.<operation>) are recorded alongside automatic instrumentation.
+    // Each span is annotated with the sandbox ID, container UUID, and
+    // operation-specific metadata (command, file path, port, session, etc.).
+    "traces": {
+      "enabled": true,
+      // Fraction of requests to trace (0.0–1.0). 1.0 traces everything; lower
+      // it to reduce overhead and cost under high traffic.
+      "head_sampling_rate": 1
+    }
   },
   // The Sandbox Durable Object + its container image.
   // Bump the migration tag whenever new_sqlite_classes changes.
@@ -15,9 +25,9 @@
       // Replace with a custom Dockerfile path if you need extra tooling
       // (e.g. git, Python, Node.js) in the sandbox container.
       "image": "./Dockerfile",
-      // "lite" is a good default for getting started; upgrade to "standard-1"
-      // (4 vCPU / 8 GiB RAM) for production workloads.
-      "instance_type": "lite",
+      // "standard-1" (4 vCPU / 8 GiB RAM) suits production workloads; drop to
+      // "lite" to minimise cost when getting started.
+      "instance_type": "standard-1",
       "max_instances": 3
     }
   ],
@@ -61,7 +71,18 @@
     // Target number of pre-warmed containers (0 = disabled, no surprise bills).
     "WARM_POOL_TARGET": "0",
     // How often the pool alarm checks health and replenishes containers (ms).
-    "WARM_POOL_REFRESH_INTERVAL": "10000"
+    "WARM_POOL_REFRESH_INTERVAL": "10000",
+    // Operator-declared instance ceiling. Set this to match
+    // containers[].max_instances above so the pool knows its capacity without
+    // crashing into the limit first. 0 = unknown (auto-learn from platform
+    // errors). Note the effective warm ceiling is max_instances minus any
+    // assigned containers, so warmTarget cannot equal max_instances while
+    // sandboxes are in use.
+    "WARM_POOL_MAX_INSTANCES": "0",
+    // Number of containers the pool starts in parallel per scale-up batch.
+    // Higher fills the pool faster; too high risks the platform throttling a
+    // cold-start stampede. Clamped to [1, 20]. Default 5.
+    "WARM_POOL_SCALE_BATCH_SIZE": "5"
   },
   "preview_urls": false
 }

--- a/packages/sandbox/CHANGELOG.md
+++ b/packages/sandbox/CHANGELOG.md
@@ -53,7 +53,6 @@
 
 - [#706](https://github.com/cloudflare/sandbox-sdk/pull/706) [`ae5f9a1`](https://github.com/cloudflare/sandbox-sdk/commit/ae5f9a10aa45dc59a48c8b9a30c5c14ea16cf75b) Thanks [@scuffi](https://github.com/scuffi)! - Add sessionless execution mode with a configurable default-session policy.
 
-  Set `enableDefaultSession: false` in `SandboxOptions` to run implicit top-level operations without a persistent shell — each command gets a fresh process with no shared state. The option is scoped to the sandbox object returned by `getSandbox(...)`; explicit per-call session IDs continue to target that session.
 
 ## 0.10.2
 

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -98,6 +98,26 @@ export default {
 };
 ```
 
+## Sandbox options
+
+Pass options as the third argument to `getSandbox()` to configure sandbox
+lifetime and container startup metadata:
+
+```ts
+const sandbox = getSandbox(env.Sandbox, 'tenant-workspace', {
+  sleepAfter: '30m',
+  labels: {
+    tenantId: 'tenant_123',
+    workload: 'code-workspace'
+  }
+});
+```
+
+Container labels are attached to the underlying Cloudflare Container for
+analytics and observability. Labels are applied when the container starts; if
+labels are changed while a container is already running, the new labels apply
+the next time the container starts.
+
 ## Quick tunnels
 
 `sandbox.tunnels.get(port)` exposes a service running inside the

--- a/packages/sandbox/src/bridge/AGENTS.md
+++ b/packages/sandbox/src/bridge/AGENTS.md
@@ -11,6 +11,7 @@ Consumer-facing documentation (API reference, deployment, security) lives in [`b
 - `warm-pool.ts` — `WarmPool` Durable Object that maintains a pool of pre-started sandbox containers (adapted from [cf-container-warm-pool](https://github.com/mikenomitch/cf-container-warm-pool)).
 - `pool.ts` — Pool management helpers used by routes.
 - `helpers.ts` — Utility functions (path validation, shell quoting, SSE formatting).
+- `tracing.ts` — Custom span instrumentation: wraps each route handler in a `bridge.<operation>` Cloudflare custom span, seeding common attributes and exposing the active span for operation-specific metadata.
 - `types.ts` — `BridgeConfig`, `BridgeEnv`, `WorkerHandlers` type definitions.
 - `openapi.ts` — OpenAPI 3.1 schema definition.
 - `openapi-html.ts` — Self-contained HTML renderer for the OpenAPI spec.

--- a/packages/sandbox/src/bridge/pool.ts
+++ b/packages/sandbox/src/bridge/pool.ts
@@ -3,6 +3,29 @@
  */
 
 import type { BridgeEnv } from './types';
+import type { WarmPoolConfig } from './warm-pool';
+
+/**
+ * Parse warm-pool configuration from bridge env vars.
+ *
+ * `WARM_POOL_MAX_INSTANCES` should match `containers[].max_instances` in
+ * wrangler.jsonc. 0/unset means auto-learn the ceiling reactively.
+ */
+export function parsePoolConfig(env: BridgeEnv): Required<WarmPoolConfig> {
+  const warmTarget =
+    Number.parseInt((env.WARM_POOL_TARGET as string) || '0', 10) || 0;
+  const refreshInterval =
+    Number.parseInt(
+      (env.WARM_POOL_REFRESH_INTERVAL as string) || '10000',
+      10
+    ) || 10_000;
+  const maxInstances =
+    Number.parseInt((env.WARM_POOL_MAX_INSTANCES as string) || '0', 10) || 0;
+  const scaleBatchSize =
+    Number.parseInt((env.WARM_POOL_SCALE_BATCH_SIZE as string) || '5', 10) || 5;
+
+  return { warmTarget, refreshInterval, maxInstances, scaleBatchSize };
+}
 
 /**
  * Prime the warm pool — pushes current configuration to the WarmPool
@@ -14,16 +37,10 @@ export async function primePool(
   env: BridgeEnv,
   warmPoolBinding: string
 ): Promise<void> {
-  const warmTarget =
-    Number.parseInt((env.WARM_POOL_TARGET as string) || '0', 10) || 0;
-  const refreshInterval =
-    Number.parseInt(
-      (env.WARM_POOL_REFRESH_INTERVAL as string) || '10000',
-      10
-    ) || 10_000;
+  const config = parsePoolConfig(env);
 
   const ns = env[warmPoolBinding] as DurableObjectNamespace;
   const poolId = ns.idFromName('global-pool');
   const poolStub = ns.get(poolId);
-  await (poolStub as any).configure({ warmTarget, refreshInterval });
+  await (poolStub as any).configure(config);
 }

--- a/packages/sandbox/src/bridge/routes.ts
+++ b/packages/sandbox/src/bridge/routes.ts
@@ -37,7 +37,8 @@ import {
 } from './helpers';
 import { OPENAPI_SCHEMA } from './openapi';
 import { renderOpenApiHtml } from './openapi-html';
-import { primePool } from './pool';
+import { parsePoolConfig, primePool } from './pool';
+import { annotate, type BridgeHonoEnv, traced } from './tracing';
 import type {
   BridgeEnv,
   ExecRequest,
@@ -55,12 +56,13 @@ import type {
 
 /**
  * The SDK's getSandbox() proxy exposes methods not declared on ISandbox
- * (destroy, tunnels). This type extends ISandbox with those extra methods
+ * (terminal, destroy) or declared with a narrower return type (getSession
+ * without terminal). This type extends ISandbox with those extra methods
  * so call sites get type safety without per-call casts.
  */
 type BridgeSandbox = ISandbox & {
-  getSession(sessionId: string): Promise<ExecutionSession>;
   terminal(options?: TerminalOptions): SandboxTerminal;
+  getSession(sessionId: string): Promise<ExecutionSession>;
   destroy(): Promise<void>;
   tunnels: {
     get(port: number, options?: TunnelOptions): Promise<TunnelInfo>;
@@ -301,13 +303,8 @@ export interface RouteConfig {
 // App factory
 // ---------------------------------------------------------------------------
 
-export function createBridgeApp(
-  config: RouteConfig
-): Hono<{ Bindings: BridgeEnv; Variables: { containerUUID: string } }> {
-  const app = new Hono<{
-    Bindings: BridgeEnv;
-    Variables: { containerUUID: string };
-  }>();
+export function createBridgeApp(config: RouteConfig): Hono<BridgeHonoEnv> {
+  const app = new Hono<BridgeHonoEnv>();
 
   const { sandboxBinding, warmPoolBinding, apiPrefix } = config;
 
@@ -352,25 +349,29 @@ export function createBridgeApp(
   // POST /sandbox
   // ------------------------------------------------------------------
 
-  app.post(`${apiPrefix}/sandbox`, async (c) => {
-    // Auth — same logic as the /sandbox/* middleware
-    const token = c.env.SANDBOX_API_KEY as string | undefined;
-    if (token) {
-      const authHeader = c.req.header('Authorization') ?? '';
-      const provided = authHeader.toLowerCase().startsWith('bearer ')
-        ? authHeader.slice(7)
-        : '';
-      if (provided !== token) {
-        return errorJson('Unauthorized', 'unauthorized', 401);
+  app.post(
+    `${apiPrefix}/sandbox`,
+    traced('create_sandbox', async (c) => {
+      // Auth — same logic as the /sandbox/* middleware
+      const token = c.env.SANDBOX_API_KEY as string | undefined;
+      if (token) {
+        const authHeader = c.req.header('Authorization') ?? '';
+        const provided = authHeader.toLowerCase().startsWith('bearer ')
+          ? authHeader.slice(7)
+          : '';
+        if (provided !== token) {
+          return errorJson('Unauthorized', 'unauthorized', 401);
+        }
       }
-    }
 
-    // Generate a sandbox ID: 16 random bytes → base32 (lowercase a-z, 2-7), 26 chars
-    const bytes = new Uint8Array(16);
-    crypto.getRandomValues(bytes);
-    const id = base32Encode(bytes);
-    return c.json({ id });
-  });
+      // Generate a sandbox ID: 16 random bytes → base32 (lowercase a-z, 2-7), 26 chars
+      const bytes = new Uint8Array(16);
+      crypto.getRandomValues(bytes);
+      const id = base32Encode(bytes);
+      annotate(c, 'sandbox.id', id);
+      return c.json({ id });
+    })
+  );
 
   // ------------------------------------------------------------------
   // Pool resolution middleware — maps sandbox ID to container UUID
@@ -379,20 +380,12 @@ export function createBridgeApp(
   app.use(`${apiPrefix}/sandbox/:id/*`, async (c, next) => {
     const sandboxId = c.req.param('id');
 
-    const warmTarget =
-      Number.parseInt((c.env.WARM_POOL_TARGET as string) || '0', 10) || 0;
-    const refreshInterval =
-      Number.parseInt(
-        (c.env.WARM_POOL_REFRESH_INTERVAL as string) || '10000',
-        10
-      ) || 10_000;
-
     const poolNs = getWarmPoolNs(c.env);
     const poolId = poolNs.idFromName('global-pool');
     const poolStub = poolNs.get(poolId);
 
     try {
-      await (poolStub as any).configure({ warmTarget, refreshInterval });
+      await (poolStub as any).configure(parsePoolConfig(c.env));
       const containerUUID = await (poolStub as any).getContainer(sandboxId);
       c.set('containerUUID', containerUUID);
     } catch (err) {
@@ -438,702 +431,789 @@ export function createBridgeApp(
   // POST /sandbox/:id/exec
   // ------------------------------------------------------------------
 
-  app.post(`${apiPrefix}/sandbox/:id/exec`, async (c) => {
-    let body: ExecRequest;
-    try {
-      body = await c.req.json<ExecRequest>();
-    } catch {
-      return errorJson('Invalid JSON body', 'invalid_request', 400);
-    }
-
-    if (!Array.isArray(body.argv) || body.argv.length === 0) {
-      return errorJson(
-        'argv must be a non-empty array',
-        'invalid_request',
-        400
-      );
-    }
-
-    const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
-    const rawSessionId = c.req.header('Session-Id');
-    let executor:
-      | BridgeSandbox
-      | Awaited<ReturnType<BridgeSandbox['getSession']>> = sandbox;
-    if (rawSessionId) {
-      const sessionId = validateSessionId(rawSessionId);
-      if (!sessionId)
-        return errorJson('Invalid session ID format', 'invalid_request', 400);
-      executor = await sandbox.getSession(sessionId);
-    }
-
-    const command = body.argv.map(shellQuote).join(' ');
-
-    const opts: { timeout?: number; cwd?: string } = {};
-    if (typeof body.timeout_ms === 'number') {
-      opts.timeout = body.timeout_ms;
-    }
-    if (typeof body.cwd === 'string') {
-      const resolvedCwd = resolveWorkspacePath(body.cwd);
-      if (!resolvedCwd) {
-        return errorJson(
-          'cwd must resolve to a location within /workspace',
-          'invalid_request',
-          403
-        );
-      }
-      opts.cwd = resolvedCwd;
-    }
-
-    // --- SSE streaming response ---
-    const { readable, writable } = new TransformStream();
-    const writer = writable.getWriter();
-    const encoder = new TextEncoder();
-
-    let closed = false;
-    let lastWrite: Promise<void> = Promise.resolve();
-
-    /** Write a single SSE event. Chains on the previous write to respect backpressure. */
-    function writeSSE(event: string, data: string): void {
-      if (closed) return;
-      // SSE spec: each line of data needs its own "data:" prefix
-      const payload = data
-        .split('\n')
-        .map((line) => `data: ${line}`)
-        .join('\n');
-      lastWrite = lastWrite.then(() =>
-        writer.write(encoder.encode(`event: ${event}\n${payload}\n\n`))
-      );
-    }
-
-    function closeStream(): void {
-      if (closed) return;
-      closed = true;
-      lastWrite.then(() => writer.close()).catch(() => {});
-    }
-
-    // Spawn the process and pump its stdout/stderr/exit through the SSE
-    // writer. Replaces the legacy callback shape with the unified
-    // `SandboxProcess` handle.
-    (async () => {
+  app.post(
+    `${apiPrefix}/sandbox/:id/exec`,
+    traced('exec', async (c) => {
+      let body: ExecRequest;
       try {
-        const proc = await executor.exec(command, opts);
+        body = await c.req.json<ExecRequest>();
+      } catch {
+        return errorJson('Invalid JSON body', 'invalid_request', 400);
+      }
 
-        const decoder = new TextDecoder();
-        const pump = async (
-          stream: ReadableStream<Uint8Array> | null,
-          name: 'stdout' | 'stderr'
-        ) => {
-          if (!stream) return;
-          const reader = stream.getReader();
-          try {
-            for (;;) {
-              const { value, done } = await reader.read();
-              if (done) break;
-              if (value && value.byteLength > 0) {
-                writeSSE(name, toBase64(decoder.decode(value)));
-              }
-            }
-          } finally {
-            reader.releaseLock();
-          }
-        };
-
-        await Promise.all([
-          pump(proc.stdout, 'stdout'),
-          pump(proc.stderr, 'stderr')
-        ]);
-        const exitCode = await proc.exitCode;
-        writeSSE('exit', JSON.stringify({ exit_code: exitCode }));
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        writeSSE(
-          'error',
-          JSON.stringify({
-            error: `exec failed: ${msg}`,
-            code: 'exec_transport_error'
-          })
+      if (!Array.isArray(body.argv) || body.argv.length === 0) {
+        return errorJson(
+          'argv must be a non-empty array',
+          'invalid_request',
+          400
         );
-      } finally {
-        closeStream();
       }
-    })();
 
-    return new Response(readable, {
-      status: 200,
-      headers: {
-        'Content-Type': 'text/event-stream',
-        'Cache-Control': 'no-cache'
+      annotate(c, 'exec.argv_count', body.argv.length);
+      if (body.argv[0]) annotate(c, 'exec.command', body.argv[0]);
+
+      const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
+      const rawSessionId = c.req.header('Session-Id');
+      let executor:
+        | BridgeSandbox
+        | Awaited<ReturnType<BridgeSandbox['getSession']>> = sandbox;
+      if (rawSessionId) {
+        const sessionId = validateSessionId(rawSessionId);
+        if (!sessionId)
+          return errorJson('Invalid session ID format', 'invalid_request', 400);
+        annotate(c, 'session.id', sessionId);
+        executor = await sandbox.getSession(sessionId);
       }
-    });
-  });
+
+      const command = body.argv.map(shellQuote).join(' ');
+
+      const opts: { timeout?: number; cwd?: string } = {};
+      if (typeof body.timeout_ms === 'number') {
+        opts.timeout = body.timeout_ms;
+        annotate(c, 'exec.timeout_ms', body.timeout_ms);
+      }
+      if (typeof body.cwd === 'string') {
+        const resolvedCwd = resolveWorkspacePath(body.cwd);
+        if (!resolvedCwd) {
+          return errorJson(
+            'cwd must resolve to a location within /workspace',
+            'invalid_request',
+            403
+          );
+        }
+        opts.cwd = resolvedCwd;
+        annotate(c, 'exec.cwd', resolvedCwd);
+      }
+
+      // --- SSE streaming response ---
+      const { readable, writable } = new TransformStream();
+      const writer = writable.getWriter();
+      const encoder = new TextEncoder();
+
+      let closed = false;
+      let lastWrite: Promise<void> = Promise.resolve();
+
+      /** Write a single SSE event. Chains on the previous write to respect backpressure. */
+      function writeSSE(event: string, data: string): void {
+        if (closed) return;
+        // SSE spec: each line of data needs its own "data:" prefix
+        const payload = data
+          .split('\n')
+          .map((line) => `data: ${line}`)
+          .join('\n');
+        lastWrite = lastWrite.then(() =>
+          writer.write(encoder.encode(`event: ${event}\n${payload}\n\n`))
+        );
+      }
+
+      function closeStream(): void {
+        if (closed) return;
+        closed = true;
+        lastWrite.then(() => writer.close()).catch(() => {});
+      }
+
+      async function pumpStream(
+        event: 'stdout' | 'stderr',
+        stream: ReadableStream<Uint8Array> | null
+      ): Promise<void> {
+        if (!stream) return;
+        const reader = stream.getReader();
+        const decoder = new TextDecoder();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          writeSSE(event, toBase64(decoder.decode(value, { stream: true })));
+        }
+        const remaining = decoder.decode();
+        if (remaining) writeSSE(event, toBase64(remaining));
+      }
+
+      (async () => {
+        try {
+          const process = await executor.exec(command, opts);
+          await Promise.all([
+            pumpStream('stdout', process.stdout),
+            pumpStream('stderr', process.stderr)
+          ]);
+          const exitCode = await process.exitCode;
+          writeSSE('exit', JSON.stringify({ exit_code: exitCode }));
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          writeSSE(
+            'error',
+            JSON.stringify({
+              error: `exec failed: ${msg}`,
+              code: 'exec_transport_error'
+            })
+          );
+        } finally {
+          closeStream();
+        }
+      })();
+
+      return new Response(readable, {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache'
+        }
+      });
+    })
+  );
 
   // ------------------------------------------------------------------
   // GET /sandbox/:id/file/*
   // ------------------------------------------------------------------
 
-  app.get(`${apiPrefix}/sandbox/:id/file/*`, async (c) => {
-    const sandboxId = c.req.param('id');
+  app.get(
+    `${apiPrefix}/sandbox/:id/file/*`,
+    traced('read_file', async (c) => {
+      const sandboxId = c.req.param('id');
 
-    // Extract everything after /file/ in the URL path
-    const fullPath = c.req.path;
-    const marker = `${apiPrefix}/sandbox/${sandboxId}/file/`;
-    const relativePath = fullPath.slice(marker.length);
+      // Extract everything after /file/ in the URL path
+      const fullPath = c.req.path;
+      const marker = `${apiPrefix}/sandbox/${sandboxId}/file/`;
+      const relativePath = fullPath.slice(marker.length);
 
-    if (!relativePath) {
-      return errorJson('file path must not be empty', 'invalid_request', 400);
-    }
+      if (!relativePath) {
+        return errorJson('file path must not be empty', 'invalid_request', 400);
+      }
 
-    // Prepend / to make it absolute before validation
-    const resolvedPath = resolveWorkspacePath(`/${relativePath}`);
-    if (!resolvedPath) {
-      return errorJson(
-        'path must resolve to a location within /workspace',
-        'invalid_request',
-        403
-      );
-    }
-
-    const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
-    const rawSessionId = c.req.header('Session-Id');
-    let executor:
-      | BridgeSandbox
-      | Awaited<ReturnType<BridgeSandbox['getSession']>> = sandbox;
-    if (rawSessionId) {
-      const sessionId = validateSessionId(rawSessionId);
-      if (!sessionId)
-        return errorJson('Invalid session ID format', 'invalid_request', 400);
-      executor = await sandbox.getSession(sessionId);
-    }
-
-    try {
-      const stream = await executor.readFileStream(resolvedPath);
-      return new Response(sseToByteStream(stream), {
-        status: 200,
-        headers: { 'Content-Type': 'application/octet-stream' }
-      });
-    } catch (err) {
-      const code = (err as { code?: string }).code;
-      if (code === 'FILE_NOT_FOUND') {
+      // Prepend / to make it absolute before validation
+      const resolvedPath = resolveWorkspacePath(`/${relativePath}`);
+      if (!resolvedPath) {
         return errorJson(
-          `File not found: ${resolvedPath}`,
-          'workspace_read_not_found',
-          404
+          'path must resolve to a location within /workspace',
+          'invalid_request',
+          403
         );
       }
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(`read failed: ${msg}`, 'exec_transport_error', 502);
-    }
-  });
+
+      annotate(c, 'file.path', resolvedPath);
+
+      const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
+      const rawSessionId = c.req.header('Session-Id');
+      let executor:
+        | BridgeSandbox
+        | Awaited<ReturnType<BridgeSandbox['getSession']>> = sandbox;
+      if (rawSessionId) {
+        const sessionId = validateSessionId(rawSessionId);
+        if (!sessionId)
+          return errorJson('Invalid session ID format', 'invalid_request', 400);
+        annotate(c, 'session.id', sessionId);
+        executor = await sandbox.getSession(sessionId);
+      }
+
+      try {
+        const stream = await executor.readFileStream(resolvedPath);
+        return new Response(sseToByteStream(stream), {
+          status: 200,
+          headers: { 'Content-Type': 'application/octet-stream' }
+        });
+      } catch (err) {
+        const code = (err as { code?: string }).code;
+        if (code === 'FILE_NOT_FOUND') {
+          return errorJson(
+            `File not found: ${resolvedPath}`,
+            'workspace_read_not_found',
+            404
+          );
+        }
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(`read failed: ${msg}`, 'exec_transport_error', 502);
+      }
+    })
+  );
 
   // ------------------------------------------------------------------
   // PUT /sandbox/:id/file/*
   // ------------------------------------------------------------------
 
-  app.put(`${apiPrefix}/sandbox/:id/file/*`, async (c) => {
-    const sandboxId = c.req.param('id');
+  app.put(
+    `${apiPrefix}/sandbox/:id/file/*`,
+    traced('write_file', async (c) => {
+      const sandboxId = c.req.param('id');
 
-    // Extract everything after /file/ in the URL path
-    const fullPath = c.req.path;
-    const marker = `${apiPrefix}/sandbox/${sandboxId}/file/`;
-    const relativePath = fullPath.slice(marker.length);
+      // Extract everything after /file/ in the URL path
+      const fullPath = c.req.path;
+      const marker = `${apiPrefix}/sandbox/${sandboxId}/file/`;
+      const relativePath = fullPath.slice(marker.length);
 
-    if (!relativePath) {
-      return errorJson('file path must not be empty', 'invalid_request', 400);
-    }
+      if (!relativePath) {
+        return errorJson('file path must not be empty', 'invalid_request', 400);
+      }
 
-    // Prepend / to make it absolute before validation
-    const resolvedPath = resolveWorkspacePath(`/${relativePath}`);
-    if (!resolvedPath) {
-      return errorJson(
-        'path must resolve to a location within /workspace',
-        'invalid_request',
-        403
-      );
-    }
-
-    const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
-    const rawSessionId = c.req.header('Session-Id');
-    let executor:
-      | BridgeSandbox
-      | Awaited<ReturnType<BridgeSandbox['getSession']>> = sandbox;
-    if (rawSessionId) {
-      const sessionId = validateSessionId(rawSessionId);
-      if (!sessionId)
-        return errorJson('Invalid session ID format', 'invalid_request', 400);
-      executor = await sandbox.getSession(sessionId);
-    }
-
-    try {
-      const buffer = await c.req.arrayBuffer();
-      const MAX_WRITE_BYTES = 32 * 1024 * 1024; // 32 MiB — matches RPC payload limit
-      if (buffer.byteLength > MAX_WRITE_BYTES) {
+      // Prepend / to make it absolute before validation
+      const resolvedPath = resolveWorkspacePath(`/${relativePath}`);
+      if (!resolvedPath) {
         return errorJson(
-          `payload too large: ${buffer.byteLength} bytes exceeds the ${MAX_WRITE_BYTES}-byte limit`,
-          'payload_too_large',
-          413
+          'path must resolve to a location within /workspace',
+          'invalid_request',
+          403
         );
       }
 
-      const bytes = new Uint8Array(buffer);
-      let b64 = '';
-      const CHUNK = 6144; // 6144 = 3 * 2048 — no intermediate padding
-      for (let i = 0; i < bytes.length; i += CHUNK) {
-        b64 += btoa(String.fromCharCode(...bytes.subarray(i, i + CHUNK)));
+      annotate(c, 'file.path', resolvedPath);
+
+      const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
+      const rawSessionId = c.req.header('Session-Id');
+      let executor:
+        | BridgeSandbox
+        | Awaited<ReturnType<BridgeSandbox['getSession']>> = sandbox;
+      if (rawSessionId) {
+        const sessionId = validateSessionId(rawSessionId);
+        if (!sessionId)
+          return errorJson('Invalid session ID format', 'invalid_request', 400);
+        annotate(c, 'session.id', sessionId);
+        executor = await sandbox.getSession(sessionId);
       }
-      await executor.writeFile(resolvedPath, b64, { encoding: 'base64' });
-      const response: WriteResponse = { ok: true };
-      return c.json(response);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(
-        `write failed: ${msg}`,
-        'workspace_archive_write_error',
-        502
-      );
-    }
-  });
+
+      try {
+        const buffer = await c.req.arrayBuffer();
+        annotate(c, 'file.size_bytes', buffer.byteLength);
+        const MAX_WRITE_BYTES = 32 * 1024 * 1024; // 32 MiB — matches RPC payload limit
+        if (buffer.byteLength > MAX_WRITE_BYTES) {
+          return errorJson(
+            `payload too large: ${buffer.byteLength} bytes exceeds the ${MAX_WRITE_BYTES}-byte limit`,
+            'payload_too_large',
+            413
+          );
+        }
+
+        const bytes = new Uint8Array(buffer);
+        let b64 = '';
+        const CHUNK = 6144; // 6144 = 3 * 2048 — no intermediate padding
+        for (let i = 0; i < bytes.length; i += CHUNK) {
+          b64 += btoa(String.fromCharCode(...bytes.subarray(i, i + CHUNK)));
+        }
+        await executor.writeFile(resolvedPath, b64, { encoding: 'base64' });
+        const response: WriteResponse = { ok: true };
+        return c.json(response);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(
+          `write failed: ${msg}`,
+          'workspace_archive_write_error',
+          502
+        );
+      }
+    })
+  );
 
   // ------------------------------------------------------------------
   // POST /sandbox/:id/tunnel/:port
   // DELETE /sandbox/:id/tunnel/:port
   // ------------------------------------------------------------------
 
-  app.post(`${apiPrefix}/sandbox/:id/tunnel/:port`, async (c) => {
-    const port = Number(c.req.param('port'));
-    if (!validatePort(port)) {
-      return errorJson('Invalid port', 'invalid_request', 400);
-    }
+  app.post(
+    `${apiPrefix}/sandbox/:id/tunnel/:port`,
+    traced('tunnel_create', async (c) => {
+      const port = Number(c.req.param('port'));
+      if (!validatePort(port)) {
+        return errorJson('Invalid port', 'invalid_request', 400);
+      }
 
-    const options = parseTunnelOptions(await c.req.text());
-    if (options instanceof Response) return options;
+      annotate(c, 'tunnel.port', port);
 
-    const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
+      const options = parseTunnelOptions(await c.req.text());
+      if (options instanceof Response) return options;
+      if (options?.name) annotate(c, 'tunnel.name', options.name);
 
-    try {
-      const tunnel = await sandbox.tunnels.get(port, options);
-      return c.json(tunnel);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(`tunnel failed: ${msg}`, 'tunnel_error', 502);
-    }
-  });
+      const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
 
-  app.delete(`${apiPrefix}/sandbox/:id/tunnel/:port`, async (c) => {
-    const port = Number(c.req.param('port'));
-    if (!validatePort(port)) {
-      return errorJson('Invalid port', 'invalid_request', 400);
-    }
+      try {
+        const tunnel = await sandbox.tunnels.get(port, options);
+        return c.json(tunnel);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(`tunnel failed: ${msg}`, 'tunnel_error', 502);
+      }
+    })
+  );
 
-    const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
+  app.delete(
+    `${apiPrefix}/sandbox/:id/tunnel/:port`,
+    traced('tunnel_destroy', async (c) => {
+      const port = Number(c.req.param('port'));
+      if (!validatePort(port)) {
+        return errorJson('Invalid port', 'invalid_request', 400);
+      }
 
-    try {
-      await sandbox.tunnels.destroy(port);
-      return c.body(null, 204);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(`tunnel failed: ${msg}`, 'tunnel_error', 502);
-    }
-  });
+      annotate(c, 'tunnel.port', port);
+
+      const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
+
+      try {
+        await sandbox.tunnels.destroy(port);
+        return c.body(null, 204);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(`tunnel failed: ${msg}`, 'tunnel_error', 502);
+      }
+    })
+  );
 
   // ------------------------------------------------------------------
   // GET /sandbox/:id/running
   // ------------------------------------------------------------------
 
-  app.get(`${apiPrefix}/sandbox/:id/running`, async (c) => {
-    const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
+  app.get(
+    `${apiPrefix}/sandbox/:id/running`,
+    traced('running', async (c) => {
+      const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
 
-    try {
-      await sandbox.exec('true');
-      const response: RunningResponse = { running: true };
-      return c.json(response);
-    } catch {
-      const response: RunningResponse = { running: false };
-      return c.json(response);
-    }
-  });
+      try {
+        await sandbox.exec('true');
+        annotate(c, 'sandbox.running', true);
+        const response: RunningResponse = { running: true };
+        return c.json(response);
+      } catch {
+        annotate(c, 'sandbox.running', false);
+        const response: RunningResponse = { running: false };
+        return c.json(response);
+      }
+    })
+  );
 
   // ------------------------------------------------------------------
   // GET /sandbox/:id/pty (WebSocket upgrade)
   // ------------------------------------------------------------------
 
-  app.get(`${apiPrefix}/sandbox/:id/pty`, async (c) => {
-    // 1. Require WebSocket upgrade
-    const upgrade = c.req.header('Upgrade');
-    if (!upgrade || upgrade.toLowerCase() !== 'websocket') {
-      return errorJson('WebSocket upgrade required', 'invalid_request', 400);
-    }
+  app.get(
+    `${apiPrefix}/sandbox/:id/pty`,
+    traced('pty', async (c) => {
+      // 1. Require WebSocket upgrade
+      const upgrade = c.req.header('Upgrade');
+      if (!upgrade || upgrade.toLowerCase() !== 'websocket') {
+        return errorJson('WebSocket upgrade required', 'invalid_request', 400);
+      }
 
-    const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
+      const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
 
-    // 2. Parse terminal options from query params
-    const colsParam = c.req.query('cols');
-    const rowsParam = c.req.query('rows');
-    const shell = c.req.query('shell');
-    const cwd = c.req.query('cwd');
-    const terminalId =
-      c.req.header('Terminal-Id') ??
-      c.req.query('terminalId') ??
-      c.req.query('terminal');
+      // 2. Parse terminal options from query params
+      const colsParam = c.req.query('cols');
+      const rowsParam = c.req.query('rows');
+      const shell = c.req.query('shell');
+      const cwd = c.req.query('cwd');
+      const terminalId =
+        c.req.header('Terminal-Id') ??
+        c.req.query('terminalId') ??
+        c.req.query('terminal');
 
-    const cols = colsParam ? Number(colsParam) : 80;
-    const rows = rowsParam ? Number(rowsParam) : 24;
+      const cols = colsParam ? Number(colsParam) : 80;
+      const rows = rowsParam ? Number(rowsParam) : 24;
 
-    if (Number.isNaN(cols) || Number.isNaN(rows)) {
-      return errorJson(
-        'cols and rows must be valid numbers',
-        'invalid_request',
-        400
-      );
-    }
+      if (Number.isNaN(cols) || Number.isNaN(rows)) {
+        return errorJson(
+          'cols and rows must be valid numbers',
+          'invalid_request',
+          400
+        );
+      }
 
-    const terminalOptions: TerminalOptions = {};
-    const connectOptions: TerminalConnectOptions = { cols, rows };
-    if (shell) {
-      terminalOptions.shell = shell;
-    }
-    if (cwd) {
-      terminalOptions.cwd = cwd;
-    }
-    if (!terminalId) {
-      return errorJson(
-        'terminalId query parameter or Terminal-Id header required',
-        'invalid_request',
-        400
-      );
-    }
+      annotate(c, 'pty.cols', cols);
+      annotate(c, 'pty.rows', rows);
 
-    const validatedId = validateSessionId(terminalId);
-    if (!validatedId)
-      return errorJson('Invalid terminal ID format', 'invalid_request', 400);
-    terminalOptions.id = validatedId;
+      const terminalOptions: TerminalOptions = {};
+      const connectOptions: TerminalConnectOptions = { cols, rows };
+      if (shell) {
+        terminalOptions.shell = shell;
+        annotate(c, 'pty.shell', shell);
+      }
+      if (cwd) {
+        terminalOptions.cwd = cwd;
+        annotate(c, 'pty.cwd', cwd);
+      }
+      if (!terminalId) {
+        return errorJson(
+          'terminalId query parameter or Terminal-Id header required',
+          'invalid_request',
+          400
+        );
+      }
 
-    try {
-      return await sandbox
-        .terminal(terminalOptions)
-        .connect(c.req.raw, connectOptions);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(`terminal failed: ${msg}`, 'exec_transport_error', 502);
-    }
-  });
+      const validatedId = validateSessionId(terminalId);
+      if (!validatedId)
+        return errorJson('Invalid terminal ID format', 'invalid_request', 400);
+      terminalOptions.id = validatedId;
+      annotate(c, 'terminal.id', validatedId);
+
+      try {
+        return await sandbox
+          .terminal(terminalOptions)
+          .connect(c.req.raw, connectOptions);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(
+          `terminal failed: ${msg}`,
+          'exec_transport_error',
+          502
+        );
+      }
+    })
+  );
 
   // ------------------------------------------------------------------
   // POST /sandbox/:id/persist
   // ------------------------------------------------------------------
 
-  app.post(`${apiPrefix}/sandbox/:id/persist`, async (c) => {
-    const root = '/workspace';
+  app.post(
+    `${apiPrefix}/sandbox/:id/persist`,
+    traced('persist', async (c) => {
+      const root = '/workspace';
 
-    // Decode any exclude paths passed from the client layer.
-    const excludesParam = c.req.query('excludes') ?? '';
-    const excludes = excludesParam
-      ? excludesParam.split(',').filter((s) => s.length > 0)
-      : [];
+      // Decode any exclude paths passed from the client layer.
+      const excludesParam = c.req.query('excludes') ?? '';
+      const excludes = excludesParam
+        ? excludesParam.split(',').filter((s) => s.length > 0)
+        : [];
 
-    // Validate excludes don't contain path traversal
-    for (const ex of excludes) {
-      if (ex.includes('..')) {
-        return errorJson(
-          'exclude paths must not contain ".."',
-          'invalid_request',
-          400
-        );
+      annotate(c, 'persist.exclude_count', excludes.length);
+
+      // Validate excludes don't contain path traversal
+      for (const ex of excludes) {
+        if (ex.includes('..')) {
+          return errorJson(
+            'exclude paths must not contain ".."',
+            'invalid_request',
+            400
+          );
+        }
       }
-    }
 
-    const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
+      const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
 
-    const tmpPath = `/tmp/sandbox-persist-${Date.now()}.tar`;
-    const excludeArgs = excludes
-      .map((rel) => `--exclude ${shellQuote(`./${rel.replace(/^\.\//, '')}`)}`)
-      .join(' ');
-    const tarCmd = excludeArgs
-      ? `tar cf ${shellQuote(tmpPath)} ${excludeArgs} -C ${shellQuote(root)} .`
-      : `tar cf ${shellQuote(tmpPath)} -C ${shellQuote(root)} .`;
+      const tmpPath = `/tmp/sandbox-persist-${Date.now()}.tar`;
+      const excludeArgs = excludes
+        .map(
+          (rel) => `--exclude ${shellQuote(`./${rel.replace(/^\.\//, '')}`)}`
+        )
+        .join(' ');
+      const tarCmd = excludeArgs
+        ? `tar cf ${shellQuote(tmpPath)} ${excludeArgs} -C ${shellQuote(root)} .`
+        : `tar cf ${shellQuote(tmpPath)} -C ${shellQuote(root)} .`;
 
-    try {
-      const result = await sandbox.exec(tarCmd).output({ encoding: 'utf8' });
+      try {
+        const result = await sandbox.exec(tarCmd).output({ encoding: 'utf8' });
 
-      if (result.exitCode !== 0) {
+        if (result.exitCode !== 0) {
+          return errorJson(
+            `tar failed (exit ${result.exitCode}): ${result.stderr}`,
+            'workspace_archive_read_error',
+            502
+          );
+        }
+
+        const stream = await sandbox.readFileStream(tmpPath);
+
+        // Best-effort cleanup; don't await so we don't delay the response.
+        sandbox.exec(`rm -f ${shellQuote(tmpPath)}`).catch(() => {});
+
+        return new Response(sseToByteStream(stream), {
+          status: 200,
+          headers: { 'Content-Type': 'application/octet-stream' }
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
         return errorJson(
-          `tar failed (exit ${result.exitCode}): ${result.stderr as string}`,
+          `persist failed: ${msg}`,
           'workspace_archive_read_error',
           502
         );
       }
-
-      const stream = await sandbox.readFileStream(tmpPath);
-
-      // Best-effort cleanup; don't await so we don't delay the response.
-      sandbox.exec(`rm -f ${shellQuote(tmpPath)}`).catch(() => {});
-
-      return new Response(sseToByteStream(stream), {
-        status: 200,
-        headers: { 'Content-Type': 'application/octet-stream' }
-      });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(
-        `persist failed: ${msg}`,
-        'workspace_archive_read_error',
-        502
-      );
-    }
-  });
+    })
+  );
 
   // ------------------------------------------------------------------
   // POST /sandbox/:id/hydrate
   // ------------------------------------------------------------------
 
-  app.post(`${apiPrefix}/sandbox/:id/hydrate`, async (c) => {
-    const root = '/workspace';
+  app.post(
+    `${apiPrefix}/sandbox/:id/hydrate`,
+    traced('hydrate', async (c) => {
+      const root = '/workspace';
 
-    const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
+      const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
 
-    // Read the raw tar bytes from the request body.
-    let tarBytes: Uint8Array;
-    try {
-      const buffer = await c.req.arrayBuffer();
-      tarBytes = new Uint8Array(buffer);
-    } catch {
-      return errorJson('Could not read request body', 'invalid_request', 400);
-    }
-
-    if (tarBytes.byteLength === 0) {
-      return errorJson('Empty tar payload', 'invalid_request', 400);
-    }
-
-    const MAX_HYDRATE_BYTES = 32 * 1024 * 1024; // 32 MiB
-    if (tarBytes.byteLength > MAX_HYDRATE_BYTES) {
-      return errorJson(
-        `tar payload too large: ${tarBytes.byteLength} bytes exceeds the ${MAX_HYDRATE_BYTES}-byte limit`,
-        'invalid_request',
-        400
-      );
-    }
-
-    try {
-      await sandbox.exec(`mkdir -p ${shellQuote(root)}`);
-
-      const tmpPath = `/tmp/sandbox-hydrate-${Date.now()}.tar`;
-
-      let b64 = '';
-      const CHUNK = 6144; // 6144 = 3 * 2048 — no intermediate padding
-      for (let i = 0; i < tarBytes.length; i += CHUNK) {
-        b64 += btoa(String.fromCharCode(...tarBytes.subarray(i, i + CHUNK)));
+      // Read the raw tar bytes from the request body.
+      let tarBytes: Uint8Array;
+      try {
+        const buffer = await c.req.arrayBuffer();
+        tarBytes = new Uint8Array(buffer);
+      } catch {
+        return errorJson('Could not read request body', 'invalid_request', 400);
       }
-      await sandbox.writeFile(tmpPath, b64, { encoding: 'base64' });
 
-      const extractResult = await sandbox
-        .exec(
-          `tar xf ${shellQuote(tmpPath)} -C ${shellQuote(root)} && rm -f ${shellQuote(tmpPath)}`
-        )
-        .output({ encoding: 'utf8' });
-      if (extractResult.exitCode !== 0) {
+      annotate(c, 'hydrate.size_bytes', tarBytes.byteLength);
+
+      if (tarBytes.byteLength === 0) {
+        return errorJson('Empty tar payload', 'invalid_request', 400);
+      }
+
+      const MAX_HYDRATE_BYTES = 32 * 1024 * 1024; // 32 MiB
+      if (tarBytes.byteLength > MAX_HYDRATE_BYTES) {
         return errorJson(
-          `tar extract failed (exit ${extractResult.exitCode}): ${extractResult.stderr as string}`,
+          `tar payload too large: ${tarBytes.byteLength} bytes exceeds the ${MAX_HYDRATE_BYTES}-byte limit`,
+          'invalid_request',
+          400
+        );
+      }
+
+      try {
+        await sandbox.exec(`mkdir -p ${shellQuote(root)}`);
+
+        const tmpPath = `/tmp/sandbox-hydrate-${Date.now()}.tar`;
+
+        let b64 = '';
+        const CHUNK = 6144; // 6144 = 3 * 2048 — no intermediate padding
+        for (let i = 0; i < tarBytes.length; i += CHUNK) {
+          b64 += btoa(String.fromCharCode(...tarBytes.subarray(i, i + CHUNK)));
+        }
+        await sandbox.writeFile(tmpPath, b64, { encoding: 'base64' });
+
+        const extractResult = await sandbox
+          .exec(
+            `tar xf ${shellQuote(tmpPath)} -C ${shellQuote(root)} && rm -f ${shellQuote(tmpPath)}`
+          )
+          .output({ encoding: 'utf8' });
+        if (extractResult.exitCode !== 0) {
+          return errorJson(
+            `tar extract failed (exit ${extractResult.exitCode}): ${extractResult.stderr}`,
+            'workspace_archive_write_error',
+            502
+          );
+        }
+
+        return c.json({ ok: true });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(
+          `hydrate failed: ${msg}`,
           'workspace_archive_write_error',
           502
         );
       }
-
-      return c.json({ ok: true });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(
-        `hydrate failed: ${msg}`,
-        'workspace_archive_write_error',
-        502
-      );
-    }
-  });
+    })
+  );
 
   // ------------------------------------------------------------------
   // POST /sandbox/:id/mount
   // ------------------------------------------------------------------
 
-  app.post(`${apiPrefix}/sandbox/:id/mount`, async (c) => {
-    let body: MountBucketRequest;
-    try {
-      body = await c.req.json<MountBucketRequest>();
-    } catch {
-      return errorJson('Invalid JSON body', 'invalid_request', 400);
-    }
+  app.post(
+    `${apiPrefix}/sandbox/:id/mount`,
+    traced('mount', async (c) => {
+      let body: MountBucketRequest;
+      try {
+        body = await c.req.json<MountBucketRequest>();
+      } catch {
+        return errorJson('Invalid JSON body', 'invalid_request', 400);
+      }
 
-    if (
-      body.bucket !== undefined &&
-      (typeof body.bucket !== 'string' || body.bucket === '')
-    ) {
-      return errorJson(
-        'bucket must be a non-empty string',
-        'invalid_request',
-        400
-      );
-    }
-    if (!body.mountPath || typeof body.mountPath !== 'string') {
-      return errorJson(
-        'mountPath must be a non-empty string',
-        'invalid_request',
-        400
-      );
-    }
-    if (!body.mountPath.startsWith('/')) {
-      return errorJson(
-        'mountPath must be an absolute path (start with /)',
-        'invalid_request',
-        400
-      );
-    }
-    if (
-      !body.options ||
-      typeof body.options !== 'object' ||
-      Array.isArray(body.options)
-    ) {
-      return errorJson('options must be an object', 'invalid_request', 400);
-    }
-    const optionsError = validateMountOptions(body.options, body.binding);
-    if (optionsError) return optionsError;
-    const bucketName = resolveMountBucketName(body);
-    if (bucketName instanceof Response) return bucketName;
+      if (
+        body.bucket !== undefined &&
+        (typeof body.bucket !== 'string' || body.bucket === '')
+      ) {
+        return errorJson(
+          'bucket must be a non-empty string',
+          'invalid_request',
+          400
+        );
+      }
+      if (!body.mountPath || typeof body.mountPath !== 'string') {
+        return errorJson(
+          'mountPath must be a non-empty string',
+          'invalid_request',
+          400
+        );
+      }
+      if (!body.mountPath.startsWith('/')) {
+        return errorJson(
+          'mountPath must be an absolute path (start with /)',
+          'invalid_request',
+          400
+        );
+      }
+      if (
+        !body.options ||
+        typeof body.options !== 'object' ||
+        Array.isArray(body.options)
+      ) {
+        return errorJson('options must be an object', 'invalid_request', 400);
+      }
+      const optionsError = validateMountOptions(body.options, body.binding);
+      if (optionsError) return optionsError;
+      const bucketName = resolveMountBucketName(body);
+      if (bucketName instanceof Response) return bucketName;
 
-    const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
-    const sdkOptions = toSDKMountOptions(body.options);
+      annotate(c, 'mount.bucket', bucketName);
+      annotate(c, 'mount.path', body.mountPath);
 
-    try {
-      await sandbox.mountBucket(bucketName, body.mountPath, sdkOptions);
-      return c.json({ ok: true });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(`mount failed: ${msg}`, 'mount_error', 502);
-    }
-  });
+      const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
+      const sdkOptions = toSDKMountOptions(body.options);
+
+      try {
+        await sandbox.mountBucket(bucketName, body.mountPath, sdkOptions);
+        return c.json({ ok: true });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(`mount failed: ${msg}`, 'mount_error', 502);
+      }
+    })
+  );
 
   // ------------------------------------------------------------------
   // POST /sandbox/:id/unmount
   // ------------------------------------------------------------------
 
-  app.post(`${apiPrefix}/sandbox/:id/unmount`, async (c) => {
-    let body: UnmountBucketRequest;
-    try {
-      body = await c.req.json<UnmountBucketRequest>();
-    } catch {
-      return errorJson('Invalid JSON body', 'invalid_request', 400);
-    }
-
-    if (!body.mountPath || typeof body.mountPath !== 'string') {
-      return errorJson(
-        'mountPath must be a non-empty string',
-        'invalid_request',
-        400
-      );
-    }
-    if (!body.mountPath.startsWith('/')) {
-      return errorJson(
-        'mountPath must be an absolute path (start with /)',
-        'invalid_request',
-        400
-      );
-    }
-
-    // Normalize to resolve '..' / '.' segments, then reject the filesystem
-    // root so the post-unmount rm -rf cleanup cannot be destructive.
-    const normalizedPath = new URL(body.mountPath, 'file:///').pathname;
-    if (normalizedPath === '/') {
-      return errorJson(
-        'mountPath must not resolve to / (filesystem root)',
-        'invalid_request',
-        400
-      );
-    }
-
-    const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
-
-    try {
-      await sandbox.unmountBucket(normalizedPath);
-
-      // The SDK unmounts the filesystem but does not remove the mount point
-      // directory. Verify the path is no longer an active mount before removing
-      // it — if fusermount failed silently we must not delete bucket contents.
-      const quoted = shellQuote(normalizedPath);
+  app.post(
+    `${apiPrefix}/sandbox/:id/unmount`,
+    traced('unmount', async (c) => {
+      let body: UnmountBucketRequest;
       try {
-        await sandbox.exec(`mountpoint -q ${quoted} || rmdir ${quoted}`);
+        body = await c.req.json<UnmountBucketRequest>();
       } catch {
-        // Best-effort — the unmount itself already succeeded
+        return errorJson('Invalid JSON body', 'invalid_request', 400);
       }
 
-      return c.json({ ok: true });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(`unmount failed: ${msg}`, 'unmount_error', 502);
-    }
-  });
+      if (!body.mountPath || typeof body.mountPath !== 'string') {
+        return errorJson(
+          'mountPath must be a non-empty string',
+          'invalid_request',
+          400
+        );
+      }
+      if (!body.mountPath.startsWith('/')) {
+        return errorJson(
+          'mountPath must be an absolute path (start with /)',
+          'invalid_request',
+          400
+        );
+      }
+
+      // Normalize to resolve '..' / '.' segments, then reject the filesystem
+      // root so the post-unmount rm -rf cleanup cannot be destructive.
+      const normalizedPath = new URL(body.mountPath, 'file:///').pathname;
+      if (normalizedPath === '/') {
+        return errorJson(
+          'mountPath must not resolve to / (filesystem root)',
+          'invalid_request',
+          400
+        );
+      }
+
+      annotate(c, 'mount.path', normalizedPath);
+
+      const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
+
+      try {
+        await sandbox.unmountBucket(normalizedPath);
+
+        // The SDK unmounts the filesystem but does not remove the mount point
+        // directory. Verify the path is no longer an active mount before removing
+        // it — if fusermount failed silently we must not delete bucket contents.
+        const quoted = shellQuote(normalizedPath);
+        try {
+          await sandbox.exec(`mountpoint -q ${quoted} || rmdir ${quoted}`);
+        } catch {
+          // Best-effort — the unmount itself already succeeded
+        }
+
+        return c.json({ ok: true });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(`unmount failed: ${msg}`, 'unmount_error', 502);
+      }
+    })
+  );
 
   // ------------------------------------------------------------------
   // POST /sandbox/:id/session
   // ------------------------------------------------------------------
 
-  app.post(`${apiPrefix}/sandbox/:id/session`, async (c) => {
-    const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
+  app.post(
+    `${apiPrefix}/sandbox/:id/session`,
+    traced('session_create', async (c) => {
+      const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
 
-    let body: { id?: string; cwd?: string; env?: Record<string, string> } = {};
-    try {
-      body = await c.req.json();
-    } catch {
-      // Empty body is fine — all fields are optional
-    }
+      let body: { id?: string; cwd?: string; env?: Record<string, string> } =
+        {};
+      try {
+        body = await c.req.json();
+      } catch {
+        // Empty body is fine — all fields are optional
+      }
 
-    try {
-      const session = await sandbox.createSession(body);
-      return c.json({ id: session.id });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(`session create failed: ${msg}`, 'session_error', 502);
-    }
-  });
+      if (body.cwd) annotate(c, 'session.cwd', body.cwd);
+
+      try {
+        const session = await sandbox.createSession(body);
+        annotate(c, 'session.id', session.id);
+        return c.json({ id: session.id });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(`session create failed: ${msg}`, 'session_error', 502);
+      }
+    })
+  );
 
   // ------------------------------------------------------------------
   // DELETE /sandbox/:id/session/:sid
   // ------------------------------------------------------------------
 
-  app.delete(`${apiPrefix}/sandbox/:id/session/:sid`, async (c) => {
-    const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
-    const sid = c.req.param('sid');
+  app.delete(
+    `${apiPrefix}/sandbox/:id/session/:sid`,
+    traced('session_delete', async (c) => {
+      const sandbox = getSandbox(getSandboxNs(c.env), c.get('containerUUID'));
+      const sid = c.req.param('sid');
+      if (!sid) {
+        return errorJson(
+          'session ID must not be empty',
+          'invalid_request',
+          400
+        );
+      }
+      annotate(c, 'session.id', sid);
 
-    try {
-      const result = await sandbox.deleteSession(sid);
-      return c.json(result);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return errorJson(`session delete failed: ${msg}`, 'session_error', 502);
-    }
-  });
+      try {
+        const result = await sandbox.deleteSession(sid);
+        return c.json(result);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return errorJson(`session delete failed: ${msg}`, 'session_error', 502);
+      }
+    })
+  );
 
   // ------------------------------------------------------------------
   // DELETE /sandbox/:id
   // ------------------------------------------------------------------
 
-  app.delete(`${apiPrefix}/sandbox/:id`, async (c) => {
-    const containerUUID = c.get('containerUUID');
-    const sandbox = getSandbox(getSandboxNs(c.env), containerUUID);
+  app.delete(
+    `${apiPrefix}/sandbox/:id`,
+    traced('destroy_sandbox', async (c) => {
+      const containerUUID = c.get('containerUUID');
+      const sandbox = getSandbox(getSandboxNs(c.env), containerUUID);
 
-    try {
-      await sandbox.destroy();
-    } catch {
-      // Best-effort — container may already be gone
-    }
+      try {
+        await sandbox.destroy();
+      } catch {
+        // Best-effort — container may already be gone
+      }
 
-    // Release the WarmPool assignment so it doesn't track a dead container
-    try {
-      const poolNs = getWarmPoolNs(c.env);
-      const poolId = poolNs.idFromName('global-pool');
-      const poolStub = poolNs.get(poolId);
-      await (poolStub as any).reportStopped(containerUUID);
-    } catch {
-      // Best-effort
-    }
+      // Release the WarmPool assignment so it doesn't track a dead container
+      try {
+        const poolNs = getWarmPoolNs(c.env);
+        const poolId = poolNs.idFromName('global-pool');
+        const poolStub = poolNs.get(poolId);
+        await (poolStub as any).reportStopped(containerUUID);
+      } catch {
+        // Best-effort
+      }
 
-    return new Response(null, { status: 204 });
-  });
+      return new Response(null, { status: 204 });
+    })
+  );
 
   // ------------------------------------------------------------------
   // Health check
@@ -1178,56 +1258,55 @@ export function createBridgeApp(
     return next();
   });
 
-  app.get(`${apiPrefix}/pool/stats`, async (c) => {
-    const warmTarget =
-      Number.parseInt((c.env.WARM_POOL_TARGET as string) || '0', 10) || 0;
-    const refreshInterval =
-      Number.parseInt(
-        (c.env.WARM_POOL_REFRESH_INTERVAL as string) || '10000',
-        10
-      ) || 10_000;
+  app.get(
+    `${apiPrefix}/pool/stats`,
+    traced('pool_stats', async (c) => {
+      const poolNs = getWarmPoolNs(c.env);
+      const poolId = poolNs.idFromName('global-pool');
+      const poolStub = poolNs.get(poolId);
 
-    const poolNs = getWarmPoolNs(c.env);
-    const poolId = poolNs.idFromName('global-pool');
-    const poolStub = poolNs.get(poolId);
+      try {
+        await (poolStub as any).configure(parsePoolConfig(c.env));
+      } catch {
+        // Continue — stats should still be readable even if config push fails.
+      }
 
-    try {
-      await (poolStub as any).configure({ warmTarget, refreshInterval });
-    } catch {
-      // Continue — stats should still be readable even if config push fails.
-    }
+      const stats = await (poolStub as any).getStats();
+      annotate(c, 'pool.warm', stats.warm);
+      annotate(c, 'pool.assigned', stats.assigned);
+      annotate(c, 'pool.total', stats.total);
+      if (stats.maxInstances !== null) {
+        annotate(c, 'pool.max_instances', stats.maxInstances);
+      }
+      return c.json(stats);
+    })
+  );
 
-    const stats = await (poolStub as any).getStats();
-    return c.json(stats);
-  });
+  app.post(
+    `${apiPrefix}/pool/shutdown-prewarmed`,
+    traced('pool_shutdown_prewarmed', async (c) => {
+      const poolNs = getWarmPoolNs(c.env);
+      const poolId = poolNs.idFromName('global-pool');
+      const poolStub = poolNs.get(poolId);
 
-  app.post(`${apiPrefix}/pool/shutdown-prewarmed`, async (c) => {
-    const warmTarget =
-      Number.parseInt((c.env.WARM_POOL_TARGET as string) || '0', 10) || 0;
-    const refreshInterval =
-      Number.parseInt(
-        (c.env.WARM_POOL_REFRESH_INTERVAL as string) || '10000',
-        10
-      ) || 10_000;
+      try {
+        await (poolStub as any).configure(parsePoolConfig(c.env));
+      } catch {
+        // Continue.
+      }
 
-    const poolNs = getWarmPoolNs(c.env);
-    const poolId = poolNs.idFromName('global-pool');
-    const poolStub = poolNs.get(poolId);
+      await (poolStub as any).shutdownPrewarmed();
+      return c.json({ ok: true });
+    })
+  );
 
-    try {
-      await (poolStub as any).configure({ warmTarget, refreshInterval });
-    } catch {
-      // Continue.
-    }
-
-    await (poolStub as any).shutdownPrewarmed();
-    return c.json({ ok: true });
-  });
-
-  app.post(`${apiPrefix}/pool/prime`, async (c) => {
-    await primePool(c.env, warmPoolBinding);
-    return c.json({ ok: true });
-  });
+  app.post(
+    `${apiPrefix}/pool/prime`,
+    traced('pool_prime', async (c) => {
+      await primePool(c.env, warmPoolBinding);
+      return c.json({ ok: true });
+    })
+  );
 
   // ------------------------------------------------------------------
   // OpenAPI routes

--- a/packages/sandbox/src/bridge/tracing.ts
+++ b/packages/sandbox/src/bridge/tracing.ts
@@ -1,0 +1,83 @@
+/**
+ * Custom span instrumentation for the bridge API.
+ *
+ * Wraps each Hono route handler in a Cloudflare custom span
+ * (`tracing.enterSpan`) named `bridge.<operation>`, seeding common attributes
+ * (sandbox ID, container UUID, HTTP method/route, response status) and exposing
+ * the active span so handlers can attach operation-specific metadata.
+ *
+ * See https://developers.cloudflare.com/workers/observability/traces/custom-spans/
+ */
+
+import { tracing } from 'cloudflare:workers';
+import type { Context } from 'hono';
+import type { BridgeEnv } from './types';
+
+/**
+ * Span shape exposed to handlers. Mirrors the `cloudflare:workers` Span without
+ * importing the class value, so the type is usable wherever the import isn't.
+ */
+export interface BridgeSpan {
+  readonly isTraced: boolean;
+  setAttribute(key: string, value?: boolean | number | string): void;
+}
+
+/** Hono environment shared by all bridge routes. */
+export interface BridgeHonoEnv {
+  Bindings: BridgeEnv;
+  Variables: { containerUUID: string; span?: BridgeSpan };
+}
+
+type BridgeContext = Context<BridgeHonoEnv>;
+type BridgeHandler = (c: BridgeContext) => Response | Promise<Response>;
+
+/** True when the runtime exposes the custom-span API. */
+function tracingAvailable(): boolean {
+  return (
+    typeof tracing === 'object' &&
+    tracing !== null &&
+    typeof tracing.enterSpan === 'function'
+  );
+}
+
+/**
+ * Wrap a route handler in a `bridge.<name>` span. Seeds common attributes and
+ * stashes the span on the context for `annotate()`. When tracing is
+ * unavailable the handler runs unchanged.
+ */
+export function traced(name: string, handler: BridgeHandler): BridgeHandler {
+  if (!tracingAvailable()) return handler;
+
+  return (c: BridgeContext) =>
+    tracing.enterSpan(`bridge.${name}`, async (span) => {
+      span.setAttribute('bridge.operation', name);
+      span.setAttribute('http.request.method', c.req.method);
+      span.setAttribute('http.route', c.req.routePath);
+
+      const sandboxId = c.req.param('id');
+      if (sandboxId) span.setAttribute('sandbox.id', sandboxId);
+
+      const containerUUID = c.get('containerUUID');
+      if (containerUUID) {
+        span.setAttribute('sandbox.container_uuid', containerUUID);
+      }
+
+      c.set('span', span);
+
+      const response = await handler(c);
+      span.setAttribute('http.response.status_code', response.status);
+      return response;
+    });
+}
+
+/**
+ * Attach an attribute to the active bridge span, if any. No-op when tracing is
+ * disabled or the request is not sampled.
+ */
+export function annotate(
+  c: BridgeContext,
+  key: string,
+  value?: boolean | number | string
+): void {
+  c.get('span')?.setAttribute(key, value);
+}

--- a/packages/sandbox/src/bridge/types.ts
+++ b/packages/sandbox/src/bridge/types.ts
@@ -78,6 +78,8 @@ export interface BridgeEnv {
   SANDBOX_API_KEY?: string;
   WARM_POOL_TARGET?: string;
   WARM_POOL_REFRESH_INTERVAL?: string;
+  WARM_POOL_MAX_INSTANCES?: string;
+  WARM_POOL_SCALE_BATCH_SIZE?: string;
   [key: string]: unknown;
 }
 

--- a/packages/sandbox/src/bridge/warm-pool.ts
+++ b/packages/sandbox/src/bridge/warm-pool.ts
@@ -23,6 +23,20 @@ export interface WarmPoolConfig {
   warmTarget?: number;
   /** How often to check and replenish warm containers (ms). @default 10000 */
   refreshInterval?: number;
+  /**
+   * Operator-declared max_instances ceiling, mirroring
+   * `containers[].max_instances` in wrangler.jsonc. Seeds the pool's capacity
+   * math so it never blindly attempts doomed starts. 0/undefined = auto-learn
+   * the ceiling reactively from platform errors (legacy behaviour).
+   * @default 0
+   */
+  maxInstances?: number;
+  /**
+   * Number of containers to start in parallel per scale-up batch. Higher
+   * values fill the pool faster but risk the platform throttling a cold-start
+   * stampede. Clamped to [1, MAX_BATCH_SIZE]. @default 5
+   */
+  scaleBatchSize?: number;
 }
 
 export interface PoolStats {
@@ -62,9 +76,16 @@ interface ContainerWithState {
 // Defaults
 // ---------------------------------------------------------------------------
 
+const DEFAULT_BATCH_SIZE = 5;
+
+/** Upper bound on parallel starts per batch to avoid a cold-start stampede. */
+const MAX_BATCH_SIZE = 20;
+
 const DEFAULT_CONFIG: Required<WarmPoolConfig> = {
   warmTarget: 0,
-  refreshInterval: 10_000
+  refreshInterval: 10_000,
+  maxInstances: 0,
+  scaleBatchSize: DEFAULT_BATCH_SIZE
 };
 
 // ---------------------------------------------------------------------------
@@ -99,6 +120,15 @@ export class WarmPool extends DurableObject<WarmPoolEnv> {
   private capacityExhausted = false;
   private initialized = false;
 
+  /** Guards against overlapping eager refills triggered by concurrent pops. */
+  private refillInFlight = false;
+
+  /**
+   * The currently in-flight eager refill, or null. Exposed for tests to await
+   * the otherwise fire-and-forget refill deterministically.
+   */
+  private refillPromise: Promise<void> | null = null;
+
   // =======================================================================
   // Public RPC methods
   // =======================================================================
@@ -125,6 +155,8 @@ export class WarmPool extends DurableObject<WarmPoolEnv> {
       this.warmContainers.delete(containerUUID);
       this.assignments.set(sandboxId, containerUUID);
       await this.persist();
+      // Refill the slot we just consumed without waiting for the alarm tick.
+      this.requestRefill();
       return containerUUID;
     }
 
@@ -138,6 +170,8 @@ export class WarmPool extends DurableObject<WarmPoolEnv> {
     if (containerUUID) {
       this.assignments.set(sandboxId, containerUUID);
       await this.persist();
+      // Pool was empty — start replenishing toward warmTarget eagerly.
+      this.requestRefill();
       return containerUUID;
     }
 
@@ -192,6 +226,27 @@ export class WarmPool extends DurableObject<WarmPoolEnv> {
   async configure(config: WarmPoolConfig): Promise<void> {
     await this.init();
     this.config = { ...DEFAULT_CONFIG, ...config };
+
+    // Clamp the batch size to a sane range so a misconfigured var can't
+    // re-introduce the cold-start stampede (or stall scale-up entirely).
+    this.config.scaleBatchSize = Math.min(
+      MAX_BATCH_SIZE,
+      Math.max(1, this.config.scaleBatchSize || DEFAULT_BATCH_SIZE)
+    );
+
+    // Seed the ceiling if the operator declared one. The configured value is an
+    // upper bound the operator promises; the platform may still impose a lower
+    // one, so never clobber a *lower* limit learned from a real capacity error.
+    // Re-seeding here (configure runs on every request) makes a probe-cleared
+    // ceiling self-healing.
+    if (this.config.maxInstances > 0) {
+      this.knownMaxInstances =
+        this.knownMaxInstances === null
+          ? this.config.maxInstances
+          : Math.min(this.knownMaxInstances, this.config.maxInstances);
+      await this.ctx.storage.put('knownMaxInstances', this.knownMaxInstances);
+    }
+
     await this.ctx.storage.put('config', this.config);
   }
 
@@ -218,6 +273,38 @@ export class WarmPool extends DurableObject<WarmPoolEnv> {
     }
 
     await this.persist();
+  }
+
+  // =======================================================================
+  // Eager refill
+  // =======================================================================
+
+  /**
+   * Kick a non-blocking refill toward warmTarget. Debounced via refillInFlight
+   * so a burst of concurrent pops triggers at most one adjustPool sweep at a
+   * time; capacity is respected because adjustPool clamps to remainingCapacity.
+   * Errors are swallowed so a failed refill never rejects the triggering call.
+   */
+  private requestRefill(): void {
+    if (this.refillInFlight) return;
+    if (this.warmContainers.size >= this.config.warmTarget) return;
+    if (this.remainingCapacity() <= 0) return;
+
+    this.refillInFlight = true;
+    this.refillPromise = (async () => {
+      try {
+        await this.adjustPool();
+      } catch (error) {
+        console.error({
+          message: 'Eager refill failed',
+          component: 'warm-pool',
+          error
+        });
+      } finally {
+        this.refillInFlight = false;
+      }
+    })();
+    this.ctx.waitUntil(this.refillPromise);
   }
 
   // =======================================================================
@@ -422,25 +509,35 @@ export class WarmPool extends DurableObject<WarmPoolEnv> {
         return;
       }
 
+      const batchSize = this.config.scaleBatchSize;
       console.info({
         message: 'Scaling up pool',
         component: 'warm-pool',
         starting: toStart,
         needed: diff,
-        capacity: this.remainingCapacity()
+        capacity: this.remainingCapacity(),
+        batchSize
       });
-      for (let i = 0; i < toStart; i++) {
-        if (this.capacityExhausted) {
-          console.log({
-            message: 'Capacity exhausted mid-loop, stopping further starts',
-            component: 'warm-pool'
-          });
-          break;
+      // Start in bounded-parallel batches: faster fill than one-at-a-time while
+      // re-checking capacity between batches so a straddling batch overshoots
+      // the ceiling by at most batchSize - 1 doomed starts.
+      for (let i = 0; i < toStart && !this.capacityExhausted; i += batchSize) {
+        const n = Math.min(batchSize, toStart - i);
+        const results = await Promise.all(
+          Array.from({ length: n }, () => this.startContainer())
+        );
+        for (const uuid of results) {
+          if (uuid) this.warmContainers.add(uuid);
         }
-        const uuid = await this.startContainer();
-        if (uuid) this.warmContainers.add(uuid);
+        // A start hitting the cap calls recordCapacityLimit() mid-batch, before
+        // this batch's successes were tracked, so it infers a ceiling that is
+        // too low. Re-derive it from the now-accurate total.
+        if (this.capacityExhausted) {
+          this.knownMaxInstances =
+            this.warmContainers.size + this.assignments.size;
+        }
+        await this.persist();
       }
-      await this.persist();
     } else if (diff < 0) {
       const excess = -diff;
       console.info({

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -123,6 +123,7 @@ type SandboxConfiguration = {
   sleepAfter?: string | number;
   keepAlive?: boolean;
   containerTimeouts?: NonNullable<SandboxOptions['containerTimeouts']>;
+  labels?: NonNullable<SandboxOptions['labels']>;
 };
 
 type CachedSandboxConfiguration = {
@@ -131,6 +132,7 @@ type CachedSandboxConfiguration = {
   sleepAfter?: string | number;
   keepAlive?: boolean;
   containerTimeouts?: NonNullable<SandboxOptions['containerTimeouts']>;
+  labels?: NonNullable<SandboxOptions['labels']>;
 };
 
 type PreviewForwardingContainerState = DurableObjectState<{}> & {
@@ -149,6 +151,7 @@ type ConfigurableSandboxStub = {
   setContainerTimeouts?: (
     timeouts: NonNullable<SandboxOptions['containerTimeouts']>
   ) => Promise<void>;
+  setLabels?: (labels: Record<string, string>) => Promise<void>;
 };
 
 type SandboxProxyStub = ConfigurableSandboxStub & {
@@ -232,6 +235,28 @@ function sameContainerTimeouts(
   );
 }
 
+function sameLabels(
+  left?: Record<string, string>,
+  right?: Record<string, string>
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+
+  const leftEntries = Object.entries(left);
+  const rightEntries = Object.entries(right);
+  if (leftEntries.length !== rightEntries.length) return false;
+
+  for (const [key, value] of leftEntries) {
+    if (right[key] !== value) return false;
+  }
+
+  return true;
+}
+
+function cloneLabels(labels: Record<string, string>): Record<string, string> {
+  return { ...labels };
+}
+
 function buildSandboxConfiguration(
   effectiveId: string,
   options: SandboxOptions | undefined,
@@ -270,6 +295,13 @@ function buildSandboxConfiguration(
     configuration.containerTimeouts = options.containerTimeouts;
   }
 
+  if (
+    options?.labels !== undefined &&
+    !sameLabels(cached?.labels, options.labels)
+  ) {
+    configuration.labels = cloneLabels(options.labels);
+  }
+
   return configuration;
 }
 
@@ -278,7 +310,8 @@ function hasSandboxConfiguration(configuration: SandboxConfiguration): boolean {
     configuration.sandboxName !== undefined ||
     configuration.sleepAfter !== undefined ||
     configuration.keepAlive !== undefined ||
-    configuration.containerTimeouts !== undefined
+    configuration.containerTimeouts !== undefined ||
+    configuration.labels !== undefined
   );
 }
 
@@ -300,6 +333,9 @@ function mergeSandboxConfiguration(
     }),
     ...(configuration.containerTimeouts !== undefined && {
       containerTimeouts: configuration.containerTimeouts
+    }),
+    ...(configuration.labels !== undefined && {
+      labels: cloneLabels(configuration.labels)
     })
   };
 }
@@ -342,6 +378,12 @@ function applySandboxConfiguration(
     );
   }
 
+  if (configuration.labels !== undefined) {
+    operations.push(
+      stub.setLabels?.(configuration.labels) ?? Promise.resolve()
+    );
+  }
+
   return Promise.all(operations).then(() => undefined);
 }
 
@@ -379,6 +421,57 @@ function translatePlatformInterruption(
   throw createPlatformInterruptedError(error, operation) ?? error;
 }
 
+function isPromiseLike(value: unknown): value is Promise<unknown> {
+  return (
+    value != null &&
+    typeof (value as { then?: unknown }).then === 'function' &&
+    typeof (value as { catch?: unknown }).catch === 'function'
+  );
+}
+
+function isObjectLike(value: unknown): value is object {
+  return (
+    (typeof value === 'object' && value !== null) || typeof value === 'function'
+  );
+}
+
+function wrapPromiseWithOperationContext<TResult>(
+  result: Promise<unknown>,
+  operation: string
+): TResult {
+  const guarded = result.catch((error: unknown) =>
+    translatePlatformInterruption(error, operation)
+  );
+
+  if (!isObjectLike(result)) return guarded as TResult;
+
+  for (const key of Reflect.ownKeys(result)) {
+    const descriptor = Object.getOwnPropertyDescriptor(result, key);
+    if (!descriptor) continue;
+
+    if ('value' in descriptor && typeof descriptor.value === 'function') {
+      const method = descriptor.value as (...args: unknown[]) => unknown;
+      descriptor.value = (...args: unknown[]) => {
+        try {
+          const methodResult = method.apply(result, args);
+          if (isPromiseLike(methodResult)) {
+            return methodResult.catch((error: unknown) =>
+              translatePlatformInterruption(error, operation)
+            );
+          }
+          return methodResult;
+        } catch (error) {
+          translatePlatformInterruption(error, operation);
+        }
+      };
+    }
+
+    Object.defineProperty(guarded, key, descriptor);
+  }
+
+  return guarded as TResult;
+}
+
 function withSandboxOperationContext<TArgs extends unknown[], TResult>(
   operation: string,
   fn: (...args: TArgs) => TResult
@@ -386,19 +479,8 @@ function withSandboxOperationContext<TArgs extends unknown[], TResult>(
   return (...args: TArgs): TResult => {
     try {
       const result = fn(...args);
-      if (
-        result != null &&
-        typeof (result as { then?: unknown }).then === 'function'
-      ) {
-        const caught = (result as unknown as Promise<unknown>).catch(
-          (error: unknown) => translatePlatformInterruption(error, operation)
-        );
-        // Preserve any own properties the source thenable attached to itself
-        // (e.g. `SandboxProcessPromise.output` / `.text` / `.json` / `.kill`).
-        // `Promise.prototype.catch` returns a bare promise, so without this
-        // copy those thenable-augmenting methods disappear.
-        Object.assign(caught, result);
-        return caught as TResult;
+      if (isPromiseLike(result)) {
+        return wrapPromiseWithOperationContext(result, operation);
       }
       return result;
     } catch (error) {
@@ -943,6 +1025,12 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
         this.client.setRetryTimeoutMs(this.computeRetryTimeoutMs());
       }
 
+      const storedLabels =
+        await this.ctx.storage.get<Record<string, string>>('labels');
+      if (storedLabels !== undefined && storedLabels !== null) {
+        this.labels = cloneLabels(storedLabels);
+      }
+
       // Restore sleep timeout if previously set via RPC
       const storedSleepAfter = await this.ctx.storage.get<string | number>(
         'sleepAfter'
@@ -998,6 +1086,10 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
     if (configuration.containerTimeouts !== undefined) {
       await this.setContainerTimeouts(configuration.containerTimeouts);
     }
+
+    if (configuration.labels !== undefined) {
+      await this.setLabels(configuration.labels);
+    }
   }
 
   // RPC method to set the sleep timeout. Idempotent: re-applying the same
@@ -1031,6 +1123,21 @@ export class Sandbox<Env = unknown> extends Container<Env> implements ISandbox {
       delete this.envVars[key];
     }
     this.envVars = { ...this.envVars, ...toSet };
+  }
+
+  async setLabels(labels: Record<string, string>): Promise<void> {
+    const nextLabels = cloneLabels(labels);
+
+    if (sameLabels(this.labels, nextLabels)) return;
+
+    await this.ctx.storage.put('labels', nextLabels);
+    this.labels = nextLabels;
+
+    if (this.ctx.container?.running === true) {
+      this.logger.warn(
+        'Container labels updated while container is running; new labels apply on the next container start'
+      );
+    }
   }
 
   async setContainerTimeouts(

--- a/packages/sandbox/tests/get-sandbox.test.ts
+++ b/packages/sandbox/tests/get-sandbox.test.ts
@@ -46,6 +46,7 @@ describe('getSandbox', () => {
         (configuration: {
           sandboxName?: { name: string; normalizeId?: boolean };
           sleepAfter?: string | number;
+          labels?: Record<string, string>;
         }) => {
           if (configuration.sleepAfter !== undefined) {
             mockStub.sleepAfter = configuration.sleepAfter;
@@ -57,7 +58,8 @@ describe('getSandbox', () => {
       setSleepAfter: vi.fn((value: string | number) => {
         mockStub.sleepAfter = value;
       }),
-      setKeepAlive: vi.fn()
+      setKeepAlive: vi.fn(),
+      setLabels: vi.fn()
     };
 
     // Mock getContainer to return our stub
@@ -97,6 +99,25 @@ describe('getSandbox', () => {
         retryable: false
       }
     });
+  });
+
+  it('preserves decorated exec promise helpers on enhanced methods', async () => {
+    const mockNamespace = {} as any;
+    const output = {
+      stdout: 'ready\n',
+      stderr: '',
+      exitCode: 0,
+      success: true
+    };
+    mockStub.exec = vi.fn(async () => ({
+      output: vi.fn(async () => output)
+    }));
+    const sandbox = getSandbox(mockNamespace, 'test-sandbox');
+
+    const processPromise = sandbox.exec('echo ready');
+
+    expect(processPromise.output).toBeTypeOf('function');
+    await expect(processPromise.output()).resolves.toMatchObject(output);
   });
 
   it('should apply sleepAfter option when provided as string', () => {
@@ -260,6 +281,95 @@ describe('getSandbox', () => {
         name: 'test-sandbox',
         normalizeId: undefined
       }
+    });
+  });
+
+  it('should apply labels option', () => {
+    const mockNamespace = {} as any;
+
+    getSandbox(mockNamespace, 'test-sandbox', {
+      labels: {
+        tenantId: 'tenant_123',
+        workload: 'code-workspace'
+      }
+    });
+
+    expect(mockStub.configure).toHaveBeenCalledWith({
+      sandboxName: {
+        name: 'test-sandbox',
+        normalizeId: undefined
+      },
+      labels: {
+        tenantId: 'tenant_123',
+        workload: 'code-workspace'
+      }
+    });
+  });
+
+  it('should apply labels alongside other options', () => {
+    const mockNamespace = {} as any;
+
+    getSandbox(mockNamespace, 'test-sandbox', {
+      sleepAfter: '5m',
+      keepAlive: true,
+      labels: { workload: 'code-workspace' }
+    });
+
+    expect(mockStub.configure).toHaveBeenCalledWith({
+      sandboxName: {
+        name: 'test-sandbox',
+        normalizeId: undefined
+      },
+      sleepAfter: '5m',
+      keepAlive: true,
+      labels: { workload: 'code-workspace' }
+    });
+  });
+
+  it('should skip repeated labels configuration for the same sandbox', async () => {
+    const mockNamespace = {} as any;
+
+    getSandbox(mockNamespace, 'test-sandbox', {
+      labels: { tenantId: 'tenant_123' }
+    });
+    await Promise.resolve();
+
+    getSandbox(mockNamespace, 'test-sandbox', {
+      labels: { tenantId: 'tenant_123' }
+    });
+
+    expect(mockStub.configure).toHaveBeenCalledTimes(1);
+  });
+
+  it('should treat labels with the same key-values as identical regardless of insertion order', async () => {
+    const mockNamespace = {} as any;
+
+    getSandbox(mockNamespace, 'test-sandbox', {
+      labels: { tenantId: 'tenant_123', workload: 'code-workspace' }
+    });
+    await Promise.resolve();
+
+    getSandbox(mockNamespace, 'test-sandbox', {
+      labels: { workload: 'code-workspace', tenantId: 'tenant_123' }
+    });
+
+    expect(mockStub.configure).toHaveBeenCalledTimes(1);
+  });
+
+  it('should configure changed labels on later calls', async () => {
+    const mockNamespace = {} as any;
+
+    getSandbox(mockNamespace, 'test-sandbox', {
+      labels: { tenantId: 'tenant_123' }
+    });
+    await Promise.resolve();
+
+    getSandbox(mockNamespace, 'test-sandbox', {
+      labels: { tenantId: 'tenant_456' }
+    });
+
+    expect(mockStub.configure).toHaveBeenNthCalledWith(2, {
+      labels: { tenantId: 'tenant_456' }
     });
   });
 

--- a/packages/sandbox/tests/sandbox.test.ts
+++ b/packages/sandbox/tests/sandbox.test.ts
@@ -25,6 +25,7 @@ vi.mock('@cloudflare/containers', () => {
     ctx: any;
     env: any;
     sleepAfter: string | number = '10m';
+    labels?: Record<string, string>;
     constructor(ctx: any, env: any) {
       this.ctx = ctx;
       this.env = env;
@@ -2724,6 +2725,75 @@ describe('Sandbox - Automatic Session Management', () => {
     });
   });
 
+  describe('labels configuration', () => {
+    it('configure() applies labels to the inherited container labels field', async () => {
+      await sandbox.configure({ labels: { tenantId: 'tenant_123' } });
+
+      expect((sandbox as any).labels).toEqual({ tenantId: 'tenant_123' });
+      expect(mockCtx.storage.put).toHaveBeenCalledWith('labels', {
+        tenantId: 'tenant_123'
+      });
+    });
+
+    it('clones labels before storing them', async () => {
+      const labels = { tenantId: 'tenant_123' };
+
+      await sandbox.setLabels(labels);
+      labels.tenantId = 'mutated';
+
+      expect((sandbox as any).labels).toEqual({ tenantId: 'tenant_123' });
+    });
+
+    it('constructor restores persisted labels', async () => {
+      const storageState = new Map<string, unknown>([
+        ['labels', { tenantId: 'tenant_123' }]
+      ]);
+      const storage = {
+        get: vi.fn(async (key: string) => storageState.get(key)),
+        put: vi.fn(async (key: string, value: unknown) => {
+          storageState.set(key, value);
+        }),
+        delete: vi.fn(async (key: string) => {
+          storageState.delete(key);
+        }),
+        list: vi.fn().mockResolvedValue(new Map())
+      };
+      const restoreCtx: MockCtx = {
+        storage: {
+          ...storage,
+          transaction: vi.fn(async (callback) => callback(storage))
+        } as any,
+        blockConcurrencyWhile: vi
+          .fn()
+          .mockImplementation(
+            <T>(callback: () => Promise<T>): Promise<T> => callback()
+          ),
+        waitUntil: vi.fn(),
+        container: { running: false, start: vi.fn() },
+        id: {
+          toString: () => 'restore-labels-sandbox',
+          equals: vi.fn(),
+          name: 'restore-labels-sandbox'
+        } as any
+      };
+
+      const restoredSandbox = new Sandbox(
+        restoreCtx as unknown as ConstructorParameters<typeof Sandbox>[0],
+        mockEnv
+      );
+
+      await Promise.all(
+        (restoreCtx.blockConcurrencyWhile as any).mock.results.map(
+          (r: { value: unknown }) => r.value
+        )
+      );
+
+      expect((restoredSandbox as any).labels).toEqual({
+        tenantId: 'tenant_123'
+      });
+    });
+  });
+
   describe('setSandboxName atomicity', () => {
     // sandboxName and normalizeId are written together; if the second write
     // rejects, in-memory state must match storage (both unchanged).
@@ -2758,6 +2828,17 @@ describe('Sandbox - Automatic Session Management', () => {
       expect(renewCallsAfterFirst).toBeGreaterThan(0);
 
       await sandbox.configure({ sleepAfter: '3s' });
+
+      expect(renewSpy.mock.calls.length).toBe(renewCallsAfterFirst);
+    });
+
+    it('does not renew activity timeout on repeated identical labels', async () => {
+      const renewSpy = vi.spyOn(sandbox as any, 'renewActivityTimeout');
+
+      await sandbox.configure({ labels: { tenantId: 'tenant_123' } });
+      const renewCallsAfterFirst = renewSpy.mock.calls.length;
+
+      await sandbox.configure({ labels: { tenantId: 'tenant_123' } });
 
       expect(renewSpy.mock.calls.length).toBe(renewCallsAfterFirst);
     });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -781,17 +781,6 @@ export interface SandboxOptions {
   keepAlive?: boolean;
 
   /**
-   * When true (the default), implicit operations automatically create and reuse
-   * a persistent default shell session. Set to false to run implicit top-level
-   * operations sessionlessly, where each command spawns a fresh process with no
-   * shared shell state. Explicit per-call session IDs continue to work normally
-   * when this is false.
-   *
-   * Default: true
-   */
-  enableDefaultSession?: boolean;
-
-  /**
    * Normalize sandbox ID to lowercase for preview URL compatibility
    *
    * Required for preview URLs because hostnames are case-insensitive (RFC 3986), which
@@ -812,6 +801,13 @@ export interface SandboxOptions {
    * @default false
    */
   normalizeId?: boolean;
+
+  /**
+   * Key-value metadata labels attached to the underlying Cloudflare Container.
+   * Labels are visible in container metrics and observability surfaces. Updated
+   * labels apply the next time the container starts.
+   */
+  labels?: Record<string, string>;
 
   /**
    * Container startup timeout configuration

--- a/tests/perf/scenarios/backup-restore.test.ts
+++ b/tests/perf/scenarios/backup-restore.test.ts
@@ -41,7 +41,8 @@ describe('Backup & Restore', () => {
   }> = [
     { label: '100mb', fileCount: 4, fileSizeMB: 25 },
     { label: '500mb', fileCount: 5, fileSizeMB: 100 },
-    { label: '1gb', fileCount: 8, fileSizeMB: 128 }
+    { label: '1gb', fileCount: 8, fileSizeMB: 128 },
+    { label: '5gb', fileCount: 20, fileSizeMB: 256 }
   ];
 
   /**
@@ -112,7 +113,7 @@ describe('Backup & Restore', () => {
         await manager.executeCommand(
           sandbox,
           populateDirCmd(dir, fileCount, fileSizeMB),
-          { timeout: 600000 }
+          { timeout: 1_800_000 }
         );
 
         const result = await manager.createBackup(sandbox, dir, {
@@ -148,7 +149,7 @@ describe('Backup & Restore', () => {
       `${METRICS.BACKUP_CREATE_LATENCY}-100mb`
     );
     expect(smallRate.rate).toBeGreaterThanOrEqual(PASS_THRESHOLD);
-  }, 3_600_000);
+  }, 7_200_000);
 
   test('should measure backup restore latency by directory size', async () => {
     if (!shouldRun) {
@@ -167,7 +168,7 @@ describe('Backup & Restore', () => {
         await manager.executeCommand(
           sandbox,
           populateDirCmd(dir, fileCount, fileSizeMB),
-          { timeout: 600000 }
+          { timeout: 1_800_000 }
         );
 
         const backup = await manager.createBackup(sandbox, dir, {
@@ -226,7 +227,7 @@ describe('Backup & Restore', () => {
       `${METRICS.BACKUP_RESTORE_LATENCY}-100mb`
     );
     expect(smallRate.rate).toBeGreaterThanOrEqual(PASS_THRESHOLD);
-  }, 3_600_000);
+  }, 7_200_000);
 
   test('should measure post-restore read and write latency', async () => {
     if (!shouldRun) {


### PR DESCRIPTION
This pull request brings the relevant `main` branch changes into `next` while preserving the `next` execution model.

Integrated upstream pull requests:

- [#786 Improve scaling of bridge warm pool under load](https://github.com/cloudflare/sandbox-sdk/pull/786)
- [#787 Add 5GB backup/restore benchmark test](https://github.com/cloudflare/sandbox-sdk/pull/787)
- [#793 Add release artifact backfill workflow](https://github.com/cloudflare/sandbox-sdk/pull/793)
- [#798 Add sandbox container labels option](https://github.com/cloudflare/sandbox-sdk/pull/798)
- [#800 Add release artifact orchestration](https://github.com/cloudflare/sandbox-sdk/pull/800)
- [#801 Bump echarts in /bridge/examples/workspace-chat/frontend](https://github.com/cloudflare/sandbox-sdk/pull/801)
- [#805 Skip already released stable versions](https://github.com/cloudflare/sandbox-sdk/pull/805)

The release tooling changes from `main` are included so prerelease and stable artifact generation use the same orchestration path. The sandbox container labels API is included with its SDK option, storage behavior, and tests. The bridge warm pool changes are included with the configured instance ceiling, eager refill, bounded parallel scale-up, and custom span tracing. The bridge example dependency update and backup/restore benchmark are also included.

The stable version package commits from [#783](https://github.com/cloudflare/sandbox-sdk/pull/783), [#785](https://github.com/cloudflare/sandbox-sdk/pull/785), and [#806](https://github.com/cloudflare/sandbox-sdk/pull/806) were not applied directly because `next` should keep its prerelease versioning flow. [#778](https://github.com/cloudflare/sandbox-sdk/pull/778) was also not carried forward because the `enableDefaultSession` option is deprecated and must not exist on `next`. The resulting branch has no `enableDefaultSession` references.

Some `main` changes were not clean cherry-picks because `next` has moved to the unified process API. The bridge `/exec` streaming route from [#786](https://github.com/cloudflare/sandbox-sdk/pull/786) was adapted from the old `stream: true` callback shape to read from the `SandboxProcess` `stdout` and `stderr` streams. The bridge persist and hydrate routes were also adjusted to use `.output({ encoding: 'utf8' })` when checking command exit codes.

This also includes a small SDK fix found while validating the minimal example: `withSandboxOperationContext()` now preserves decorated `sandbox.exec()` promises so helper methods like `.output()`, `.text()`, `.json()`, and `.kill()` survive the wrapper. A regression test covers that behavior.

Validation run:

```bash
npm run build -w @cloudflare/sandbox
npm test -w @cloudflare/sandbox -- get-sandbox.test.ts sandbox.test.ts
npm test -w @cloudflare/sandbox-bridge -- --run src/__tests__/warm-pool.test.ts src/__tests__/tracing.test.ts
npm run typecheck -w @cloudflare/sandbox-bridge
npm run typecheck -w @cloudflare/sandbox
npm run check
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->