### PR TITLE
Backport R2 object key decoding fix

### DIFF
--- a/.changeset/decode-mounted-r2-object-keys.md
+++ b/.changeset/decode-mounted-r2-object-keys.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Allow mounted R2 buckets to open object keys containing spaces, symbols, percent signs, and non-ASCII characters.

--- a/packages/sandbox/src/storage-mount/outbound/r2-egress-handler.ts
+++ b/packages/sandbox/src/storage-mount/outbound/r2-egress-handler.ts
@@ -62,6 +62,14 @@ function normalizeObjectKey(value: string): string {
   return value.replace(/^\/+/, '');
 }
 
+function decodeObjectKey(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 function trimTrailingSlashes(s: string): string {
   let end = s.length;
   while (end > 0 && s[end - 1] === '/') end--;
@@ -668,7 +676,8 @@ export const r2EgressHandler: OutboundHandler<
     return new Response('Bad Request: empty path', { status: 400 });
   }
 
-  const { bucket: bucketName, key } = parsed;
+  const { bucket: bucketName, key: encodedKey } = parsed;
+  const key = decodeObjectKey(encodedKey);
 
   if (!ctx.params?.buckets || !(bucketName in ctx.params.buckets)) {
     return new Response(

--- a/packages/sandbox/tests/r2-egress-handler.test.ts
+++ b/packages/sandbox/tests/r2-egress-handler.test.ts
@@ -344,6 +344,47 @@ describe('r2EgressHandler', () => {
       expect(text).toBe('Hello, World!');
     });
 
+    it('resolves encoded object keys exactly once', async () => {
+      const cases = [
+        ['with%23hash.txt', 'with#hash.txt'],
+        [
+          '%E8%AB%8B%E6%B1%82%E6%9B%B8.pdf%23a3f9c2e18b4d',
+          '請求書.pdf#a3f9c2e18b4d'
+        ],
+        ['pct%2520once.txt', 'pct%20once.txt'],
+        ['folder%2Ffile.txt', 'folder/file.txt'],
+        ['bad%escape.txt', 'bad%escape.txt']
+      ];
+
+      for (const [path, key] of cases) {
+        const r2 = createMockR2Bucket(
+          new Map([[key, { body: key, etag: '"test-etag"' }]])
+        );
+        const res = await r2EgressHandler(
+          req('GET', `/MY_BUCKET/${path}`),
+          makeEnv(r2),
+          makeCtx()
+        );
+
+        expect(res.status).toBe(200);
+        expect(await res.text()).toBe(key);
+        expect(r2.get).toHaveBeenCalledWith(key);
+      }
+    });
+
+    it('does not decode an encoded separator in the bucket segment', async () => {
+      const r2 = createMockR2Bucket(new Map());
+
+      const res = await r2EgressHandler(
+        req('GET', '/MY_BUCKET%2FOTHER/secret.txt'),
+        makeEnv(r2),
+        makeCtx()
+      );
+
+      expect(res.status).toBe(403);
+      expect(r2.get).not.toHaveBeenCalled();
+    });
+
     it('returns 404 for missing key', async () => {
       const r2 = createMockR2Bucket(new Map());
       const res = await r2EgressHandler(


### PR DESCRIPTION
Backports #877 to `next`.

This decodes mounted R2 object keys exactly once while keeping the bucket segment unchanged for authorization checks.