### PR TITLE
Update Devin Outpost to conditionally issue R2 head request

### DIFF
--- a/devin/src/index.ts
+++ b/devin/src/index.ts
@@ -4,6 +4,8 @@ import { reconcile } from './reconcile';
 
 export { CheckpointProxy } from './persistence';
 
+const CHECKPOINT_PRESENT_KEY = 'checkpointPresent';
+
 /**
  * One Durable Object per Devin session. The DO is deliberately dumb: it knows
  * how to start/stop its Cloudflare Container, but it does not call Devin and it
@@ -39,8 +41,22 @@ export class DevinWorker extends DurableObject<Env> {
 
     await this.#starting;
     await this.#stopContainer(sessionId, reason);
-    if (reason === 'terminated')
+    if (reason === 'terminated') {
       await deleteCheckpoint(this.env.DEVIN_CHECKPOINTS, sessionId);
+      await this.ctx.storage.delete(CHECKPOINT_PRESENT_KEY);
+    }
+  }
+
+  /** Whether this session has an R2 checkpoint the container can restore. */
+  async hasCheckpoint(): Promise<boolean> {
+    return (
+      (await this.ctx.storage.get<boolean>(CHECKPOINT_PRESENT_KEY)) === true
+    );
+  }
+
+  /** Recorded by the checkpoint proxy after a successful upload to R2. */
+  async recordCheckpointSaved(): Promise<void> {
+    await this.ctx.storage.put(CHECKPOINT_PRESENT_KEY, true);
   }
 
   async #startContainer(

--- a/devin/src/persistence.ts
+++ b/devin/src/persistence.ts
@@ -16,11 +16,15 @@ export class CheckpointProxy extends WorkerEntrypoint<
     if (new URL(request.url).pathname !== CHECKPOINT_PATH)
       return new Response('Not found', { status: 404 });
 
-    const key = checkpointKey(this.ctx.props.sessionId);
+    const sessionId = this.ctx.props.sessionId;
+    const key = checkpointKey(sessionId);
     switch (request.method) {
       case 'HEAD': {
-        const object = await this.env.DEVIN_CHECKPOINTS.head(key);
-        return new Response(null, { status: object ? 200 : 404 });
+        // Answer from the session's Durable Object rather than probing R2, so a
+        // fresh session with no checkpoint never issues a HeadObject against a
+        // missing key (which R2 records as an error-level span).
+        const present = await this.#worker(sessionId).hasCheckpoint();
+        return new Response(null, { status: present ? 200 : 404 });
       }
       case 'GET': {
         const object = await this.env.DEVIN_CHECKPOINTS.get(key);
@@ -46,6 +50,7 @@ export class CheckpointProxy extends WorkerEntrypoint<
           this.env.DEVIN_CHECKPOINTS.put(key, readable),
           request.body.pipeTo(writable)
         ]);
+        await this.#worker(sessionId).recordCheckpointSaved();
         return new Response(null, { status: 204 });
       }
       default:
@@ -54,6 +59,10 @@ export class CheckpointProxy extends WorkerEntrypoint<
           headers: { allow: 'HEAD, GET, PUT' }
         });
     }
+  }
+
+  #worker(sessionId: string) {
+    return this.env.DevinWorker.get(this.env.DevinWorker.idFromName(sessionId));
   }
 }
 

