### PR TITLE
Fix restore archive part assembly command

### DIFF
--- a/.changeset/accelerate-backup-restores.md
+++ b/.changeset/accelerate-backup-restores.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Fix slow backup restores caused by inefficient archive part assembly.

--- a/packages/sandbox-container/src/services/backup/transfer-operations.ts
+++ b/packages/sandbox-container/src/services/backup/transfer-operations.ts
@@ -316,7 +316,7 @@ while IFS=: read -r offset expected_bytes part_file; do
     echo "downloaded part size mismatch at offset $offset: expected $expected_bytes got $actual_bytes" >&2
     exit 1
   fi
-  dd if="$part_file" of="$tmp_archive" bs=1 seek="$offset" conv=notrunc status=none
+  dd if="$part_file" of="$tmp_archive" bs=1M seek="$offset" oflag=seek_bytes conv=notrunc status=none
 done <<EOF
 $part_files
 EOF

--- a/packages/sandbox-container/tests/services/backup-service.test.ts
+++ b/packages/sandbox-container/tests/services/backup-service.test.ts
@@ -795,6 +795,10 @@ describe('BackupService', () => {
       expect(command).toContain('for pid in $pids; do');
       expect(command).toContain('wait "$pid"');
       expect(command).toContain('wc -c < "$part_file"');
+      expect(command).toContain(
+        'dd if="$part_file" of="$tmp_archive" bs=1M seek="$offset" oflag=seek_bytes conv=notrunc status=none'
+      );
+      expect(command).not.toContain('bs=1 seek="$offset"');
       expect(command).toContain('mv "$tmp_archive" \'/var/backups/app.sqsh\'');
       expect(command).not.toContain("rm -f '/var/backups/app.sqsh'");
       expect(options).toEqual({ timeoutMs: 1_810_000 });


### PR DESCRIPTION
# Summary

Fix backup restores with improved archive part assembly command. Using `dd` with `bs=1` caused hundreds of millions of system calls for larger archives, making a 256 MiB restore take around 200 seconds. This changes the block size to 1 MiB while preserving exact byte offsets and existing validation.