### PR TITLE
Fix stable release promotion flow

### DIFF
--- a/.github/reconcile-workflow.test.sh
+++ b/.github/reconcile-workflow.test.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 manual=.github/workflows/reconcile-stable-release.yml
-for expected in 'group: release-refs/heads/main' 'cancel-in-progress: false' 'Resolve manual release identity' 'checkout_ref: ${{ needs.release-identity.outputs.release-sha }}' 'artifact_key: ${{ needs.release-identity.outputs.release-sha }}' 'hashFiles(' 'deploy: ${{ steps.hash.outputs.deploy }}' 'source-tag "ci-${{ needs.hashes.outputs.docker }}"' 'path: ${{ runner.temp }}/release-root/packages' 'release-orchestrator.ts stable' '--mode "${{ needs.release-identity.outputs.release-mode }}"'; do
+for expected in 'group: release-refs/heads/main' 'cancel-in-progress: false' 'Resolve manual release identity' 'checkout_ref: ${{ needs.release-identity.outputs.release-sha }}' 'artifact_key: ${{ needs.release-identity.outputs.release-sha }}' 'hashFiles(' 'deploy: ${{ steps.hash.outputs.deploy }}' 'source-tag "ci-${{ needs.hashes.outputs.docker }}"' 'path: ${{ runner.temp }}/release-root/packages' 'release-orchestrator.ts stable' '--mode "${{ needs.release-identity.outputs.release-mode }}"' 'pull-requests: write' 'Promote public references' "if: needs.release-identity.outputs.release-mode == 'current'" 'GH_TOKEN: ${{ steps.app-token.outputs.token }}' 'git rev-parse origin/main' 'promote-references.ts'; do
   grep -Fq -- "$expected" "$manual" || { echo "manual workflow missing: $expected" >&2; exit 1; }
 done
 if grep -Eq 'source[_-]tag:|inputs\.source[_-]tag|source-tag.*inputs' "$manual"; then
   echo 'manual workflow must not accept free-form source tag' >&2
   exit 1
 fi
+awk '/name: Promote public references/{f=1} f&&/^[[:space:]]+- name:/{if (++steps > 1) exit} f{print}' "$manual" | grep -Fq 'if: always()' && {
+  echo 'promotion must run only after successful reconciliation' >&2
+  exit 1
+} || true

--- a/.github/release-identity.test.ts
+++ b/.github/release-identity.test.ts
@@ -3,12 +3,22 @@ import assert from 'node:assert/strict';
 import {
   chooseReleaseIdentity,
   deriveStableReleaseIdentity,
+  npmVersionViewArgs,
   runStableIdentityCli,
   type StableIdentityDeps
 } from './release-identity.ts';
 
 const SHA = '0123456789abcdef0123456789abcdef01234567';
 const HISTORICAL_SHA = '89abcdef0123456789abcdef0123456789abcdef';
