### PR TITLE
Run nightly performance tests on next

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -237,3 +237,15 @@ jobs:
             -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
             -H "Content-Type: application/json" \
             -d '{"run_id": "perf-${{ github.run_id }}"}'
+
+  dispatch-next:
+    needs: performance-tests
+    if: ${{ always() && github.event_name == 'schedule' && github.ref_name == 'main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Run performance tests on next
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run performance.yml --repo "$GITHUB_REPOSITORY" --ref next --field scenario=all


### PR DESCRIPTION
## Summary

Run the existing performance workflow on `next` after the scheduled `main` performance run completes.

The established `main` benchmark jobs remain unchanged. The follow-up job dispatches the same workflow with `ref: next`, using the branch behavior already supported by Benchbox and avoiding concurrent use of shared performance resources.

## Testing

- `npm run test:release-tools`
- Prettier workflow validation
- Pre-push typecheck