--- a/devin/test/index.test.ts
+++ b/devin/test/index.test.ts
@@ -29,6 +29,8 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
 type WorkerStub = {
   ensureRunning: Mock;
   stop: Mock;
+  hasCheckpoint: Mock;
+  recordCheckpointSaved: Mock;
 };
 
 type TestNamespace = Env['DevinWorker'] & {
@@ -65,7 +67,9 @@ function makeNamespace(stubs = new Map<string, WorkerStub>()): TestNamespace {
       if (!stubs.has(id)) {
         stubs.set(id, {
           ensureRunning: vi.fn().mockResolvedValue(undefined),
-          stop: vi.fn().mockResolvedValue(undefined)
+          stop: vi.fn().mockResolvedValue(undefined),
+          hasCheckpoint: vi.fn().mockResolvedValue(false),
+          recordCheckpointSaved: vi.fn().mockResolvedValue(undefined)
         });
       }
       return stubFor(stubs, id);
@@ -107,10 +111,23 @@ function fakeContainer(running = false, destroyError?: Error) {
   };
 }
 
-function makeCtx(container = fakeContainer()) {
+function makeStorage(initial: Record<string, unknown> = {}) {
+  const store = new Map<string, unknown>(Object.entries(initial));
+  return {
+    store,
+    get: vi.fn(async (key: string) => store.get(key)),
+    put: vi.fn(async (key: string, value: unknown) => {
+      store.set(key, value);
+    }),
+    delete: vi.fn(async (key: string) => store.delete(key))
+  };
+}
+
+function makeCtx(container = fakeContainer(), storage = makeStorage()) {
   const checkpointBinding = { fetch: vi.fn() };
   return {
     container,
+    storage,
     exports: {
       CheckpointProxy: vi.fn(() => checkpointBinding)
     },
@@ -162,9 +179,10 @@ describe('checkpoint proxy', () => {
       }),
       delete: vi.fn()
     };
+    const stubs = new Map<string, WorkerStub>();
     const proxy = new TestCheckpointProxy(
       { props: { sessionId: 'devin-1' } },
-      baseEnv({ DEVIN_CHECKPOINTS: bucket })
+      baseEnv({ DEVIN_CHECKPOINTS: bucket, DevinWorker: makeNamespace(stubs) })
     );
     const upload = new Request(
       'http://checkpoint.internal/checkpoint?key=sessions/devin-2.tar.zst',
@@ -182,12 +200,19 @@ describe('checkpoint proxy', () => {
     );
     expect(uploaded).toBe('new archive');
     expect(fixedLength).toBe(11);
+    // The upload marks the session's DO as having a checkpoint; R2 is never
+    // probed to answer the container's restore HEAD.
+    expect(
+      stubFor(stubs, 'id:devin-1').recordCheckpointSaved
+    ).toHaveBeenCalled();
 
+    stubFor(stubs, 'id:devin-1').hasCheckpoint.mockResolvedValue(true);
     const head = await proxy.fetch(
       new Request('http://checkpoint.internal/checkpoint', { method: 'HEAD' })
     );
     expect(head.status).toBe(200);
-    expect(bucket.head).toHaveBeenCalledWith('sessions/devin-1.tar.zst');
+    expect(stubFor(stubs, 'id:devin-1').hasCheckpoint).toHaveBeenCalled();
+    expect(bucket.head).not.toHaveBeenCalled();
 
     const download = await proxy.fetch(
       new Request('http://checkpoint.internal/checkpoint')
@@ -195,6 +220,27 @@ describe('checkpoint proxy', () => {
     expect(download.status).toBe(200);
     expect(download.headers.get('content-length')).toBe('13');
     await expect(download.text()).resolves.toBe('saved archive');
+  });
+
+  it('reports no checkpoint via the DO without probing R2', async () => {
+    const bucket = {
+      head: vi.fn().mockResolvedValue(null),
+      get: vi.fn().mockResolvedValue(null),
+      put: vi.fn(),
+      delete: vi.fn()
+    };
+    const stubs = new Map<string, WorkerStub>();
+    const proxy = new TestCheckpointProxy(
+      { props: { sessionId: 'devin-1' } },
+      baseEnv({ DEVIN_CHECKPOINTS: bucket, DevinWorker: makeNamespace(stubs) })
+    );
+
+    const head = await proxy.fetch(
+      new Request('http://checkpoint.internal/checkpoint', { method: 'HEAD' })
+    );
+    expect(head.status).toBe(404);
+    expect(stubFor(stubs, 'id:devin-1').hasCheckpoint).toHaveBeenCalled();
+    expect(bucket.head).not.toHaveBeenCalled();
   });
 
   it('is not routed through the public Worker endpoint', async () => {
@@ -603,13 +649,33 @@ describe('Durable Object container actuator', () => {
   it('deletes the checkpoint when a session is terminated', async () => {
     const container = fakeContainer(false);
     const env = baseEnv();
-    const durableObject = newTestDevinWorker(makeCtx(container), env);
+    const storage = makeStorage({ checkpointPresent: true });
+    const durableObject = newTestDevinWorker(makeCtx(container, storage), env);
 
     await durableObject.stop('devin-1', 'terminated');
 
     expect(env.DEVIN_CHECKPOINTS.delete).toHaveBeenCalledWith(
       'sessions/devin-1.tar.zst'
     );
+    expect(storage.delete).toHaveBeenCalledWith('checkpointPresent');
+    expect(storage.store.has('checkpointPresent')).toBe(false);
+  });
+
+  it('tracks checkpoint presence across save and terminate', async () => {
+    const storage = makeStorage();
+    const durableObject = newTestDevinWorker(
+      makeCtx(fakeContainer(false), storage),
+      baseEnv()
+    );
+
+    await expect(durableObject.hasCheckpoint()).resolves.toBe(false);
+
+    await durableObject.recordCheckpointSaved();
+    expect(storage.store.get('checkpointPresent')).toBe(true);
+    await expect(durableObject.hasCheckpoint()).resolves.toBe(true);
+
+    await durableObject.stop('devin-1', 'terminated');
+    await expect(durableObject.hasCheckpoint()).resolves.toBe(false);
   });
 
   it('keeps the checkpoint when terminating a container fails', async () => {


### PR DESCRIPTION
A Devin session container runs `devin-checkpoint restore` on start, which issues a `HEAD /checkpoint` to the internal proxy to decide whether to restore a saved workspace. `CheckpointProxy` answered that by calling `DEVIN_CHECKPOINTS.head(key)`. For any session that has never suspended, `key` (`sessions/<sessionId>.tar.zst`) doesn't exist yet — R2's `.head()` returns `null` and the proxy correctly returns `404`, but R2's observability layer still records the underlying `HeadObject` miss as an **error-level `r2_head` span** (`code 10007`, "The specified key does not exist"). The result is a noisy error span on every fresh session even though nothing failed.

This makes the session's Durable Object the source of truth for checkpoint existence, so the restore probe never issues a `HeadObject` against a missing key:

```
DevinWorker (DO):
  recordCheckpointSaved()  -> storage.put("checkpointPresent", true)   // set after a successful PUT
  hasCheckpoint()          -> storage.get("checkpointPresent") === true
  stop(reason="terminated")-> deleteCheckpoint(...); storage.delete("checkpointPresent")

CheckpointProxy:
  HEAD -> status = (await worker(sessionId).hasCheckpoint()) ? 200 : 404   // was: DEVIN_CHECKPOINTS.head(key)
  PUT  -> ...put(key, body); await worker(sessionId).recordCheckpointSaved()
  GET  -> unchanged (streams from R2)
```

`CheckpointProxy` reaches the DO via `env.DevinWorker.get(idFromName(sessionId))`, the same deterministic per-session id the reconciler uses. The container scripts (`devin-checkpoint`, `start-devin-worker`) are untouched, so restore behavior is identical — a fresh session still gets `404 → "no checkpoint found" → start fresh`, just without the spurious error span. `GET` still reads from R2 and only runs after a `200` HEAD, so it only touches keys known to exist.

> [!NOTE]
> This code will be removed once the backup/restore flow is able to use native snapshotting.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->