### PR TITLE
Allow stable releases to start E2E jobs

### DIFF
--- a/.github/reusable-workflow-permissions.test.ts
+++ b/.github/reusable-workflow-permissions.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+import { parse } from 'yaml';
+
+type JobConfig = {
+  permissions?: Record<string, string>;
+};
+
+type WorkflowConfig = {
+  jobs: Record<string, JobConfig | undefined>;
+};
+
+function readWorkflow(path: string): WorkflowConfig {
+  return parse(readFileSync(path, 'utf8')) as WorkflowConfig;
+}
+
+function assertPermission(
+  workflow: WorkflowConfig,
+  jobName: string,
+  permission: string,
+  access: string
+): void {
+  const job = workflow.jobs[jobName];
+
+  assert.ok(job, `Expected workflow to define ${jobName}`);
+  assert.equal(
+    job.permissions?.[permission],
+    access,
+    `Expected ${jobName} to grant ${permission}: ${access}`
+  );
+}
+
+test('release callers grant permissions required by reusable E2E', () => {
+  const release = readWorkflow('.github/workflows/release.yml');
+  const prerelease = readWorkflow('.github/workflows/reusable-prerelease.yml');
+
+  assertPermission(release, 'prerelease', 'pull-requests', 'read');
+  assertPermission(prerelease, 'e2e', 'pull-requests', 'read');
+  assertPermission(release, 'e2e', 'pull-requests', 'read');
+});

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
       id-token: write
       contents: read
       actions: read
+      pull-requests: read
       packages: write
     with:
       channel: next
@@ -131,6 +132,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      pull-requests: read
     uses: ./.github/workflows/reusable-e2e.yml
     with:
       worker_name_prefix: sandbox-e2e-test-worker-main

--- a/.github/workflows/reusable-prerelease.yml
+++ b/.github/workflows/reusable-prerelease.yml
@@ -140,6 +140,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      pull-requests: read
     uses: ./.github/workflows/reusable-e2e.yml
     with:
       worker_name_prefix: ${{ inputs.worker_name_prefix }}


### PR DESCRIPTION
Allow stable release workflows to start E2E jobs

Reusable E2E checks can read pull request state to reject superseded PR deployments. GitHub requires every caller in a reusable-workflow chain to grant that permission, even when a stable release invocation does not supply a PR number.

The stable Release workflow omitted `pull-requests: read`, so GitHub could reject the workflow before creating any jobs. Pass the permission through the release call paths and add a configuration test covering both stable and prerelease callers.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/sandbox-sdk/pull/843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->