### PR TITLE
Fix multipart backups with HTTPS interception

### DIFF
--- a/.changeset/fix-intercepted-multipart-backups.md
+++ b/.changeset/fix-intercepted-multipart-backups.md
@@ -1,0 +1,5 @@
+---
+'@cloudflare/sandbox': patch
+---
+
+Allow multipart backup uploads to trust the runtime HTTPS interception certificate, so backups larger than 10 MiB work when `interceptHttps` is enabled.

--- a/packages/sandbox-container/src/cert.ts
+++ b/packages/sandbox-container/src/cert.ts
@@ -14,6 +14,12 @@ const SYSTEM_CA_BUNDLE_PATHS = [
 const CERT_WAIT_TIMEOUT_MS = 5000;
 const CERT_WAIT_POLL_MS = 100;
 
+let runtimeCertPEM: string | undefined;
+
+export function getRuntimeCertPEM(): string | undefined {
+  return runtimeCertPEM;
+}
+
 function findSystemBundle(): string | undefined {
   return SYSTEM_CA_BUNDLE_PATHS.find((bundlePath) => existsSync(bundlePath));
 }
@@ -30,6 +36,7 @@ async function waitForCertFile(certPath: string): Promise<boolean> {
 }
 
 export async function trustRuntimeCert(): Promise<void> {
+  runtimeCertPEM = undefined;
   // Default to the Cloudflare containers injected CA certificate
   const certPath =
     process.env.SANDBOX_CA_CERT ||
@@ -52,6 +59,7 @@ export async function trustRuntimeCert(): Promise<void> {
     process.exit(1);
   }
 
+  runtimeCertPEM = certContent;
   process.env.NODE_EXTRA_CA_CERTS = certPath;
 
   const systemBundlePath = findSystemBundle();

--- a/packages/sandbox-container/src/services/backup-service.ts
+++ b/packages/sandbox-container/src/services/backup-service.ts
@@ -19,7 +19,11 @@ export class BackupService {
   private restoreOperations: RestoreOperations;
   private transferOperations: TransferOperations;
 
-  constructor(logger: Logger, commandContextService: CommandContextService) {
+  constructor(
+    logger: Logger,
+    commandContextService: CommandContextService,
+    runtimeCertPEM?: () => string | undefined
+  ) {
     this.archiveOperations = new ArchiveOperations(
       logger,
       commandContextService
@@ -30,7 +34,8 @@ export class BackupService {
     );
     this.transferOperations = new TransferOperations(
       logger,
-      commandContextService
+      commandContextService,
+      runtimeCertPEM
     );
   }
 

--- a/packages/sandbox-container/src/services/backup/transfer-operations.ts
+++ b/packages/sandbox-container/src/services/backup/transfer-operations.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@repo/shared';
 import { shellEscape } from '@repo/shared';
 import { ErrorCode } from '@repo/shared/errors';
+import { getRuntimeCertPEM } from '../../cert';
 import {
   type ServiceError,
   type ServiceResult,
@@ -85,7 +86,10 @@ function validateDownloadCoverage(
 export class TransferOperations {
   constructor(
     private logger: Logger,
-    private commandContextService: CommandContextService
+    private commandContextService: CommandContextService,
+    private readonly runtimeCertPEM: () =>
+      | string
+      | undefined = getRuntimeCertPEM
   ) {}
 
   private async executeInternal(
@@ -125,6 +129,7 @@ export class TransferOperations {
     for (let attempt = 1; attempt <= BACKUP_UPLOAD_MAX_ATTEMPTS; attempt++) {
       try {
         const body = archiveFile.slice(part.offset, part.offset + part.size);
+        const runtimeCertPEM = this.runtimeCertPEM();
         const response = await fetch(part.url, {
           method: 'PUT',
           headers: {
@@ -132,7 +137,8 @@ export class TransferOperations {
             'Content-Type': 'application/octet-stream'
           },
           body,
-          signal: AbortSignal.timeout(BACKUP_UPLOAD_TIMEOUT_MS)
+          signal: AbortSignal.timeout(BACKUP_UPLOAD_TIMEOUT_MS),
+          ...(runtimeCertPEM && { tls: { ca: runtimeCertPEM } })
         });
 
         if (!response.ok) {

--- a/packages/sandbox-container/tests/cert.test.ts
+++ b/packages/sandbox-container/tests/cert.test.ts
@@ -10,7 +10,7 @@ mock.module('node:fs', () => ({
   appendFileSync: mockAppendFileSync
 }));
 
-import { trustRuntimeCert } from '../src/cert';
+import { getRuntimeCertPEM, trustRuntimeCert } from '../src/cert';
 
 const DEFAULT_CERT_PATH = '/etc/cloudflare/certs/cloudflare-containers-ca.crt';
 const PRIMARY_SYSTEM_CA_BUNDLE = '/etc/ssl/certs/ca-certificates.crt';
@@ -93,6 +93,7 @@ describe('trustRuntimeCert', () => {
     await trustRuntimeCert();
 
     expect(mockReadFileSync).toHaveBeenCalledWith(DEFAULT_CERT_PATH, 'utf8');
+    expect(getRuntimeCertPEM()).toBe(certContent);
     expect(mockAppendFileSync).toHaveBeenCalledWith(
       PRIMARY_SYSTEM_CA_BUNDLE,
       `\n${certContent}`

--- a/packages/sandbox-container/tests/services/backup-service.test.ts
+++ b/packages/sandbox-container/tests/services/backup-service.test.ts
@@ -92,7 +92,11 @@ describe('BackupService', () => {
         return result.data;
       }
     );
-    service = new BackupService(mockLogger, mockCommandContextService);
+    service = new BackupService(
+      mockLogger,
+      mockCommandContextService,
+      () => undefined
+    );
   });
 
   afterEach(() => {
@@ -232,6 +236,42 @@ describe('BackupService', () => {
           ]
         }
       });
+      expect(mockFetch.mock.calls[0]?.[1]).not.toHaveProperty('tls');
+    });
+
+    it('passes the runtime interception CA to multipart fetch', async () => {
+      const runtimeCertPEM =
+        '-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----';
+      service = new BackupService(
+        mockLogger,
+        mockCommandContextService,
+        () => runtimeCertPEM
+      );
+      vi.spyOn(Bun, 'file').mockReturnValue({
+        exists: async () => true,
+        slice: vi.fn().mockReturnValue(new Blob(['part-a']))
+      } as unknown as ReturnType<typeof Bun.file>);
+      mockFetch.mockResolvedValue(
+        new Response(null, {
+          status: 200,
+          headers: { etag: '"etag-1"' }
+        })
+      );
+
+      const result = await service.uploadParts('/var/backups/test.sqsh', [
+        {
+          partNumber: 1,
+          url: 'https://example.com/part-1',
+          offset: 0,
+          size: 10
+        }
+      ]);
+
+      expect(result.success).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://example.com/part-1',
+        expect.objectContaining({ tls: { ca: runtimeCertPEM } })
+      );
     });
 
     it('fails when the archive does not exist', async () => {


### PR DESCRIPTION
## Summary

Multipart backup uploads used Bun's startup trust store, so archives of 10 MiB or more failed when HTTPS interception was enabled.

Pass the injected runtime certificate directly to each multipart upload request.

Resolves #892 on `next`.
