### PR TITLE
Guard pull request quality configuration

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -20,9 +20,13 @@ e2e-tests:
   - 'tests/e2e/**'
   - 'vitest.e2e.config.ts'
 ci-config:
+  - '.github/path-filters.yml'
+  - '.github/quality-config.test.ts'
+  - '.github/test-release-tools.sh'
+  - '.github/workflows/pr.yml'
+  - '.github/workflows/reusable-quality.yml'
   - '.github/workflows/reusable-e2e.yml'
   - '.github/workflows/pr-privileged.yml'
-  - '.github/path-filters.yml'
 deps:
   - 'package.json'
   - 'package-lock.json'

--- a/.github/quality-config.test.ts
+++ b/.github/quality-config.test.ts
@@ -1,0 +1,303 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+import { parse } from 'yaml';
+
+const pathFiltersSource = readFileSync('.github/path-filters.yml', 'utf8');
+const pathFiltersConfig = parse(pathFiltersSource) as Record<string, string[]>;
+const prWorkflowSource = readFileSync('.github/workflows/pr.yml', 'utf8');
+const prWorkflowConfig = parseWorkflow(prWorkflowSource);
+const qualityWorkflowSource = readFileSync(
+  '.github/workflows/reusable-quality.yml',
+  'utf8'
+);
+type WorkflowConfig = {
+  jobs: Record<string, JobConfig | undefined>;
+};
+
+type JobConfig = {
+  if?: unknown;
+  name?: unknown;
+  needs?: unknown;
+  steps?: StepConfig[];
+  uses?: unknown;
+  with?: Record<string, unknown>;
+};
+
+type StepConfig = {
+  name?: string;
+  run?: unknown;
+  if?: unknown;
+};
+
+function parseWorkflow(source: string): WorkflowConfig {
+  return parse(source) as WorkflowConfig;
+}
+
+function job(workflow: WorkflowConfig, jobName: string): JobConfig {
+  const config = workflow.jobs[jobName];
+
+  assert.ok(config, `Expected workflow to define ${jobName}`);
+
+  return config;
+}
+
+function jobSteps(workflow: WorkflowConfig, jobName: string): StepConfig[] {
+  const steps = job(workflow, jobName).steps;
+
+  assert.ok(Array.isArray(steps), `Expected ${jobName} to define steps`);
+
+  return steps;
+}
+
+function runStepInvokes(step: StepConfig, command: string): boolean {
+  if (typeof step.run !== 'string' || step.if !== undefined) {
+    return false;
+  }
+
+  return step.run
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '' && !line.startsWith('#'))
+    .some((line) => line === command || line.startsWith(`${command} `));
+}
+
+function assertActiveJobRun(
+  workflowSource: string,
+  jobName: string,
+  command: string
+): void {
+  const workflow = parseWorkflow(workflowSource);
+  const steps = jobSteps(workflow, jobName);
+
+  assert.ok(
+    steps.some((step) => runStepInvokes(step, command)),
+    `Expected ${jobName} to unconditionally invoke ${command}`
+  );
+}
+
+function assertFilterIncludes(filterName: string, pattern: string): void {
+  assert.ok(
+    pathFiltersConfig[filterName]?.includes(pattern),
+    `Expected ${filterName} path filter to include ${pattern}`
+  );
+}
+
+function deriveConditionsScript(workflow = prWorkflowConfig): string {
+  const deriveStep = jobSteps(workflow, 'detect-changes').find(
+    (step) => step.name === 'Derive conditions'
+  );
+
+  assert.equal(typeof deriveStep?.run, 'string');
+
+  return deriveStep.run;
+}
+
+function derivedConditionFilters(
+  outputName: string,
+  workflow = prWorkflowConfig
+): string[] {
+  const lines = deriveConditionsScript(workflow).split('\n');
+  const trueOutput = `echo "${outputName}=true" >> "$GITHUB_OUTPUT"`;
+  const falseOutput = `echo "${outputName}=false" >> "$GITHUB_OUTPUT"`;
+  const trueIndexes = lines.flatMap((line, index) =>
+    line.trim() === trueOutput ? [index] : []
+  );
+  const falseIndexes = lines.flatMap((line, index) =>
+    line.trim() === falseOutput ? [index] : []
+  );
+
+  assert.deepEqual(trueIndexes.length, 1, `Expected one active ${trueOutput}`);
+  assert.deepEqual(
+    falseIndexes.length,
+    1,
+    `Expected one active ${falseOutput}`
+  );
+
+  const trueIndex = trueIndexes[0];
+  const ifIndex = lines.findLastIndex(
+    (line, index) => index < trueIndex && line.trim().startsWith('if [[')
+  );
+  assert.ok(ifIndex >= 0, `Expected an if block producing ${outputName}`);
+
+  const conditionEndIndex = lines.findIndex(
+    (line, index) => index >= ifIndex && line.trim().endsWith(']]; then')
+  );
+  assert.ok(
+    conditionEndIndex >= ifIndex && conditionEndIndex < trueIndex,
+    `Expected ${outputName} output immediately after its condition`
+  );
+  assert.ok(
+    lines.slice(conditionEndIndex + 1, trueIndex).every((line) => !line.trim()),
+    `Expected no commands before ${trueOutput}`
+  );
+  assert.equal(
+    lines
+      .slice(trueIndex + 1, falseIndexes[0])
+      .filter((line) => line.trim() === 'else').length,
+    1,
+    `Expected ${outputName} false output in the matching else block`
+  );
+
+  const condition = lines
+    .slice(ifIndex, conditionEndIndex + 1)
+    .filter((line) => !line.trim().startsWith('#'))
+    .join('\n');
+  const filterExpression =
+    /"\$\{\{\s*steps\.filter\.outputs\.([\w-]+)\s*\}\}"\s*==\s*"true"/g;
+  const filters = [...condition.matchAll(filterExpression)].map(
+    (match) => match[1]
+  );
+  const residue = condition
+    .replace(filterExpression, '')
+    .replace(/if\s*\[\[/, '')
+    .replace(/\]\];\s*then/, '')
+    .replaceAll('||', '')
+    .replaceAll('\\', '')
+    .trim();
+
+  assert.equal(
+    residue,
+    '',
+    `Expected ${outputName} condition to contain only active filter expressions`
+  );
+
+  return filters;
+}
+
+function assertDerivedCondition(
+  outputName: string,
+  expectedFilters: string[],
+  workflow = prWorkflowConfig
+): void {
+  assert.deepEqual(
+    derivedConditionFilters(outputName, workflow),
+    expectedFilters,
+    `Expected exact filters for ${outputName}`
+  );
+}
+
+function jobNeeds(config: JobConfig): string[] {
+  if (typeof config.needs === 'string') {
+    return [config.needs];
+  }
+
+  assert.ok(
+    Array.isArray(config.needs),
+    'Expected job needs to be a string or array'
+  );
+  return config.needs as string[];
+}
+
+function assertPRContainerForwarding(workflowSource: string): void {
+  assert.equal(
+    job(parseWorkflow(workflowSource), 'quality').with?.run_container_tests,
+    "${{ needs.detect-changes.outputs.needs-container-tests == 'true' }}"
+  );
+}
+
+test('CI configuration changes request quality checks', () => {
+  assertDerivedCondition('needs-quality', [
+    'any-source',
+    'build-config',
+    'ci-config',
+    'deps',
+    'changesets'
+  ]);
+});
+
+test('quality guard and workflow changes request quality checks', () => {
+  assertFilterIncludes('ci-config', '.github/quality-config.test.ts');
+  assertFilterIncludes('ci-config', '.github/workflows/reusable-quality.yml');
+  assertFilterIncludes('ci-config', '.github/workflows/pr.yml');
+  assertFilterIncludes('ci-config', '.github/path-filters.yml');
+  assertFilterIncludes('ci-config', '.github/test-release-tools.sh');
+});
+
+test('derived output assertions reject comments and wrong output blocks', () => {
+  const commentedWorkflow = parseWorkflow(
+    prWorkflowSource.replace(
+      '             || "${{ steps.filter.outputs.ci-config }}" == "true" \\\n',
+      '             # "${{ steps.filter.outputs.ci-config }}" == "true" \\\n'
+    )
+  );
+  assert.throws(() =>
+    assertDerivedCondition(
+      'needs-quality',
+      ['any-source', 'build-config', 'ci-config', 'deps', 'changesets'],
+      commentedWorkflow
+    )
+  );
+
+  const wrongBlockWorkflow = parseWorkflow(
+    prWorkflowSource
+      .replace(
+        '             || "${{ steps.filter.outputs.container }}" == "true" \\\n',
+        '             || "${{ steps.filter.outputs.sdk }}" == "true" \\\n'
+      )
+      .replace(
+        '             || "${{ steps.filter.outputs.ci-config }}" == "true" \\\n',
+        '             || "${{ steps.filter.outputs.container }}" == "true" \\\n'
+      )
+  );
+  assert.throws(() =>
+    assertDerivedCondition(
+      'needs-container-tests',
+      ['shared', 'container', 'build-config', 'deps'],
+      wrongBlockWorkflow
+    )
+  );
+});
+
+test('PR quality caller forwards the container test condition', () => {
+  assertPRContainerForwarding(prWorkflowSource);
+  assert.throws(() =>
+    assertPRContainerForwarding(
+      prWorkflowSource.replace(
+        "run_container_tests: ${{ needs.detect-changes.outputs.needs-container-tests == 'true' }}",
+        'run_container_tests: false'
+      )
+    )
+  );
+});
+
+test('PR has an independent unconditional configuration guard', () => {
+  const configGuard = job(prWorkflowConfig, 'config-guard');
+
+  assert.equal(configGuard.name, 'ci/config');
+  assert.equal(configGuard.if, undefined);
+  assert.equal(configGuard.needs, undefined);
+  assert.equal(configGuard.uses, undefined);
+  assertActiveJobRun(
+    prWorkflowSource,
+    'config-guard',
+    'npm run test:release-tools'
+  );
+
+  const basicGate = job(prWorkflowConfig, 'basic-gate');
+  assert.equal(basicGate.name, 'ci/basic');
+  assert.ok(jobNeeds(basicGate).includes('config-guard'));
+  assert.ok(
+    jobSteps(prWorkflowConfig, 'basic-gate').some(
+      (step) =>
+        typeof step.run === 'string' &&
+        step.run
+          .split('\n')
+          .map((line) => line.trim())
+          .filter((line) => !line.startsWith('#'))
+          .includes(
+            'if [[ "${{ needs.config-guard.result }}" != "success" ]]; then'
+          )
+    ),
+    'Expected ci/basic to require successful configuration validation'
+  );
+});
+
+test('quality workflow runs release/config tests from the PR quality job', () => {
+  assertActiveJobRun(
+    qualityWorkflowSource,
+    'lint-typecheck',
+    'npm run test:release-tools'
+  );
+});

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,9 +45,9 @@ jobs:
              || "${{ steps.filter.outputs.sdk }}" == "true" \
              || "${{ steps.filter.outputs.build-config }}" == "true" \
              || "${{ steps.filter.outputs.deps }}" == "true" ]]; then
