### PR TITLE
Fix E2E readiness smoke probe command

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -304,7 +304,7 @@ jobs:
               response=$(mktemp)
               status=$(curl -sS --max-time 30 -o "$response" -w '%{http_code}' \
                 -X POST "${headers[@]}" \
-                --data "{\"command\":\"/bin/echo $marker\"}" \
+                --data "{\"command\":[\"/bin/echo\",\"$marker\"]}" \
                 "$URL/api/execute" || true)
               if [[ $status == 200 ]] && jq -e --arg marker "$marker" \
                 '.success == true and .exitCode == 0 and (.stdout | contains($marker))' \

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -304,7 +304,7 @@ jobs:
               response=$(mktemp)
               status=$(curl -sS --max-time 30 -o "$response" -w '%{http_code}' \
                 -X POST "${headers[@]}" \
-                --data "{\"command\":[\"/bin/echo\",\"$marker\"]}" \
+                --data "{\"command\":\"/bin/echo $marker\"}" \
                 "$URL/api/execute" || true)
               if [[ $status == 200 ]] && jq -e --arg marker "$marker" \
                 '.success == true and .exitCode == 0 and (.stdout | contains($marker))' \

--- a/tests/e2e/test-worker/index.ts
+++ b/tests/e2e/test-worker/index.ts
@@ -533,7 +533,10 @@ console.log('Terminal server on port ' + port);
 
       // Command execution
       if (url.pathname === '/api/execute' && request.method === 'POST') {
-        const result = await executor.exec(body.command, {
+        const command = Array.isArray(body.command)
+          ? body.command.join(' ')
+          : body.command;
+        const result = await executor.exec(command, {
           env: body.env,
           cwd: body.cwd,
           timeout: body.timeout


### PR DESCRIPTION
# Summary

The E2E readiness check sends its command as an argv array, while the test worker passes commands to `sandbox.exec()` as strings. That array was reaching the container and causing `command.match is not a function` during the deploy smoke test.

This normalizes array commands in the test worker’s `/api/execute` route before passing them to the SDK. String commands are unchanged. This keeps the workaround scoped to the E2E test worker without changing the workflow or Sandbox API.