+
+test('npm identity lookup bypasses cached registry metadata', () => {
+  assert.deepEqual(npmVersionViewArgs('@cloudflare/sandbox@1.2.3'), [
+    'view',
+    '@cloudflare/sandbox@1.2.3',
+    'version',
+    '--prefer-online'
+  ]);
+});
 
 function fakeIdentityDeps(): StableIdentityDeps {
   return {

--- a/.github/release-identity.ts
+++ b/.github/release-identity.ts
@@ -133,7 +133,7 @@ const nodeStableIdentityDeps: StableIdentityDeps = {
     );
   },
   npmVersionExists: async (packageVersion) => {
-    const result = spawnSync('npm', ['view', packageVersion, 'version'], {
+    const result = spawnSync('npm', npmVersionViewArgs(packageVersion), {
       encoding: 'utf8'
     });
     if (result.status === 0) {
@@ -203,13 +203,17 @@ function tagSHAFromGit(gitTag: string): string | null {
 
 function npmVersionExistsCheck(version: string): boolean {
   try {
-    execFileSync('npm', ['view', `@cloudflare/sandbox@${version}`, 'version'], {
+    execFileSync('npm', npmVersionViewArgs(`@cloudflare/sandbox@${version}`), {
       stdio: 'ignore'
     });
     return true;
   } catch {
     return false;
   }
+}
+
+export function npmVersionViewArgs(packageVersion: string): string[] {
+  return ['view', packageVersion, 'version', '--prefer-online'];
 }
 
 function runLegacyIdentityCli(): string {

--- a/.github/release-plan.test.ts
+++ b/.github/release-plan.test.ts
@@ -125,28 +125,44 @@ describe('planStableRelease', () => {
     });
   });
 
-  test('advances absent or older latest and leaves equal latest unchanged', () => {
+  test('publishes a missing current version to absent or older latest', () => {
+    for (const latest of ['missing', '1.2.2'] as const) {
+      const prepared = makePreparedRelease();
+      const plan = planStableRelease(
+        makeContext(),
+        inspection({ npm: 'missing', latest }),
+        prepared
+      );
+      assert.deepEqual(plan.latestAction, { type: 'set', version: '1.2.3' });
+      assert.deepEqual(
+        plan.operations.filter((operation) => operation.type === 'publish-npm'),
+        [
+          {
+            type: 'publish-npm',
+            prepared: prepared.npm,
+            npmTag: 'latest'
+          }
+        ]
+      );
+    }
+  });
+
+  test('requires maintainer authentication when a published version is not latest', () => {
     for (const latest of ['missing', '1.2.2'] as const) {
       const plan = planStableRelease(
         makeContext(),
         inspection({ latest }),
         makePreparedRelease()
       );
-      assert.deepEqual(plan.latestAction, { type: 'set', version: '1.2.3' });
-      assert.deepEqual(
-        plan.operations.filter(
-          (operation) => operation.type === 'set-npm-latest'
-        ),
-        [
-          {
-            type: 'set-npm-latest',
-            packageName: '@cloudflare/sandbox',
-            version: '1.2.3'
-          }
-        ]
-      );
-    }
 
+      assert.deepEqual(plan.operations, []);
+      assert.deepEqual(plan.conflicts, [
+        'npm.latest: @cloudflare/sandbox@1.2.3 is already published but latest does not point to it; run "npm dist-tag add @cloudflare/sandbox@1.2.3 latest" with maintainer authentication, then retry'
+      ]);
+    }
+  });
+
+  test('leaves equal latest unchanged', () => {
     const equal = planStableRelease(
       makeContext(),
       inspection({ latest: '1.2.3' }),
@@ -177,7 +193,8 @@ describe('planStableRelease', () => {
         npm: 'missing',
         git: 'missing',
         github: 'missing',
-        docker: 'missing'
+        docker: 'missing',
+        latest: 'missing'
       }),
       prepared
     );
@@ -187,11 +204,6 @@ describe('planStableRelease', () => {
         type: 'create-git-tag',
         tag: context.versionTag,
         sha: context.releaseSHA
-      },
-      {
-        type: 'publish-npm',
-        prepared: prepared.npm,
-        npmTag: 'release-1-2-3'
       },
       {
         type: 'create-github-release',
@@ -221,11 +233,16 @@ describe('planStableRelease', () => {
           repository: 'docker.io/cloudflare/sandbox',
           tag: '1.2.3'
         }
+      },
+      {
+        type: 'publish-npm',
+        prepared: prepared.npm,
+        npmTag: 'latest'
       }
     ]);
   });
 
-  test('orders git tag before npm publish and latest last', () => {
+  test('orders git tag first and current npm publish last', () => {
     const prepared = makePreparedRelease();
     const plan = planStableRelease(
       makeContext(),
@@ -239,7 +256,7 @@ describe('planStableRelease', () => {
 
     assert.deepEqual(
       plan.operations.map((operation) => operation.type),
-      ['create-git-tag', 'publish-npm', 'set-npm-latest']
+      ['create-git-tag', 'publish-npm']
     );
   });
 
@@ -257,11 +274,7 @@ describe('planStableRelease', () => {
       version: '1.2.4'
     });
     assert.deepEqual(
-      plan.operations.filter(
-        (operation) =>
-          operation.type === 'publish-npm' ||
-          operation.type === 'set-npm-latest'
-      ),
+      plan.operations.filter((operation) => operation.type === 'publish-npm'),
       [
         {
           type: 'publish-npm',
@@ -272,7 +285,7 @@ describe('planStableRelease', () => {
     );
   });
 
-  test('publishes under a non-latest tag before separately setting latest', () => {
+  test('publishes a current release directly to latest', () => {
     const prepared = makePreparedRelease();
     const plan = planStableRelease(
       makeContext(),
@@ -281,21 +294,34 @@ describe('planStableRelease', () => {
     );
 
     assert.deepEqual(
-      plan.operations.filter(
-        (operation) =>
-          operation.type === 'publish-npm' ||
-          operation.type === 'set-npm-latest'
-      ),
+      plan.operations.filter((operation) => operation.type === 'publish-npm'),
+      [
+        {
+          type: 'publish-npm',
+          prepared: prepared.npm,
+          npmTag: 'latest'
+        }
+      ]
+    );
+  });
+
+  test('publishes a historical release under a non-latest tag when latest is absent', () => {
+    const context = { ...makeContext(), mode: 'historical' as const };
+    const prepared = makePreparedRelease();
+    const plan = planStableRelease(
+      context,
+      inspection({ npm: 'missing', latest: 'missing' }),
+      prepared
+    );
+
+    assert.deepEqual(plan.latestAction, { type: 'none' });
+    assert.deepEqual(
+      plan.operations.filter((operation) => operation.type === 'publish-npm'),
       [
         {
           type: 'publish-npm',
           prepared: prepared.npm,
           npmTag: 'release-1-2-3'
-        },
-        {
-          type: 'set-npm-latest',
-          packageName: '@cloudflare/sandbox',
-          version: '1.2.3'
         }
       ]
     );

--- a/.github/release-plan.ts
+++ b/.github/release-plan.ts
@@ -4,7 +4,6 @@ import type { PreparedNpmPackage } from './npm-package-prep.ts';
 import type { DockerRef } from './release-platform.ts';
 import type {
   CommitSHA,
-  NpmPackageName,
   StableVersion,
   VersionTag
 } from './release-primitives.ts';
@@ -17,11 +16,6 @@ export type ReleaseOperation =
       type: 'publish-npm';
       prepared: PreparedNpmPackage;
       npmTag: string;
-    }
-  | {
-      type: 'set-npm-latest';
-      packageName: NpmPackageName;
-      version: StableVersion;
     }
   | { type: 'create-git-tag'; tag: VersionTag; sha: CommitSHA }
   | {
@@ -67,21 +61,14 @@ export function planStableRelease(
   }
 
   // Tag first so identity recovery stays valid if later steps fail.
-  // Publish npm under a non-latest tag before Docker/GitHub assets.
-  // Move npm latest only after immutable artifacts are planned last.
+  // Publish current npm releases directly to latest only after every other
+  // release artifact is complete.
   const operations: ReleaseOperation[] = [];
   if (inspection.git.versionTag.state === 'missing') {
     operations.push({
       type: 'create-git-tag',
       tag: context.versionTag,
       sha: context.releaseSHA
-    });
-  }
-  if (inspection.npm.version.state === 'missing') {
-    operations.push({
-      type: 'publish-npm',
-      prepared: prepared.npm,
-      npmTag: npmPublicationTag(context.version)
     });
   }
   if (inspection.github.release.state === 'missing') {
@@ -117,11 +104,14 @@ export function planStableRelease(
       });
     }
   }
-  if (latestAction.type === 'set') {
+  if (inspection.npm.version.state === 'missing') {
     operations.push({
-      type: 'set-npm-latest',
-      packageName: context.npmPackageName,
-      version: latestAction.version
+      type: 'publish-npm',
+      prepared: prepared.npm,
+      npmTag:
+        context.mode === 'current' && latestAction.type === 'set'
+          ? 'latest'
+          : npmPublicationTag(context.version)
     });
   }
 
@@ -152,6 +142,15 @@ function collectConflicts(
       );
     }
   }
+  if (
+    context.mode === 'current' &&
+    inspection.npm.version.state === 'matching' &&
+    latestNeedsUpdate(context, inspection)
+  ) {
+    conflicts.push(
+      `npm.latest: ${context.npmPackageName}@${context.version} is already published but latest does not point to it; run "npm dist-tag add ${context.npmPackageName}@${context.version} latest" with maintainer authentication, then retry`
+    );
+  }
   addConflict(conflicts, 'git.versionTag', inspection.git.versionTag);
   addConflict(conflicts, 'github.release', inspection.github.release);
   for (const asset of inspection.github.assets) {
@@ -167,6 +166,15 @@ function decideLatest(
   context: StableReleaseContext,
   inspection: StableInspection
 ): LatestAction {
+  if (context.mode === 'historical') {
+    if (inspection.npm.latest.state === 'matching') {
+      return {
+        type: 'preserve',
+        version: inspection.npm.latest.observed.version
+      };
+    }
+    return { type: 'none' };
+  }
   if (inspection.npm.latest.state === 'missing') {
     return { type: 'set', version: context.version };
   }
@@ -179,6 +187,20 @@ function decideLatest(
   if (comparison < 0) return { type: 'set', version: context.version };
   if (comparison === 0) return { type: 'none' };
   return { type: 'preserve', version: observed };
+}
+
+function latestNeedsUpdate(
+  context: StableReleaseContext,
+  inspection: StableInspection
+): boolean {
+  if (inspection.npm.latest.state === 'missing') return true;
+  if (inspection.npm.latest.state === 'conflict') return false;
+  return (
+    compareStableSemver(
+      inspection.npm.latest.observed.version,
+      context.version
+    ) < 0
+  );
 }
 
 function addConflict(

--- a/.github/release-platform.test.ts
+++ b/.github/release-platform.test.ts
@@ -123,6 +123,45 @@ describe('ReleasePlatform', () => {
     ]);
   });
 
+  test('exec npm inspections bypass cached registry metadata', async () => {
+    const calls: Array<{ command: string; args: readonly string[] }> = [];
+    const platform = new ExecReleasePlatform({
+      command: async (command, args) => {
+        calls.push({ command, args });
+        return { exitCode: 0, stdout: '"1.2.3"', stderr: '' };
+      }
+    });
+
+    await platform.npm.inspectVersion(
+      '@cloudflare/sandbox',
+      stableVersion('1.2.3')
+    );
+    await platform.npm.inspectDistTag('@cloudflare/sandbox', 'latest');
+
+    assert.deepEqual(calls, [
+      {
+        command: 'npm',
+        args: [
+          'view',
+          '@cloudflare/sandbox@1.2.3',
+          'version',
+          '--json',
+          '--prefer-online'
+        ]
+      },
+      {
+        command: 'npm',
+        args: [
+          'view',
+          '@cloudflare/sandbox',
+          'dist-tags.latest',
+          '--json',
+          '--prefer-online'
+        ]
+      }
+    ]);
+  });
+
   test('exec npm inspection returns missing for E404 and throws for auth', async () => {
     const missing = new ExecReleasePlatform({
       command: async () => ({

--- a/.github/release-platform.ts
+++ b/.github/release-platform.ts
@@ -51,11 +51,6 @@ export interface NpmReleaseClient {
     prepared: PreparedNpmPackage,
     tag: string
   ): Promise<void>;
-  setDistTag(
-    name: SandboxPackageName,
-    version: StableVersion,
-    tag: 'latest'
-  ): Promise<void>;
 }
 
 export interface GitTagClient {
@@ -128,7 +123,8 @@ function createNpmClient(executor: ProcessExecutor): NpmReleaseClient {
         'view',
         packageVersion,
         'version',
-        '--json'
+        '--json',
+        '--prefer-online'
       ]);
       if (isNpmMissing(result)) {
         return undefined;
@@ -146,7 +142,8 @@ function createNpmClient(executor: ProcessExecutor): NpmReleaseClient {
         'view',
         name,
         `dist-tags.${tag}`,
-        '--json'
+        '--json',
+        '--prefer-online'
       ]);
       if (isNpmMissing(result)) {
         return undefined;
@@ -166,17 +163,6 @@ function createNpmClient(executor: ProcessExecutor): NpmReleaseClient {
           '--access',
           'public',
           '--tag',
-          tag
-        ])
-      );
-    },
-    setDistTag: async (name, version, tag) => {
-      requireSuccess(
-        `npm dist-tag for ${name}@${version}`,
-        await executor.command('npm', [
-          'dist-tag',
-          'add',
-          `${name}@${version}`,
           tag
         ])
       );

--- a/.github/release-tooling.md
+++ b/.github/release-tooling.md
@@ -34,7 +34,10 @@ is missing, the engine creates only that missing state. If a Git tag, Docker
 digest, GitHub Release tag, npm identity, local export, source image, or binary
 asset conflicts, the run fails before remote mutation. After applying missing
 state, the engine performs a fresh inspection and requires a complete matching
-release before promotion can start.
+release before promotion can start. Current releases publish npm directly to
+`latest` as the final mutation so trusted publishing does not require a
+separate authenticated dist-tag update. If the version already exists while
+`latest` is behind, CI reports the maintainer command required before retrying.
 
 Promotion is a separate current-main worktree transition. A run that creates or
 updates `promote/<version>` stops; Changesets runs only on a later `main` push

--- a/.github/stable-release-engine.test.ts
+++ b/.github/stable-release-engine.test.ts
@@ -24,6 +24,16 @@ describe('runStableReleaseEngine', () => {
 
     assert.equal(result.finalPlan.operations.length, 0);
     assert.equal(platform.distTags.get('@cloudflare/sandbox:latest'), '1.2.3');
+    assert.equal(
+      platform.operations.at(-1),
+      'npm.publish /tmp/pkg/pkg.tgz latest'
+    );
+    assert.equal(
+      platform.operations.some((operation) =>
+        operation.startsWith('npm.distTag')
+      ),
+      false
+    );
   });
 
   test('scenario already complete release performs no mutation', async () => {
@@ -203,6 +213,30 @@ describe('runStableReleaseEngine', () => {
         assert.match(String(error.errors[1]), /cleanup failed/);
         return true;
       }
+    );
+  });
+
+  test('does not publish npm when an earlier Docker copy fails', async () => {
+    const platform = seededPlatformWithSourceImage();
+    platform.docker.copyImage = async () => {
+      throw new Error('copy failed');
+    };
+
+    await assert.rejects(
+      runStableReleaseEngine({
+        context: makeContext(),
+        platform,
+        prepare: async () => makePreparedRelease()
+      }),
+      /copy failed/
+    );
+
+    assert.equal(platform.npmVersions.size, 0);
+    assert.equal(
+      platform.operations.some((operation) =>
+        operation.startsWith('npm.publish')
+      ),
+      false
     );
   });
 

--- a/.github/stable-release-engine.ts
+++ b/.github/stable-release-engine.ts
@@ -120,13 +120,6 @@ async function applyOperation(
         operation.npmTag
       );
       return;
-    case 'set-npm-latest':
-      await platform.npm.setDistTag(
-        operation.packageName,
-        operation.version,
-        'latest'
-      );
-      return;
     case 'create-git-tag':
       await platform.git.createTag(operation.tag, operation.sha);
       return;

--- a/.github/test/release-platform-fake.ts
+++ b/.github/test/release-platform-fake.ts
@@ -43,10 +43,6 @@ export class FakeReleasePlatform implements ReleasePlatform {
           stableVersion(prepared.version)
         );
       }
-    },
-    setDistTag: async (name: string, version: StableVersion, tag: 'latest') => {
-      this.operations.push(`npm.distTag ${name}@${version} ${tag}`);
-      this.distTags.set(`${name}:${tag}`, version);
     }
   };
   readonly git = {

--- a/.github/workflows/reconcile-stable-release.yml
+++ b/.github/workflows/reconcile-stable-release.yml
@@ -157,6 +157,7 @@ jobs:
       actions: read
       contents: write
       id-token: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -222,3 +223,15 @@ jobs:
           if [ -d "$RUNNER_TEMP/release-root" ]; then
             git worktree remove --force "$RUNNER_TEMP/release-root" || true
           fi
+
+      - name: Promote public references
+        if: needs.release-identity.outputs.release-mode == 'current'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          git fetch origin main
+          main_sha="$(git rev-parse origin/main)"
+          npx tsx .github/promote-references.ts \
+            --version "$RELEASE_VERSION" \
+            --main-sha "$main_sha"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -4,7 +4,7 @@ How to cut and finish a stable Sandbox SDK release.
 
 ## Overview
 
-Merging a **Version Packages** PR to `main` starts the release. CI publishes that version (npm package, container images, git tag, and GitHub Release), then opens a **promotion** PR that updates Docker image pins in the repo. The release workflow stops after creating or updating that promotion PR. Once promotion is merged, a later push to `main` can open the next Version Packages PR when there are new changesets.
+Merging a **Version Packages** PR to `main` starts the release. CI creates the container images, git tag, GitHub Release, and binary assets before publishing the npm package directly to `latest` as the final release mutation. It then opens a **promotion** PR that updates Docker image pins in the repo. The release workflow stops after creating or updating that promotion PR. Once promotion is merged, a later push to `main` can open the next Version Packages PR when there are new changesets.
 
 If a run fails partway through, retrying the same version is usually safe: CI fills in missing pieces and will not replace artifacts that already exist with different content.
 
@@ -42,7 +42,7 @@ If packages and images are published but promotion is not merged yet, the releas
 ## Automatic and manual runs
 
 - **Automatic:** pushes to `main` may run the stable release workflow.
-- **Manual:** **Reconcile stable release** in Actions uses the same rules when you need to finish or retry a version without waiting for another push.
+- **Manual:** **Reconcile stable release** in Actions uses the same rules when you need to finish or retry a version without waiting for another push. Successful reconciliation of the current release also creates or updates the promotion PR; historical reconciliation does not move repository references backward.
 
 Only one stable release or reconcile run proceeds at a time on `main`; others queue. Queued runs are normal.
 
@@ -53,6 +53,7 @@ Retry the same version first: re-run the failed workflow, or start **Reconcile s
 | Situation                                                  | Likely meaning                                   | Action                                                                                   |
 | ---------------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------- |
 | Failed during publish                                      | Transient error or incomplete progress           | Retry the same version                                                                   |
+| npm version exists but `latest` points to an older version | npm publishing completed without tag promotion   | A maintainer must run the exact `npm dist-tag add` command reported by CI, then retry    |
 | npm package exists but the matching git tag does not       | Broken or half-finished release identity         | Investigate before publishing again; do not skip ahead to a new version to paper over it |
 | Conflict, unexpected image digest, or wrong tag target     | An existing artifact does not match this release | Investigate; CI will not overwrite mismatched immutable artifacts                        |
 | Promote PR is open and there is no new Version Packages PR | Normal sequencing                                | Merge promote (or confirm refs already match)                                            |


### PR DESCRIPTION
Publish current stable npm packages directly to `latest` only after all
other release artifacts are complete.

npm trusted publishing authenticates `npm publish`, but not a later
`npm dist-tag add`. Publishing to a temporary tag therefore left 0.12.6
published while `latest` remained on 0.12.5, which also prevented the
public-reference promotion PR from being created.

This keeps normal stable releases tokenless, reports an actionable
maintainer command for already-published versions whose `latest` tag is
behind, and lets current-version reconciliation create the promotion PR.
Historical reconciliation does not move repository references backward.
Registry inspections bypass cached metadata before making release identity
or convergence decisions.

Validation:

- `npm run test:release-tools`
- `npm run check`
- `npm test -w @cloudflare/sandbox`
- `npm test -w @repo/sandbox-container`

The root `npm test` command also ran, but its S3 mount example integration
test requires a server on `localhost:8787` and failed with connection
refused; Turbo then cancelled the remaining jobs.