-            echo "needs-sdk-tests=true" >> $GITHUB_OUTPUT
+            echo "needs-sdk-tests=true" >> "$GITHUB_OUTPUT"
           else
-            echo "needs-sdk-tests=false" >> $GITHUB_OUTPUT
+            echo "needs-sdk-tests=false" >> "$GITHUB_OUTPUT"
           fi
 
           # Needs container unit tests?
@@ -55,20 +55,44 @@ jobs:
              || "${{ steps.filter.outputs.container }}" == "true" \
              || "${{ steps.filter.outputs.build-config }}" == "true" \
              || "${{ steps.filter.outputs.deps }}" == "true" ]]; then
-            echo "needs-container-tests=true" >> $GITHUB_OUTPUT
+            echo "needs-container-tests=true" >> "$GITHUB_OUTPUT"
           else
-            echo "needs-container-tests=false" >> $GITHUB_OUTPUT
+            echo "needs-container-tests=false" >> "$GITHUB_OUTPUT"
           fi
 
           # Needs quality checks? (source or config changes)
           if [[ "${{ steps.filter.outputs.any-source }}" == "true" \
              || "${{ steps.filter.outputs.build-config }}" == "true" \
+             || "${{ steps.filter.outputs.ci-config }}" == "true" \
              || "${{ steps.filter.outputs.deps }}" == "true" \
              || "${{ steps.filter.outputs.changesets }}" == "true" ]]; then
