### PR TITLE
Add common tooling to devin container image

### DIFF
--- a/devin/Dockerfile
+++ b/devin/Dockerfile
@@ -27,12 +27,21 @@ FROM debian:bookworm-slim
 # - ffmpeg for screen recording
 # - passwordless sudo for session-time commands that invoke sudo
 # ca-certificates is needed by the Devin CLI/runtime HTTPS clients.
+# - build-essential, python3/pip, awscli, zip/unzip, wget, ripgrep, jq,
+#   socat: common tooling expected in the session environment.
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     bash ca-certificates curl git sudo chromium ffmpeg zstd \
+    build-essential python3 python3-pip awscli zip unzip wget ripgrep jq socat \
   && echo 'root ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/90-devin-root \
   && chmod 0440 /etc/sudoers.d/90-devin-root \
   && rm -rf /var/lib/apt/lists/*
+
+# uv (Python package/project manager) is not packaged in Debian; install the
+# standalone binary from Astral into a system-wide location.
+RUN set -eux; \
+    curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh; \
+    uv --version
 
 COPY --from=devin-cli /usr/local/bin/devin /usr/local/bin/devin
 COPY bin/start-devin-worker /usr/local/bin/start-devin-worker


### PR DESCRIPTION
Sessions expect standard build and CLI tooling to be present. Install the documented dependency set (build-essential, python3/pip, awscli, zip/unzip, wget, ripgrep, jq, socat) via apt and uv via the Astral installer, since uv is not packaged in Debian.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->