### PR TITLE
Fix credential proxy copy scope

### DIFF
--- a/.changeset/secure-credential-proxy-copy-source.md
+++ b/.changeset/secure-credential-proxy-copy-source.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Enforce mounted bucket and prefix boundaries for server-side copy operations when using `credentialProxy`.

--- a/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
+++ b/packages/sandbox/src/storage-mount/s3-credential-proxy-handler.ts
@@ -437,6 +437,72 @@ function isObjectKeyWithinPrefix(
   );
 }
 
+type ParsedCopySource = {
+  bucket: string;
+  objectKey: string;
+};
+
+function parseCopySourceHeader(value: string): ParsedCopySource | null {
+  const encodedPath = value.split('?', 1)[0];
+  if (!encodedPath) {
+    return null;
+  }
+
+  let decodedPath: string;
+  try {
+    decodedPath = decodeURIComponent(encodedPath);
+  } catch {
+    return null;
+  }
+
+  const path = decodedPath.startsWith('/') ? decodedPath.slice(1) : decodedPath;
+  const separatorIndex = path.indexOf('/');
+  if (separatorIndex <= 0 || separatorIndex === path.length - 1) {
+    return null;
+  }
+
+  return {
+    bucket: path.slice(0, separatorIndex),
+    objectKey: path.slice(separatorIndex + 1)
+  };
+}
+
+function validateCopySourceWithinMountScope(
+  headers: Headers,
+  bucket: string,
+  prefix: string | undefined
+): Response | null {
+  const copySources = [
+    ['x-amz-copy-source', headers.get('x-amz-copy-source')],
+    ['x-goog-copy-source', headers.get('x-goog-copy-source')]
+  ].filter((entry): entry is [string, string] => entry[1] !== null);
+
+  if (copySources.length > 1) {
+    return new Response('Bad Request: multiple copy source headers', {
+      status: 400
+    });
+  }
+  if (copySources.length === 0) {
+    return null;
+  }
+
+  const [headerName, value] = copySources[0];
+  const copySource = parseCopySourceHeader(value);
+  if (!copySource) {
+    return new Response(`Bad Request: invalid ${headerName}`, { status: 400 });
+  }
+  if (
+    copySource.bucket !== bucket ||
+    !isObjectKeyWithinPrefix(copySource.objectKey, prefix)
+  ) {
+    return new Response('Forbidden: copy source is outside mounted scope', {
+      status: 403
+    });
+  }
+
+  return null;
+}
+
 function isRequestWithinMountScope(
   realPath: string,
   url: URL,
@@ -728,6 +794,14 @@ export const s3CredentialProxyHandler: OutboundHandler<
     return new Response('Forbidden: request is outside mounted bucket scope', {
       status: 403
     });
+  }
+  const copySourceError = validateCopySourceWithinMountScope(
+    request.headers,
+    mount.bucket,
+    mount.prefix
+  );
+  if (copySourceError) {
+    return copySourceError;
   }
   const cleanHeaders = buildCleanHeaders(request.headers);
   const cleanRequest = new Request(realUrl.toString(), {

--- a/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
+++ b/packages/sandbox/tests/s3-credential-proxy-handler.test.ts
@@ -564,6 +564,268 @@ describe('s3CredentialProxyHandler mount scope enforcement', () => {
 
     vi.restoreAllMocks();
   });
+
+  it('allows copy sources inside the configured prefix', async () => {
+    let capturedRequest: Request | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      capturedRequest = input instanceof Request ? input : new Request(input);
+      return new Response('ok', { status: 200 });
+    });
+    const req = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/project-a/copied.txt`,
+      'PUT',
+      {
+        'x-amz-copy-source': `/${BUCKET}/project-a/source%20file.txt?versionId=1`
+      }
+    );
+
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ prefix: 'project-a' })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+
+    expect(res.status).toBe(200);
+    expect(capturedRequest?.headers.get('x-amz-copy-source')).toBe(
+      `/${BUCKET}/project-a/source%20file.txt?versionId=1`
+    );
+
+    vi.restoreAllMocks();
+  });
+
+  it('rejects copy sources from a different bucket', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const req = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/project-a/copied.txt`,
+      'PUT',
+      { 'x-amz-copy-source': '/other-bucket/secret.txt' }
+    );
+
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ prefix: 'project-a' })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toContain('copy source is outside mounted scope');
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('rejects copy sources outside the configured prefix', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const req = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/project-a/copied.txt`,
+      'PUT',
+      { 'x-amz-copy-source': `/${BUCKET}/project-b/secret.txt` }
+    );
+
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ prefix: 'project-a' })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('allows multipart copy sources inside the configured prefix', async () => {
+    let capturedRequest: Request | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      capturedRequest = input instanceof Request ? input : new Request(input);
+      return new Response('ok', { status: 200 });
+    });
+    const req = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/project-a/copied.txt?partNumber=1&uploadId=upload-1`,
+      'PUT',
+      { 'x-amz-copy-source': `/${BUCKET}/project-a/source.txt` }
+    );
+
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ prefix: 'project-a' })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+
+    expect(res.status).toBe(200);
+    expect(capturedRequest?.headers.get('x-amz-copy-source')).toBe(
+      `/${BUCKET}/project-a/source.txt`
+    );
+
+    vi.restoreAllMocks();
+  });
+
+  it('rejects out-of-scope multipart copy sources', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const req = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/project-a/copied.txt?partNumber=1&uploadId=upload-1`,
+      'PUT',
+      { 'x-amz-copy-source': `/${BUCKET}/project-b/secret.txt` }
+    );
+
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ prefix: 'project-a' })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    `/${BUCKET}/project-a-evil/secret.txt`,
+    `/${BUCKET}/project-a%252Fsecret.txt`
+  ])('rejects ambiguous out-of-prefix copy source %s', async (copySource) => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const req = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/project-a/copied.txt`,
+      'PUT',
+      { 'x-amz-copy-source': copySource }
+    );
+
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ prefix: 'project-a' })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('rejects malformed copy sources', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const req = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/project-a/copied.txt`,
+      'PUT',
+      { 'x-amz-copy-source': `/${BUCKET}/project-a/%ZZ` }
+    );
+
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ prefix: 'project-a' })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.text()).toContain('invalid x-amz-copy-source');
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('allows GCS copy sources inside the configured prefix', async () => {
+    let capturedRequest: Request | undefined;
+    vi.spyOn(globalThis, 'fetch').mockImplementationOnce(async (input) => {
+      capturedRequest = input instanceof Request ? input : new Request(input);
+      return new Response('ok', { status: 200 });
+    });
+    const req = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/project-a/copied.txt`,
+      'PUT',
+      { 'x-goog-copy-source': `/${BUCKET}/project-a/source%2Ffile.txt` }
+    );
+
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(
+        makeParams({
+          prefix: 'project-a',
+          provider: 'gcs',
+          authStrategy: 'gcs',
+          endpoint: 'https://storage.googleapis.com'
+        })
+      ) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(res.status).toBe(200);
+    expect(capturedRequest?.headers.get('x-goog-copy-source')).toBe(
+      `/${BUCKET}/project-a/source%2Ffile.txt`
+    );
+    expect(capturedRequest?.headers.get('Authorization')).toMatch(
+      /^GOOG4-HMAC-SHA256/
+    );
+
+    vi.restoreAllMocks();
+  });
+
+  it('rejects out-of-scope GCS copy sources', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const req = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/project-a/copied.txt`,
+      'PUT',
+      { 'x-goog-copy-source': `/${BUCKET}/project-b/secret.txt` }
+    );
+
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(
+        makeParams({
+          prefix: 'project-a',
+          provider: 'gcs',
+          authStrategy: 'gcs',
+          endpoint: 'https://storage.googleapis.com'
+        })
+      ) as Parameters<typeof s3CredentialProxyHandler>[2]
+    );
+
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('rejects requests with multiple copy source headers', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const req = makeRequest(
+      `/${MOUNT_ID}/${BUCKET}/project-a/copied.txt`,
+      'PUT',
+      {
+        'x-amz-copy-source': `/${BUCKET}/project-a/source.txt`,
+        'x-goog-copy-source': `/${BUCKET}/project-a/source.txt`
+      }
+    );
+
+    const res = await s3CredentialProxyHandler(
+      req,
+      {} as Cloudflare.Env,
+      makeCtx(makeParams({ prefix: 'project-a' })) as Parameters<
+        typeof s3CredentialProxyHandler
+      >[2]
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.text()).toContain('multiple copy source headers');
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
 });
 
 describe('s3CredentialProxyHandler SigV4 signing', () => {


### PR DESCRIPTION
# Summary

This makes sure copy requests through `credentialProxy` stay inside the mounted bucket and prefix.

It checks the S3/R2 and GCS copy headers before signing, including multipart copies, while keeping normal in-scope copies working.