-            echo "needs-quality=true" >> $GITHUB_OUTPUT
+            echo "needs-quality=true" >> "$GITHUB_OUTPUT"
           else
-            echo "needs-quality=false" >> $GITHUB_OUTPUT
+            echo "needs-quality=false" >> "$GITHUB_OUTPUT"
           fi
+
+  # --- Configuration guard (unconditional and independent of reusable workflows) ---
+  config-guard:
+    name: ci/config
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+
+      - run: npm ci --prefer-offline --no-audit --no-fund
+
+      - name: Validate CI configuration
+        run: npm run test:release-tools
 
   # --- Build (JS only, no Docker — Docker moves to pr-privileged.yml) ---
   build:
@@ -95,15 +119,20 @@ jobs:
   basic-gate:
     name: ci/basic
     if: always()
-    needs: [build, quality]
+    needs: [config-guard, build, quality]
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
       - name: Check job results
         run: |
+          echo "config: ${{ needs.config-guard.result }}"
           echo "build: ${{ needs.build.result }}"
           echo "quality: ${{ needs.quality.result }}"
 
+          if [[ "${{ needs.config-guard.result }}" != "success" ]]; then
+            echo "::error::CI configuration validation did not succeed"
+            exit 1
+          fi
           if [[ "${{ needs.build.result }}" == "failure" || "${{ needs.build.result }}" == "cancelled" ]]; then
             echo "::error::Build failed or was cancelled"
             exit 1

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Monorepo structure lint
         run: npx sherif
 
