### PR TITLE
Backport preview package publisher

### DIFF
--- a/.github/npm-package-prep.test.ts
+++ b/.github/npm-package-prep.test.ts
@@ -1,0 +1,200 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { nodeNpmPrepDeps, prepareNpmPackage } from './npm-package-prep.ts';
+
+describe('prepareNpmPackage', () => {
+  test('rewrites @repo/shared workspace range only in staged manifest and validates exported pack files', async () => {
+    const writes = new Map<string, string>();
+    const removed: string[] = [];
+    const prepared = await prepareNpmPackage(
+      {
+        releaseRoot: '/repo/release',
+        packageName: '@cloudflare/sandbox',
+        version: '1.2.3'
+      },
+      {
+        makeTempDir: () => '/tmp/sandbox-npm-1',
+        copyPackage: (from, to) => writes.set('copy', `${from}->${to}`),
+        readFile: (path) =>
+          path.endsWith('package.json')
+            ? '{"name":"@cloudflare/sandbox","version":"1.2.3","dependencies":{"@repo/shared":"workspace:*"},"exports":{".":{"import":"./dist/index.js","types":"./dist/index.d.ts"}}}'
+            : 'ok',
+        writeFile: (path, content) => writes.set(path, content),
+        exists: (path) =>
+          path.endsWith('dist/index.js') || path.endsWith('dist/index.d.ts'),
+        command: async () => ({
+          exitCode: 0,
+          stdout:
+            '[{"filename":"cloudflare-sandbox-1.2.3.tgz","files":[{"path":"package.json"},{"path":"dist/index.js"},{"path":"dist/index.d.ts"}]}]',
+          stderr: ''
+        }),
+        remove: async (path) => removed.push(path),
+        workspaceVersions: () => new Map([['@repo/shared', '1.2.3']])
+      }
+    );
+    assert.equal(prepared.packageName, '@cloudflare/sandbox');
+    assert.equal(prepared.version, '1.2.3');
+    assert.equal(prepared.packageDir, '/tmp/sandbox-npm-1/package');
+    assert.equal(
+      prepared.tarballPath,
+      join('/tmp/sandbox-npm-1/package', 'cloudflare-sandbox-1.2.3.tgz')
+    );
+    const stagedManifest =
+      writes.get('/tmp/sandbox-npm-1/package/package.json') ?? '';
+    assert.match(stagedManifest, /"@repo\/shared": "\^1\.2\.3"/);
+    assert.doesNotMatch(stagedManifest, /workspace:|"\*"/);
+    await prepared.cleanup();
+    await prepared.cleanup();
+    assert.deepEqual(removed, ['/tmp/sandbox-npm-1']);
+  });
+
+  test('uses versionOverride for prerelease without editing releaseRoot', async () => {
+    const writes = new Map<string, string>();
+    const prepared = await prepareNpmPackage(
+      {
+        releaseRoot: '/repo/release',
+        packageName: '@cloudflare/sandbox',
+        version: '1.2.3',
+        versionOverride: '1.2.3-beta.1'
+      },
+      fakeDeps(writes)
+    );
+    assert.equal(prepared.packageName, '@cloudflare/sandbox');
+    assert.equal(prepared.version, '1.2.3-beta.1');
+    assert.match(
+      writes.get('/tmp/sandbox-npm-test/package/package.json') ?? '',
+      /"version": "1\.2\.3-beta\.1"/
+    );
+    assert.equal(
+      prepared.tarballPath,
+      '/tmp/sandbox-npm-test/package/cloudflare-sandbox-1.2.3-beta.1.tgz'
+    );
+  });
+
+  test('cleans up once when export validation fails', async () => {
+    const removed: string[] = [];
+    await assert.rejects(
+      prepareNpmPackage(
+        {
+          releaseRoot: '/repo/release',
+          packageName: '@cloudflare/sandbox',
+          version: '1.2.3'
+        },
+        {
+          ...fakeDeps(new Map()),
+          exists: (path) => !path.endsWith('dist/index.d.ts'),
+          remove: async (path) => removed.push(path)
+        }
+      ),
+      /Declared export file is missing from staged package: dist\/index\.d\.ts/
+    );
+    assert.deepEqual(removed, ['/tmp/sandbox-npm-test']);
+  });
+
+  test('reads workspace versions when historical root has no shared package', () => {
+    const releaseRoot = mkdtempSync(join(tmpdir(), 'sandbox-release-root-'));
+    try {
+      const sandboxDir = join(releaseRoot, 'packages', 'sandbox');
+      mkdirSync(sandboxDir, { recursive: true });
+      writeFileSync(
+        join(sandboxDir, 'package.json'),
+        '{"name":"@cloudflare/sandbox","version":"1.2.3"}'
+      );
+
+      assert.deepEqual(
+        nodeNpmPrepDeps.workspaceVersions(releaseRoot),
+        new Map([['@cloudflare/sandbox', '1.2.3']])
+      );
+    } finally {
+      rmSync(releaseRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('retries cleanup after removal fails', async () => {
+    let attempts = 0;
+    const prepared = await prepareNpmPackage(
+      {
+        releaseRoot: '/repo/release',
+        packageName: '@cloudflare/sandbox',
+        version: '1.2.3'
+      },
+      {
+        ...fakeDeps(new Map()),
+        remove: async () => {
+          attempts += 1;
+          if (attempts === 1) {
+            throw new Error('remove failed');
+          }
+        }
+      }
+    );
+
+    await assert.rejects(prepared.cleanup(), /remove failed/);
+    await prepared.cleanup();
+    await prepared.cleanup();
+    assert.equal(attempts, 2);
+  });
+});
+
+function fakeDeps(writes: Map<string, string>) {
+  return {
+    makeTempDir: () => '/tmp/sandbox-npm-test',
+    copyPackage: (from: string, to: string) =>
+      writes.set('copy', `${from}->${to}`),
+    readFile: (path: string) =>
+      path.endsWith('package.json')
+        ? '{"name":"@cloudflare/sandbox","version":"1.2.3","dependencies":{"@repo/shared":"workspace:*"},"exports":{".":{"import":"./dist/index.js","types":"./dist/index.d.ts"}}}'
+        : 'ok',
+    writeFile: (path: string, content: string) => writes.set(path, content),
+    exists: (path: string) =>
+      path.endsWith('dist/index.js') || path.endsWith('dist/index.d.ts'),
+    command: async () => ({
+      exitCode: 0,
+      stdout:
+        '[{"filename":"cloudflare-sandbox-1.2.3-beta.1.tgz","files":[{"path":"package.json"},{"path":"dist/index.js"},{"path":"dist/index.d.ts"}]}]',
+      stderr: ''
+    }),
+    remove: async () => undefined,
+    workspaceVersions: () => new Map([['@repo/shared', '1.2.3']])
+  };
+}
+
+import { parseNpmPackResult } from './npm-package-prep.ts';
+
+describe('parseNpmPackResult', () => {
+  test('accepts array and single-object npm pack JSON', () => {
+    assert.equal(
+      parseNpmPackResult(
+        '[{"filename":"pkg.tgz","files":[{"path":"package.json"}]}]'
+      ).filename,
+      'pkg.tgz'
+    );
+    assert.equal(
+      parseNpmPackResult(
+        '{"filename":"pkg.tgz","files":[{"path":"package.json"}]}'
+      ).filename,
+      'pkg.tgz'
+    );
+  });
+
+  test('ignores leading npm notices before JSON', () => {
+    assert.equal(
+      parseNpmPackResult(
+        'npm notice\n[{"filename":"pkg.tgz","files":[{"path":"package.json"}]}]'
+      ).filename,
+      'pkg.tgz'
+    );
+  });
+
+  test('accepts package-name keyed npm pack JSON', () => {
+    assert.equal(
+      parseNpmPackResult(
+        '{"@cloudflare/sandbox":{"filename":"cloudflare-sandbox-0.12.5.tgz","files":[{"path":"package.json"}]}}'
+      ).filename,
+      'cloudflare-sandbox-0.12.5.tgz'
+    );
+  });
+});

--- a/.github/npm-package-prep.ts
+++ b/.github/npm-package-prep.ts
@@ -1,0 +1,380 @@
+import { spawnSync } from 'node:child_process';
+import {
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export interface ProcessResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface PreparedNpmPackage {
+  packageName: '@cloudflare/sandbox';
+  version: string;
+  packageDir: string;
+  tarballPath: string;
+  cleanup(): Promise<void>;
+}
+
+export interface NpmPrepInput {
+  releaseRoot: string;
+  packageName: '@cloudflare/sandbox';
+  version: string;
+  versionOverride?: string;
+}
+
+export interface NpmPrepDeps {
+  makeTempDir(prefix: string): string;
+  copyPackage(from: string, to: string): void;
+  readFile(path: string): string;
+  writeFile(path: string, content: string): void;
+  exists(path: string): boolean;
+  command(
+    command: string,
+    args: readonly string[],
+    options: { cwd: string }
+  ): Promise<ProcessResult>;
+  remove(path: string): Promise<void>;
+  workspaceVersions(releaseRoot: string): Map<string, string>;
+}
+
+interface Manifest {
+  name: string;
+  version: string;
+  exports?: Record<string, string | Record<string, string>>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+}
+
+interface PackResult {
+  filename: string;
+  files: { path: string }[];
+}
+
+export async function prepareNpmPackage(
+  input: NpmPrepInput,
+  deps: NpmPrepDeps = nodeNpmPrepDeps
+): Promise<PreparedNpmPackage> {
+  const tempRoot = deps.makeTempDir('sandbox-npm-');
+  const packageDir = join(tempRoot, 'package');
+  let cleaned = false;
+  const cleanup = async () => {
+    if (!cleaned) {
+      await deps.remove(tempRoot);
+      cleaned = true;
+    }
+  };
+
+  try {
+    deps.copyPackage(
+      join(input.releaseRoot, 'packages', 'sandbox'),
+      packageDir
+    );
+    const manifestPath = join(packageDir, 'package.json');
+    const manifest = JSON.parse(deps.readFile(manifestPath)) as Manifest;
+    validateManifest(manifest, input.packageName, input.version);
+    if (input.versionOverride !== undefined) {
+      manifest.version = input.versionOverride;
+    }
+    const workspaceVersions = deps.workspaceVersions(input.releaseRoot);
+    rewriteWorkspaceRanges(manifest, workspaceVersions);
+    rejectWorkspaceRanges(manifest, workspaceVersions);
+    deps.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    const exportedFiles = exportedManifestFiles(manifest);
+    validateExportFiles(exportedFiles, packageDir, deps.exists);
+    const pack = await npmPack(packageDir, deps);
+    validatePackFiles(pack, exportedFiles);
+
+    return {
+      packageName: input.packageName,
+      version: manifest.version,
+      packageDir,
+      tarballPath: join(packageDir, pack.filename),
+      cleanup
+    };
+  } catch (error) {
+    try {
+      await cleanup();
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [error, cleanupError],
+        error instanceof Error
+          ? error.message
+          : 'npm package preparation failed and cleanup also failed'
+      );
+    }
+    throw error;
+  }
+}
+
+function validateManifest(
+  manifest: Manifest,
+  packageName: '@cloudflare/sandbox',
+  version: string
+): void {
+  if (manifest.name !== packageName) {
+    throw new Error(
+      `Staged package name ${manifest.name} is not ${packageName}`
+    );
+  }
+  if (manifest.version !== version) {
+    throw new Error(
+      `Staged package version ${manifest.version} does not match requested ${version}`
+    );
+  }
+}
+
+function rewriteWorkspaceRanges(
+  manifest: Manifest,
+  versions: Map<string, string>
+): void {
+  for (const field of [
+    'dependencies',
+    'devDependencies',
+    'peerDependencies',
+    'optionalDependencies'
+  ] as const) {
+    const dependencies = manifest[field];
+    if (dependencies === undefined) {
+      continue;
+    }
+    for (const [name, range] of Object.entries(dependencies)) {
+      const version = versions.get(name);
+      if (
+        version !== undefined &&
+        (range === '*' || range.startsWith('workspace:'))
+      ) {
+        dependencies[name] = version.startsWith('0.0.0-')
+          ? version
+          : `^${version}`;
+      }
+    }
+  }
+}
+
+function rejectWorkspaceRanges(
+  manifest: Manifest,
+  versions: Map<string, string>
+): void {
+  for (const field of [
+    'dependencies',
+    'devDependencies',
+    'peerDependencies',
+    'optionalDependencies'
+  ] as const) {
+    const dependencies = manifest[field];
+    if (dependencies === undefined) {
+      continue;
+    }
+    for (const [name, range] of Object.entries(dependencies)) {
+      if (
+        versions.has(name) &&
+        (range === '*' || range.startsWith('workspace:'))
+      ) {
+        throw new Error(
+          `Staged manifest keeps unresolved workspace range for ${name}: ${range}`
+        );
+      }
+    }
+  }
+}
+
+function exportedManifestFiles(manifest: Manifest): string[] {
+  const files = new Set<string>();
+  for (const value of Object.values(manifest.exports ?? {})) {
+    if (typeof value === 'string') {
+      files.add(value.replace(/^\.\//, ''));
+    } else {
+      for (const nested of Object.values(value)) {
+        files.add(nested.replace(/^\.\//, ''));
+      }
+    }
+  }
+  return [...files].sort();
+}
+
+function validateExportFiles(
+  files: readonly string[],
+  packageDir: string,
+  exists: (path: string) => boolean
+): void {
+  for (const file of files) {
+    if (!exists(join(packageDir, file))) {
+      throw new Error(
+        `Declared export file is missing from staged package: ${file}`
+      );
+    }
+  }
+}
+
+async function npmPack(
+  packageDir: string,
+  deps: NpmPrepDeps
+): Promise<PackResult> {
+  const result = await deps.command('npm', ['pack', '--json'], {
+    cwd: packageDir
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `npm pack failed: ${result.stderr.trim() || result.stdout.trim()}`
+    );
+  }
+  const pack = parseNpmPackResult(result.stdout);
+  if (pack.filename.trim() === '') {
+    throw new Error(`npm pack produced no tarball: ${result.stdout.trim()}`);
+  }
+  return pack;
+}
+
+export function parseNpmPackResult(stdout: string): PackResult {
+  const jsonText = extractJsonPayload(stdout);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText) as unknown;
+  } catch (error) {
+    throw new Error(
+      `npm pack produced invalid JSON: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  const candidate = unwrapNpmPackCandidate(parsed);
+  if (
+    candidate === null ||
+    typeof candidate !== 'object' ||
+    !('filename' in candidate) ||
+    typeof (candidate as { filename: unknown }).filename !== 'string' ||
+    !('files' in candidate) ||
+    !Array.isArray((candidate as { files: unknown }).files)
+  ) {
+    throw new Error(`npm pack produced no tarball: ${stdout.trim()}`);
+  }
+
+  const files = (candidate as { files: unknown[] }).files.map((file) => {
+    if (
+      file === null ||
+      typeof file !== 'object' ||
+      !('path' in file) ||
+      typeof (file as { path: unknown }).path !== 'string'
+    ) {
+      throw new Error(
+        `npm pack produced malformed file list: ${stdout.trim()}`
+      );
+    }
+    return { path: (file as { path: string }).path };
+  });
+
+  return {
+    filename: (candidate as { filename: string }).filename,
+    files
+  };
+}
+
+function unwrapNpmPackCandidate(parsed: unknown): unknown {
+  if (Array.isArray(parsed)) {
+    return parsed[0];
+  }
+  if (parsed === null || typeof parsed !== 'object') {
+    return parsed;
+  }
+  if ('filename' in parsed) {
+    return parsed;
+  }
+  const values = Object.values(parsed as Record<string, unknown>);
+  if (values.length === 1) {
+    return values[0];
+  }
+  return parsed;
+}
+
+function extractJsonPayload(stdout: string): string {
+  const trimmed = stdout.trim();
+  if (trimmed === '') {
+    throw new Error('npm pack produced empty output');
+  }
+  const arrayStart = trimmed.indexOf('[');
+  const objectStart = trimmed.indexOf('{');
+  let start = -1;
+  if (arrayStart >= 0 && (objectStart < 0 || arrayStart < objectStart)) {
+    start = arrayStart;
+  } else if (objectStart >= 0) {
+    start = objectStart;
+  }
+  if (start < 0) {
+    throw new Error(`npm pack produced no JSON payload: ${trimmed}`);
+  }
+  return trimmed.slice(start);
+}
+
+function validatePackFiles(
+  pack: PackResult,
+  exportedFiles: readonly string[]
+): void {
+  const paths = new Set(pack.files.map((file) => file.path));
+  for (const required of ['package.json', ...exportedFiles]) {
+    if (!paths.has(required)) {
+      throw new Error(`npm pack output is missing ${required}`);
+    }
+  }
+  for (const path of paths) {
+    if (path.startsWith('../') || path.startsWith('/')) {
+      throw new Error(`npm pack output escapes package boundary: ${path}`);
+    }
+  }
+}
+
+function runProcess(
+  command: string,
+  args: readonly string[],
+  options: { cwd: string }
+): ProcessResult {
+  const result = spawnSync(command, [...args], {
+    cwd: options.cwd,
+    encoding: 'utf8'
+  });
+  return {
+    exitCode: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? ''
+  };
+}
+
+function readWorkspaceVersions(releaseRoot: string): Map<string, string> {
+  const versions = new Map<string, string>();
+  for (const relativePath of [
+    'packages/sandbox/package.json',
+    'packages/shared/package.json'
+  ]) {
+    const manifestPath = join(releaseRoot, relativePath);
+    if (!existsSync(manifestPath)) {
+      continue;
+    }
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+      name: string;
+      version: string;
+    };
+    versions.set(manifest.name, manifest.version);
+  }
+  return versions;
+}
+
+export const nodeNpmPrepDeps: NpmPrepDeps = {
+  makeTempDir: (prefix) => mkdtempSync(join(tmpdir(), prefix)),
+  copyPackage: (from, to) => cpSync(from, to, { recursive: true }),
+  readFile: (path) => readFileSync(path, 'utf8'),
+  writeFile: (path, content) => writeFileSync(path, content),
+  exists: existsSync,
+  command: async (command, args, options) => runProcess(command, args, options),
+  remove: async (path) => rmSync(path, { recursive: true, force: true }),
+  workspaceVersions: readWorkspaceVersions
+};

--- a/.github/publish-preview-package.test.ts
+++ b/.github/publish-preview-package.test.ts
@@ -1,0 +1,64 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { publishPreviewPackage } from './publish-preview-package.ts';
+
+test('publishes an isolated preview package and always cleans it', async () => {
+  const events: string[] = [];
+
+  await publishPreviewPackage(
+    { releaseRoot: '/repo', versionOverride: '0.0.0-pr-123-abc' },
+    {
+      readFile: () => '{"name":"@cloudflare/sandbox","version":"1.2.3"}',
+      prepareNpmPackage: async (input) => {
+        assert.deepEqual(input, {
+          releaseRoot: '/repo',
+          packageName: '@cloudflare/sandbox',
+          version: '1.2.3',
+          versionOverride: '0.0.0-pr-123-abc'
+        });
+        return {
+          packageName: '@cloudflare/sandbox',
+          version: '0.0.0-pr-123-abc',
+          packageDir: '/tmp/package',
+          tarballPath: '/tmp/package/package.tgz',
+          cleanup: async () => {
+            events.push('cleanup');
+          }
+        };
+      },
+      publish: async (packageDir) => {
+        events.push(`publish:${packageDir}`);
+      }
+    }
+  );
+
+  assert.deepEqual(events, ['publish:/tmp/package', 'cleanup']);
+});
+
+test('cleans the isolated package when preview publication fails', async () => {
+  const events: string[] = [];
+
+  await assert.rejects(
+    publishPreviewPackage(
+      { releaseRoot: '/repo', versionOverride: '0.0.0-pr-123-abc' },
+      {
+        readFile: () => '{"name":"@cloudflare/sandbox","version":"1.2.3"}',
+        prepareNpmPackage: async () => ({
+          packageName: '@cloudflare/sandbox',
+          version: '0.0.0-pr-123-abc',
+          packageDir: '/tmp/package',
+          tarballPath: '/tmp/package/package.tgz',
+          cleanup: async () => {
+            events.push('cleanup');
+          }
+        }),
+        publish: async () => {
+          throw new Error('publish failed');
+        }
+      }
+    ),
+    /publish failed/
+  );
+
+  assert.deepEqual(events, ['cleanup']);
+});

--- a/.github/publish-preview-package.ts
+++ b/.github/publish-preview-package.ts
@@ -1,0 +1,100 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  prepareNpmPackage,
+  type NpmPrepInput,
+  type PreparedNpmPackage
+} from './npm-package-prep.ts';
+
+export interface PreviewPackageInput {
+  releaseRoot: string;
+  versionOverride: string;
+}
+
+export interface PreviewPackageDeps {
+  readFile(path: string): string;
+  prepareNpmPackage(input: NpmPrepInput): Promise<PreparedNpmPackage>;
+  publish(packageDir: string): Promise<void>;
+}
+
+const nodePreviewPackageDeps: PreviewPackageDeps = {
+  readFile: (path) => readFileSync(path, 'utf8'),
+  prepareNpmPackage,
+  publish: async (packageDir) => {
+    execFileSync('npx', ['pkg-pr-new', 'publish', packageDir], {
+      stdio: 'inherit'
+    });
+  }
+};
+
+export async function publishPreviewPackage(
+  input: PreviewPackageInput,
+  deps: PreviewPackageDeps = nodePreviewPackageDeps
+): Promise<void> {
+  const manifest = parsePackageManifest(
+    deps.readFile(join(input.releaseRoot, 'packages/sandbox/package.json'))
+  );
+  const prepared = await deps.prepareNpmPackage({
+    releaseRoot: input.releaseRoot,
+    packageName: '@cloudflare/sandbox',
+    version: manifest.version,
+    versionOverride: input.versionOverride
+  });
+
+  try {
+    await deps.publish(prepared.packageDir);
+  } finally {
+    await prepared.cleanup();
+  }
+}
+
+function parsePackageManifest(content: string): { version: string } {
+  const manifest: unknown = JSON.parse(content);
+  if (
+    typeof manifest !== 'object' ||
+    manifest === null ||
+    !('version' in manifest) ||
+    typeof manifest.version !== 'string' ||
+    manifest.version.length === 0
+  ) {
+    throw new Error('Sandbox package manifest has no version');
+  }
+  return { version: manifest.version };
+}
+
+function requireArg(args: Map<string, string>, name: string): string {
+  const value = args.get(name);
+  if (value === undefined || value.length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+async function main(): Promise<void> {
+  const args = new Map<string, string>();
+  for (let index = 2; index < process.argv.length; index += 2) {
+    const name = process.argv[index];
+    const value = process.argv[index + 1];
+    if (!name?.startsWith('--') || value === undefined) {
+      throw new Error(`Invalid argument: ${name ?? ''}`);
+    }
+    args.set(name, value);
+  }
+
+  await publishPreviewPackage({
+    releaseRoot: requireArg(args, '--release-root'),
+    versionOverride: requireArg(args, '--version')
+  });
+}
+
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

Backport the preview package tooling expected by the privileged PR workflow from `main`.

Source-changing PRs targeting `next` currently fail in `publish-preview` because the workflow checks out the PR head and then invokes `.github/publish-preview-package.ts`, which is missing from `next`.
