### PR TITLE
Run execution lifecycle checks in CI

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -5,6 +5,7 @@ sdk:
   - 'packages/sandbox/package.json'
 container:
   - 'packages/sandbox-container/**'
+  - 'packages/sandbox-execution/**'
 docker-config:
   - 'packages/sandbox/Dockerfile'
   - 'docker-bake.hcl'

--- a/.github/quality-config.test.ts
+++ b/.github/quality-config.test.ts
@@ -12,6 +12,10 @@ const qualityWorkflowSource = readFileSync(
   '.github/workflows/reusable-quality.yml',
   'utf8'
 );
+const turboConfig = JSON.parse(readFileSync('turbo.json', 'utf8')) as {
+  tasks: { test: { inputs: string[] } };
+};
+
 type WorkflowConfig = {
   jobs: Record<string, JobConfig | undefined>;
 };
@@ -21,6 +25,7 @@ type JobConfig = {
   name?: unknown;
   needs?: unknown;
   steps?: StepConfig[];
+  'timeout-minutes'?: unknown;
   uses?: unknown;
   with?: Record<string, unknown>;
 };
@@ -197,7 +202,37 @@ function assertPRContainerForwarding(workflowSource: string): void {
   );
 }
 
-test('CI configuration changes request quality checks', () => {
+function assertContainerTestJob(workflowSource: string): void {
+  const workflow = parseWorkflow(workflowSource);
+
+  const containerTests = job(workflow, 'container-tests');
+
+  assert.equal(containerTests.if, '${{ inputs.run_container_tests }}');
+  assert.equal(containerTests['timeout-minutes'], 10);
+  assertActiveJobRun(
+    workflowSource,
+    'container-tests',
+    'npm test -w @repo/sandbox-container'
+  );
+  assertActiveJobRun(
+    workflowSource,
+    'container-tests',
+    'npm test -w @repo/sandbox-execution'
+  );
+}
+
+test('sandbox-execution changes request container-backed tests', () => {
+  assertFilterIncludes('container', 'packages/sandbox-execution/**');
+  assertFilterIncludes('any-source', 'packages/**');
+  assertDerivedCondition('needs-container-tests', [
+    'shared',
+    'container',
+    'build-config',
+    'deps'
+  ]);
+});
+
+test('source and configuration changes request quality checks', () => {
   assertDerivedCondition('needs-quality', [
     'any-source',
     'build-config',
@@ -300,4 +335,64 @@ test('quality workflow runs release/config tests from the PR quality job', () =>
     'lint-typecheck',
     'npm run test:release-tools'
   );
+});
+
+test('quality workflow requires active container and execution package tests', () => {
+  assertContainerTestJob(qualityWorkflowSource);
+});
+
+test('quality workflow container test assertions reject inactive matches', () => {
+  const command = 'npm test -w @repo/sandbox-execution';
+
+  for (const replacement of [
+    '# run: npm test -w @repo/sandbox-execution',
+    'if: false\n        run: npm test -w @repo/sandbox-execution',
+    'if: ${{ 1 == 0 }}\n        run: npm test -w @repo/sandbox-execution',
+    'run: echo npm test -w @repo/sandbox-execution'
+  ]) {
+    assert.throws(() =>
+      assertActiveJobRun(
+        qualityWorkflowSource.replace(
+          'run: npm test -w @repo/sandbox-execution',
+          replacement
+        ),
+        'container-tests',
+        command
+      )
+    );
+  }
+
+  assert.throws(() =>
+    assertActiveJobRun(
+      qualityWorkflowSource
+        .replace(
+          'run: npm test -w @repo/sandbox-execution',
+          'run: npm test -w @repo/sandbox'
+        )
+        .replace(
+          '\n  container-tests:\n',
+          '\n      - name: Wrong-job execution lifecycle tests\n        run: npm test -w @repo/sandbox-execution\n\n  container-tests:\n'
+        ),
+      'container-tests',
+      command
+    )
+  );
+
+  assert.throws(() =>
+    assertContainerTestJob(
+      qualityWorkflowSource.replace(
+        '    if: ${{ inputs.run_container_tests }}',
+        '    if: false'
+      )
+    )
+  );
+});
+
+test('sandbox-execution test harness files are package-relative Turbo inputs', () => {
+  const testInputs = turboConfig.tasks.test.inputs;
+
+  assert.ok(testInputs.includes('Dockerfile.test'));
+  assert.ok(testInputs.includes('scripts/**'));
+  assert.ok(!testInputs.includes('packages/sandbox-execution/Dockerfile.test'));
+  assert.ok(!testInputs.includes('packages/sandbox-execution/scripts/**'));
 });

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -143,7 +143,7 @@ jobs:
       contents: read
     if: ${{ inputs.run_container_tests }}
     runs-on: ${{ inputs.runner }}
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
         with:
@@ -179,4 +179,8 @@ jobs:
 
       - name: Container unit tests (Bun)
         run: npm test -w @repo/sandbox-container
+        timeout-minutes: 5
+
+      - name: Execution lifecycle tests (Docker/Tini)
+        run: npm test -w @repo/sandbox-execution
         timeout-minutes: 5

--- a/turbo.json
+++ b/turbo.json
@@ -27,6 +27,8 @@
         "src/**/*.astro",
         "tests/**/*.ts",
         "vitest.config.ts",
+        "Dockerfile.test",
+        "scripts/**",
         "package.json"
       ],
       "env": ["NODE_ENV"]


### PR DESCRIPTION
Run the Docker-backed `@repo/sandbox-execution` process-lifecycle suite in CI so the supervisor's process-group and orphan-reaping guarantees are enforced, not just asserted once by hand.

Process-tree supervision and Tini-backed reaping are exactly the kind of guarantee that rots silently: a regression would not surface until a real sandbox leaked zombies in production. This wires the lifecycle suite into the reusable quality workflow, extends the path filters so it triggers on execution-substrate changes, declares its inputs in `turbo.json` for correct caching, and — because the guarding config is only useful if it stays correct — extends the quality-config guard to assert the new wiring.

Depends on the SDK process PR (its actual parent) and builds on the config guarded by `naresh/quality-config-guard`. No source overlap with the other migration PRs; retarget to `next` once the core stack merges.

---

Part of the unified process-execution stack.

**Core stack** — each builds on the previous:
- <kbd>&nbsp;5&nbsp;</kbd> #819 — Replace sessions with recoverable processes
- <kbd>&nbsp;4&nbsp;</kbd> #818 — Rebuild container runtime around process RPC
- <kbd>&nbsp;3&nbsp;</kbd> #817 — Define shared process contracts and errors
- <kbd>&nbsp;2&nbsp;</kbd> #816 — Build execution substrate for supervised processes
- <kbd>&nbsp;1&nbsp;</kbd> #815 — Guard pull request quality configuration
- `next`

**Migrations** — each builds on <kbd>&nbsp;5&nbsp;</kbd> #819:
- #820 — Migrate bridge clients to process resources
- #821 — Migrate examples to unified execution
- #822 — Migrate E2E workflows to process handles
- #823 — Document unified process execution
- #824 — Run execution lifecycle checks in CI &nbsp;👈