+      - name: Release and quality configuration tests
+        run: npm run test:release-tools
+
       - name: Validate changesets
         if: ${{ inputs.run_changeset_validation }}
         run: node scripts/validate-changesets.js .changeset/*.md

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,6 @@ perf-results/
 sandbox-linux-*
 
 test-results/
+
+# Superpowers working artifacts
+.superpowers/

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,8 @@
         "vite": "^7.3.5",
         "vitest": "^4.1.8",
         "wrangler": "^4.102.0",
-        "ws": "^8.21.0"
+        "ws": "^8.21.0",
+        "yaml": "^2.9.0"
       }
     },
     "bridge/worker": {
@@ -6360,6 +6361,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
       "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
@@ -12336,6 +12338,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {
@@ -14396,9 +14399,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -14608,7 +14611,6 @@
         "@repo/sandbox-execution": "*",
         "@repo/shared": "*",
         "acorn": "^8.14.0",
-        "async-mutex": "^0.5.0",
         "capnweb": "^0.8.0",
         "tar-stream": "^3.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "vite": "^7.3.5",
     "vitest": "^4.1.8",
     "wrangler": "^4.102.0",
-    "ws": "^8.21.0"
+    "ws": "^8.21.0",
+    "yaml": "^2.9.0"
   },
   "private": true,
   "packageManager": "npm@11.6.4"


### PR DESCRIPTION
Make the pull-request quality workflow validate its own configuration so path filters and job wiring cannot silently drift from the checks they gate.

A misconfigured path filter fails open: the job it guards is skipped, the PR goes green, and nobody notices the check never ran. Later in this stack a Docker-backed execution-lifecycle job is added whose entire value depends on being triggered correctly, so that failure mode is worth closing now.

This adds a release-tools-style test that parses the PR workflow, the path filters, and the reusable quality workflow and asserts they stay internally consistent, then runs it on every pull request. The CI configuration becomes a tested artifact rather than trusted YAML.

It lands first and independently so the CI-hardening concern is reviewable on its own and ready before the lifecycle job needs it.

---

Part of the unified process-execution stack.

**Core stack** — each builds on the previous:
- <kbd>&nbsp;5&nbsp;</kbd> #819 — Replace sessions with recoverable processes
- <kbd>&nbsp;4&nbsp;</kbd> #818 — Rebuild container runtime around process RPC
- <kbd>&nbsp;3&nbsp;</kbd> #817 — Define shared process contracts and errors
- <kbd>&nbsp;2&nbsp;</kbd> #816 — Build execution substrate for supervised processes
- <kbd>&nbsp;1&nbsp;</kbd> #815 — Guard pull request quality configuration &nbsp;👈
- `next`

**Migrations** — each builds on <kbd>&nbsp;5&nbsp;</kbd> #819:
- #820 — Migrate bridge clients to process resources
- #821 — Migrate examples to unified execution
- #822 — Migrate E2E workflows to process handles
- #823 — Document unified process execution
- #824 — Run execution lifecycle checks in CI
