### PR TITLE
Allow release workflows to start E2E jobs

### DIFF
--- a/.github/reusable-workflow-permissions.test.ts
+++ b/.github/reusable-workflow-permissions.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+import { parse } from 'yaml';
+
+type JobConfig = {
+  permissions?: Record<string, string>;
+};
+
+type WorkflowConfig = {
+  jobs: Record<string, JobConfig | undefined>;
+};
+
+function readWorkflow(path: string): WorkflowConfig {
+  return parse(readFileSync(path, 'utf8')) as WorkflowConfig;
+}
+
+function assertPermission(
+  workflow: WorkflowConfig,
+  jobName: string,
+  permission: string,
+  access: string
+): void {
+  const job = workflow.jobs[jobName];
+
+  assert.ok(job, `Expected workflow to define ${jobName}`);
+  assert.equal(
+    job.permissions?.[permission],
+    access,
+    `Expected ${jobName} to grant ${permission}: ${access}`
+  );
+}
+
+test('release callers grant permissions required by reusable E2E', () => {
+  const release = readWorkflow('.github/workflows/release.yml');
+  const prerelease = readWorkflow('.github/workflows/reusable-prerelease.yml');
+
+  assertPermission(release, 'prerelease', 'pull-requests', 'read');
+  assertPermission(prerelease, 'e2e', 'pull-requests', 'read');
+  assertPermission(release, 'e2e', 'pull-requests', 'read');
+});

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       id-token: write
       contents: read
       actions: read
+      pull-requests: read
       packages: write
     with:
       channel: next
@@ -137,6 +138,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      pull-requests: read
     uses: ./.github/workflows/reusable-e2e.yml
     with:
       worker_name_prefix: sandbox-e2e-test-worker-main

--- a/.github/workflows/reusable-prerelease.yml
+++ b/.github/workflows/reusable-prerelease.yml
@@ -140,6 +140,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      pull-requests: read
     uses: ./.github/workflows/reusable-e2e.yml
     with:
       worker_name_prefix: ${{ inputs.worker_name_prefix }}


### PR DESCRIPTION
Allow release workflows to start E2E jobs

Reusable E2E checks can read pull request state to reject superseded PR deployments. GitHub requires every caller in a reusable-workflow chain to grant that permission, even when a release invocation does not supply a PR number.

The `next` prerelease and `main` release callers omitted `pull-requests: read`, so GitHub rejected Release runs before creating any jobs. The first failure started with the commit that added the E2E permission requirement.

Pass the permission through both release call chains and add a configuration test covering the nested callers.
